### PR TITLE
Расчет метаданных в отдельном тред-пуле

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -45,6 +45,7 @@ import java.util.EnumMap;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -174,12 +175,13 @@ public abstract class ServerContext {
     return documentContext;
   }
 
+  @SneakyThrows
   private Configuration computeConfigurationMetadata() {
     if (configurationRoot == null) {
       return Configuration.create();
     }
-
-    return Configuration.create(configurationRoot);
+    ForkJoinPool customThreadPool = new ForkJoinPool();
+    return customThreadPool.submit(() -> Configuration.create(configurationRoot)).get();
   }
 
   private void addMdoRefByUri(URI uri, DocumentContext documentContext) {


### PR DESCRIPTION
Запрос конфигурации впервые выполняется внутри параллельного стрима. Метаданные внутри тоже используют параллельные стримы. Из-за исчерпания свободных потоков (все потоки, кроме текущего, висят на ожидании расчета конфигурации) метаданные рассчитываются в одном потоке. Переопределение тред-пула развязывает параллелизацию метаданных и сбора контекста
