### PR TITLE
Исправлена ошибка чтения параметров SourceDefinedMethodCallInlayHintSupplier

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
@@ -173,7 +173,7 @@ public class SourceDefinedMethodCallInlayHintSupplier implements InlayHintSuppli
 
 
   private boolean showParametersWithTheSameName() {
-    var parameters = configuration.getCodeLensOptions().getParameters().getOrDefault(getId(), Either.forLeft(true));
+    var parameters = configuration.getInlayHintOptions().getParameters().getOrDefault(getId(), Either.forLeft(true));
     if (parameters.isLeft()) {
       return DEFAULT_SHOW_PARAMETERS_WITH_THE_SAME_NAME;
     } else {
@@ -185,7 +185,7 @@ public class SourceDefinedMethodCallInlayHintSupplier implements InlayHintSuppli
   }
 
   private boolean showDefaultValues() {
-    var parameters = configuration.getCodeLensOptions().getParameters().getOrDefault(getId(), Either.forLeft(true));
+    var parameters = configuration.getInlayHintOptions().getParameters().getOrDefault(getId(), Either.forLeft(true));
     if (parameters.isLeft()) {
       return DEFAULT_DEFAULT_VALUES;
     } else {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfigurationTest.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.codelens.CodeLensO
 import com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.DiagnosticsOptions;
 import com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.Mode;
 import com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.SkipSupport;
+import com.github._1c_syntax.bsl.languageserver.configuration.inlayhints.InlayHintOptions;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.utils.Absolute;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -152,6 +153,7 @@ class LanguageServerConfigurationTest {
     // when
     CodeLensOptions codeLensOptions = configuration.getCodeLensOptions();
     DiagnosticsOptions diagnosticsOptions = configuration.getDiagnosticsOptions();
+    InlayHintOptions inlayHintOptions = configuration.getInlayHintOptions();
 
     // then
     assertThat(codeLensOptions.getParameters().get("cognitiveComplexity")).isNull();
@@ -162,6 +164,10 @@ class LanguageServerConfigurationTest {
     assertThat(diagnosticsOptions.getMode()).isEqualTo(Mode.ON);
     assertThat(diagnosticsOptions.getSkipSupport()).isEqualTo(SkipSupport.NEVER);
     assertThat(diagnosticsOptions.getParameters()).isEmpty();
+
+    assertThat(inlayHintOptions.getParameters())
+      .containsEntry("sourceDefinedMethodCall", Either.forRight(Map.of("showParametersWithTheSameName", true)));
+
   }
 
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplierTest.java
@@ -21,7 +21,9 @@
  */
 package com.github._1c_syntax.bsl.languageserver.inlayhints;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintKind;
@@ -33,16 +35,21 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.util.List;
+import java.util.Map;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
+@CleanupContextBeforeClassAndAfterEachTestMethod
 class SourceDefinedMethodCallInlayHintSupplierTest {
 
   private final static String FILE_PATH = "./src/test/resources/inlayhints/SourceDefinedMethodCallInlayHintSupplier.bsl";
 
   @Autowired
   private SourceDefinedMethodCallInlayHintSupplier supplier;
+
+  @Autowired
+  private LanguageServerConfiguration configuration;
 
   @Test
   void testDefaultInlayHints() {
@@ -79,5 +86,55 @@ class SourceDefinedMethodCallInlayHintSupplierTest {
       })
     ;
   }
+
+  @Test
+  void testInlayHintsShowParametersWithTheSameName() {
+
+    // given
+    configuration.getInlayHintOptions().getParameters().put(
+      supplier.getId(),
+      Either.forRight(Map.of("showParametersWithTheSameName", true))
+    );
+
+    var documentContext = TestUtils.getDocumentContextFromFile(FILE_PATH);
+    MethodSymbol firstMethod = documentContext.getSymbolTree().getMethods().get(0);
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var range = firstMethod.getRange();
+    var params = new InlayHintParams(textDocumentIdentifier, range);
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then
+    assertThat(inlayHints)
+      .hasSize(3)
+      .anySatisfy(inlayHint -> {
+        assertThat(inlayHint.getLabel()).isEqualTo(Either.forLeft("Player:"));
+        assertThat(inlayHint.getKind()).isEqualTo(InlayHintKind.Parameter);
+        assertThat(inlayHint.getPosition()).isEqualTo(new Position(3, 14));
+        assertThat(inlayHint.getPaddingRight()).isTrue();
+        assertThat(inlayHint.getPaddingLeft()).isNull();
+        assertThat(inlayHint.getTooltip().getRight().getValue()).isEqualTo("* **Player**: ");
+      })
+      .anySatisfy(inlayHint -> {
+        assertThat(inlayHint.getLabel()).isEqualTo(Either.forLeft("PlayersHealth:"));
+        assertThat(inlayHint.getKind()).isEqualTo(InlayHintKind.Parameter);
+        assertThat(inlayHint.getPosition()).isEqualTo(new Position(3, 23));
+        assertThat(inlayHint.getPaddingRight()).isTrue();
+        assertThat(inlayHint.getPaddingLeft()).isNull();
+        assertThat(inlayHint.getTooltip().getRight().getValue()).isEqualTo("* **PlayersHealth**: ");
+      })
+      .anySatisfy(inlayHint -> {
+        assertThat(inlayHint.getLabel()).isEqualTo(Either.forLeft("Amount:"));
+        assertThat(inlayHint.getKind()).isEqualTo(InlayHintKind.Parameter);
+        assertThat(inlayHint.getPosition()).isEqualTo(new Position(3, 32));
+        assertThat(inlayHint.getPaddingRight()).isTrue();
+        assertThat(inlayHint.getPaddingLeft()).isNull();
+        assertThat(inlayHint.getTooltip().getRight().getValue()).isEqualTo("* **Amount**: ");
+      })
+    ;
+  }
+
 
 }

--- a/src/test/resources/.partial-bsl-language-server.json
+++ b/src/test/resources/.partial-bsl-language-server.json
@@ -4,6 +4,13 @@
       "cyclomaticComplexity": false
     }
   },
+  "inlayHint": {
+    "parameters": {
+      "sourceDefinedMethodCall": {
+        "showParametersWithTheSameName": true
+      }
+    }
+  },
   "diagnostics": {
     "mode": "on"
   }


### PR DESCRIPTION
## Описание
1. Исправлена ошибка чтения параметров SourceDefinedMethodCallInlayHintSupplier теперь ищет настройки в параметрах inlayHint а не CodeLens
2. Добавлен тест на параметр showParametersWithTheSameName для SourceDefinedMethodCallInlayHintSupplier
3. Добавлен тест на чтение параметров inlayHints в конфигурации.

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes #3063

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [X] Ветка PR обновлена из develop
- [X] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [X] Изменения покрыты тестами
- [X] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
