### PR TITLE
Адаптация к грядущему релизу lsp4j 0.11.0, исправление инициализации запроса на rename

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -56,7 +56,8 @@ dependencies {
     api("info.picocli:picocli-spring-boot-starter:4.5.2")
 
     // lsp4j core
-    api("org.eclipse.lsp4j", "org.eclipse.lsp4j", "0.10.0")
+//    api("org.eclipse.lsp4j", "org.eclipse.lsp4j", "0.10.0")
+    api("com.github.eclipse.lsp4j", "org.eclipse.lsp4j", "5cc2304f3fde9b1e82bf9e76eb6e6be4bf8fb28c")
 
     // 1c-syntax
     api("com.github.1c-syntax", "bsl-parser", "b088f749bad11ba6ce9c2a33bce8ade0c5f44736") {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/AbstractQuickFixSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/AbstractQuickFixSupplier.java
@@ -75,7 +75,7 @@ public abstract class AbstractQuickFixSupplier implements CodeActionSupplier {
 
   @Value
   private static class LightDiagnostic {
-    Either<String, Number> code;
+    Either<String, Integer> code;
     Range range;
     String source;
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/FixAllCodeActionSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/FixAllCodeActionSupplier.java
@@ -59,7 +59,7 @@ public class FixAllCodeActionSupplier extends AbstractQuickFixSupplier {
   }
 
   private List<CodeAction> getFixAllCodeAction(
-    Either<String, Number> diagnosticCode,
+    Either<String, Integer> diagnosticCode,
     CodeActionParams params,
     DocumentContext documentContext
   ) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/QuickFixSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/QuickFixSupplier.java
@@ -45,7 +45,7 @@ public class QuickFixSupplier {
   // Возможно через аннотацию.
 
   @SuppressWarnings("unchecked")
-  public <T extends Either<String, Number>> Optional<Class<? extends QuickFixProvider>> getQuickFixClass(
+  public <T extends Either<String, Integer>> Optional<Class<? extends QuickFixProvider>> getQuickFixClass(
     T diagnosticCode
   ) {
     return Optional.ofNullable(

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/metadata/DiagnosticCode.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/metadata/DiagnosticCode.java
@@ -23,22 +23,22 @@ package com.github._1c_syntax.bsl.languageserver.diagnostics.metadata;
 
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
-public class DiagnosticCode extends Either<String, Number> {
+public class DiagnosticCode extends Either<String, Integer> {
 
   public DiagnosticCode(String code) {
     super(code, null);
   }
 
-  public DiagnosticCode(String left, Number right) {
+  public DiagnosticCode(String left, Integer right) {
     super(left, right);
   }
 
   public String getStringValue() {
-    return isLeft() ? getLeft() : Integer.toString(getRight().intValue());
+    return isLeft() ? getLeft() : Integer.toString(getRight());
   }
 
-  public static String getStringValue(Either<String, Number> diagnosticCode) {
-    return diagnosticCode.isLeft() ? diagnosticCode.getLeft() : Integer.toString(diagnosticCode.getRight().intValue());
+  public static String getStringValue(Either<String, Integer> diagnosticCode) {
+    return diagnosticCode.isLeft() ? diagnosticCode.getLeft() : Integer.toString(diagnosticCode.getRight());
   }
 
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/reporters/JUnitTestSuites.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/reporters/JUnitTestSuites.java
@@ -91,7 +91,7 @@ class JUnitTestSuites {
       this.testcase = new ArrayList<>();
 
       List<Diagnostic> diagnostics = fileInfo.getDiagnostics();
-      Map<Either<String, Number>, List<Diagnostic>> groupedDiagnostics = diagnostics.stream()
+      Map<Either<String, Integer>, List<Diagnostic>> groupedDiagnostics = diagnostics.stream()
         .collect(Collectors.groupingBy(
           Diagnostic::getCode,
           Collectors.toList())

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/reporters/databind/DiagnosticCodeSerializer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/reporters/databind/DiagnosticCodeSerializer.java
@@ -33,10 +33,10 @@ import java.io.IOException;
  * Сериализатор для {@link Either}, выступающего в роли хранилища кода диагностики.
  * См. {@link DiagnosticCode}
  */
-public class DiagnosticCodeSerializer extends JsonSerializer<Either<String, Number>> {
+public class DiagnosticCodeSerializer extends JsonSerializer<Either<String, Integer>> {
   @Override
   public void serialize(
-    Either<String, Number> value,
+    Either<String, Integer> value,
     JsonGenerator gen,
     SerializerProvider serializers
   ) throws IOException {


### PR DESCRIPTION
Наткнулся на https://github.com/eclipse/lsp4j/issues/478 при локальной отладке.
Исправление - в еще не вышедшем lsp4j 0.11.0, поэтому временно перевел сборку на jitpack.io