### PR TITLE
Исключил commons-logging.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,6 +54,14 @@ val isSnapshot = gitVersioning.gitVersionDetails.refType != GitRefType.TAG
 
 val languageToolVersion = "6.1"
 
+allprojects {
+    configurations {
+        all {
+            exclude(group = "commons-logging")
+        }
+    }
+}
+
 dependencyManagement {
     imports {
         mavenBom("io.sentry:sentry-bom:6.25.2")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -54,14 +54,6 @@ val isSnapshot = gitVersioning.gitVersionDetails.refType != GitRefType.TAG
 
 val languageToolVersion = "6.1"
 
-allprojects {
-    configurations {
-        all {
-            exclude(group = "commons-logging")
-        }
-    }
-}
-
 dependencyManagement {
     imports {
         mavenBom("io.sentry:sentry-bom:6.25.2")
@@ -96,7 +88,9 @@ dependencies {
     api("io.github.1c-syntax", "supportconf", "0.1.1")
 
     // JLanguageTool
-    implementation("org.languagetool", "languagetool-core", languageToolVersion)
+    implementation("org.languagetool", "languagetool-core", languageToolVersion){
+        exclude("commons-logging", "commons-logging")
+    }
     implementation("org.languagetool", "language-en", languageToolVersion)
     implementation("org.languagetool", "language-ru", languageToolVersion)
 
@@ -106,7 +100,9 @@ dependencies {
     // commons utils
     implementation("commons-io", "commons-io", "2.13.0")
     implementation("org.apache.commons", "commons-lang3", "3.12.0")
-    implementation("commons-beanutils", "commons-beanutils", "1.9.4")
+    implementation("commons-beanutils", "commons-beanutils", "1.9.4"){
+        exclude("commons-logging", "commons-logging")
+    }
     implementation("org.apache.commons", "commons-collections4", "4.4")
     implementation("org.apache.commons", "commons-exec", "1.3")
 

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -74,7 +74,7 @@ dependencies {
     api("org.eclipse.lsp4j", "org.eclipse.lsp4j.websocket.jakarta", "0.21.0")
 
     // 1c-syntax
-    api("com.github.1c-syntax", "bsl-parser", "0.22.0") {
+    api("com.github.1c-syntax", "bsl-parser", "bba7c0b091aca562ec082829a49f525a9bb5d7ef") {
         exclude("com.tunnelvisionlabs", "antlr4-annotations")
         exclude("com.ibm.icu", "*")
         exclude("org.antlr", "ST4")


### PR DESCRIPTION
Эта зависимость выкидывает выхлоп на старте
```
Standard Commons Logging discovery in action with spring-jcl: please remove commons-logging.jar from classpath in order to avoid potential conflicts
```
Из-за которого рушится плагин в vsc и не может подключиться.