### PR TITLE
Отслеживание смерти родительского процесса

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcher.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcher.java
@@ -30,7 +30,7 @@ import org.springframework.scheduling.annotation.Scheduled;
 import org.springframework.stereotype.Component;
 
 /**
- * Отслеживатель жизни родительского процесса, запустившего Language Server.
+ * Наблюдатель за жизнью родительского процесса, запустившего Language Server.
  */
 @Component
 @Slf4j

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcher.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcher.java
@@ -1,0 +1,77 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright © 2018-2021
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Gryzlov <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver;
+
+import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.springframework.context.event.EventListener;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+/**
+ * Отслеживатель жизни родительского процесса, запустившего Language Server.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public class ParentProcessWatcher {
+
+  private final LanguageServer languageServer;
+  private long parentProcessId;
+
+  /**
+   * Обработчик события {@link LanguageServerInitializeRequestReceivedEvent}.
+   * <p>
+   * Анализирует параметры запроса и подготавливает данные для слежения за родительским процессом.
+   *
+   * @param event Событие
+   */
+  @EventListener
+  public void handleEvent(LanguageServerInitializeRequestReceivedEvent event) {
+    var processId = event.getParams().getProcessId();
+    if (processId == null) {
+      return;
+    }
+    parentProcessId = processId;
+  }
+
+  /**
+   * Фоновая процедура, отслеживающая родительский процесс.
+   */
+  @Scheduled(fixedDelay = 30000L)
+  public void watch() {
+    if (parentProcessId == 0) {
+      return;
+    }
+
+    var processIsAlive = ProcessHandle.of(parentProcessId)
+      .map(ProcessHandle::isAlive)
+      .orElse(Boolean.FALSE);
+
+    if (processIsAlive.equals(Boolean.FALSE)) {
+      LOGGER.error("Parent process with pid {} is not found. Closing application...", parentProcessId);
+      languageServer.exit();
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcher.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcher.java
@@ -65,11 +65,11 @@ public class ParentProcessWatcher {
       return;
     }
 
-    var processIsAlive = ProcessHandle.of(parentProcessId)
+    boolean processIsAlive = ProcessHandle.of(parentProcessId)
       .map(ProcessHandle::isAlive)
-      .orElse(Boolean.FALSE);
+      .orElse(false);
 
-    if (processIsAlive.equals(Boolean.FALSE)) {
+    if (!processIsAlive) {
       LOGGER.error("Parent process with pid {} is not found. Closing application...", parentProcessId);
       languageServer.exit();
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/EventPublisherAspect.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/EventPublisherAspect.java
@@ -25,11 +25,14 @@ import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConf
 import com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageServerConfigurationChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
 import lombok.NoArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.aspectj.lang.JoinPoint;
 import org.aspectj.lang.annotation.AfterReturning;
 import org.aspectj.lang.annotation.Aspect;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.services.LanguageServer;
 import org.springframework.context.ApplicationEvent;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.context.ApplicationEventPublisherAware;
@@ -69,6 +72,15 @@ public class EventPublisherAspect implements ApplicationEventPublisherAware {
   @AfterReturning("Pointcuts.isDocumentContext() && Pointcuts.isRebuildCall()")
   public void documentContextRebuild(JoinPoint joinPoint) {
     publishEvent(new DocumentContextContentChangedEvent((DocumentContext) joinPoint.getThis()));
+  }
+
+  @AfterReturning("Pointcuts.isLanguageServer() && Pointcuts.isInitializeCall() && args(initializeParams)")
+  public void languageServerInitialize(JoinPoint joinPoint, InitializeParams initializeParams) {
+    var event = new LanguageServerInitializeRequestReceivedEvent(
+      (LanguageServer) joinPoint.getThis(),
+      initializeParams
+    );
+    publishEvent(event);
   }
 
   private void publishEvent(ApplicationEvent event) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/Pointcuts.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/Pointcuts.java
@@ -38,6 +38,7 @@ public class Pointcuts {
    */
   @Pointcut("within(com.github._1c_syntax.bsl.languageserver..*)")
   public void isBSLLanguageServerScope() {
+    // no-op
   }
 
   /**
@@ -45,6 +46,7 @@ public class Pointcuts {
    */
   @Pointcut("within(com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration)")
   public void isLanguageServerConfiguration() {
+    // no-op
   }
 
   /**
@@ -52,6 +54,7 @@ public class Pointcuts {
    */
   @Pointcut("within(com.github._1c_syntax.bsl.languageserver.context.DocumentContext)")
   public void isDocumentContext() {
+    // no-op
   }
 
   /**
@@ -59,6 +62,7 @@ public class Pointcuts {
    */
   @Pointcut("within(org.eclipse.lsp4j.services.LanguageServer+)")
   public void isLanguageServer() {
+    // no-op
   }
 
   /**
@@ -66,6 +70,7 @@ public class Pointcuts {
    */
   @Pointcut("within(com.github._1c_syntax.bsl.languageserver.context.ServerContext)")
   public void isServerContext() {
+    // no-op
   }
 
   /**
@@ -73,6 +78,7 @@ public class Pointcuts {
    */
   @Pointcut("within(com.github._1c_syntax.bsl.languageserver.diagnostics.BSLDiagnostic+)")
   public void isBSLDiagnostic() {
+    // no-op
   }
 
   /**
@@ -80,6 +86,7 @@ public class Pointcuts {
    */
   @Pointcut("isBSLLanguageServerScope() && execution(* rebuild(..))")
   public void isRebuildCall() {
+    // no-op
   }
 
   /**
@@ -87,6 +94,7 @@ public class Pointcuts {
    */
   @Pointcut("isBSLLanguageServerScope() && execution(* update(..))")
   public void isUpdateCall() {
+    // no-op
   }
 
   /**
@@ -94,6 +102,7 @@ public class Pointcuts {
    */
   @Pointcut("isBSLLanguageServerScope() && execution(* reset(..))")
   public void isResetCall() {
+    // no-op
   }
 
   /**
@@ -101,6 +110,7 @@ public class Pointcuts {
    */
   @Pointcut("isBSLLanguageServerScope() && execution(* getDiagnostics(..))")
   public void isGetDiagnosticsCall() {
+    // no-op
   }
 
   /**
@@ -108,5 +118,6 @@ public class Pointcuts {
    */
   @Pointcut("isBSLLanguageServerScope() && execution(* initialize(..))")
   public void isInitializeCall() {
+    // no-op
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/Pointcuts.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/Pointcuts.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.BSLDiagnostic;
 import org.aspectj.lang.annotation.Pointcut;
+import org.eclipse.lsp4j.services.LanguageServer;
 
 /**
  * Сборник общих Pointcut для AOP-слоя.
@@ -51,6 +52,13 @@ public class Pointcuts {
    */
   @Pointcut("within(com.github._1c_syntax.bsl.languageserver.context.DocumentContext)")
   public void isDocumentContext() {
+  }
+
+  /**
+   * Это обращение к реализации {@link LanguageServer}.
+   */
+  @Pointcut("within(org.eclipse.lsp4j.services.LanguageServer+)")
+  public void isLanguageServer() {
   }
 
   /**
@@ -93,5 +101,12 @@ public class Pointcuts {
    */
   @Pointcut("isBSLLanguageServerScope() && execution(* getDiagnostics(..))")
   public void isGetDiagnosticsCall() {
+  }
+
+  /**
+   * Это вызов метода initialize.
+   */
+  @Pointcut("isBSLLanguageServerScope() && execution(* initialize(..))")
+  public void isInitializeCall() {
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/events/LanguageServerInitializeRequestReceivedEvent.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/events/LanguageServerInitializeRequestReceivedEvent.java
@@ -1,0 +1,53 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright © 2018-2021
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Gryzlov <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.events;
+
+import lombok.Getter;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.springframework.context.ApplicationEvent;
+
+/**
+ * Описание события получения языковым сервером запроса initialize.
+ * <p>
+ * В качестве источника события содержит ссылку на {@link LanguageServer}.
+ */
+public class LanguageServerInitializeRequestReceivedEvent extends ApplicationEvent {
+
+  private static final long serialVersionUID = 7153531865051478056L;
+
+  /**
+   * Параметры вызванного запроса initialize.
+   */
+  @Getter
+  private final transient InitializeParams params;
+
+  public LanguageServerInitializeRequestReceivedEvent(LanguageServer source, InitializeParams params) {
+    super(source);
+    this.params = params;
+  }
+
+  @Override
+  public LanguageServer getSource() {
+    return (LanguageServer) super.getSource();
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/events/package-info.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/events/package-info.java
@@ -1,0 +1,28 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright © 2018-2021
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Gryzlov <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+/**
+ * События пакета com.github._1c_syntax.bsl.languageserver.
+ */
+@ParametersAreNonnullByDefault
+package com.github._1c_syntax.bsl.languageserver.events;
+
+import javax.annotation.ParametersAreNonnullByDefault;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcherTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcherTest.java
@@ -1,0 +1,56 @@
+package com.github._1c_syntax.bsl.languageserver;
+
+import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
+import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.services.LanguageServer;
+import org.junit.jupiter.api.Test;
+import org.mockito.InjectMocks;
+import org.mockito.Mock;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+@SpringBootTest
+class ParentProcessWatcherTest {
+
+  @InjectMocks
+  private ParentProcessWatcher parentProcessWatcher;
+
+  @Mock
+  private LanguageServer languageServer;
+
+  @Test
+  void testParentProcessIsDead() {
+    // given
+    var params = new InitializeParams();
+    params.setProcessId(-1);
+
+    var event = new LanguageServerInitializeRequestReceivedEvent(languageServer, params);
+    parentProcessWatcher.handleEvent(event);
+
+    // when
+    parentProcessWatcher.watch();
+
+    // then
+    verify(languageServer, times(1)).exit();
+  }
+
+  @Test
+  void testParentProcessIsAlive() {
+    // given
+    var params = new InitializeParams();
+    params.setProcessId((int) ProcessHandle.current().pid());
+
+    var event = new LanguageServerInitializeRequestReceivedEvent(languageServer, params);
+    parentProcessWatcher.handleEvent(event);
+
+    // when
+    parentProcessWatcher.watch();
+
+    // then
+    verify(languageServer, never()).exit();
+  }
+
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcherTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcherTest.java
@@ -1,3 +1,24 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright © 2018-2021
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Gryzlov <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
 package com.github._1c_syntax.bsl.languageserver;
 
 import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

Добавлено фоновое задание, периодически проверяющее, что процесс, стартовавший сервер, все еще жив. Данные о процессе берутся из initialize-запроса:
https://microsoft.github.io/language-server-protocol/specifications/specification-current/#initialize

Вотчер будет отслеживать наличие процесса с pid равным processId.

Коммуникация между вотчером и BSLLanguageServer реализована посредством Events API для исключения циклических зависимостей между вотчером и сервером.

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes:

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (перевод на английский не обязателен)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
