### PR TITLE
Установка повышенного размера metaspace для работы шага QA

### DIFF
--- a/gradle.properties
+++ b/gradle.properties
@@ -1,1 +1,2 @@
 org.gradle.parallel=true
+org.gradle.jvmargs=-Xmx1024m -XX:MaxMetaspaceSize=512m


### PR DESCRIPTION
По умолчанию metaspace для градль-процесса ограничивается 256 мегабайтами.

https://docs.gradle.org/current/userguide/build_environment.html#sec:configuring_jvm_memory