### PR TITLE
Перевод fileinfo на относительные пути

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
@@ -111,6 +111,7 @@ public class AnalyzeCommand implements Command {
 
     // clean up AST after diagnostic computing to free up RAM.
     documentContext.clearASTData();
+    diagnosticProvider.clearComputedDiagnostics(documentContext);
 
     return fileInfo;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.cli;
 
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.MetricStorage;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.DiagnosticSupplier;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.FileInfo;
@@ -33,6 +34,7 @@ import me.tongfei.progressbar.ProgressBar;
 import me.tongfei.progressbar.ProgressBarStyle;
 import org.apache.commons.cli.CommandLine;
 import org.apache.commons.io.FileUtils;
+import org.eclipse.lsp4j.Diagnostic;
 
 import java.io.File;
 import java.io.IOException;
@@ -75,21 +77,23 @@ public class AnalyzeCommand implements Command {
 
     Collection<File> files = FileUtils.listFiles(srcDir.toFile(), new String[]{"bsl", "os"}, true);
 
-    List<FileInfo> diagnostics;
+    List<FileInfo> fileInfos;
     try (ProgressBar pb = new ProgressBar("Analyzing files...", files.size(), ProgressBarStyle.ASCII)) {
-      diagnostics = files.parallelStream()
-        .peek(file -> pb.step())
-        .map(this::getFileContextFromFile)
+      fileInfos = files.parallelStream()
+        .map((File file) -> {
+          pb.step();
+          return getFileInfoFromFile(srcDir, file);
+        })
         .collect(Collectors.toList());
     }
 
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), diagnostics, srcDirOption);
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), fileInfos, srcDirOption);
     ReportersAggregator aggregator = new ReportersAggregator(outputDir, reporters);
     aggregator.report(analysisInfo);
     return 0;
   }
 
-  private FileInfo getFileContextFromFile(File file) {
+  private FileInfo getFileInfoFromFile(Path srcDir, File file) {
     String textDocumentContent;
     try {
       textDocumentContent = FileUtils.readFileToString(file, StandardCharsets.UTF_8);
@@ -98,7 +102,12 @@ public class AnalyzeCommand implements Command {
     }
 
     DocumentContext documentContext = context.addDocument(file.toURI().toString(), textDocumentContent);
-    FileInfo fileInfo = new FileInfo(documentContext, diagnosticProvider.computeDiagnostics(documentContext));
+
+    Path filePath = srcDir.relativize(file.toPath().toAbsolutePath());
+    List<Diagnostic> diagnostics = diagnosticProvider.computeDiagnostics(documentContext);
+    MetricStorage metrics = documentContext.getMetrics();
+
+    FileInfo fileInfo = new FileInfo(filePath, diagnostics, metrics);
 
     // clean up AST after diagnostic computing to free up RAM.
     documentContext.clearASTData();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FileInfo.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FileInfo.java
@@ -44,7 +44,7 @@ public class FileInfo {
 
   public FileInfo(String sourceDir, DocumentContext documentContext, List<Diagnostic> diagnostics) {
     URI uri = URI.create(documentContext.getUri());
-    path = Paths.get(sourceDir).toAbsolutePath().relativize(Paths.get(uri));
+    path = Paths.get(sourceDir).toAbsolutePath().relativize(Paths.get(uri).toAbsolutePath());
     this.diagnostics = new ArrayList<>(diagnostics);
     metrics = documentContext.getMetrics();
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FileInfo.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FileInfo.java
@@ -42,9 +42,9 @@ public class FileInfo {
   private final List<Diagnostic> diagnostics;
   private MetricStorage metrics;
 
-  public FileInfo(DocumentContext documentContext, List<Diagnostic> diagnostics) {
+  public FileInfo(String sourceDir, DocumentContext documentContext, List<Diagnostic> diagnostics) {
     URI uri = URI.create(documentContext.getUri());
-    path = Paths.get(uri);
+    path = Paths.get(sourceDir).toAbsolutePath().relativize(Paths.get(uri));
     this.diagnostics = new ArrayList<>(diagnostics);
     metrics = documentContext.getMetrics();
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericIssueReport.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericIssueReport.java
@@ -36,7 +36,6 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 
 import java.net.URI;
-import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.EnumMap;
@@ -61,12 +60,10 @@ public class GenericIssueReport {
   private static Map<DiagnosticSeverity, String> typeMap = new EnumMap<>(DiagnosticSeverity.class);
 
   static {
-
     severityMap.put(DiagnosticSeverity.Error, SEVERITY_CRITICAL);
     severityMap.put(DiagnosticSeverity.Hint, SEVERITY_INFO);
     severityMap.put(DiagnosticSeverity.Information, SEVERITY_MINOR);
     severityMap.put(DiagnosticSeverity.Warning, SEVERITY_MAJOR);
-
   }
 
   static {
@@ -88,22 +85,16 @@ public class GenericIssueReport {
 
   public GenericIssueReport(AnalysisInfo analysisInfo) {
     List<GenericIssueEntry> listGenericIssueEntry = new ArrayList<>();
-    Path sourceRoot = Paths.get(analysisInfo.getSourceDir());
     for (FileInfo fileInfo : analysisInfo.getFileinfos()) {
       for (Diagnostic diagnostic : fileInfo.getDiagnostics()) {
         GenericIssueEntry entry = new GenericIssueEntry(
-          getRelativizePath(sourceRoot, fileInfo.getPath()),
-          diagnostic,
-          sourceRoot
+          fileInfo.getPath().toString(),
+          diagnostic
         );
         listGenericIssueEntry.add(entry);
       }
     }
     issues = listGenericIssueEntry;
-  }
-
-  private static String getRelativizePath(Path sourceRoot, Path path) {
-    return sourceRoot.toAbsolutePath().relativize(path.toAbsolutePath()).toString();
   }
 
   @Value
@@ -135,7 +126,7 @@ public class GenericIssueReport {
       this.secondaryLocations = new ArrayList<>(secondaryLocations);
     }
 
-    public GenericIssueEntry(String fileName, Diagnostic diagnostic, Path sourceRoot) {
+    public GenericIssueEntry(String fileName, Diagnostic diagnostic) {
       DiagnosticSeverity localSeverity = diagnostic.getSeverity();
 
 
@@ -159,7 +150,7 @@ public class GenericIssueReport {
         secondaryLocations = new ArrayList<>();
       } else {
         secondaryLocations = relatedInformation.stream()
-          .map(diagnosticRelatedInformation -> new Location(diagnosticRelatedInformation, sourceRoot))
+          .map(Location::new)
           .collect(Collectors.toList());
       }
     }
@@ -188,12 +179,9 @@ public class GenericIssueReport {
       textRange = new TextRange(diagnostic.getRange());
     }
 
-    public Location(DiagnosticRelatedInformation relatedInformation, Path sourceRoot) {
+    public Location(DiagnosticRelatedInformation relatedInformation) {
       message = relatedInformation.getMessage();
-      filePath = getRelativizePath(
-        sourceRoot,
-        Paths.get(URI.create(relatedInformation.getLocation().getUri())).toAbsolutePath()
-      );
+      filePath = Paths.get(URI.create(relatedInformation.getLocation().getUri())).toString();
       textRange = new TextRange(relatedInformation.getLocation().getRange());
     }
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitTestSuites.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitTestSuites.java
@@ -39,8 +39,6 @@ import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
 
 import java.io.IOException;
-import java.nio.file.Path;
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Locale;
@@ -59,11 +57,8 @@ class JUnitTestSuites {
   @JacksonXmlElementWrapper(useWrapping = false)
   private final List<JUnitTestSuite> testsuite;
 
-  private static Path sourceDir = Paths.get(".");
-
   public JUnitTestSuites(AnalysisInfo analysisInfo) {
     name = "bsl-language-server";
-    setSourceDir(Paths.get(analysisInfo.getSourceDir()).toAbsolutePath());
 
     testsuite = analysisInfo.getFileinfos().stream()
       .filter(fileInfo -> !fileInfo.getDiagnostics().isEmpty())
@@ -79,10 +74,6 @@ class JUnitTestSuites {
     this.testsuite = new ArrayList<>(testsuite);
   }
 
-  private static void setSourceDir(Path path) {
-    sourceDir = path;
-  }
-
   @Value
   static class JUnitTestSuite {
 
@@ -93,7 +84,7 @@ class JUnitTestSuites {
     private final List<JUnitTestCase> testcase;
 
     public JUnitTestSuite(FileInfo fileInfo) {
-      this.name = sourceDir.relativize(fileInfo.getPath().toAbsolutePath()).toString();
+      this.name = fileInfo.getPath().toString();
       this.testcase = new ArrayList<>();
 
       List<Diagnostic> diagnostics = fileInfo.getDiagnostics();

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ConsoleReporterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ConsoleReporterTest.java
@@ -64,8 +64,9 @@ class ConsoleReporterTest {
     );
 
     DocumentContext documentContext = TestUtils.getDocumentContext("");
-    FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
+    String sourceDir = ".";
+    FileInfo fileInfo = new FileInfo(sourceDir, documentContext, Collections.singletonList(diagnostic));
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), sourceDir);
 
     ConsoleReporter reporter = new ConsoleReporter();
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericReporterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericReporterTest.java
@@ -91,8 +91,9 @@ class GenericReporterTest {
     Location location = new Location("file:///fake-uri2.bsl", Ranges.create(0, 2, 2, 3));
     diagnostics.get(0).setRelatedInformation(Collections.singletonList(new DiagnosticRelatedInformation(location, "message")));
 
-    FileInfo fileInfo = new FileInfo(documentContext, diagnostics);
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
+    String sourceDir = ".";
+    FileInfo fileInfo = new FileInfo(sourceDir, documentContext, diagnostics);
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), sourceDir);
 
     AbstractDiagnosticReporter reporter = new GenericIssueReporter();
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitReporterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JUnitReporterTest.java
@@ -92,8 +92,9 @@ class JUnitReporterTest {
       "",
       new ServerContext()
     );
-    FileInfo fileInfo = new FileInfo(documentContext, diagnostics);
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
+    String sourceDir = ".";
+    FileInfo fileInfo = new FileInfo(sourceDir, documentContext, diagnostics);
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), sourceDir);
 
     AbstractDiagnosticReporter reporter = new JUnitReporter();
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JsonReporterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/JsonReporterTest.java
@@ -66,8 +66,9 @@ class JsonReporterTest {
     );
 
     DocumentContext documentContext = TestUtils.getDocumentContext("");
-    FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
+    String sourceDir = ".";
+    FileInfo fileInfo = new FileInfo(sourceDir, documentContext, Collections.singletonList(diagnostic));
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), sourceDir);
 
     JsonReporter reporter = new JsonReporter();
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ReportersAggregatorTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ReportersAggregatorTest.java
@@ -66,8 +66,9 @@ class ReportersAggregatorTest {
     );
 
     DocumentContext documentContext = TestUtils.getDocumentContext("");
-    FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
+    String sourceDir = ".";
+    FileInfo fileInfo = new FileInfo(sourceDir, documentContext, Collections.singletonList(diagnostic));
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), sourceDir);
 
     aggregator.report(analysisInfo);
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/TSLintReporterTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/TSLintReporterTest.java
@@ -70,8 +70,9 @@ class TSLintReporterTest {
     );
 
     DocumentContext documentContext = TestUtils.getDocumentContext("");
-    FileInfo fileInfo = new FileInfo(documentContext, Collections.singletonList(diagnostic));
-    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), ".");
+    String sourceDir = ".";
+    FileInfo fileInfo = new FileInfo(sourceDir, documentContext, Collections.singletonList(diagnostic));
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), sourceDir);
 
     TSLintReporter reporter = new TSLintReporter();
 


### PR DESCRIPTION
## Описание

FileInfo теперь хранит относительный путь. Путь строится относительно параметра sourceDir.

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предворяя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу запрос не будет принят! -->
<!--  -->
Closes: #633

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Локально тесты прошли успешно (запускал команду `gradlew test`)
- [x] Лицензии для новых файлов обновил (запускал команду `gradlew licenseFormat`)