### PR TITLE
Передача executor service во все сервисы

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -62,6 +62,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.LanguageServer;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
@@ -88,8 +89,6 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
   private final ServerContext context;
   private final ServerInfo serverInfo;
 
-  private final ExecutorService executorService = Executors.newCachedThreadPool();
-
   private boolean shutdownWasCalled;
 
   @Override
@@ -98,6 +97,7 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
     clientCapabilitiesHolder.setCapabilities(params.getCapabilities());
     
     setConfigurationRoot(params);
+    ExecutorService executorService = Executors.newCachedThreadPool(new CustomizableThreadFactory("populate-context-"));
     CompletableFuture.runAsync(context::populateContext, executorService);
 
     var capabilities = new ServerCapabilities();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -72,6 +72,8 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Optional;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Slf4j
 @Component
@@ -85,6 +87,9 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
   private final ClientCapabilitiesHolder clientCapabilitiesHolder;
   private final ServerContext context;
   private final ServerInfo serverInfo;
+
+  private final ExecutorService executorService = Executors.newCachedThreadPool();
+
   private boolean shutdownWasCalled;
 
   @Override
@@ -93,7 +98,7 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
     clientCapabilitiesHolder.setCapabilities(params.getCapabilities());
     
     setConfigurationRoot(params);
-    CompletableFuture.runAsync(context::populateContext);
+    CompletableFuture.runAsync(context::populateContext, executorService);
 
     var capabilities = new ServerCapabilities();
     capabilities.setTextDocumentSync(getTextDocumentSyncOptions());

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -93,6 +93,7 @@ import org.eclipse.lsp4j.WorkspaceEdit;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Either3;
 import org.eclipse.lsp4j.services.TextDocumentService;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -124,7 +125,7 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
   private final RenameProvider renameProvider;
   private final InlayHintProvider inlayHintProvider;
 
-  private final ExecutorService executorService = Executors.newCachedThreadPool();
+  private final ExecutorService executorService = Executors.newCachedThreadPool(new CustomizableThreadFactory("text-document-service-"));
 
   @Override
   public CompletableFuture<Hover> hover(HoverParams params) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
@@ -39,6 +39,8 @@ import org.springframework.stereotype.Component;
 import java.lang.reflect.InvocationTargetException;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 
 @Component
 @RequiredArgsConstructor
@@ -48,9 +50,14 @@ public class BSLWorkspaceService implements WorkspaceService {
   private final CommandProvider commandProvider;
   private final SymbolProvider symbolProvider;
 
+  private final ExecutorService executorService = Executors.newCachedThreadPool();
+
   @Override
   public CompletableFuture<Either<List<? extends SymbolInformation>,List<? extends WorkspaceSymbol>>> symbol(WorkspaceSymbolParams params) {
-    return CompletableFuture.supplyAsync(() -> Either.forRight(symbolProvider.getSymbols(params)));
+    return CompletableFuture.supplyAsync(
+      () -> Either.forRight(symbolProvider.getSymbols(params)),
+      executorService
+    );
   }
 
   @Override
@@ -71,6 +78,9 @@ public class BSLWorkspaceService implements WorkspaceService {
   public CompletableFuture<Object> executeCommand(ExecuteCommandParams params) {
     var arguments = commandProvider.extractArguments(params);
 
-    return CompletableFuture.supplyAsync(() -> commandProvider.executeCommand(arguments));
+    return CompletableFuture.supplyAsync(
+      () -> commandProvider.executeCommand(arguments),
+      executorService
+    );
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
@@ -34,6 +34,7 @@ import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.WorkspaceService;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
 import java.lang.reflect.InvocationTargetException;
@@ -50,7 +51,7 @@ public class BSLWorkspaceService implements WorkspaceService {
   private final CommandProvider commandProvider;
   private final SymbolProvider symbolProvider;
 
-  private final ExecutorService executorService = Executors.newCachedThreadPool();
+  private final ExecutorService executorService = Executors.newCachedThreadPool(new CustomizableThreadFactory("workspace-service-"));
 
   @Override
   public CompletableFuture<Either<List<? extends SymbolInformation>,List<? extends WorkspaceSymbol>>> symbol(WorkspaceSymbolParams params) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/SentryAspect.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/SentryAspect.java
@@ -27,6 +27,7 @@ import jakarta.annotation.PreDestroy;
 import lombok.NoArgsConstructor;
 import org.aspectj.lang.annotation.AfterThrowing;
 import org.aspectj.lang.annotation.Aspect;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
@@ -43,7 +44,7 @@ public class SentryAspect {
 
   @PostConstruct
   private void init() {
-    executorService = Executors.newCachedThreadPool();
+    executorService = Executors.newCachedThreadPool(new CustomizableThreadFactory("sentry-"));
   }
 
   @PreDestroy


### PR DESCRIPTION
## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

Добавлена передача cachedThreadPool в методы всех сервисов, использующих supplyAsync. See #3104.

Не уверен насчет дедлоков, но ховер стал отвечать намного-намного быстрее, не дожидаясь конца расчета конфигурации (проверял на УХе)

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes #3104

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->
