### PR TITLE
Добавление owner в SourceDefinedSymbol

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
@@ -36,8 +36,6 @@ import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
 import com.github._1c_syntax.bsl.parser.BSLParserBaseVisitor;
 import com.github._1c_syntax.bsl.parser.BSLParserRuleContext;
-import com.github._1c_syntax.mdclasses.mdo.MDObjectBase;
-import com.github._1c_syntax.mdclasses.metadata.additional.MDOReference;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -195,21 +193,15 @@ public final class MethodSymbolComputer
       .map(MethodDescription::isDeprecated)
       .orElse(false);
 
-    String mdoRef = documentContext.getMdObject()
-      .map(MDObjectBase::getMdoReference)
-      .map(MDOReference::getMdoRef)
-      .orElse("");
-
     return MethodSymbol.builder()
       .name(subName.getText())
-      .uri(documentContext.getUri())
+      .owner(documentContext)
       .range(Ranges.create(startNode, stopNode))
       .subNameRange(Ranges.create(subName))
       .function(function)
       .export(export)
       .description(description)
       .deprecated(deprecated)
-      .mdoRef(mdoRef)
       .parameters(createParameters(paramList, description))
       .compilerDirectiveKind(compilerDirective)
       .annotations(annotations)

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/RegionSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/RegionSymbolComputer.java
@@ -67,7 +67,7 @@ public final class RegionSymbolComputer
   public ParseTree visitRegionStart(BSLParser.RegionStartContext ctx) {
 
     RegionSymbol.RegionSymbolBuilder builder = RegionSymbol.builder()
-      .uri(documentContext.getUri())
+      .owner(documentContext)
       .name(ctx.regionName().getText())
       .regionNameRange(Ranges.create(ctx.regionName()))
       .startRange(Ranges.create(ctx));

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputer.java
@@ -26,10 +26,16 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTreeVisitor;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import lombok.Getter;
+import lombok.Setter;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolKind;
 
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
@@ -56,7 +62,7 @@ public class SymbolTreeComputer implements Computer<SymbolTree> {
     allOfThem.sort(Comparator.comparingInt(symbol -> symbol.getRange().getStart().getLine()));
 
     List<SourceDefinedSymbol> topLevelSymbols = new ArrayList<>();
-    SourceDefinedSymbol currentParent = SourceDefinedSymbol.emptySymbol();
+    SourceDefinedSymbol currentParent = emptySymbol();
 
     for (SourceDefinedSymbol symbol : allOfThem) {
       currentParent = placeSymbol(topLevelSymbols, currentParent, symbol);
@@ -85,5 +91,30 @@ public class SymbolTreeComputer implements Computer<SymbolTree> {
     }
 
     return placeSymbol(topLevelSymbols, maybeParent.get(), symbol);
+  }
+
+  private static SourceDefinedSymbol emptySymbol() {
+    return new SourceDefinedSymbol() {
+      @Getter
+      private final DocumentContext owner = null;
+      @Getter
+      private final String name = "empty";
+      @Getter
+      private final SymbolKind symbolKind = SymbolKind.Null;
+      @Getter
+      private final Range range = Ranges.create(-1, 0, -1, 0);
+      @Getter
+      private final Range selectionRange = Ranges.create(-1, 0, -1, 0);
+      @Getter
+      @Setter
+      private Optional<SourceDefinedSymbol> parent = Optional.empty();
+      @Getter
+      private final List<SourceDefinedSymbol> children = Collections.emptyList();
+
+      @Override
+      public void accept(SymbolTreeVisitor visitor) {
+      }
+
+    };
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
@@ -78,7 +78,7 @@ public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> impl
   ) {
     return VariableSymbol.builder()
       .name(varName.getText())
-      .uri(documentContext.getUri())
+      .owner(documentContext)
       .range(Ranges.create(ctx))
       .variableNameRange(Ranges.create(varName))
       .export(export)

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.context.symbol;
 
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.annotations.Annotation;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.annotations.CompilerDirectiveKind;
 import lombok.Builder;
@@ -33,7 +34,6 @@ import lombok.experimental.NonFinal;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -48,7 +48,7 @@ public class MethodSymbol implements SourceDefinedSymbol {
   @Builder.Default
   SymbolKind symbolKind = SymbolKind.Method;
 
-  URI uri;
+  DocumentContext owner;
   Range range;
   Range subNameRange;
 
@@ -66,12 +66,6 @@ public class MethodSymbol implements SourceDefinedSymbol {
   Optional<MethodDescription> description;
 
   boolean deprecated;
-
-  /**
-   * Ссылка на объект метаданных, в модуле которого находится метод
-   * Формат ссылки: Document.Заказ, CommonModule.ОбщегоНазначения
-   */
-  String mdoRef;
 
   @Builder.Default
   List<ParameterDefinition> parameters = new ArrayList<>();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/RegionSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/RegionSymbol.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.context.symbol;
 
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -31,7 +32,6 @@ import lombok.experimental.NonFinal;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 
-import java.net.URI;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
@@ -45,7 +45,7 @@ public class RegionSymbol implements SourceDefinedSymbol {
   String name;
   @Builder.Default
   SymbolKind symbolKind = SymbolKind.Namespace;
-  URI uri;
+  DocumentContext owner;
   Range range;
   Range startRange;
   Range endRange;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SourceDefinedSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SourceDefinedSymbol.java
@@ -22,13 +22,8 @@
 package com.github._1c_syntax.bsl.languageserver.context.symbol;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
-import lombok.Getter;
-import lombok.Setter;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.SymbolKind;
 
-import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
@@ -47,30 +42,5 @@ public interface SourceDefinedSymbol extends Symbol {
 
   default Optional<SourceDefinedSymbol> getRootParent() {
     return getParent().flatMap(SourceDefinedSymbol::getRootParent).or(() -> Optional.of(this));
-  }
-
-  static SourceDefinedSymbol emptySymbol() {
-    return new SourceDefinedSymbol() {
-      @Getter
-      private final DocumentContext owner = null;
-      @Getter
-      private final String name = "empty";
-      @Getter
-      private final SymbolKind symbolKind = SymbolKind.Null;
-      @Getter
-      private final Range range = Ranges.create(-1, 0, -1, 0);
-      @Getter
-      private final Range selectionRange = Ranges.create(-1, 0, -1, 0);
-      @Getter
-      @Setter
-      private Optional<SourceDefinedSymbol> parent = Optional.empty();
-      @Getter
-      private final List<SourceDefinedSymbol> children = Collections.emptyList();
-
-      @Override
-      public void accept(SymbolTreeVisitor visitor) {
-      }
-
-    };
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SourceDefinedSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SourceDefinedSymbol.java
@@ -21,19 +21,19 @@
  */
 package com.github._1c_syntax.bsl.languageserver.context.symbol;
 
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import lombok.Getter;
 import lombok.Setter;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
 
 public interface SourceDefinedSymbol extends Symbol {
-  URI getUri();
+  DocumentContext getOwner();
 
   Range getRange();
 
@@ -52,13 +52,15 @@ public interface SourceDefinedSymbol extends Symbol {
   static SourceDefinedSymbol emptySymbol() {
     return new SourceDefinedSymbol() {
       @Getter
+      private final DocumentContext owner = null;
+      @Getter
       private final String name = "empty";
       @Getter
       private final SymbolKind symbolKind = SymbolKind.Null;
       @Getter
-      private final URI uri = URI.create("");
-      @Getter
       private final Range range = Ranges.create(-1, 0, -1, 0);
+      @Getter
+      private final Range selectionRange = Ranges.create(-1, 0, -1, 0);
       @Getter
       @Setter
       private Optional<SourceDefinedSymbol> parent = Optional.empty();
@@ -69,10 +71,6 @@ public interface SourceDefinedSymbol extends Symbol {
       public void accept(SymbolTreeVisitor visitor) {
       }
 
-      @Override
-      public Range getSelectionRange() {
-        return getRange();
-      }
     };
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.context.symbol;
 
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.variable.VariableDescription;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.variable.VariableKind;
 import lombok.Builder;
@@ -33,7 +34,6 @@ import lombok.experimental.NonFinal;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 
-import java.net.URI;
 import java.util.Collections;
 import java.util.List;
 import java.util.Optional;
@@ -46,7 +46,7 @@ public class VariableSymbol implements SourceDefinedSymbol {
   String name;
   @Builder.Default
   SymbolKind symbolKind = SymbolKind.Variable;
-  URI uri;
+  DocumentContext owner;
   Range range;
   Range variableNameRange;
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerTest.java
@@ -259,13 +259,13 @@ class MethodSymbolComputerTest {
   }
 
   @Test
-  void testMdoRef() throws IOException {
+  void testOwner() throws IOException {
 
     var path = Absolute.path(PATH_TO_METADATA);
     serverContext.setConfigurationRoot(path);
-    checkModule(serverContext, PATH_TO_MODULE_FILE, "CommonModule.ПервыйОбщийМодуль", 7);
-    checkModule(serverContext, PATH_TO_CATALOG_FILE, "Catalog.Справочник1", 2);
-    checkModule(serverContext, PATH_TO_CATALOG_MODULE_FILE, "Catalog.Справочник1", 1);
+    checkModule(serverContext, PATH_TO_MODULE_FILE, 7);
+    checkModule(serverContext, PATH_TO_CATALOG_FILE, 2);
+    checkModule(serverContext, PATH_TO_CATALOG_MODULE_FILE, 1);
   }
 
   @Test
@@ -289,7 +289,6 @@ class MethodSymbolComputerTest {
   private void checkModule(
     ServerContext serverContext,
     String path,
-    String mdoRef,
     int methodsCount
   ) throws IOException {
     var file = new File(PATH_TO_METADATA, path);
@@ -298,6 +297,6 @@ class MethodSymbolComputerTest {
     List<MethodSymbol> methods = documentContext.getSymbolTree().getMethods();
     assertThat(methods.size()).isEqualTo(methodsCount);
     assertThat(methods.get(0).getName()).isEqualTo("Тест");
-    assertThat(methods.get(0).getMdoRef()).isEqualTo(mdoRef);
+    assertThat(methods.get(0).getOwner()).isEqualTo(documentContext);
   }
 }


### PR DESCRIPTION
uri заменен на owner для упрощения получения информации о владельце символа.
На текущий момент все SourceDefinedSymbol строятся по DocumentContext, соответственно, владелец символа однозначно может быть определен не просто как URI, но и как DocumentContext