### PR TITLE
Доработка форматтера

### DIFF
--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLSPLauncherTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLSPLauncherTest.java
@@ -173,6 +173,26 @@ class BSLLSPLauncherTest {
 
   @Test
   @ExpectSystemExitWithStatus(0)
+  void testFormatTwoFiles() {
+    // given
+    String[] args = "--format --src ./src/test/resources/cli/test.bsl.txt,./src/test/resources/cli/test.bsl".split(" ");
+
+    // when
+    try {
+      BSLLSPLauncher.main(args);
+    } catch (RuntimeException ignored) {
+      // catch prevented system.exit call
+    }
+
+    // then
+    // main-method should runs without exceptions
+    assertThat(outContent.toString()).isEmpty();
+    // assertThat(errContent.toString()).contains("100%");
+    assertThat(errContent.toString()).doesNotContain("ERROR");
+  }
+
+  @Test
+  @ExpectSystemExitWithStatus(0)
   void testFormatSilent() {
     // given
     String[] args = "--format --src ./src/test/resources/cli --silent".split(" ");


### PR DESCRIPTION
Добавлена возможность форматировать несколько файлов/директорий…одновременно. дополнительные элементы перечисляются через запятую

## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->
Параметр srcDir команды форматтера теперь разбивает значение по запятым
## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Close #1942 

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [x] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
