### PR TITLE
OnestatementPerLine fp fix

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/OneStatementPerLineDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/OneStatementPerLineDiagnostic.java
@@ -65,7 +65,7 @@ public class OneStatementPerLineDiagnostic extends AbstractVisitorDiagnostic imp
   @Override
   public ParseTree visitStatement(BSLParser.StatementContext ctx) {
 
-    if (ctx.preprocessor() != null) {
+    if (ctx.preprocessor() != null || ctx.exception != null) {
       return super.visitStatement(ctx);
     }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/OneStatementPerLineDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/OneStatementPerLineDiagnosticTest.java
@@ -29,7 +29,8 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
-import static org.assertj.core.api.Assertions.assertThat;
+import static com.github._1c_syntax.bsl.languageserver.util.Assertions.assertThat;
+
 
 class OneStatementPerLineDiagnosticTest extends AbstractDiagnosticTest<OneStatementPerLineDiagnostic> {
 
@@ -42,9 +43,10 @@ class OneStatementPerLineDiagnosticTest extends AbstractDiagnosticTest<OneStatem
     List<Diagnostic> diagnostics = getDiagnostics();
 
     assertThat(diagnostics).hasSize(3);
-    assertThat(diagnostics.get(0).getRange()).isEqualTo(Ranges.create(3, 8, 3, 14));
-    assertThat(diagnostics.get(1).getRange()).isEqualTo(Ranges.create(8, 18, 8, 32));
-    assertThat(diagnostics.get(2).getRange()).isEqualTo(Ranges.create(12, 5, 12, 9));
+    assertThat(diagnostics, true)
+      .hasRange(3, 8, 3, 14)
+      .hasRange(3, 8, 3, 14)
+      .hasRange(3, 8, 3, 14);
   }
 
   @Test

--- a/src/test/resources/diagnostics/OneStatementPerLineDiagnostic.bsl
+++ b/src/test/resources/diagnostics/OneStatementPerLineDiagnostic.bsl
@@ -11,3 +11,14 @@
 #КонецОбласти
 
 А=1; А=2; А=3;
+
+Процедура А()
+ УспешноПодключено = ПодключитьВнешнююКомпоненту(
+		#Если Клиент Тогда
+			"C:\Projects\ETPAddin\Bin\Debug-Win32\AddInNative\AddInNative.dll",
+		#Иначе
+			"C:\Projects\ETPAddin\Bin\Debug-x64\AddInNative\AddInNative.dll",
+		#КонецЕсли
+			"ETP",
+			ТипВнешнейКомпоненты.Native);
+КонецПроцедуры


### PR DESCRIPTION
## Описание
Пропуск диагностики OneStatementPerLine при ошибке разбора

## Связанные задачи
Closes: #630

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [ ] Ветка PR обновлена из develop
- [ ] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Локально тесты прошли успешно (запускал команду `gradlew test`)
- [ ] Лицензии для новых файлов обновил (запускал команду `gradlew licenseFormat`)

### Для диагностик

- [ ] Диагностика создана с использованием шаблона (запускал команду `gradlew newDiagnostic`)
- [ ] Описание диагностики заполнено для обоих языков (перевод на английский не обязателен)
  - [ ] Автогенерируемый блок заполнен (запускал команду `gradlew updateDiagnosticDocs`)
- [ ] Индекс диагностик обновлен (запускал команду `gradlew updateDiagnosticsIndex`)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
