### PR TITLE
RedundantAccessToObject разрешать обращение по имени в модулях повтИсп

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/RedundantAccessToObjectDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/RedundantAccessToObjectDiagnostic.java
@@ -29,8 +29,10 @@ import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticS
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticTag;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticType;
 import com.github._1c_syntax.bsl.parser.BSLParser;
+import com.github._1c_syntax.mdclasses.mdo.MDCommonModule;
 import com.github._1c_syntax.mdclasses.mdo.support.MDOType;
 import com.github._1c_syntax.mdclasses.mdo.support.ModuleType;
+import com.github._1c_syntax.mdclasses.mdo.support.ReturnValueReuse;
 import com.github._1c_syntax.utils.CaseInsensitivePattern;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.eclipse.lsp4j.Diagnostic;
@@ -92,7 +94,10 @@ public class RedundantAccessToObjectDiagnostic extends AbstractVisitorDiagnostic
     var typeModule = documentContext.getModuleType();
     if (typeModule == ModuleType.CommonModule || typeModule == ModuleType.ManagerModule) {
       documentContext.getMdObject().ifPresent(mdObjectBase -> {
-        needCheckName = true;
+
+        needCheckName = !(mdObjectBase instanceof MDCommonModule)
+          || ((MDCommonModule) mdObjectBase).getReturnValuesReuse() == ReturnValueReuse.DONT_USE;
+
         skipLValue = true;
         namePatternWithDot = CaseInsensitivePattern.compile(
           String.format(getManagerModuleName(mdObjectBase.getType()), mdObjectBase.getName())
@@ -128,7 +133,7 @@ public class RedundantAccessToObjectDiagnostic extends AbstractVisitorDiagnostic
     var identifier = ctx.IDENTIFIER();
     var modifiers = ctx.modifier();
 
-    if (identifier == null || modifiers.size() == 0) {
+    if (identifier == null || modifiers.isEmpty()) {
       return ctx;
     }
 
@@ -194,7 +199,7 @@ public class RedundantAccessToObjectDiagnostic extends AbstractVisitorDiagnostic
   private static boolean notHasAccessIndex(BSLParser.AcceptorContext acceptor) {
     var modifiers = acceptor.modifier();
     return modifiers == null
-      || modifiers.size() == 0
+      || modifiers.isEmpty()
       || modifiers.get(0) == null
       || modifiers.get(0).accessIndex() == null;
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/RedundantAccessToObjectDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/RedundantAccessToObjectDiagnosticTest.java
@@ -22,7 +22,6 @@
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.mdclasses.mdo.MDCommonModule;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/RedundantAccessToObjectDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/RedundantAccessToObjectDiagnosticTest.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.mdclasses.mdo.MDCommonModule;
 import com.github._1c_syntax.mdclasses.mdo.support.ReturnValueReuse;
@@ -43,7 +44,7 @@ import static com.github._1c_syntax.bsl.languageserver.util.Assertions.assertTha
 import static org.mockito.Mockito.spy;
 import static org.mockito.Mockito.when;
 
-@CleanupContextBeforeClassAndAfterClass
+@CleanupContextBeforeClassAndAfterEachTestMethod
 class RedundantAccessToObjectDiagnosticTest extends AbstractDiagnosticTest<RedundantAccessToObjectDiagnostic> {
   RedundantAccessToObjectDiagnosticTest() {
     super(RedundantAccessToObjectDiagnostic.class);


### PR DESCRIPTION
## Описание
RedundantAccessToObject разрешать обращение по имени в модулях повтИсп

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes #1546

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [ ] Ветка PR обновлена из develop
- [ ] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
