### PR TITLE
Восстановление правила FieldsFromJoinsWithoutIsNull после изменения парсера запросов 

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic.java
@@ -21,7 +21,6 @@
  */
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
-import com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.Disabled;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticMetadata;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticSeverity;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticTag;
@@ -47,7 +46,6 @@ import java.util.Set;
 import java.util.stream.Collectors;
 import java.util.stream.Stream;
 
-@Disabled
 @DiagnosticMetadata(
   type = DiagnosticType.ERROR,
   severity = DiagnosticSeverity.CRITICAL,
@@ -61,11 +59,15 @@ import java.util.stream.Stream;
 )
 public class FieldsFromJoinsWithoutIsNullDiagnostic extends AbstractSDBLVisitorDiagnostic {
 
+  // схема расчета - находится поле из соединения,
+  // далее идет поиск вверх по родительским узлам для проверки вхождения в разных вариациях ЕСТЬNULL или ЕСТЬ NULL
+  // для оптимизации ищем вверх не до начального узла всего дерева, а до узла, в котором искать уже нет смысла
+
   private static final Integer SELECT_ROOT = SDBLParser.RULE_selectedField;
   private static final Collection<Integer> SELECT_STATEMENTS = Set.of(SELECT_ROOT, SDBLParser.RULE_builtInFunctions,
     SDBLParser.RULE_isNullPredicate);
 
-  private static final Integer WHERE_ROOT = SDBLParser.RULE_predicate;
+  private static final Integer WHERE_ROOT = SDBLParser.RULE_query;
   private static final Collection<Integer> WHERE_STATEMENTS = Set.of(WHERE_ROOT, SDBLParser.RULE_builtInFunctions,
     SDBLParser.RULE_isNullPredicate);
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic.java
@@ -63,16 +63,16 @@ public class FieldsFromJoinsWithoutIsNullDiagnostic extends AbstractSDBLVisitorD
   // далее идет поиск вверх по родительским узлам для проверки вхождения в разных вариациях ЕСТЬNULL или ЕСТЬ NULL
   // для оптимизации ищем вверх не до начального узла всего дерева, а до узла, в котором искать уже нет смысла
 
-  private static final Integer SELECT_ROOT = SDBLParser.RULE_selectedField;
-  private static final Collection<Integer> SELECT_STATEMENTS = Set.of(SELECT_ROOT, SDBLParser.RULE_builtInFunctions,
+  private static final Integer EXCLUDED_TOP_RULE_FOR_SELECT = SDBLParser.RULE_selectedField;
+  private static final Collection<Integer> SELECT_STATEMENTS = Set.of(EXCLUDED_TOP_RULE_FOR_SELECT, SDBLParser.RULE_builtInFunctions,
     SDBLParser.RULE_isNullPredicate);
 
-  private static final Integer WHERE_ROOT = SDBLParser.RULE_query;
-  private static final Collection<Integer> WHERE_STATEMENTS = Set.of(WHERE_ROOT, SDBLParser.RULE_builtInFunctions,
+  private static final Integer EXCLUDED_TOP_RULE_FOR_WHERE = SDBLParser.RULE_query;
+  private static final Collection<Integer> WHERE_STATEMENTS = Set.of(EXCLUDED_TOP_RULE_FOR_WHERE, SDBLParser.RULE_builtInFunctions,
     SDBLParser.RULE_isNullPredicate);
 
-  private static final Integer JOIN_ROOT = SDBLParser.RULE_joinPart;
-  private static final Collection<Integer> JOIN_STATEMENTS = Set.of(JOIN_ROOT, SDBLParser.RULE_builtInFunctions);
+  private static final Integer EXCLUDED_TOP_RULE_FOR_JOIN = SDBLParser.RULE_joinPart;
+  private static final Collection<Integer> JOIN_STATEMENTS = Set.of(EXCLUDED_TOP_RULE_FOR_JOIN, SDBLParser.RULE_builtInFunctions);
 
   public static final Collection<Integer> RULES_OF_PARENT_FOR_SEARCH_CONDITION = Set.of(SDBLParser.RULE_predicate,
     SDBLParser.RULE_query);
@@ -167,7 +167,7 @@ public class FieldsFromJoinsWithoutIsNullDiagnostic extends AbstractSDBLVisitorD
   }
 
   private void checkSelect(String tableName, SDBLParser.SelectedFieldsContext columns) {
-    checkStatements(tableName, columns, SELECT_STATEMENTS, SELECT_ROOT, true);
+    checkStatements(tableName, columns, SELECT_STATEMENTS, EXCLUDED_TOP_RULE_FOR_SELECT, true);
   }
 
   private void checkStatements(String tableName, BSLParserRuleContext expression, Collection<Integer> statements,
@@ -225,7 +225,7 @@ public class FieldsFromJoinsWithoutIsNullDiagnostic extends AbstractSDBLVisitorD
     Optional.ofNullable(where)
       .stream().flatMap(searchConditionsContext -> searchConditionsContext.condidions.stream())
       .forEach(searchConditionContext -> checkStatements(tableName, searchConditionContext,
-        WHERE_STATEMENTS, WHERE_ROOT, true));
+        WHERE_STATEMENTS, EXCLUDED_TOP_RULE_FOR_WHERE, true));
   }
 
   private void checkAllJoins(String tableName, SDBLParser.JoinPartContext currentJoinPart) {
@@ -235,7 +235,7 @@ public class FieldsFromJoinsWithoutIsNullDiagnostic extends AbstractSDBLVisitorD
       .filter(joinPartContext -> joinPartContext != currentJoinPart)
       .map(SDBLParser.JoinPartContext::logicalExpression)
       .forEach(searchConditionsContext -> checkStatements(tableName, searchConditionsContext,
-        JOIN_STATEMENTS, JOIN_ROOT, false));
+        JOIN_STATEMENTS, EXCLUDED_TOP_RULE_FOR_JOIN, false));
   }
 
   private List<DiagnosticRelatedInformation> getRelatedInformation(SDBLParser.JoinPartContext self) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic.java
@@ -64,15 +64,16 @@ public class FieldsFromJoinsWithoutIsNullDiagnostic extends AbstractSDBLVisitorD
   // для оптимизации ищем вверх не до начального узла всего дерева, а до узла, в котором искать уже нет смысла
 
   private static final Integer EXCLUDED_TOP_RULE_FOR_SELECT = SDBLParser.RULE_selectedField;
-  private static final Collection<Integer> SELECT_STATEMENTS = Set.of(EXCLUDED_TOP_RULE_FOR_SELECT, SDBLParser.RULE_builtInFunctions,
-    SDBLParser.RULE_isNullPredicate);
+  private static final Collection<Integer> SELECT_STATEMENTS = Set.of(EXCLUDED_TOP_RULE_FOR_SELECT,
+    SDBLParser.RULE_builtInFunctions, SDBLParser.RULE_isNullPredicate);
 
   private static final Integer EXCLUDED_TOP_RULE_FOR_WHERE = SDBLParser.RULE_query;
-  private static final Collection<Integer> WHERE_STATEMENTS = Set.of(EXCLUDED_TOP_RULE_FOR_WHERE, SDBLParser.RULE_builtInFunctions,
-    SDBLParser.RULE_isNullPredicate);
+  private static final Collection<Integer> WHERE_STATEMENTS = Set.of(EXCLUDED_TOP_RULE_FOR_WHERE,
+    SDBLParser.RULE_builtInFunctions, SDBLParser.RULE_isNullPredicate);
 
   private static final Integer EXCLUDED_TOP_RULE_FOR_JOIN = SDBLParser.RULE_joinPart;
-  private static final Collection<Integer> JOIN_STATEMENTS = Set.of(EXCLUDED_TOP_RULE_FOR_JOIN, SDBLParser.RULE_builtInFunctions);
+  private static final Collection<Integer> JOIN_STATEMENTS = Set.of(EXCLUDED_TOP_RULE_FOR_JOIN,
+    SDBLParser.RULE_builtInFunctions);
 
   public static final Collection<Integer> RULES_OF_PARENT_FOR_SEARCH_CONDITION = Set.of(SDBLParser.RULE_predicate,
     SDBLParser.RULE_query);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnosticTest.java
@@ -26,7 +26,6 @@ import org.assertj.core.api.Assertions;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.DiagnosticRelatedInformation;
 import org.eclipse.lsp4j.Range;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 
 import java.util.Arrays;
@@ -41,7 +40,6 @@ class FieldsFromJoinsWithoutIsNullDiagnosticTest extends AbstractDiagnosticTest<
   }
 
   @Test
-  @Disabled
   void test() {
 
     List<Diagnostic> diagnostics = getDiagnostics();


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->
- Восстановление правила FieldsFromJoinsWithoutIsNull после изменения парсера запросов 
- убран признак Disabled
- кратко документирован алгоритм

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes #2900

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
Фактически исправил одно выражение 
- `private static final Integer WHERE_ROOT = SDBLParser.RULE_query;`