### PR TITLE
Fix quick fix assert that fixes

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -181,7 +181,7 @@ public class DocumentContext {
     String[] contentListUnboxed = getContentList();
 
     if (start.getLine() > contentListUnboxed.length || end.getLine() > contentListUnboxed.length) {
-      throw new ArrayIndexOutOfBoundsException("Ranje goes beyond the boundaries of the parsed document");
+      throw new ArrayIndexOutOfBoundsException("Range goes beyond the boundaries of the parsed document");
     }
 
     String startString = contentListUnboxed[start.getLine()];

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -178,10 +178,15 @@ public class DocumentContext {
     Position start = range.getStart();
     Position end = range.getEnd();
 
+    String[] contentListUnboxed = getContentList();
+
+    if (start.getLine() > contentListUnboxed.length || end.getLine() > contentListUnboxed.length) {
+      throw new ArrayIndexOutOfBoundsException("Ranje goes beyond the boundaries of the parsed document");
+    }
+
+    String startString = contentListUnboxed[start.getLine()];
     StringBuilder sb = new StringBuilder();
 
-    String[] contentListUnboxed = getContentList();
-    String startString = contentListUnboxed[start.getLine()];
     if (start.getLine() == end.getLine()) {
       sb.append(startString, start.getCharacter(), end.getCharacter());
     } else {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -185,11 +185,11 @@ public class DocumentContext {
     if (start.getLine() == end.getLine()) {
       sb.append(startString, start.getCharacter(), end.getCharacter());
     } else {
-      sb.append(startString.substring(start.getCharacter()));
+      sb.append(startString.substring(start.getCharacter())).append("\n");
     }
 
     for (int i = start.getLine() + 1; i <= end.getLine() - 1; i++) {
-      sb.append(contentListUnboxed[i]);
+      sb.append(contentListUnboxed[i]).append("\n");
     }
 
     if (start.getLine() != end.getLine()) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyRegionDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyRegionDiagnosticTest.java
@@ -53,20 +53,29 @@ class EmptyRegionDiagnosticTest extends AbstractDiagnosticTest<EmptyRegionDiagno
 
   @Test
   void testQuickFix() {
+
     final DocumentContext documentContext = getDocumentContext();
     List<Diagnostic> diagnostics = getDiagnostics();
-    final Diagnostic firstDiagnostic = diagnostics.get(0);
+    final Diagnostic externalRegionDiagnostic = diagnostics.get(2);
+    final Diagnostic internalRegionDiagnostic = diagnostics.get(1);
 
-    List<CodeAction> quickFixes = getQuickFixes(firstDiagnostic);
-
+    List<CodeAction> quickFixes = getQuickFixes(externalRegionDiagnostic);
     assertThat(quickFixes).hasSize(1);
 
     final CodeAction quickFix = quickFixes.get(0);
 
-    assertThat(quickFix).of(diagnosticInstance).in(documentContext)
-      .fixes(firstDiagnostic);
+    assertThat(quickFix)
+      .of(diagnosticInstance)
+      .in(documentContext)
+      .fixes(externalRegionDiagnostic);
 
-    assertThat(quickFix).in(documentContext)
+    assertThat(quickFix)
+      .of(diagnosticInstance)
+      .in(documentContext)
+      .fixes(internalRegionDiagnostic);
+
+    assertThat(quickFix)
+      .in(documentContext)
       .hasChanges(1)
       .hasNewText("");
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyRegionDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyRegionDiagnosticTest.java
@@ -22,16 +22,13 @@
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.eclipse.lsp4j.CodeAction;
-import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.Diagnostic;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
 
 import static com.github._1c_syntax.bsl.languageserver.util.Assertions.assertThat;
-import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.FAKE_DOCUMENT_URI;
 
 class EmptyRegionDiagnosticTest extends AbstractDiagnosticTest<EmptyRegionDiagnostic> {
   EmptyRegionDiagnosticTest() {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/util/assertions/CodeActionAssert.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/util/assertions/CodeActionAssert.java
@@ -62,6 +62,9 @@ public class CodeActionAssert extends AbstractAssert<CodeActionAssert, CodeActio
     // check that actual value we want to make assertions on is not null.
     isNotNull();
 
+    // saving original state
+    String cashedContent = documentContext.getContent();
+
     // apply edits from quick fix
     final List<TextEdit> textEdits = getTextEdits();
 
@@ -100,6 +103,9 @@ public class CodeActionAssert extends AbstractAssert<CodeActionAssert, CodeActio
 
     // check if expected diagnostic is not present in new diagnostic list
     Assertions.assertThat(diagnostics).doesNotContain(diagnostic);
+
+    // returning to original state
+    documentContext.rebuild(cashedContent);
 
     return this;
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/util/assertions/CodeActionAssert.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/util/assertions/CodeActionAssert.java
@@ -63,7 +63,7 @@ public class CodeActionAssert extends AbstractAssert<CodeActionAssert, CodeActio
     isNotNull();
 
     // saving original state
-    String cashedContent = documentContext.getContent();
+    String cachedContent = documentContext.getContent();
 
     // apply edits from quick fix
     final List<TextEdit> textEdits = getTextEdits();
@@ -105,7 +105,7 @@ public class CodeActionAssert extends AbstractAssert<CodeActionAssert, CodeActio
     Assertions.assertThat(diagnostics).doesNotContain(diagnostic);
 
     // returning to original state
-    documentContext.rebuild(cashedContent);
+    documentContext.rebuild(cachedContent);
 
     return this;
   }


### PR DESCRIPTION
## Описание
<!--- Опишите внесеннные изменения -->
* Исправил assertThat.of().in().fixes() - после применения qf удаляла из контента все переносы строк
* Вызов assertThat.of().in().fixes() модифицировал documentContext из-за чего повторная попытка работа с ним приводила в к ошибкам в рантайме или неверным значениям
* Добавил более внятное сообщение об ошибке для documentContext.getText() если range выходит за края разбираемого документа

WIP так как есть еще ряд моментов, которые хочется проверить.

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предворяя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу запрос не будет принят! -->
<!--  -->
Closes: #764
