### PR TITLE
Расширение API диагностик - isPreferred и фильтр по типам код экшенов

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CodeActionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CodeActionProvider.java
@@ -39,6 +39,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import java.util.stream.Collectors;
 
 @Component
@@ -82,8 +83,12 @@ public final class CodeActionProvider {
     DocumentContext documentContext
   ) {
 
+    List<String> only = Optional.ofNullable(params.getContext().getOnly())
+      .orElse(Collections.emptyList());
+
     return codeActionSuppliers.stream()
       .flatMap(codeActionSupplier -> codeActionSupplier.getCodeActions(params, documentContext).stream())
+      .filter(codeAction -> only.isEmpty() || only.contains(codeAction.getKind()))
       .map(Either::<Command, CodeAction>forRight)
       .collect(Collectors.toList());
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CodeActionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CodeActionProvider.java
@@ -73,6 +73,9 @@ public final class CodeActionProvider {
     codeAction.setDiagnostics(diagnostics);
     codeAction.setEdit(edit);
     codeAction.setKind(CodeActionKind.QuickFix);
+    if (diagnostics.size() == 1) {
+      codeAction.setIsPreferred(Boolean.TRUE);
+    }
 
     return Collections.singletonList(codeAction);
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CodeActionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CodeActionProviderTest.java
@@ -42,6 +42,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.annotation.DirtiesContext;
 
+import javax.annotation.CheckForNull;
 import java.util.Collections;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -102,6 +103,7 @@ class CodeActionProviderTest {
       .anyMatch(codeAction -> codeAction.getDiagnostics().contains(diagnostics.get(0)))
       .anyMatch(codeAction -> codeAction.getDiagnostics().contains(diagnostics.get(1)))
       .anyMatch(codeAction -> codeAction.getKind().equals(CodeActionKind.QuickFix))
+      .allMatch(codeAction -> (codeAction.getDiagnostics().size() == 1) == toBoolean(codeAction.getIsPreferred()))
     ;
   }
 
@@ -162,5 +164,12 @@ class CodeActionProviderTest {
       .extracting(CodeAction::getKind)
       .containsOnly(CodeActionKind.Refactor)
     ;
+  }
+
+  private static boolean toBoolean(@CheckForNull Boolean value) {
+    if (value == null) {
+      return false;
+    }
+    return value;
   }
 }


### PR DESCRIPTION
## Описание
<!--- Опишите внесеннные изменения -->

Добавлено заполнение поля isPreferred для квик-фиксов, исправляющих одну диагностику.
Исправлена фильтрация код экшенов при передаче отбора only

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предворяя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу запрос не будет принят! -->
<!--  -->
Closes: #1434
Fixes: #1375

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (перевод на английский не обязателен)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
