### PR TITLE
Исправление публикации информации о зависимостях bsl ls в режиме подключения как библиотеки

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -1,4 +1,3 @@
-import groovy.util.Node
 import me.qoomon.gradle.gitversioning.GitVersioningPluginConfig
 import me.qoomon.gradle.gitversioning.GitVersioningPluginConfig.VersionDescription
 import org.apache.tools.ant.filters.EscapeUnicode
@@ -17,6 +16,7 @@ plugins {
     id("org.springframework.boot") version "2.4.4"
     id("com.github.1c-syntax.bslls-dev-tools") version "0.3.3"
     id("io.freefair.aspectj.post-compile-weaving") version "5.3.3.3"
+    id("ru.vyarus.pom") version "2.1.0"
 }
 
 apply(plugin = "io.spring.dependency-management")
@@ -109,9 +109,6 @@ dependencies {
     testImplementation("com.ginsberg", "junit5-system-exit", "1.0.0")
     testImplementation("org.awaitility", "awaitility", "4.0.3")
 }
-
-configurations.implementation.get().isCanBeResolved = true
-configurations.api.get().isCanBeResolved = true
 
 java {
     sourceCompatibility = JavaVersion.VERSION_11
@@ -256,25 +253,8 @@ artifacts {
 publishing {
     publications {
         create<MavenPublication>("maven") {
-            artifact(tasks["jar"])
-            artifact(tasks["sourcesJar"])
+            from(components["java"])
             artifact(tasks["bootJar"])
-            artifact(tasks["javadocJar"])
-            pom.withXml {
-                val dependenciesNode = asNode().appendNode("dependencies")
-
-                configurations.api.get().resolvedConfiguration.firstLevelModuleDependencies.forEach(addDependency(dependenciesNode, "compile"))
-                configurations.implementation.get().resolvedConfiguration.firstLevelModuleDependencies.forEach(addDependency(dependenciesNode, "provided"))
-            }
         }
     }
-}
-
-fun addDependency(dependenciesNode: Node, scope: String): (ResolvedDependency) -> Unit = { artifact: ResolvedDependency ->
-    val dependency = artifact.module.id
-    val dependencyNode = dependenciesNode.appendNode("dependency")
-    dependencyNode.appendNode("groupId", dependency.group)
-    dependencyNode.appendNode("artifactId", dependency.name)
-    dependencyNode.appendNode("version", dependency.version)
-    dependencyNode.appendNode("scope", scope)
 }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -14,12 +14,11 @@ plugins {
     id("com.github.ben-manes.versions") version "0.38.0"
     id("io.freefair.javadoc-links") version "5.3.3.3"
     id("org.springframework.boot") version "2.4.4"
+    id("io.spring.dependency-management") version "1.0.11.RELEASE"
     id("com.github.1c-syntax.bslls-dev-tools") version "0.3.3"
     id("io.freefair.aspectj.post-compile-weaving") version "5.3.3.3"
     id("ru.vyarus.pom") version "2.1.0"
 }
-
-apply(plugin = "io.spring.dependency-management")
 
 repositories {
     mavenCentral()
@@ -258,3 +257,4 @@ publishing {
         }
     }
 }
+

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -263,8 +263,8 @@ publishing {
             pom.withXml {
                 val dependenciesNode = asNode().appendNode("dependencies")
 
-                configurations.implementation.get().resolvedConfiguration.firstLevelModuleDependencies.forEach(addDependency(dependenciesNode, "runtime"))
-                configurations.implementation.get().resolvedConfiguration.firstLevelModuleDependencies.forEach(addDependency(dependenciesNode, "compile"))
+                configurations.api.get().resolvedConfiguration.firstLevelModuleDependencies.forEach(addDependency(dependenciesNode, "compile"))
+                configurations.implementation.get().resolvedConfiguration.firstLevelModuleDependencies.forEach(addDependency(dependenciesNode, "provided"))
             }
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -258,3 +258,6 @@ publishing {
     }
 }
 
+tasks.withType<GenerateModuleMetadata> {
+    enabled = false
+}


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

Вместо явного пакетирования зависимостей в pom.xml используется плагин для gradle.
Отключена генерация gradle metadata, т.к. она конфликтует с spring dependency managament plugin.

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes: #1618

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [ ] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (перевод на английский не обязателен)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
