### PR TITLE
Ускорение 2 диагностик - UsingHardcodePath и UsingHardcodeSecretInformation - убрал замену всех кавычек на удаление крайних кавычек

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodePathDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodePathDiagnostic.java
@@ -84,8 +84,9 @@ public class UsingHardcodePathDiagnostic extends AbstractVisitorDiagnostic {
    */
   @Override
   public ParseTree visitString(BSLParser.StringContext ctx) {
-    String content = ctx.getText().replace("\"", "");
-    if (content.length() > 2) {
+    // пропускаю 4 символа, т.к. 2 кавычки и значимые 2 символа точно не попадют под регулярки
+    if (ctx.getText().length() > 4) {
+      String content = ctx.getText().substring(1, ctx.getText().length() - 1);
       Matcher matcher = patternPath.matcher(content);
       Matcher matcherURL = patternURL.matcher(content);
       if (matcher.find() && !matcherURL.find()) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodeSecretInformationDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodeSecretInformationDiagnostic.java
@@ -232,9 +232,9 @@ public class UsingHardcodeSecretInformationDiagnostic extends AbstractVisitorDia
   }
 
   private static boolean isNotEmptyStringByToken(Token token) {
-    boolean result = token.getType() == BSLParser.STRING && token.getText().length() != 2;
+    boolean result = token.getType() == BSLParser.STRING && token.getText().length() > 2;
     if (result) {
-      boolean foundStars = PATTERN_CHECK_PASSWORD.matcher(token.getText().replace("\"", "")).find();
+      boolean foundStars = PATTERN_CHECK_PASSWORD.matcher(token.getText().substring(1, token.getText().length() - 1)).find();
       if (foundStars) {
         result = false;
       }


### PR DESCRIPTION
## Описание
<!--- Опишите внесеннные изменения -->
- UsingHardcodePath
- UsingHardcodeSecretInformation

- вместо замены всех кавычек во всех строках избавляюсь только от крайних кавычек

Ускорение аналогично принятому ПР https://github.com/1c-syntax/bsl-language-server/pull/1565

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предворяя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу запрос не будет принят! -->
<!--  -->
Closes:-

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (перевод на английский не обязателен)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
