### PR TITLE
fix: исправлено нарушение контракта compareTo

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/Symbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/Symbol.java
@@ -68,7 +68,29 @@ public class Symbol implements Comparable<Symbol> {
     if (this.equals(o)) {
       return 0;
     }
-    return hashCode() > o.hashCode() ? 1 : -1;
+
+    int compareResult = mdoRef.compareTo(o.mdoRef);
+    if (compareResult != 0) {
+      return compareResult;
+    }
+
+    compareResult = moduleType.compareTo(o.moduleType);
+    if (compareResult != 0) {
+      return compareResult;
+    }
+
+    compareResult = scopeName.compareTo(o.scopeName);
+    if (compareResult != 0) {
+      return compareResult;
+    }
+
+    compareResult = symbolKind.compareTo(o.symbolKind);
+    if (compareResult != 0) {
+      return compareResult;
+    }
+
+    compareResult = symbolName.compareTo(o.symbolName);
+    return compareResult;
   }
 
 }


### PR DESCRIPTION
контракт "x.compareTo(…y)) == -signum(y.compareTo(x))" не выполняется при сравнении объектов с одинаковым hashcode

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
