### PR TITLE
Исправлен расчет облости имени переменной при обращении к ее свойству

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
@@ -245,7 +245,7 @@ public class ReferenceIndexFiller {
 
       var variableName = ctx.IDENTIFIER().getText();
       findVariableSymbol(variableName)
-        .ifPresent(s -> addVariableUsage(s.getRootParent(SymbolKind.Method), variableName, Ranges.create(ctx), true));
+        .ifPresent(s -> addVariableUsage(s.getRootParent(SymbolKind.Method), variableName, Ranges.create(ctx.IDENTIFIER()), true));
       return super.visitCallStatement(ctx);
     }
 
@@ -257,7 +257,7 @@ public class ReferenceIndexFiller {
 
       var variableName = ctx.IDENTIFIER().getText();
       findVariableSymbol(variableName)
-        .ifPresent(s -> addVariableUsage(s.getRootParent(SymbolKind.Method), variableName, Ranges.create(ctx), true));
+        .ifPresent(s -> addVariableUsage(s.getRootParent(SymbolKind.Method), variableName, Ranges.create(ctx.IDENTIFIER()), true));
       return super.visitComplexIdentifier(ctx);
     }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFillerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFillerTest.java
@@ -108,6 +108,54 @@ class ReferenceIndexFillerTest {
   }
 
   @Test
+  void testFindVariablesRangesCallStatement() {
+    DocumentContext documentContext = TestUtils.getDocumentContextFromFile(
+      "./src/test/resources/references/ReferenceIndexFillerVariableTest.bsl"
+    );
+    referenceIndexFiller.fill(documentContext);
+
+    var referencedSymbol = referenceIndex.getReference(
+      documentContext.getUri(),
+      new Position(33, 10)
+    );
+    assertThat(referencedSymbol).isPresent();
+    assertThat(referencedSymbol).get()
+      .extracting(Reference::getSymbol)
+      .extracting(Symbol::getName)
+      .isEqualTo("Модуль");
+
+    referencedSymbol = referenceIndex.getReference(
+      documentContext.getUri(),
+      new Position(33, 13)
+    );
+    assertThat(referencedSymbol).isEmpty();
+  }
+
+  @Test
+  void testFindVariablesRangesComplexIdentifier() {
+    DocumentContext documentContext = TestUtils.getDocumentContextFromFile(
+      "./src/test/resources/references/ReferenceIndexFillerVariableTest.bsl"
+    );
+    referenceIndexFiller.fill(documentContext);
+
+    var referencedSymbol = referenceIndex.getReference(
+      documentContext.getUri(),
+      new Position(34, 16)
+    );
+    assertThat(referencedSymbol).isPresent();
+    assertThat(referencedSymbol).get()
+      .extracting(Reference::getSymbol)
+      .extracting(Symbol::getName)
+      .isEqualTo("Модуль");
+
+    referencedSymbol = referenceIndex.getReference(
+      documentContext.getUri(),
+      new Position(34, 23)
+    );
+    assertThat(referencedSymbol).isEmpty();
+  }
+
+  @Test
   void testErrorVariables() {
     DocumentContext documentContext = TestUtils.getDocumentContextFromFile(
       "./src/test/resources/references/ReferenceIndexFillerErrorVariableTest.bsl"


### PR DESCRIPTION
## Описание
При обращении к свойствам переменных в референс индекс попадало значение
области имени переменной вмести с именем свойства.
Из-за этого в VSCode при наведении на свойство отображалась подсказка
для переменной.
Сейчас в область попадает только имя переменной.

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes #2743 2743

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)
