### PR TITLE
Выделение SourceDefinedSymbol из интерфейса Symbol

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
@@ -202,6 +202,7 @@ public final class MethodSymbolComputer
 
     return MethodSymbol.builder()
       .name(subName.getText())
+      .uri(documentContext.getUri())
       .range(Ranges.create(startNode, stopNode))
       .subNameRange(Ranges.create(subName))
       .function(function)

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/RegionSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/RegionSymbolComputer.java
@@ -67,6 +67,7 @@ public final class RegionSymbolComputer
   public ParseTree visitRegionStart(BSLParser.RegionStartContext ctx) {
 
     RegionSymbol.RegionSymbolBuilder builder = RegionSymbol.builder()
+      .uri(documentContext.getUri())
       .name(ctx.regionName().getText())
       .regionNameRange(Ranges.create(ctx.regionName()))
       .startRange(Ranges.create(ctx));

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputer.java
@@ -22,9 +22,9 @@
 package com.github._1c_syntax.bsl.languageserver.context.computer;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.LocatableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
@@ -49,26 +49,26 @@ public class SymbolTreeComputer implements Computer<SymbolTree> {
     List<RegionSymbol> regions = new RegionSymbolComputer(documentContext).compute();
     List<VariableSymbol> variables = new VariableSymbolComputer(documentContext).compute();
 
-    List<LocatableSymbol> allOfThem = new ArrayList<>(methods);
+    List<SourceDefinedSymbol> allOfThem = new ArrayList<>(methods);
     allOfThem.addAll(regions);
     allOfThem.addAll(variables);
 
     allOfThem.sort(Comparator.comparingInt(symbol -> symbol.getRange().getStart().getLine()));
 
-    List<LocatableSymbol> topLevelSymbols = new ArrayList<>();
-    LocatableSymbol currentParent = LocatableSymbol.emptySymbol();
+    List<SourceDefinedSymbol> topLevelSymbols = new ArrayList<>();
+    SourceDefinedSymbol currentParent = SourceDefinedSymbol.emptySymbol();
 
-    for (LocatableSymbol symbol : allOfThem) {
+    for (SourceDefinedSymbol symbol : allOfThem) {
       currentParent = placeSymbol(topLevelSymbols, currentParent, symbol);
     }
 
     return new SymbolTree(topLevelSymbols);
   }
 
-  private static LocatableSymbol placeSymbol(
-    List<LocatableSymbol> topLevelSymbols,
-    LocatableSymbol currentParent,
-    LocatableSymbol symbol
+  private static SourceDefinedSymbol placeSymbol(
+    List<SourceDefinedSymbol> topLevelSymbols,
+    SourceDefinedSymbol currentParent,
+    SourceDefinedSymbol symbol
   ) {
 
     if (Ranges.containsRange(currentParent.getRange(), symbol.getRange())) {
@@ -78,7 +78,7 @@ public class SymbolTreeComputer implements Computer<SymbolTree> {
       return symbol;
     }
 
-    Optional<LocatableSymbol> maybeParent = currentParent.getParent();
+    Optional<SourceDefinedSymbol> maybeParent = currentParent.getParent();
     if (maybeParent.isEmpty()) {
       topLevelSymbols.add(symbol);
       return symbol;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputer.java
@@ -22,9 +22,9 @@
 package com.github._1c_syntax.bsl.languageserver.context.computer;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.LocatableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
@@ -49,23 +49,27 @@ public class SymbolTreeComputer implements Computer<SymbolTree> {
     List<RegionSymbol> regions = new RegionSymbolComputer(documentContext).compute();
     List<VariableSymbol> variables = new VariableSymbolComputer(documentContext).compute();
 
-    List<Symbol> allOfThem = new ArrayList<>(methods);
+    List<LocatableSymbol> allOfThem = new ArrayList<>(methods);
     allOfThem.addAll(regions);
     allOfThem.addAll(variables);
 
     allOfThem.sort(Comparator.comparingInt(symbol -> symbol.getRange().getStart().getLine()));
 
-    List<Symbol> topLevelSymbols = new ArrayList<>();
-    Symbol currentParent = Symbol.emptySymbol();
+    List<LocatableSymbol> topLevelSymbols = new ArrayList<>();
+    LocatableSymbol currentParent = LocatableSymbol.emptySymbol();
 
-    for (Symbol symbol : allOfThem) {
+    for (LocatableSymbol symbol : allOfThem) {
       currentParent = placeSymbol(topLevelSymbols, currentParent, symbol);
     }
 
     return new SymbolTree(topLevelSymbols);
   }
 
-  private static Symbol placeSymbol(List<Symbol> topLevelSymbols, Symbol currentParent, Symbol symbol) {
+  private static LocatableSymbol placeSymbol(
+    List<LocatableSymbol> topLevelSymbols,
+    LocatableSymbol currentParent,
+    LocatableSymbol symbol
+  ) {
 
     if (Ranges.containsRange(currentParent.getRange(), symbol.getRange())) {
       currentParent.getChildren().add(symbol);
@@ -74,7 +78,7 @@ public class SymbolTreeComputer implements Computer<SymbolTree> {
       return symbol;
     }
 
-    Optional<Symbol> maybeParent = currentParent.getParent();
+    Optional<LocatableSymbol> maybeParent = currentParent.getParent();
     if (maybeParent.isEmpty()) {
       topLevelSymbols.add(symbol);
       return symbol;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
@@ -78,6 +78,7 @@ public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> impl
   ) {
     return VariableSymbol.builder()
       .name(varName.getText())
+      .uri(documentContext.getUri())
       .range(Ranges.create(ctx))
       .variableNameRange(Ranges.create(varName))
       .export(export)

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/LocatableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/LocatableSymbol.java
@@ -1,0 +1,78 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright © 2018-2020
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Gryzlov <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.context.symbol;
+
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import lombok.Getter;
+import lombok.Setter;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolKind;
+
+import java.net.URI;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+public interface LocatableSymbol extends Symbol {
+  URI getUri();
+
+  Range getRange();
+
+  Range getSelectionRange();
+
+  Optional<LocatableSymbol> getParent();
+
+  void setParent(Optional<LocatableSymbol> symbol);
+
+  List<LocatableSymbol> getChildren();
+
+  default Optional<LocatableSymbol> getRootParent() {
+    return getParent().flatMap(LocatableSymbol::getRootParent).or(() -> Optional.of(this));
+  }
+
+  static LocatableSymbol emptySymbol() {
+    return new LocatableSymbol() {
+      @Getter
+      private final String name = "empty";
+      @Getter
+      private final SymbolKind symbolKind = SymbolKind.Null;
+      @Getter
+      private final URI uri = URI.create("");
+      @Getter
+      private final Range range = Ranges.create(-1, 0, -1, 0);
+      @Getter
+      @Setter
+      private Optional<LocatableSymbol> parent = Optional.empty();
+      @Getter
+      private final List<LocatableSymbol> children = Collections.emptyList();
+
+      @Override
+      public void accept(SymbolTreeVisitor visitor) {
+      }
+
+      @Override
+      public Range getSelectionRange() {
+        return getRange();
+      }
+    };
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 @Builder
 @EqualsAndHashCode(exclude = {"children", "parent"})
 @ToString(exclude = {"children", "parent"})
-public class MethodSymbol implements LocatableSymbol {
+public class MethodSymbol implements SourceDefinedSymbol {
   String name;
 
   @Builder.Default
@@ -56,10 +56,10 @@ public class MethodSymbol implements LocatableSymbol {
   @Setter
   @Builder.Default
   @NonFinal
-  Optional<LocatableSymbol> parent = Optional.empty();
+  Optional<SourceDefinedSymbol> parent = Optional.empty();
 
   @Builder.Default
-  List<LocatableSymbol> children = new ArrayList<>();
+  List<SourceDefinedSymbol> children = new ArrayList<>();
 
   boolean function;
   boolean export;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
@@ -33,6 +33,7 @@ import lombok.experimental.NonFinal;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -41,12 +42,13 @@ import java.util.Optional;
 @Builder
 @EqualsAndHashCode(exclude = {"children", "parent"})
 @ToString(exclude = {"children", "parent"})
-public class MethodSymbol implements Symbol {
+public class MethodSymbol implements LocatableSymbol {
   String name;
 
   @Builder.Default
   SymbolKind symbolKind = SymbolKind.Method;
 
+  URI uri;
   Range range;
   Range subNameRange;
 
@@ -54,10 +56,10 @@ public class MethodSymbol implements Symbol {
   @Setter
   @Builder.Default
   @NonFinal
-  Optional<Symbol> parent = Optional.empty();
+  Optional<LocatableSymbol> parent = Optional.empty();
 
   @Builder.Default
-  List<Symbol> children = new ArrayList<>();
+  List<LocatableSymbol> children = new ArrayList<>();
 
   boolean function;
   boolean export;
@@ -88,5 +90,10 @@ public class MethodSymbol implements Symbol {
   @Override
   public void accept(SymbolTreeVisitor visitor) {
     visitor.visitMethod(this);
+  }
+
+  @Override
+  public Range getSelectionRange() {
+    return getSubNameRange();
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/RegionSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/RegionSymbol.java
@@ -41,7 +41,7 @@ import java.util.stream.Collectors;
 @Builder(access = lombok.AccessLevel.PUBLIC)
 @EqualsAndHashCode(exclude = {"children", "parent"})
 @ToString(exclude = {"children", "parent"})
-public class RegionSymbol implements LocatableSymbol {
+public class RegionSymbol implements SourceDefinedSymbol {
   String name;
   @Builder.Default
   SymbolKind symbolKind = SymbolKind.Namespace;
@@ -55,10 +55,10 @@ public class RegionSymbol implements LocatableSymbol {
   @Setter
   @Builder.Default
   @NonFinal
-  Optional<LocatableSymbol> parent = Optional.empty();
+  Optional<SourceDefinedSymbol> parent = Optional.empty();
 
   @Builder.Default
-  List<LocatableSymbol> children = new ArrayList<>();
+  List<SourceDefinedSymbol> children = new ArrayList<>();
 
   public List<MethodSymbol> getMethods() {
     return children.stream()

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/RegionSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/RegionSymbol.java
@@ -31,6 +31,7 @@ import lombok.experimental.NonFinal;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -40,10 +41,11 @@ import java.util.stream.Collectors;
 @Builder(access = lombok.AccessLevel.PUBLIC)
 @EqualsAndHashCode(exclude = {"children", "parent"})
 @ToString(exclude = {"children", "parent"})
-public class RegionSymbol implements Symbol {
+public class RegionSymbol implements LocatableSymbol {
   String name;
   @Builder.Default
   SymbolKind symbolKind = SymbolKind.Namespace;
+  URI uri;
   Range range;
   Range startRange;
   Range endRange;
@@ -53,10 +55,10 @@ public class RegionSymbol implements Symbol {
   @Setter
   @Builder.Default
   @NonFinal
-  Optional<Symbol> parent = Optional.empty();
+  Optional<LocatableSymbol> parent = Optional.empty();
 
   @Builder.Default
-  List<Symbol> children = new ArrayList<>();
+  List<LocatableSymbol> children = new ArrayList<>();
 
   public List<MethodSymbol> getMethods() {
     return children.stream()
@@ -68,5 +70,10 @@ public class RegionSymbol implements Symbol {
   @Override
   public void accept(SymbolTreeVisitor visitor) {
     visitor.visitRegion(this);
+  }
+
+  @Override
+  public Range getSelectionRange() {
+    return getRegionNameRange();
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SourceDefinedSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SourceDefinedSymbol.java
@@ -32,25 +32,25 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
-public interface LocatableSymbol extends Symbol {
+public interface SourceDefinedSymbol extends Symbol {
   URI getUri();
 
   Range getRange();
 
   Range getSelectionRange();
 
-  Optional<LocatableSymbol> getParent();
+  Optional<SourceDefinedSymbol> getParent();
 
-  void setParent(Optional<LocatableSymbol> symbol);
+  void setParent(Optional<SourceDefinedSymbol> symbol);
 
-  List<LocatableSymbol> getChildren();
+  List<SourceDefinedSymbol> getChildren();
 
-  default Optional<LocatableSymbol> getRootParent() {
-    return getParent().flatMap(LocatableSymbol::getRootParent).or(() -> Optional.of(this));
+  default Optional<SourceDefinedSymbol> getRootParent() {
+    return getParent().flatMap(SourceDefinedSymbol::getRootParent).or(() -> Optional.of(this));
   }
 
-  static LocatableSymbol emptySymbol() {
-    return new LocatableSymbol() {
+  static SourceDefinedSymbol emptySymbol() {
+    return new SourceDefinedSymbol() {
       @Getter
       private final String name = "empty";
       @Getter
@@ -61,9 +61,9 @@ public interface LocatableSymbol extends Symbol {
       private final Range range = Ranges.create(-1, 0, -1, 0);
       @Getter
       @Setter
-      private Optional<LocatableSymbol> parent = Optional.empty();
+      private Optional<SourceDefinedSymbol> parent = Optional.empty();
       @Getter
-      private final List<LocatableSymbol> children = Collections.emptyList();
+      private final List<SourceDefinedSymbol> children = Collections.emptyList();
 
       @Override
       public void accept(SymbolTreeVisitor visitor) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/Symbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/Symbol.java
@@ -21,16 +21,11 @@
  */
 package com.github._1c_syntax.bsl.languageserver.context.symbol;
 
-import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
-import lombok.Getter;
-import lombok.Setter;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
 
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 
 public interface Symbol {
 
@@ -38,20 +33,8 @@ public interface Symbol {
 
   SymbolKind getSymbolKind();
 
-  Range getRange();
-
-  Optional<Symbol> getParent();
-
-  void setParent(Optional<Symbol> symbol);
-
-  List<Symbol> getChildren();
-
   default boolean isDeprecated() {
     return false;
-  }
-
-  default Optional<Symbol> getRootParent() {
-    return getParent().flatMap(Symbol::getRootParent).or(() -> Optional.of(this));
   }
 
   default List<SymbolTag> getTags() {
@@ -61,25 +44,5 @@ public interface Symbol {
   }
 
   void accept(SymbolTreeVisitor visitor);
-
-  static Symbol emptySymbol() {
-    return new Symbol() {
-      @Getter
-      private final String name = "empty";
-      @Getter
-      private final SymbolKind symbolKind = SymbolKind.Null;
-      @Getter
-      private final Range range = Ranges.create(-1, 0, -1, 0);
-      @Getter
-      @Setter
-      private Optional<Symbol> parent = Optional.empty();
-      @Getter
-      private final List<Symbol> children = Collections.emptyList();
-
-      @Override
-      public void accept(SymbolTreeVisitor visitor) {
-      }
-    };
-  }
 
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SymbolTree.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SymbolTree.java
@@ -36,10 +36,10 @@ import java.util.stream.Collectors;
 
 @Value
 public class SymbolTree {
-  List<LocatableSymbol> children;
+  List<SourceDefinedSymbol> children;
 
   @Getter(lazy = true)
-  List<LocatableSymbol> childrenFlat = createChildrenFlat();
+  List<SourceDefinedSymbol> childrenFlat = createChildrenFlat();
 
   @Getter(lazy = true)
   List<MethodSymbol> methods = createMethods();
@@ -108,8 +108,8 @@ public class SymbolTree {
       .findAny();
   }
 
-  private List<LocatableSymbol> createChildrenFlat() {
-    List<LocatableSymbol> symbols = new ArrayList<>();
+  private List<SourceDefinedSymbol> createChildrenFlat() {
+    List<SourceDefinedSymbol> symbols = new ArrayList<>();
     getChildren().forEach(child -> flatten(child, symbols));
 
     return symbols;
@@ -119,7 +119,7 @@ public class SymbolTree {
     return getChildrenFlat(MethodSymbol.class);
   }
 
-  private static void flatten(LocatableSymbol symbol, List<LocatableSymbol> symbols) {
+  private static void flatten(SourceDefinedSymbol symbol, List<SourceDefinedSymbol> symbols) {
     symbols.add(symbol);
     symbol.getChildren().forEach(child -> flatten(child, symbols));
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SymbolTree.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SymbolTree.java
@@ -36,10 +36,10 @@ import java.util.stream.Collectors;
 
 @Value
 public class SymbolTree {
-  List<Symbol> children;
+  List<LocatableSymbol> children;
 
   @Getter(lazy = true)
-  List<Symbol> childrenFlat = createChildrenFlat();
+  List<LocatableSymbol> childrenFlat = createChildrenFlat();
 
   @Getter(lazy = true)
   List<MethodSymbol> methods = createMethods();
@@ -108,8 +108,8 @@ public class SymbolTree {
       .findAny();
   }
 
-  private List<Symbol> createChildrenFlat() {
-    List<Symbol> symbols = new ArrayList<>();
+  private List<LocatableSymbol> createChildrenFlat() {
+    List<LocatableSymbol> symbols = new ArrayList<>();
     getChildren().forEach(child -> flatten(child, symbols));
 
     return symbols;
@@ -119,7 +119,7 @@ public class SymbolTree {
     return getChildrenFlat(MethodSymbol.class);
   }
 
-  private static void flatten(Symbol symbol, List<Symbol> symbols) {
+  private static void flatten(LocatableSymbol symbol, List<LocatableSymbol> symbols) {
     symbols.add(symbol);
     symbol.getChildren().forEach(child -> flatten(child, symbols));
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
@@ -42,7 +42,7 @@ import java.util.Optional;
 @Builder
 @EqualsAndHashCode(exclude = {"children", "parent"})
 @ToString(exclude = {"children", "parent"})
-public class VariableSymbol implements LocatableSymbol {
+public class VariableSymbol implements SourceDefinedSymbol {
   String name;
   @Builder.Default
   SymbolKind symbolKind = SymbolKind.Variable;
@@ -54,10 +54,10 @@ public class VariableSymbol implements LocatableSymbol {
   @Setter
   @Builder.Default
   @NonFinal
-  Optional<LocatableSymbol> parent = Optional.empty();
+  Optional<SourceDefinedSymbol> parent = Optional.empty();
 
   @Builder.Default
-  List<LocatableSymbol> children = Collections.emptyList();
+  List<SourceDefinedSymbol> children = Collections.emptyList();
 
   VariableKind kind;
   boolean export;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
@@ -33,6 +33,7 @@ import lombok.experimental.NonFinal;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 
+import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -41,10 +42,11 @@ import java.util.Optional;
 @Builder
 @EqualsAndHashCode(exclude = {"children", "parent"})
 @ToString(exclude = {"children", "parent"})
-public class VariableSymbol implements Symbol {
+public class VariableSymbol implements LocatableSymbol {
   String name;
   @Builder.Default
   SymbolKind symbolKind = SymbolKind.Variable;
+  URI uri;
   Range range;
   Range variableNameRange;
 
@@ -52,10 +54,10 @@ public class VariableSymbol implements Symbol {
   @Setter
   @Builder.Default
   @NonFinal
-  Optional<Symbol> parent = Optional.empty();
+  Optional<LocatableSymbol> parent = Optional.empty();
 
   @Builder.Default
-  List<Symbol> children = Collections.emptyList();
+  List<LocatableSymbol> children = Collections.emptyList();
 
   VariableKind kind;
   boolean export;
@@ -65,4 +67,10 @@ public class VariableSymbol implements Symbol {
   public void accept(SymbolTreeVisitor visitor) {
     visitor.visitVariable(this);
   }
+
+  @Override
+  public Range getSelectionRange() {
+    return getVariableNameRange();
+  }
+
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractSymbolTreeDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractSymbolTreeDiagnostic.java
@@ -21,9 +21,9 @@
  */
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
+import com.github._1c_syntax.bsl.languageserver.context.symbol.LocatableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTreeVisitor;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 
@@ -36,11 +36,11 @@ public abstract class AbstractSymbolTreeDiagnostic extends AbstractDiagnostic im
     visitChildren(documentContext.getSymbolTree().getChildren());
   }
 
-  void visitChildren(List<Symbol> children) {
+  void visitChildren(List<LocatableSymbol> children) {
     children.forEach(this::visit);
   }
 
-  void visit(Symbol symbol) {
+  void visit(LocatableSymbol symbol) {
     symbol.accept(this);
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractSymbolTreeDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractSymbolTreeDiagnostic.java
@@ -21,9 +21,9 @@
  */
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
-import com.github._1c_syntax.bsl.languageserver.context.symbol.LocatableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTreeVisitor;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 
@@ -36,11 +36,11 @@ public abstract class AbstractSymbolTreeDiagnostic extends AbstractDiagnostic im
     visitChildren(documentContext.getSymbolTree().getChildren());
   }
 
-  void visitChildren(List<LocatableSymbol> children) {
+  void visitChildren(List<SourceDefinedSymbol> children) {
     children.forEach(this::visit);
   }
 
-  void visit(LocatableSymbol symbol) {
+  void visit(SourceDefinedSymbol symbol) {
     symbol.accept(this);
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
@@ -22,7 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.LocatableSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -41,7 +41,7 @@ public final class DocumentSymbolProvider {
       .collect(Collectors.toList());
   }
 
-  private static DocumentSymbol toDocumentSymbol(LocatableSymbol symbol) {
+  private static DocumentSymbol toDocumentSymbol(SourceDefinedSymbol symbol) {
     var documentSymbol = new DocumentSymbol(
       symbol.getName(),
       symbol.getSymbolKind(),

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
@@ -22,12 +22,8 @@
 package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.LocatableSymbol;
 import org.eclipse.lsp4j.DocumentSymbol;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.springframework.stereotype.Component;
@@ -45,12 +41,12 @@ public final class DocumentSymbolProvider {
       .collect(Collectors.toList());
   }
 
-  private static DocumentSymbol toDocumentSymbol(Symbol symbol) {
+  private static DocumentSymbol toDocumentSymbol(LocatableSymbol symbol) {
     var documentSymbol = new DocumentSymbol(
       symbol.getName(),
       symbol.getSymbolKind(),
       symbol.getRange(),
-      getSelectionRange(symbol)
+      symbol.getSelectionRange()
     );
 
     List<DocumentSymbol> children = symbol.getChildren().stream()
@@ -61,20 +57,6 @@ public final class DocumentSymbolProvider {
     documentSymbol.setChildren(children);
 
     return documentSymbol;
-  }
-
-  private static Range getSelectionRange(Symbol symbol) {
-    Range selectionRange;
-    if (symbol instanceof MethodSymbol) {
-      selectionRange = ((MethodSymbol) symbol).getSubNameRange();
-    } else if (symbol instanceof RegionSymbol) {
-      selectionRange = ((RegionSymbol) symbol).getRegionNameRange();
-    } else if (symbol instanceof VariableSymbol) {
-      selectionRange = ((VariableSymbol) symbol).getVariableNameRange();
-    } else {
-      selectionRange = symbol.getRange();
-    }
-    return selectionRange;
   }
 
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.LocatableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.variable.VariableKind;
@@ -70,7 +71,7 @@ public class SymbolProvider {
       .collect(Collectors.toList());
   }
 
-  private static Stream<Pair<URI, Symbol>> getSymbolPairs(DocumentContext documentContext) {
+  private static Stream<Pair<URI, LocatableSymbol>> getSymbolPairs(DocumentContext documentContext) {
     return documentContext.getSymbolTree().getChildrenFlat().stream()
       .filter(SymbolProvider::isSupported)
       .map(symbol -> Pair.of(documentContext.getUri(), symbol));
@@ -88,7 +89,7 @@ public class SymbolProvider {
     }
   }
 
-  private static SymbolInformation createSymbolInformation(Pair<URI, Symbol> symbolPair) {
+  private static SymbolInformation createSymbolInformation(Pair<URI, LocatableSymbol> symbolPair) {
     var uri = symbolPair.getKey();
     var symbol = symbolPair.getValue();
     var symbolInformation = new SymbolInformation(

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
@@ -23,7 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.LocatableSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.variable.VariableKind;
@@ -71,7 +71,7 @@ public class SymbolProvider {
       .collect(Collectors.toList());
   }
 
-  private static Stream<Pair<URI, LocatableSymbol>> getSymbolPairs(DocumentContext documentContext) {
+  private static Stream<Pair<URI, SourceDefinedSymbol>> getSymbolPairs(DocumentContext documentContext) {
     return documentContext.getSymbolTree().getChildrenFlat().stream()
       .filter(SymbolProvider::isSupported)
       .map(symbol -> Pair.of(documentContext.getUri(), symbol));
@@ -89,7 +89,7 @@ public class SymbolProvider {
     }
   }
 
-  private static SymbolInformation createSymbolInformation(Pair<URI, LocatableSymbol> symbolPair) {
+  private static SymbolInformation createSymbolInformation(Pair<URI, SourceDefinedSymbol> symbolPair) {
     var uri = symbolPair.getKey();
     var symbol = symbolPair.getValue();
     var symbolInformation = new SymbolInformation(


### PR DESCRIPTION
Из интерфейса Symbol выделены куски, отвечающие за место определения символа - юри и рэнж. Введено понятие selectionRange для определения "места интереса" для данного символа.
В последствии интерфейс Symbol может быть использован как более общее понятие для чего-то, находящегося в документе, например, вызов метода глобального контекста, или стандартного метода объекта. В противовес этому SourceDefinedSymbol - это символ, у которого есть явное местоположение в исходном коде.
