### PR TITLE
Доработка репортера для junit 

### DIFF
--- a/src/main/java/org/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
+++ b/src/main/java/org/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
@@ -77,6 +77,7 @@ public class AnalyzeCommand implements Command {
     }
 
     AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), diagnostics);
+    analysisInfo.setSourceDir(srcDirOption);
     ReportersAggregator aggregator = new ReportersAggregator(outputDir, reporters);
     aggregator.report(analysisInfo);
     return 0;

--- a/src/main/java/org/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
+++ b/src/main/java/org/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
@@ -76,8 +76,7 @@ public class AnalyzeCommand implements Command {
         .collect(Collectors.toList());
     }
 
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), diagnostics);
-    analysisInfo.setSourceDir(srcDirOption);
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), diagnostics, srcDirOption);
     ReportersAggregator aggregator = new ReportersAggregator(outputDir, reporters);
     aggregator.report(analysisInfo);
     return 0;

--- a/src/main/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/AnalysisInfo.java
+++ b/src/main/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/AnalysisInfo.java
@@ -41,5 +41,5 @@ public class AnalysisInfo {
   @JsonSerialize(using = LocalDateTimeSerializer.class)
   private final LocalDateTime date;
   private final List<FileInfo> fileinfos;
-  private String sourceDir = ".";
+  private final String sourceDir;
 }

--- a/src/main/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/AnalysisInfo.java
+++ b/src/main/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/AnalysisInfo.java
@@ -41,4 +41,5 @@ public class AnalysisInfo {
   @JsonSerialize(using = LocalDateTimeSerializer.class)
   private final LocalDateTime date;
   private final List<FileInfo> fileinfos;
+  private String sourceDir = ".";
 }

--- a/src/main/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitReporter.java
+++ b/src/main/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitReporter.java
@@ -56,7 +56,7 @@ public class JUnitReporter extends AbstractDiagnosticReporter {
     try {
       File reportFile = new File(outputDir.toFile(), "./bsl-junit.xml");
       mapper.writeValue(reportFile, jUnitReport);
-      LOGGER.info("JUnit report saved to {}", reportFile.getAbsolutePath());
+      LOGGER.info("JUnit report saved to {}", reportFile.getCanonicalPath());
     } catch (IOException e) {
       throw new RuntimeException(e);
     }

--- a/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ConsoleReporterTest.java
+++ b/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ConsoleReporterTest.java
@@ -64,7 +64,7 @@ class ConsoleReporterTest {
 
     DocumentContext documentContext = new DocumentContext("file:///fake-uri.bsl", "");
     FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo));
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
 
     ConsoleReporter reporter = new ConsoleReporter();
 

--- a/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericReporterTest.java
+++ b/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericReporterTest.java
@@ -71,7 +71,7 @@ class GenericReporterTest {
 
     DocumentContext documentContext = new DocumentContext("file:///fake-uri.bsl", "");
     FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo));
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
 
     AbstractDiagnosticReporter reporter = new GenericIssueReporter();
 

--- a/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitReporterTest.java
+++ b/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitReporterTest.java
@@ -88,7 +88,7 @@ class JUnitReporterTest {
 
     DocumentContext documentContext = new DocumentContext(Paths.get("./src/test/java/diagnostics/CanonicalSpellingKeywordsDiagnostic.bsl").toUri().toString(), "");
     FileInfo fileInfo = new FileInfo(documentContext, diagnostics);
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo));
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
 
     AbstractDiagnosticReporter reporter = new JUnitReporter();
 

--- a/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitReporterTest.java
+++ b/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitReporterTest.java
@@ -35,8 +35,11 @@ import org.junit.jupiter.api.Test;
 
 import java.io.File;
 import java.io.IOException;
+import java.nio.file.Paths;
 import java.time.LocalDateTime;
+import java.util.ArrayList;
 import java.util.Collections;
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -58,16 +61,33 @@ class JUnitReporterTest {
   void report() throws IOException {
 
     // given
-    Diagnostic diagnostic = new Diagnostic(
+    List<Diagnostic> diagnostics = new ArrayList<>();
+    diagnostics.add(new Diagnostic(
       RangeHelper.newRange(0, 1, 2, 3),
       "message",
       DiagnosticSeverity.Error,
       "test-source",
       "test"
-    );
+    ));
 
-    DocumentContext documentContext = new DocumentContext("file:///fake-uri.bsl", "");
-    FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
+    diagnostics.add(new Diagnostic(
+      RangeHelper.newRange(0, 1, 2, 4),
+      "message4",
+      DiagnosticSeverity.Error,
+      "test-source2",
+      "test3"
+    ));
+
+    diagnostics.add(new Diagnostic(
+      RangeHelper.newRange(3, 1, 4, 4),
+      "message4",
+      DiagnosticSeverity.Error,
+      "test-source2",
+      "test3"
+    ));
+
+    DocumentContext documentContext = new DocumentContext(Paths.get("./src/test/java/diagnostics/CanonicalSpellingKeywordsDiagnostic.bsl").toUri().toString(), "");
+    FileInfo fileInfo = new FileInfo(documentContext, diagnostics);
     AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo));
 
     AbstractDiagnosticReporter reporter = new JUnitReporter();

--- a/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JsonReporterTest.java
+++ b/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JsonReporterTest.java
@@ -67,6 +67,7 @@ class JsonReporterTest {
     DocumentContext documentContext = new DocumentContext("file:///fake-uri.bsl", "");
     FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
     AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo));
+    analysisInfo.setSourceDir(".");
 
     JsonReporter reporter = new JsonReporter();
 

--- a/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JsonReporterTest.java
+++ b/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JsonReporterTest.java
@@ -66,8 +66,7 @@ class JsonReporterTest {
 
     DocumentContext documentContext = new DocumentContext("file:///fake-uri.bsl", "");
     FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo));
-    analysisInfo.setSourceDir(".");
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
 
     JsonReporter reporter = new JsonReporter();
 

--- a/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ReportersAggregatorTest.java
+++ b/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ReportersAggregatorTest.java
@@ -66,7 +66,7 @@ class ReportersAggregatorTest {
 
     DocumentContext documentContext = new DocumentContext("file:///fake-uri.bsl", "");
     FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo));
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
 
     aggregator.report(analysisInfo);
 

--- a/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/TSLintReporterTest.java
+++ b/src/test/java/org/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/TSLintReporterTest.java
@@ -70,7 +70,7 @@ class TSLintReporterTest {
 
     DocumentContext documentContext = new DocumentContext("file:///fake-uri.bsl", "");
     FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo));
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
 
     TSLintReporter reporter = new TSLintReporter();
 


### PR DESCRIPTION
#351

Поправил формирование отчета в формате junit
 - убрал множественные failure
 - поправил имена атрибутов
 - Скорректировал имена файлов - теперь используются относительные

Добавил в класс AnalysisInfo sourceDir - каталог с исходниками. По умолчанию это текущий каталог. Добавлен проброс из cli каталога исходников в AnalysisInfo