### PR TITLE
исправлено падение анализа на БСП 3.1 из-за ошибки в RefefernceIndexFiller

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
@@ -132,7 +132,7 @@ public class ReferenceIndexFiller {
       if (NotifyDescription.isNotifyDescription(ctx)) {
         final var doCallContext = ctx.doCall();
         if (doCallContext == null){
-          return ctx;
+          return super.visitNewExpression(ctx);
         }
         var callParamList = doCallContext.callParamList().callParam();
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
@@ -130,6 +130,9 @@ public class ReferenceIndexFiller {
     @Override
     public BSLParserRuleContext visitNewExpression(BSLParser.NewExpressionContext ctx) {
       if (NotifyDescription.isNotifyDescription(ctx)) {
+        if (ctx.doCall() == null){
+          return ctx;
+        }
         var callParamList = ctx.doCall().callParamList().callParam();
 
         if (NotifyDescription.notifyDescriptionContainsHandler(callParamList)) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
@@ -130,10 +130,11 @@ public class ReferenceIndexFiller {
     @Override
     public BSLParserRuleContext visitNewExpression(BSLParser.NewExpressionContext ctx) {
       if (NotifyDescription.isNotifyDescription(ctx)) {
-        if (ctx.doCall() == null){
+        final var doCallContext = ctx.doCall();
+        if (doCallContext == null){
           return ctx;
         }
-        var callParamList = ctx.doCall().callParamList().callParam();
+        var callParamList = doCallContext.callParamList().callParam();
 
         if (NotifyDescription.notifyDescriptionContainsHandler(callParamList)) {
           addCallbackMethodCall(


### PR DESCRIPTION
из репо 1с-синтакс

## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->
Исправлено падение анализа на БСП 3.1
- ![image](https://user-images.githubusercontent.com/2920817/179393954-571f5ac1-6275-4c0a-99c3-94f48e83f2f7.png)
- .
- 
![image](https://user-images.githubusercontent.com/2920817/179393965-f7a54ee9-8c85-4278-9452-f436c95b3237.png)

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes 

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
