### PR TITLE
Не вешать диагностику на ноды с ошибкой разбора.

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticStorage.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticStorage.java
@@ -55,12 +55,20 @@ public class DiagnosticStorage {
   }
 
   protected void addDiagnostic(BSLParserRuleContext node) {
+    if (node.exception != null) {
+      return;
+    }
+
     addDiagnostic(
       Ranges.create(node)
     );
   }
 
   protected void addDiagnostic(BSLParserRuleContext node, String diagnosticMessage) {
+    if (node.exception != null) {
+      return;
+    }
+
     addDiagnostic(
       Ranges.create(node),
       diagnosticMessage
@@ -116,6 +124,10 @@ public class DiagnosticStorage {
   }
 
   protected void addDiagnostic(BSLParserRuleContext node, List<DiagnosticRelatedInformation> relatedInformation) {
+    if (node.exception != null) {
+      return;
+    }
+
     addDiagnostic(
       node,
       diagnostic.getInfo().getDiagnosticMessage(),
@@ -136,6 +148,11 @@ public class DiagnosticStorage {
     String diagnosticMessage,
     List<DiagnosticRelatedInformation> relatedInformation
   ) {
+
+    if (node.exception != null) {
+      return;
+    }
+
     addDiagnostic(
       Ranges.create(node),
       diagnosticMessage,


### PR DESCRIPTION
## Описание
Не вешать диагностику на ноды с ошибкой разбора.
Позволит не только избежать рандомных падений на сонаре, но и уберет лишние срабатывания в линтере при наборе текста.

## Связанные задачи
Closes: #632

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [ ] Ветка PR обновлена из develop
- [ ] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Локально тесты прошли успешно (запускал команду `gradlew test`)
- [ ] Лицензии для новых файлов обновил (запускал команду `gradlew licenseFormat`)

### Для диагностик

- [ ] Диагностика создана с использованием шаблона (запускал команду `gradlew newDiagnostic`)
- [ ] Описание диагностики заполнено для обоих языков (перевод на английский не обязателен)
  - [ ] Автогенерируемый блок заполнен (запускал команду `gradlew updateDiagnosticDocs`)
- [ ] Индекс диагностик обновлен (запускал команду `gradlew updateDiagnosticsIndex`)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
