### PR TITLE
Revert "Bump com.diffplug.spotless from 7.0.4 to 8.1.0"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,7 +7,7 @@ plugins {
     `java-library`
     `maven-publish`
     jacoco
-    id("com.diffplug.spotless") version "8.1.0"
+    id("com.diffplug.spotless") version "7.0.4"
     id("me.qoomon.git-versioning") version "6.4.4"
     id("io.freefair.lombok") version "9.1.0"
     id("io.freefair.javadoc-links") version "9.1.0"


### PR DESCRIPTION
Reverts 1c-syntax/bsl-language-server#3749

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build tool dependency version.

<sub>✏️ Tip: You can customize this high-level summary in your review settings.</sub>

<!-- end of auto-generated comment: release notes by coderabbit.ai -->