### PR TITLE
Fix/generate regions action

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplier.java
@@ -21,15 +21,20 @@
  */
 package com.github._1c_syntax.bsl.languageserver.codeactions;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Regions;
+import com.github._1c_syntax.mdclasses.metadata.Configuration;
+import com.github._1c_syntax.mdclasses.metadata.additional.ConfigurationSource;
 import com.github._1c_syntax.mdclasses.metadata.additional.ModuleType;
 import com.github._1c_syntax.mdclasses.metadata.additional.ScriptVariant;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
 import org.springframework.stereotype.Component;
@@ -48,6 +53,12 @@ import java.util.stream.Collectors;
 @Component
 public class GenerateStandardRegionsSupplier implements CodeActionSupplier {
 
+  private final LanguageServerConfiguration languageServerConfiguration;
+
+  public GenerateStandardRegionsSupplier(LanguageServerConfiguration languageServerConfiguration) {
+    this.languageServerConfiguration = languageServerConfiguration;
+  }
+
   /**
    * При необходимости создает {@code CodeAction} для генерации отсутствующих
    * стандартных областей 1С
@@ -62,13 +73,14 @@ public class GenerateStandardRegionsSupplier implements CodeActionSupplier {
 
     ModuleType moduleType = documentContext.getModuleType();
     FileType fileType = documentContext.getFileType();
-    ScriptVariant configurationLanguage = documentContext.getServerContext().getConfiguration().getScriptVariant();
+
+    ScriptVariant regionsLanguage = getRegionsLanguage(documentContext, fileType);
     Set<String> neededStandardRegions;
 
     if (fileType == FileType.BSL) {
-      neededStandardRegions = Regions.getStandardRegionsNamesByModuleType(moduleType, configurationLanguage);
+      neededStandardRegions = Regions.getStandardRegionsNamesByModuleType(moduleType, regionsLanguage);
     } else {
-      neededStandardRegions = Regions.getOneScriptStandardRegions(configurationLanguage);
+      neededStandardRegions = Regions.getOneScriptStandardRegions(regionsLanguage);
     }
 
     Set<String> documentRegionsNames = documentContext.getSymbolTree().getModuleLevelRegions().stream()
@@ -81,12 +93,12 @@ public class GenerateStandardRegionsSupplier implements CodeActionSupplier {
     }
 
     String regionFormat =
-      configurationLanguage == ScriptVariant.ENGLISH ? "#Region %s%n%n#EndRegion%n" : "#Область %s%n%n#КонецОбласти%n";
+      regionsLanguage == ScriptVariant.ENGLISH ? "#Region %s%n%n#EndRegion%n" : "#Область %s%n%n#КонецОбласти%n";
 
     String result = neededStandardRegions.stream()
       .map(s -> String.format(regionFormat, s))
       .collect(Collectors.joining("\n"));
-    TextEdit textEdit = new TextEdit(params.getRange(), result);
+    TextEdit textEdit = new TextEdit(calculateFixRange(params.getRange()), result);
 
     WorkspaceEdit edit = new WorkspaceEdit();
     Map<String, List<TextEdit>> changes = Map.of(documentContext.getUri().toString(),
@@ -98,5 +110,38 @@ public class GenerateStandardRegionsSupplier implements CodeActionSupplier {
     codeAction.setKind(CodeActionKind.Refactor);
     codeAction.setEdit(edit);
     return List.of(codeAction);
+  }
+
+  private ScriptVariant getRegionsLanguage(DocumentContext documentContext, FileType fileType) {
+
+    ScriptVariant regionsLanguage;
+    Configuration configuration = documentContext.getServerContext().getConfiguration();
+    if (configuration.getConfigurationSource() == ConfigurationSource.EMPTY || fileType == FileType.OS) {
+      regionsLanguage = ScriptVariant.RUSSIAN;
+    } else {
+      regionsLanguage = documentContext.getServerContext().getConfiguration().getScriptVariant();
+    }
+    return regionsLanguage;
+  }
+
+  private Range calculateFixRange(Range range) {
+
+    Position start = range.getStart();
+    if (start == null) {
+      start = new Position(0, 0);
+    } else {
+      start.setCharacter(0);
+    }
+
+    Position end = range.getEnd();
+    if (end == null) {
+      end = new Position(0, 0);
+    } else {
+      end.setCharacter(0);
+    }
+
+    range.setStart(start);
+    range.setEnd(end);
+    return range;
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplier.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.codeactions;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
@@ -37,6 +38,7 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
 import org.eclipse.lsp4j.WorkspaceEdit;
+import org.jetbrains.annotations.NotNull;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -117,9 +119,20 @@ public class GenerateStandardRegionsSupplier implements CodeActionSupplier {
     ScriptVariant regionsLanguage;
     Configuration configuration = documentContext.getServerContext().getConfiguration();
     if (configuration.getConfigurationSource() == ConfigurationSource.EMPTY || fileType == FileType.OS) {
-      regionsLanguage = ScriptVariant.RUSSIAN;
+      regionsLanguage = getScriptVariantFromConfigLanguage();
     } else {
       regionsLanguage = documentContext.getServerContext().getConfiguration().getScriptVariant();
+    }
+    return regionsLanguage;
+  }
+
+  @NotNull
+  private ScriptVariant getScriptVariantFromConfigLanguage() {
+    ScriptVariant regionsLanguage;
+    if (languageServerConfiguration.getLanguage() == Language.EN) {
+      regionsLanguage = ScriptVariant.ENGLISH;
+    } else {
+      regionsLanguage = ScriptVariant.RUSSIAN;
     }
     return regionsLanguage;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/Regions.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/Regions.java
@@ -28,6 +28,7 @@ import lombok.experimental.UtilityClass;
 
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.Set;
 import java.util.regex.Pattern;
 
@@ -142,15 +143,17 @@ public class Regions {
    */
   public static Set<String> getOneScriptStandardRegions(ScriptVariant configurationLanguage) {
 
-    Set<String> regionsName = new HashSet<>();
+    Set<String> regionsName = new LinkedHashSet<>();
 
     if (configurationLanguage == ScriptVariant.ENGLISH) {
+      regionsName.add(Keywords.VARIABLES_REGION_EN);
       regionsName.add(Keywords.PUBLIC_REGION_EN);
       regionsName.add(Keywords.INTERNAL_REGION_EN);
       regionsName.add(Keywords.PRIVATE_REGION_EN);
       return regionsName;
     }
 
+    regionsName.add(Keywords.VARIABLES_REGION_RU);
     regionsName.add(Keywords.PUBLIC_REGION_RU);
     regionsName.add(Keywords.INTERNAL_REGION_RU);
     regionsName.add(Keywords.PRIVATE_REGION_RU);
@@ -170,7 +173,7 @@ public class Regions {
   }
 
   private static Set<String> getStandardRegionNames(ModuleType moduleType, ScriptVariant language) {
-    Set<String> regionsName = new HashSet<>();
+    Set<String> regionsName = new LinkedHashSet<>();
     switch (moduleType) {
       case FormModule:
         addFormModuleRegionsNames(regionsName, language);


### PR DESCRIPTION
## Описание
<!--- Опишите внесеннные изменения -->
1. Исправлена сортировка имен областей. Теперь используется LinkedHashSet вместо HashSet, чтобы гарантировать порядок областей в порядке их добавления в коде.
2. Исправлено определения языка генерации областей: если не удалось определить тип конфигурации, или файл является файлом OneScript, язык определяется по языку указанному в language server configuration. В противном случае язык берется из языка конфигурации.
3. Исправлена ошибка разрыва текста при генерации стандартных областей, в случаях когда перед применением code action курсор стоит не в начале строки.
4. Для OS-файлов добавлена генерация области описания переменных.
## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предворяя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу запрос не будет принят! -->
<!--  -->
Closes: #1334 #1335 #1336 #1337 

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)
