### PR TITLE
Добавлена возможность по выводу в отчет строк требующих покрытия

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageReport.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageReport.java
@@ -1,0 +1,109 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright © 2018-2020
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Gryzlov <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.diagnostics.reporter;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
+import com.github._1c_syntax.bsl.languageserver.diagnostics.FileInfo;
+import lombok.Getter;
+import lombok.Value;
+
+import java.util.ArrayList;
+import java.util.List;
+
+@JacksonXmlRootElement(localName = "coverage")
+public class GenericCoverageReport {
+
+  @JacksonXmlProperty(isAttribute = true)
+  @Getter
+  public final String version;
+
+  @JacksonXmlElementWrapper(useWrapping = false)
+  @Getter
+  public final List<GenericCoverageReportEntry> file;
+
+  public GenericCoverageReport(AnalysisInfo analysisInfo) {
+
+    version = "1";
+    file = new ArrayList<>();
+
+    for (FileInfo fileInfo : analysisInfo.getFileinfos()) {
+      file.add(new GenericCoverageReportEntry(fileInfo));
+    }
+  }
+
+  public GenericCoverageReport(
+    @JsonProperty("version") String version,
+    @JsonProperty("file") List<GenericCoverageReportEntry> file
+  ) {
+
+    this.version = version;
+    this.file = new ArrayList<>(file);
+  }
+
+  @Value
+  static class GenericCoverageReportEntry {
+
+    @JacksonXmlProperty(isAttribute = true)
+    public String path;
+
+    @JacksonXmlElementWrapper(useWrapping = false)
+    public List<LineToCoverEntry> lineToCover;
+
+    public GenericCoverageReportEntry(FileInfo fileInfo) {
+      this.path = fileInfo.getPath().toString();
+      this.lineToCover = new ArrayList<>();
+
+      for (int lineToCover : fileInfo.getMetrics().getCovlocData()) {
+        this.lineToCover.add(new LineToCoverEntry(lineToCover, false));
+      }
+    }
+
+    public GenericCoverageReportEntry(
+      @JsonProperty("path") String path,
+      @JsonProperty("version") List<LineToCoverEntry> lineToCover
+    ) {
+      this.path = path;
+      this.lineToCover = new ArrayList<>();
+    }
+  }
+
+  @Value
+  static class LineToCoverEntry {
+
+    @JacksonXmlProperty(isAttribute = true)
+    public int lineNumber;
+
+    @JacksonXmlProperty(isAttribute = true)
+    public boolean covered;
+
+    public LineToCoverEntry(
+      @JsonProperty("lineNumber") int lineNumber,
+      @JsonProperty("covered") boolean covered
+    ) {
+      this.covered = covered;
+      this.lineNumber = lineNumber;
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageReport.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageReport.java
@@ -26,22 +26,20 @@ import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlProperty;
 import com.fasterxml.jackson.dataformat.xml.annotation.JacksonXmlRootElement;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.FileInfo;
-import lombok.Getter;
 import lombok.Value;
 
 import java.util.ArrayList;
 import java.util.List;
 
 @JacksonXmlRootElement(localName = "coverage")
+@Value
 public class GenericCoverageReport {
 
   @JacksonXmlProperty(isAttribute = true)
-  @Getter
-  public final String version;
+  final String version;
 
   @JacksonXmlElementWrapper(useWrapping = false)
-  @Getter
-  public final List<GenericCoverageReportEntry> file;
+  final List<GenericCoverageReportEntry> file;
 
   public GenericCoverageReport(AnalysisInfo analysisInfo) {
 
@@ -66,10 +64,10 @@ public class GenericCoverageReport {
   static class GenericCoverageReportEntry {
 
     @JacksonXmlProperty(isAttribute = true)
-    public String path;
+    String path;
 
     @JacksonXmlElementWrapper(useWrapping = false)
-    public List<LineToCoverEntry> lineToCover;
+    List<LineToCoverEntry> lineToCover;
 
     public GenericCoverageReportEntry(FileInfo fileInfo) {
       this.path = fileInfo.getPath().toString();
@@ -82,10 +80,10 @@ public class GenericCoverageReport {
 
     public GenericCoverageReportEntry(
       @JsonProperty("path") String path,
-      @JsonProperty("version") List<LineToCoverEntry> lineToCover
+      @JsonProperty("lineToCover") List<LineToCoverEntry> lineToCover
     ) {
       this.path = path;
-      this.lineToCover = new ArrayList<>();
+      this.lineToCover = new ArrayList<>(lineToCover);
     }
   }
 
@@ -93,10 +91,10 @@ public class GenericCoverageReport {
   static class LineToCoverEntry {
 
     @JacksonXmlProperty(isAttribute = true)
-    public int lineNumber;
+    int lineNumber;
 
     @JacksonXmlProperty(isAttribute = true)
-    public boolean covered;
+    boolean covered;
 
     public LineToCoverEntry(
       @JsonProperty("lineNumber") int lineNumber,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageReporter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageReporter.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright © 2018-2020
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Gryzlov <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.diagnostics.reporter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.SerializationFeature;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import lombok.extern.slf4j.Slf4j;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Path;
+
+@Slf4j
+public class GenericCoverageReporter extends AbstractDiagnosticReporter {
+
+  public static final String KEY = "genericCoverage";
+
+  public GenericCoverageReporter() {
+    super();
+  }
+
+  public GenericCoverageReporter(Path outputDir) {
+    super(outputDir);
+  }
+
+  @Override
+  public void report(AnalysisInfo analysisInfo) {
+
+    GenericCoverageReport report = new GenericCoverageReport(analysisInfo);
+
+    ObjectMapper mapper = new XmlMapper();
+    mapper.enable(SerializationFeature.INDENT_OUTPUT);
+
+    try {
+      File reportFile = new File(outputDir.toFile(), "genericCoverage.xml");
+      mapper.writeValue(reportFile, report);
+      LOGGER.info("Generic coverage report saved to {}", reportFile.getCanonicalPath());
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ReportersAggregator.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/ReportersAggregator.java
@@ -69,6 +69,7 @@ public class ReportersAggregator {
     map.put(JUnitReporter.KEY, JUnitReporter.class);
     map.put(TSLintReporter.KEY, TSLintReporter.class);
     map.put(GenericIssueReporter.KEY, GenericIssueReporter.class);
+    map.put(GenericCoverageReporter.KEY, GenericCoverageReporter.class);
 
     return map;
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageTest.java
@@ -1,0 +1,85 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright © 2018-2020
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Gryzlov <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.diagnostics.reporter;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.dataformat.xml.XmlMapper;
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.diagnostics.FileInfo;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.apache.commons.io.FileUtils;
+import org.eclipse.lsp4j.Diagnostic;
+import org.junit.jupiter.api.AfterEach;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.time.LocalDateTime;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class GenericCoverageTest {
+
+  private final File file = new File("./genericCoverage.xml");
+
+  @BeforeEach
+  void setUp() {
+    FileUtils.deleteQuietly(file);
+  }
+
+  @AfterEach
+  void tearDown() {
+    FileUtils.deleteQuietly(file);
+  }
+
+  @Test
+  void report() throws IOException {
+
+    // given
+    String sourceDir = ".";
+    String filePath = "./src/test/resources/context/DocumentContextLocForCoverTest.bsl";
+
+    // when
+    DocumentContext documentContext = TestUtils.getDocumentContextFromFile(filePath);
+    FileInfo fileInfo = new FileInfo(sourceDir, documentContext, new ArrayList<>());
+    AnalysisInfo analysisInfo = new AnalysisInfo(LocalDateTime.now(), Collections.singletonList(fileInfo), sourceDir);
+
+    AbstractDiagnosticReporter reporter = new GenericCoverageReporter();
+    reporter.report(analysisInfo);
+
+    // then
+    ObjectMapper mapper = new XmlMapper();
+    GenericCoverageReport report = mapper.readValue(file, GenericCoverageReport.class);
+
+    assertThat(report).isNotNull();
+    assertThat(report.version).isEqualTo("1");
+    assertThat(report.file.size()).isEqualTo(1);
+
+    GenericCoverageReport.GenericCoverageReportEntry fileEntry = report.file.get(0);
+
+    assertThat(fileEntry.getPath()).isEqualTo(fileInfo.getPath().toString());
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/reporter/GenericCoverageTest.java
@@ -27,7 +27,6 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.FileInfo;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.apache.commons.io.FileUtils;
-import org.eclipse.lsp4j.Diagnostic;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -37,7 +36,6 @@ import java.io.IOException;
 import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -75,11 +73,17 @@ public class GenericCoverageTest {
     GenericCoverageReport report = mapper.readValue(file, GenericCoverageReport.class);
 
     assertThat(report).isNotNull();
-    assertThat(report.version).isEqualTo("1");
-    assertThat(report.file.size()).isEqualTo(1);
+    assertThat(report.getVersion()).isEqualTo("1");
+    assertThat(report.getFile().size()).isEqualTo(1);
 
-    GenericCoverageReport.GenericCoverageReportEntry fileEntry = report.file.get(0);
+    GenericCoverageReport.GenericCoverageReportEntry fileEntry = report.getFile().get(0);
 
     assertThat(fileEntry.getPath()).isEqualTo(fileInfo.getPath().toString());
+    assertThat(fileEntry.getLineToCover().size()).isEqualTo(12);
+
+    GenericCoverageReport.LineToCoverEntry lineToCover = fileEntry.getLineToCover().get(0);
+
+    assertThat(lineToCover.getLineNumber()).isEqualTo(5);
+    assertThat(lineToCover.isCovered()).isFalse();
   }
 }


### PR DESCRIPTION
## Описание
Добавлена возможность по выводу в отчет строк требующих покрытия в формате GenericCoverage

Closes #1105

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)