### PR TITLE
Исправление падения на расчете рэнжа для имени области

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/Ranges.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/Ranges.java
@@ -82,12 +82,13 @@ public final class Ranges {
   public Range create(Token startToken, Token endToken) {
     int startLine = startToken.getLine() - 1;
     int startChar = startToken.getCharPositionInLine();
-    int endLine = endToken.getLine() - 1;
+    var tokenToCalculateEnd = endToken == null ? startToken : endToken;
+    int endLine = tokenToCalculateEnd.getLine() - 1;
     int endChar;
-    if (endToken.getType() == Token.EOF) {
-      endChar = endToken.getCharPositionInLine();
+    if (tokenToCalculateEnd.getType() == Token.EOF) {
+      endChar = tokenToCalculateEnd.getCharPositionInLine();
     } else {
-      endChar = endToken.getCharPositionInLine() + endToken.getText().length();
+      endChar = tokenToCalculateEnd.getCharPositionInLine() + tokenToCalculateEnd.getText().length();
     }
 
     return create(startLine, startChar, endLine, endChar);


### PR DESCRIPTION
Если по какой-то причине endToken == null, используем startToken для рассчета рэнжа