### PR TITLE
Add GitHub Actions workflow to build bootJar on comment

### DIFF
--- a/.github/workflows/build-bootJar-on-comment.yaml
+++ b/.github/workflows/build-bootJar-on-comment.yaml
@@ -1,0 +1,79 @@
+name: Build bootJar on PR comment
+
+on:
+  issue_comment:
+    types: [created]
+
+permissions:
+  contents: read
+  issues: write       # писать комментарии в PR (issues API)
+  actions: read
+
+jobs:
+  build-jar:
+    # Только если комментарий к PR и в нём есть /buildJar
+    if: >
+      github.event.issue.pull_request != '' &&
+      contains(github.event.comment.body, '/buildJar')
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17 (Corretto) with Gradle cache
+        uses: actions/setup-java@v4
+        with:
+          distribution: 'corretto'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Make Gradle wrapper executable (if needed)
+        run: chmod +x ./gradlew
+
+      - name: Build bootJar
+        run: ./gradlew bootJar
+
+      - name: List built JARs
+        id: list_jars
+        run: |
+          if ! ls build/libs/*.jar >/dev/null 2>&1; then
+            echo "No JAR found in build/libs"
+            exit 1
+          fi
+
+          echo "Найдены JAR-файлы:"
+          ls -1 build/libs/*.jar
+
+          # Собираем список файлов в формате markdown-списка
+          {
+            for path in build/libs/*.jar; do
+              echo "- \`$(basename "$path")\`"
+            done
+          } > jar_list.txt
+
+          echo 'list<<EOF' >> "$GITHUB_OUTPUT"
+          cat jar_list.txt >> "$GITHUB_OUTPUT"
+          echo 'EOF' >> "$GITHUB_OUTPUT"
+
+      - name: Upload JAR artifact
+        id: upload_jar
+        uses: actions/upload-artifact@v4
+        with:
+          # имя артефакта; можешь поменять на что-то своё
+          name: bootJar-${{ github.run_id }}
+          path: build/libs/*.jar
+          # retention-days: 7  # при желании
+
+      - name: Comment on PR with JAR link
+        uses: peter-evans/create-or-update-comment@v4
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+          issue-number: ${{ github.event.issue.number }}
+          body: |
+            ✅ Собраны JAR-файлы для этого PR по команде `/buildJar`.
+
+            **Артефакт:** [${{ steps.upload_jar.outputs.artifact-name }}](${{ steps.upload_jar.outputs.artifact-url }})
+
+            **Файлы внутри:**
+            ${{ steps.list_jars.outputs.list }}


### PR DESCRIPTION
This workflow builds a boot JAR when a comment is made on a PR. It checks out the repository, sets up JDK, builds the JAR, lists the built JARs, uploads the artifact, and comments on the PR with the JAR link.

## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes 

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [ ] Ветка PR обновлена из develop
- [ ] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Added GitHub Actions workflow enabling on-demand bootJar builds triggered by PR comments containing "/buildJar". Build artifacts are automatically uploaded and results are posted back to the pull request for easy access.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->