### PR TITLE
lsp4j 0.10.0 + обновление зависимостей

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -9,11 +9,11 @@ plugins {
     `java-library`
     `maven-publish`
     jacoco
-    id("net.kyori.indra.license-header") version "1.0.2"
+    id("net.kyori.indra.license-header") version "1.2.1"
     id("org.sonarqube") version "3.0"
     id("io.franzbecker.gradle-lombok") version "4.0.0"
     id("me.qoomon.git-versioning") version "3.0.0"
-    id("com.github.ben-manes.versions") version "0.33.0"
+    id("com.github.ben-manes.versions") version "0.36.0"
     id("io.freefair.javadoc-links") version "5.2.1"
     id("org.springframework.boot") version "2.3.5.RELEASE"
     id("com.github.1c-syntax.bslls-dev-tools") version "0.3.3"
@@ -43,7 +43,7 @@ gitVersioning.apply(closureOf<GitVersioningPluginConfig> {
     })
 })
 
-val jacksonVersion = "2.11.2"
+val jacksonVersion = "2.11.3"
 val junitVersion = "5.6.1"
 val languageToolVersion = "5.1"
 
@@ -56,7 +56,7 @@ dependencies {
     api("info.picocli:picocli-spring-boot-starter:4.5.2")
 
     // lsp4j core
-    api("org.eclipse.lsp4j", "org.eclipse.lsp4j", "0.9.0")
+    api("org.eclipse.lsp4j", "org.eclipse.lsp4j", "0.10.0")
 
     // 1c-syntax
     api("com.github.1c-syntax", "bsl-parser", "2cfed6c4f59b3ea2e24e0badfd4f1ff21df7215a") {
@@ -108,8 +108,8 @@ dependencies {
     testImplementation("org.springframework.boot:spring-boot-starter-test")
 
     // test utils
-    testImplementation("org.assertj", "assertj-core", "3.18.0")
-    testImplementation("org.mockito", "mockito-core", "3.6.0")
+    testImplementation("org.assertj", "assertj-core", "3.18.1")
+    testImplementation("org.mockito", "mockito-core", "3.6.28")
     testImplementation("com.ginsberg", "junit5-system-exit", "1.0.0")
     testImplementation("org.awaitility", "awaitility", "4.0.3")
 }

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/Symbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/Symbol.java
@@ -26,6 +26,7 @@ import lombok.Getter;
 import lombok.Setter;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
 
 import java.util.Collections;
 import java.util.List;
@@ -51,6 +52,12 @@ public interface Symbol {
 
   default Optional<Symbol> getRootParent() {
     return getParent().flatMap(Symbol::getRootParent).or(() -> Optional.of(this));
+  }
+
+  default List<SymbolTag> getTags() {
+    return this.isDeprecated()
+      ? Collections.singletonList(SymbolTag.Deprecated)
+      : Collections.emptyList();
   }
 
   void accept(SymbolTreeVisitor visitor);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
@@ -57,7 +57,7 @@ public final class DocumentSymbolProvider {
       .map(DocumentSymbolProvider::toDocumentSymbol)
       .collect(Collectors.toList());
 
-    documentSymbol.setDeprecated(symbol.isDeprecated());
+    documentSymbol.setTags(symbol.getTags());
     documentSymbol.setChildren(children);
 
     return documentSymbol;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
@@ -96,7 +96,7 @@ public class SymbolProvider {
       symbol.getSymbolKind(),
       new Location(uri.toString(), symbol.getRange())
     );
-    symbolInformation.setDeprecated(symbol.isDeprecated());
+    symbolInformation.setTags(symbol.getTags());
     return symbolInformation;
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -70,7 +71,7 @@ class DocumentSymbolProviderTest {
       .anyMatch(documentSymbol -> documentSymbol.getRange().equals(Ranges.create(7, 0, 8, 12)))
       .anyMatch(documentSymbol -> documentSymbol.getRange().equals(Ranges.create(10, 0, 13, 14)))
       .anyMatch(documentSymbol -> documentSymbol.getRange().equals(Ranges.create(47, 0, 48, 12)))
-      .filteredOn(DocumentSymbol::getDeprecated)
+      .filteredOn(documentSymbol1 -> documentSymbol1.getTags().contains(SymbolTag.Deprecated))
       .anyMatch(documentSymbol -> documentSymbol.getRange().equals(Ranges.create(47, 0, 48, 12)))
     ;
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.utils.Absolute;
 import lombok.SneakyThrows;
 import org.eclipse.lsp4j.SymbolKind;
+import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -70,25 +71,25 @@ class SymbolProviderTest {
         symbolInformation.getName().equals("НеУстаревшаяПроцедура")
           && uriContains(symbolInformation, "ПервыйОбщийМодуль")
           && symbolInformation.getKind() == SymbolKind.Method
-          && !symbolInformation.getDeprecated()
+          && !symbolInformation.getTags().contains(SymbolTag.Deprecated)
       )
       .anyMatch(symbolInformation ->
         symbolInformation.getName().equals("НеУстаревшаяПроцедура")
           && uriContains(symbolInformation, "РегистрСведений1")
           && symbolInformation.getKind() == SymbolKind.Method
-          && !symbolInformation.getDeprecated()
+          && !symbolInformation.getTags().contains(SymbolTag.Deprecated)
       )
       .anyMatch(symbolInformation ->
         symbolInformation.getName().equals("УстаревшаяПроцедура")
           && uriContains(symbolInformation, "ПервыйОбщийМодуль")
           && symbolInformation.getKind() == SymbolKind.Method
-          && symbolInformation.getDeprecated()
+          && symbolInformation.getTags().contains(SymbolTag.Deprecated)
       )
       .anyMatch(symbolInformation ->
         symbolInformation.getName().equals("ВалютаУчета")
           && uriContains(symbolInformation, "ManagedApplicationModule")
           && symbolInformation.getKind() == SymbolKind.Variable
-          && !symbolInformation.getDeprecated()
+          && !symbolInformation.getTags().contains(SymbolTag.Deprecated)
       )
     ;
   }


### PR DESCRIPTION
Spring Boot, JUnit и Javadoc оставлены на потом.
Бамп спринг-бута замедляет анализ на 15%, бамп junit без спрингбута роняет тесты (конфликты зависимостей), новый javadoc не собирается из-за несовместимости с котлином 1.4

Closes #1486 