### PR TITLE
Использование Set для обхода ошибки дублирования узлов методов в дереве разбора

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
@@ -46,6 +46,7 @@ import javax.annotation.Nullable;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
@@ -60,7 +61,7 @@ public final class MethodSymbolComputer
     BSLParser.ANNOTATION_ATCLIENTATSERVER_SYMBOL);
 
   private final DocumentContext documentContext;
-  private final List<MethodSymbol> methods = new ArrayList<>();
+  private final Set<MethodSymbol> methods = new HashSet<>();
 
   public MethodSymbolComputer(DocumentContext documentContext) {
     this.documentContext = documentContext;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/RegionSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/RegionSymbolComputer.java
@@ -33,7 +33,9 @@ import org.eclipse.lsp4j.Range;
 import java.util.ArrayDeque;
 import java.util.ArrayList;
 import java.util.Deque;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Set;
 
 public final class RegionSymbolComputer
   extends BSLParserBaseVisitor<ParseTree>
@@ -42,7 +44,7 @@ public final class RegionSymbolComputer
   private final DocumentContext documentContext;
   private final Deque<Pair<RegionSymbol.RegionSymbolBuilder, BSLParser.RegionStartContext>> regionStack =
     new ArrayDeque<>();
-  private final List<RegionSymbol> regions = new ArrayList<>();
+  private final Set<RegionSymbol> regions = new HashSet<>();
 
   public RegionSymbolComputer(DocumentContext documentContext) {
     this.documentContext = documentContext;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
@@ -34,13 +34,15 @@ import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 
 import java.util.ArrayList;
+import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> implements Computer<List<VariableSymbol>> {
 
   private final DocumentContext documentContext;
-  private final List<VariableSymbol> variables = new ArrayList<>();
+  private final Set<VariableSymbol> variables = new HashSet<>();
 
   public VariableSymbolComputer(DocumentContext documentContext) {
     this.documentContext = documentContext;


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

Реализовано хранение только уникальных символов в символ-компьютерах.
Неуникальность возникала при возврате деревом разбора от antlr нескольких разных узлов subContext на одинаковые методы в файле

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes #1872

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
