### PR TITLE
Информативное наименование диагностики UsageWriteLogEvent на английском языке

### DIFF
--- a/docs/en/diagnostics/UsageWriteLogEvent.md
+++ b/docs/en/diagnostics/UsageWriteLogEvent.md
@@ -1,4 +1,4 @@
-# Incorrect use of the method (UsageWriteLogEvent)
+# Incorrect use of the method "WriteLogEvent" (UsageWriteLogEvent)
 
 |     Type     |        Scope        | Severity |    Activated<br>by default    |    Minutes<br>to fix    |               Tags                |
 |:------------:|:-------------------:|:--------:|:-----------------------------:|:-----------------------:|:---------------------------------:|

--- a/docs/en/diagnostics/index.md
+++ b/docs/en/diagnostics/index.md
@@ -153,7 +153,7 @@ Total: **157**
  [UnsafeSafeModeMethodCall](UnsafeSafeModeMethodCall.md) | Unsafe SafeMode method call | Yes | Blocker | Error | `deprecated`<br>`error` 
  [UnusedLocalMethod](UnusedLocalMethod.md) | Unused local method | Yes | Major | Code smell | `standard`<br>`suspicious`<br>`unused` 
  [UnusedParameters](UnusedParameters.md) | Unused parameter | Yes | Major | Code smell | `design`<br>`unused` 
- [UsageWriteLogEvent](UsageWriteLogEvent.md) | Incorrect use of the method | Yes | Info | Code smell | `standard`<br>`badpractice` 
+ [UsageWriteLogEvent](UsageWriteLogEvent.md) | Incorrect use of the method "WriteLogEvent" | Yes | Info | Code smell | `standard`<br>`badpractice` 
  [UseLessForEach](UseLessForEach.md) | Useless collection iteration | Yes | Critical | Error | `clumsy` 
  [UsingCancelParameter](UsingCancelParameter.md) | Using parameter "Cancel" | Yes | Major | Code smell | `standard`<br>`badpractice` 
  [UsingExternalCodeTools](UsingExternalCodeTools.md) | Using external code tools | Yes | Critical | Security Hotspot | `standard`<br>`design` 

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/parameters-schema.json
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/parameters-schema.json
@@ -1801,13 +1801,13 @@
             "$id": "#/definitions/UnusedParameters"
         },
         "UsageWriteLogEvent": {
-            "description": "Incorrect use of the method",
+            "description": "Incorrect use of the method \"WriteLogEvent()\"",
             "default": true,
             "type": [
                 "boolean",
                 "object"
             ],
-            "title": "Incorrect use of the method",
+            "title": "Incorrect use of the method \"WriteLogEvent()\"",
             "$id": "#/definitions/UsageWriteLogEvent"
         },
         "UseLessForEach": {

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/parameters-schema.json
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/parameters-schema.json
@@ -1801,13 +1801,13 @@
             "$id": "#/definitions/UnusedParameters"
         },
         "UsageWriteLogEvent": {
-            "description": "Incorrect use of the method \"WriteLogEvent()\"",
+            "description": "Incorrect use of the method \"WriteLogEvent\"",
             "default": true,
             "type": [
                 "boolean",
                 "object"
             ],
-            "title": "Incorrect use of the method \"WriteLogEvent()\"",
+            "title": "Incorrect use of the method \"WriteLogEvent\"",
             "$id": "#/definitions/UsageWriteLogEvent"
         },
         "UseLessForEach": {

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/diagnostics/UsageWriteLogEventDiagnostic_en.properties
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/diagnostics/UsageWriteLogEventDiagnostic_en.properties
@@ -1,5 +1,5 @@
 diagnosticMessage=Correct the transfer of invalid parameters in the method "WriteLogEvent"
-diagnosticName=Incorrect use of the method
+diagnosticName=Incorrect use of the method "WriteLogEvent"
 wrongNumberMessage=Incorrect number of method parameters
 noSecondParameter=The 2nd parameter with the type "EventLogLevel" is missing
 noComment=НThe 5th parameter "Comment" is missing


### PR DESCRIPTION
## Описание
Описание диагностики UsageWriteLogEvent на английском языке — «Incorrect use of the method». Оно не вполне информативно, так как не содержит названия конкретного метода. На русском всё в порядке — «Неверное использование метода "ЗаписьЖурналаРегистрации"».

Добавил имя метода в строку лэнгпаке диагностики UsageWriteLogEvent для английского языка. Остальные файлы, включенные в PR (документация, параметры диагностик), были изменены автоматически при сборке.

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes #1896

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [x] Описание диагностики заполнено для обоих языков

## Дополнительно
Пункт «Изменения покрыты тестами» проставлен (т.к. был рассмотрен), но по факту покрывать этот коммит тестами выглядит избыточным. Кроме того, не вполне понятно, как должен выглядеть такой тест.

Мне кажется, имеет смысл опустить.