### PR TITLE
perf: Снижено время и память при analyze

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -170,6 +170,8 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
   // Executors per document URI to serialize didChange operations and avoid race conditions
   private final Map<URI, DocumentChangeExecutor> documentExecutors = new ConcurrentHashMap<>();
 
+  private boolean clientSupportsPullDiagnostics;
+
   /**
    * @return общий ограниченный пул для обработки запросов LSP.
    */
@@ -177,8 +179,10 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
     return bslLsExecutors.getLspExecutor();
   }
 
-  private boolean clientSupportsPullDiagnostics;
-
+  /**
+   * Корректное завершение работы: останавливает per-document воркеры
+   * {@link DocumentChangeExecutor}. Вызывается Spring через {@link PreDestroy}.
+   */
   @PreDestroy
   private void onDestroy() {
     documentExecutors.values().forEach(DocumentChangeExecutor::shutdown);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentChangeExecutor;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.BslLsExecutors;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.DiagnosticParams;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.Diagnostics;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.ProtocolExtension;
@@ -117,7 +118,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either3;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -127,7 +127,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -166,21 +165,24 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
   private final ClientCapabilitiesHolder clientCapabilitiesHolder;
   private final SemanticTokensProvider semanticTokensProvider;
   private final DocumentHighlightProvider documentHighlightProvider;
-
-  private final ExecutorService executorService = Executors.newCachedThreadPool(new CustomizableThreadFactory("text-document-service-"));
+  private final BslLsExecutors bslLsExecutors;
 
   // Executors per document URI to serialize didChange operations and avoid race conditions
   private final Map<URI, DocumentChangeExecutor> documentExecutors = new ConcurrentHashMap<>();
+
+  /**
+   * @return общий ограниченный пул для обработки запросов LSP.
+   */
+  private ExecutorService executorService() {
+    return bslLsExecutors.getLspExecutor();
+  }
 
   private boolean clientSupportsPullDiagnostics;
 
   @PreDestroy
   private void onDestroy() {
-    // Shutdown all document executors
     documentExecutors.values().forEach(DocumentChangeExecutor::shutdown);
     documentExecutors.clear();
-
-    executorService.shutdown();
   }
 
   @Override
@@ -859,7 +861,7 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
     return waitFuture.thenCompose(ignored ->
       CompletableFutures.computeAsync(
-        executorService,
+        executorService(),
         cancelChecker -> {
           cancelChecker.checkCanceled();
           var lock = context.getDocumentLock(documentContext.getUri());

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -50,6 +50,7 @@ import lombok.Locked;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ParseTree;
 import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.lsp4j.Diagnostic;
@@ -65,11 +66,14 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Locale;
+import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.locks.ReentrantLock;
 import java.util.regex.Pattern;
 
@@ -98,6 +102,15 @@ public class DocumentContext implements Comparable<DocumentContext> {
 
   @Nullable
   private String content;
+
+  /**
+   * Fingerprint текущего {@link #content} (хэш + длина).
+   * <p>
+   * Используется для быстрого сравнения нового текста с уже разобранным:
+   * если совпадает — повторный парсинг и пересчёт {@link #symbolTree} не выполняются.
+   * Значение {@code 0} означает «хэш не вычислен / контента нет».
+   */
+  private long contentHashAndLength;
 
   @Getter
   private int version;
@@ -142,6 +155,14 @@ public class DocumentContext implements Comparable<DocumentContext> {
 
   private final Lazy<List<SDBLTokenizer>> queries = new Lazy<>(this::computeQueries, computeLock);
 
+  /**
+   * Кэш узлов AST, собранных по {@code ruleIndex}, по всему дереву документа.
+   * Очищается вместе с AST в {@link #clearSecondaryData()}.
+   *
+   * @see #getCachedRuleNodes(int)
+   */
+  private final Map<Integer, Collection<? extends ParseTree>> ruleNodesCache = new ConcurrentHashMap<>();
+
   public DocumentContext(URI uri) {
     this.uri = uri;
     this.fileType = computeFileType(uri);
@@ -175,13 +196,25 @@ public class DocumentContext implements Comparable<DocumentContext> {
   }
 
   public List<Token> getTokensFromDefaultChannel() {
-    return getTokens().stream().filter(token -> token.getChannel() == DEFAULT_CHANNEL).toList();
+    final List<Token> tokens = getTokens();
+    final List<Token> result = new java.util.ArrayList<>(tokens.size());
+    for (Token token : tokens) {
+      if (token.getChannel() == DEFAULT_CHANNEL) {
+        result.add(token);
+      }
+    }
+    return result;
   }
 
   public List<Token> getComments() {
-    return getTokens().stream()
-      .filter(token -> token.getType() == BSLLexer.LINE_COMMENT)
-      .toList();
+    final List<Token> tokens = getTokens();
+    final List<Token> result = new java.util.ArrayList<>();
+    for (Token token : tokens) {
+      if (token.getType() == BSLLexer.LINE_COMMENT) {
+        result.add(token);
+      }
+    }
+    return result;
   }
 
   @Locked("computeLock")
@@ -274,6 +307,24 @@ public class DocumentContext implements Comparable<DocumentContext> {
     return queries.getOrCompute();
   }
 
+  /**
+   * Возвращает все узлы AST с указанным {@code ruleIndex}, обходя дерево
+   * только один раз на документ. Результаты переиспользуются всеми вызывающими.
+   * <p>
+   * Используйте в диагностиках вместо
+   * {@code Trees.findAllRuleNodes(documentContext.getAst(), ruleIndex)}, если
+   * то же правило нужно нескольким независимым диагностикам.
+   *
+   * @param ruleIndex константа {@code BSLParser.RULE_*}
+   * @return неизменяемое представление коллекции узлов
+   */
+  public Collection<? extends ParseTree> getCachedRuleNodes(int ruleIndex) {
+    return ruleNodesCache.computeIfAbsent(
+      ruleIndex,
+      idx -> Collections.unmodifiableCollection(Trees.findAllRuleNodes(getAst(), idx))
+    );
+  }
+
   public List<Diagnostic> getDiagnostics() {
     return diagnostics.getOrCompute();
   }
@@ -304,11 +355,26 @@ public class DocumentContext implements Comparable<DocumentContext> {
         return;
       }
 
+      // Stage-cache: при идентичном контенте пропускаем перепарсинг и
+      // пересчёт SymbolTree, обновляем только версию и зависимые данные.
+      // Хэш + длина — быстрый предфильтр, equals — гарантия от коллизий
+      // (например, "Aa" и "BB" имеют одинаковый String.hashCode()).
+      long newHash = computeContentHash(content);
+      if (this.content != null
+        && tokenizer != null
+        && this.contentHashAndLength == newHash
+        && this.content.equals(content)) {
+        this.version = version;
+        clearDependantData();
+        return;
+      }
+
       if (!isComputedDataFrozen) {
         clearSecondaryData();
       }
 
       this.content = content;
+      this.contentHashAndLength = newHash;
       if (tokenizer != null) {
         tokenizer.rebuild(content);
       } else {
@@ -321,6 +387,14 @@ public class DocumentContext implements Comparable<DocumentContext> {
       releaseLocks();
     }
 
+  }
+
+  /**
+   * Лёгкий fingerprint содержимого: длина в высоких 32 битах + {@link String#hashCode()}
+   * в младших. Не криптостойкий — нужен только для определения «текст не менялся».
+   */
+  private static long computeContentHash(String content) {
+    return ((long) content.length() << 32) ^ (content.hashCode() & 0xFFFFFFFFL);
   }
 
   protected void rebuildFromFileSystem() {
@@ -338,9 +412,11 @@ public class DocumentContext implements Comparable<DocumentContext> {
     try {
 
       content = null;
+      contentHashAndLength = 0;
       contentList.clear();
       tokenizer = null;
       queries.clear();
+      ruleNodesCache.clear();
       clearDependantData();
 
       if (!isComputedDataFrozen) {
@@ -416,32 +492,53 @@ public class DocumentContext implements Comparable<DocumentContext> {
     var metricsTemp = new MetricStorage();
     final List<MethodSymbol> methodsUnboxed = symbolTree.getMethods();
 
-    metricsTemp.setFunctions(Math.toIntExact(methodsUnboxed.stream().filter(MethodSymbol::isFunction).count()));
-    metricsTemp.setProcedures(methodsUnboxed.size() - metricsTemp.getFunctions());
+    int functions = 0;
+    for (MethodSymbol m : methodsUnboxed) {
+      if (m.isFunction()) {
+        functions++;
+      }
+    }
+    metricsTemp.setFunctions(functions);
+    metricsTemp.setProcedures(methodsUnboxed.size() - functions);
 
-    int[] nclocData = getTokensFromDefaultChannel().stream()
-      .mapToInt(Token::getLine)
-      .distinct().toArray();
-    metricsTemp.setNclocData(nclocData);
-    metricsTemp.setNcloc(nclocData.length);
-
-    int lines;
+    // One-pass обход токенов: NCLOC, comments и lines считаются за один проход.
     final List<Token> tokensUnboxed = getTokens();
     if (tokensUnboxed.isEmpty()) {
-      lines = 0;
+      metricsTemp.setNclocData(new int[0]);
+      metricsTemp.setNcloc(0);
+      metricsTemp.setLines(0);
+      metricsTemp.setComments(0);
     } else {
-      lines = tokensUnboxed.getLast().getLine();
+      final java.util.BitSet nclocLines = new java.util.BitSet();
+      final java.util.BitSet commentLines = new java.util.BitSet();
+      int lastLine = 0;
+      for (Token token : tokensUnboxed) {
+        int line = token.getLine();
+        if (line > lastLine) {
+          lastLine = line;
+        }
+        int channel = token.getChannel();
+        int type = token.getType();
+        if (channel == DEFAULT_CHANNEL) {
+          nclocLines.set(line);
+        }
+        if (type == BSLLexer.LINE_COMMENT) {
+          commentLines.set(line);
+        }
+      }
+
+      int[] nclocData = new int[nclocLines.cardinality()];
+      int idx = 0;
+      for (int line = nclocLines.nextSetBit(0); line >= 0; line = nclocLines.nextSetBit(line + 1)) {
+        nclocData[idx++] = line;
+      }
+      metricsTemp.setNclocData(nclocData);
+      metricsTemp.setNcloc(nclocData.length);
+      metricsTemp.setLines(lastLine);
+      metricsTemp.setComments(commentLines.cardinality());
     }
-    metricsTemp.setLines(lines);
 
-    int comments = (int) getComments()
-      .stream()
-      .map(Token::getLine)
-      .distinct()
-      .count();
-    metricsTemp.setComments(comments);
-
-    int statements = Trees.findAllRuleNodes(getAst(), BSLParser.RULE_statement).size();
+    int statements = getCachedRuleNodes(BSLParser.RULE_statement).size();
     metricsTemp.setStatements(statements);
 
     metricsTemp.setCognitiveComplexity(getCognitiveComplexityData().fileComplexity());

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -66,6 +66,8 @@ import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.BitSet;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
@@ -95,6 +97,14 @@ import static org.antlr.v4.runtime.Token.DEFAULT_CHANNEL;
 public class DocumentContext implements Comparable<DocumentContext> {
 
   private static final Pattern CONTENT_SPLIT_PATTERN = Pattern.compile("\r?\n|\r");
+
+  /**
+   * Сдвиг для упаковки длины контента в старшие 32 бита fingerprint'а.
+   *
+   * @see #computeContentHash(String)
+   */
+  private static final int CONTENT_LENGTH_SHIFT = 32;
+  private static final long CONTENT_HASH_MASK = 0xFFFFFFFFL;
 
   @Getter
   @EqualsAndHashCode.Include
@@ -161,7 +171,7 @@ public class DocumentContext implements Comparable<DocumentContext> {
    *
    * @see #getCachedRuleNodes(int)
    */
-  private final Map<Integer, Collection<? extends ParseTree>> ruleNodesCache = new ConcurrentHashMap<>();
+  private final Map<Integer, Collection<ParseTree>> ruleNodesCache = new ConcurrentHashMap<>();
 
   public DocumentContext(URI uri) {
     this.uri = uri;
@@ -195,9 +205,15 @@ public class DocumentContext implements Comparable<DocumentContext> {
     return tokenizer.getTokens();
   }
 
+  /**
+   * Возвращает токены {@linkplain Token#DEFAULT_CHANNEL канала по умолчанию},
+   * то есть код без скрытых каналов (whitespace, комментарии).
+   *
+   * @return токены кода
+   */
   public List<Token> getTokensFromDefaultChannel() {
-    final List<Token> tokens = getTokens();
-    final List<Token> result = new java.util.ArrayList<>(tokens.size());
+    final var tokens = getTokens();
+    final var result = new ArrayList<Token>(tokens.size());
     for (Token token : tokens) {
       if (token.getChannel() == DEFAULT_CHANNEL) {
         result.add(token);
@@ -206,9 +222,14 @@ public class DocumentContext implements Comparable<DocumentContext> {
     return result;
   }
 
+  /**
+   * Возвращает токены однострочных комментариев документа.
+   *
+   * @return токены {@code //}-комментариев
+   */
   public List<Token> getComments() {
-    final List<Token> tokens = getTokens();
-    final List<Token> result = new java.util.ArrayList<>();
+    final var tokens = getTokens();
+    final var result = new ArrayList<Token>();
     for (Token token : tokens) {
       if (token.getType() == BSLLexer.LINE_COMMENT) {
         result.add(token);
@@ -318,7 +339,7 @@ public class DocumentContext implements Comparable<DocumentContext> {
    * @param ruleIndex константа {@code BSLParser.RULE_*}
    * @return неизменяемое представление коллекции узлов
    */
-  public Collection<? extends ParseTree> getCachedRuleNodes(int ruleIndex) {
+  public Collection<ParseTree> getCachedRuleNodes(int ruleIndex) {
     return ruleNodesCache.computeIfAbsent(
       ruleIndex,
       idx -> Collections.unmodifiableCollection(Trees.findAllRuleNodes(getAst(), idx))
@@ -343,12 +364,23 @@ public class DocumentContext implements Comparable<DocumentContext> {
     isComputedDataFrozen = false;
   }
 
+  /**
+   * Перестроить документ под новое содержимое.
+   * <p>
+   * Если новая версия совпадает с текущей или новый текст идентичен уже
+   * разобранному (по {@link #computeContentHash(String)} + {@link String#equals(Object)}) —
+   * перепарсинг и пересчёт {@link SymbolTree} пропускаются, обновляются только
+   * версия документа и зависимые данные.
+   *
+   * @param content новое содержимое документа
+   * @param version версия документа из протокола LSP
+   */
   protected void rebuild(String content, int version) {
     acquireLocks();
 
     try {
 
-      boolean versionMatches = version == this.version && version != 0;
+      var versionMatches = version == this.version && version != 0;
 
       if (versionMatches && (this.content != null)) {
         clearDependantData();
@@ -359,7 +391,7 @@ public class DocumentContext implements Comparable<DocumentContext> {
       // пересчёт SymbolTree, обновляем только версию и зависимые данные.
       // Хэш + длина — быстрый предфильтр, equals — гарантия от коллизий
       // (например, "Aa" и "BB" имеют одинаковый String.hashCode()).
-      long newHash = computeContentHash(content);
+      var newHash = computeContentHash(content);
       if (this.content != null
         && tokenizer != null
         && this.contentHashAndLength == newHash
@@ -394,9 +426,13 @@ public class DocumentContext implements Comparable<DocumentContext> {
    * в младших. Не криптостойкий — нужен только для определения «текст не менялся».
    */
   private static long computeContentHash(String content) {
-    return ((long) content.length() << 32) ^ (content.hashCode() & 0xFFFFFFFFL);
+    return ((long) content.length() << CONTENT_LENGTH_SHIFT) ^ (content.hashCode() & CONTENT_HASH_MASK);
   }
 
+  /**
+   * Перестроить документ, прочитав содержимое из файла на диске.
+   * Используется при первичной загрузке проекта (CLI {@code analyze}).
+   */
   protected void rebuildFromFileSystem() {
     try {
       var newContent = FileUtils.readFileToString(new File(uri), StandardCharsets.UTF_8);
@@ -406,6 +442,12 @@ public class DocumentContext implements Comparable<DocumentContext> {
     }
   }
 
+  /**
+   * Очистить производные данные документа (AST, токенайзер, кэши, метрики).
+   * <p>
+   * Если документ помечен {@link #freezeComputedData()} — данные о сложности,
+   * метриках и подавлении диагностик сохраняются.
+   */
   protected void clearSecondaryData() {
     acquireLocks();
 
@@ -488,11 +530,32 @@ public class DocumentContext implements Comparable<DocumentContext> {
     return cyclomaticComplexityComputer.compute();
   }
 
+  /**
+   * Собрать сводные метрики документа: число процедур/функций, NCLOC,
+   * комментариев, операторов и метрики сложности.
+   *
+   * @return заполненный {@link MetricStorage}
+   */
   private MetricStorage computeMetrics() {
     var metricsTemp = new MetricStorage();
-    final List<MethodSymbol> methodsUnboxed = symbolTree.getMethods();
 
-    int functions = 0;
+    fillMethodMetrics(metricsTemp);
+    fillTokenMetrics(metricsTemp);
+
+    metricsTemp.setStatements(getCachedRuleNodes(BSLParser.RULE_statement).size());
+    metricsTemp.setCognitiveComplexity(getCognitiveComplexityData().fileComplexity());
+    metricsTemp.setCyclomaticComplexity(getCyclomaticComplexityData().fileComplexity());
+
+    return metricsTemp;
+  }
+
+  /**
+   * Заполняет в {@code metricsTemp} число процедур и функций по символьному дереву.
+   */
+  private void fillMethodMetrics(MetricStorage metricsTemp) {
+    final var methodsUnboxed = symbolTree.getMethods();
+
+    var functions = 0;
     for (MethodSymbol m : methodsUnboxed) {
       if (m.isFunction()) {
         functions++;
@@ -500,51 +563,56 @@ public class DocumentContext implements Comparable<DocumentContext> {
     }
     metricsTemp.setFunctions(functions);
     metricsTemp.setProcedures(methodsUnboxed.size() - functions);
+  }
 
-    // One-pass обход токенов: NCLOC, comments и lines считаются за один проход.
-    final List<Token> tokensUnboxed = getTokens();
+  /**
+   * One-pass обход токенов: заполняет NCLOC, число комментариев и общее число
+   * строк в {@code metricsTemp} за один проход.
+   */
+  private void fillTokenMetrics(MetricStorage metricsTemp) {
+    final var tokensUnboxed = getTokens();
     if (tokensUnboxed.isEmpty()) {
       metricsTemp.setNclocData(new int[0]);
       metricsTemp.setNcloc(0);
       metricsTemp.setLines(0);
       metricsTemp.setComments(0);
-    } else {
-      final java.util.BitSet nclocLines = new java.util.BitSet();
-      final java.util.BitSet commentLines = new java.util.BitSet();
-      int lastLine = 0;
-      for (Token token : tokensUnboxed) {
-        int line = token.getLine();
-        if (line > lastLine) {
-          lastLine = line;
-        }
-        int channel = token.getChannel();
-        int type = token.getType();
-        if (channel == DEFAULT_CHANNEL) {
-          nclocLines.set(line);
-        }
-        if (type == BSLLexer.LINE_COMMENT) {
-          commentLines.set(line);
-        }
-      }
-
-      int[] nclocData = new int[nclocLines.cardinality()];
-      int idx = 0;
-      for (int line = nclocLines.nextSetBit(0); line >= 0; line = nclocLines.nextSetBit(line + 1)) {
-        nclocData[idx++] = line;
-      }
-      metricsTemp.setNclocData(nclocData);
-      metricsTemp.setNcloc(nclocData.length);
-      metricsTemp.setLines(lastLine);
-      metricsTemp.setComments(commentLines.cardinality());
+      return;
     }
 
-    int statements = getCachedRuleNodes(BSLParser.RULE_statement).size();
-    metricsTemp.setStatements(statements);
+    final var nclocLines = new BitSet();
+    final var commentLines = new BitSet();
+    var lastLine = 0;
+    for (Token token : tokensUnboxed) {
+      var line = token.getLine();
+      if (line > lastLine) {
+        lastLine = line;
+      }
+      if (token.getChannel() == DEFAULT_CHANNEL) {
+        nclocLines.set(line);
+      }
+      if (token.getType() == BSLLexer.LINE_COMMENT) {
+        commentLines.set(line);
+      }
+    }
 
-    metricsTemp.setCognitiveComplexity(getCognitiveComplexityData().fileComplexity());
-    metricsTemp.setCyclomaticComplexity(getCyclomaticComplexityData().fileComplexity());
+    metricsTemp.setNclocData(toLineArray(nclocLines));
+    metricsTemp.setNcloc(nclocLines.cardinality());
+    metricsTemp.setLines(lastLine);
+    metricsTemp.setComments(commentLines.cardinality());
+  }
 
-    return metricsTemp;
+  /**
+   * Преобразует {@link BitSet} с номерами строк в плотный {@code int[]} в
+   * возрастающем порядке.
+   */
+  private static int[] toLineArray(BitSet lines) {
+    var data = new int[lines.cardinality()];
+    var idx = 0;
+    for (var line = lines.nextSetBit(0); line >= 0; line = lines.nextSetBit(line + 1)) {
+      data[idx] = line;
+      idx++;
+    }
+    return data;
   }
 
   private DiagnosticIgnoranceComputer.Data computeDiagnosticIgnorance() {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -395,6 +395,15 @@ public class ServerContext {
     return documentContext;
   }
 
+  /**
+   * Загрузить метаданные конфигурации 1С из {@link #configurationRoot}.
+   * <p>
+   * Если уже выполняемся на потоке CPU-пула — чтение и разбор делаем на
+   * текущем потоке, чтобы избежать starvation/deadlock'а от
+   * {@code submit().get()} в тот же пул.
+   *
+   * @return разобранная конфигурация или пустая, если корень не задан
+   */
   private CF computeConfigurationMetadata() {
     if (configurationRoot == null) {
       return (CF) MDClasses.createConfiguration();
@@ -427,6 +436,12 @@ public class ServerContext {
     return configuration;
   }
 
+  /**
+   * Регистрирует документ в индексе по {@code mdoRef}.
+   * Внутренний {@link EnumMap} оборачивается в
+   * {@link Collections#synchronizedMap(Map)}, чтобы конкурентные {@code put}
+   * для разных типов модулей одного объекта были безопасны.
+   */
   private void addMdoRefByUri(URI uri, DocumentContext documentContext) {
     var mdoRef = documentContext.getMdoRef();
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -23,7 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.context;
 
 import com.github._1c_syntax.bsl.languageserver.WorkDoneProgressHelper;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
-import com.github._1c_syntax.bsl.languageserver.utils.NamedForkJoinWorkerThreadFactory;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.BslLsExecutors;
 import com.github._1c_syntax.bsl.languageserver.utils.Resources;
 import com.github._1c_syntax.bsl.mdclasses.CF;
 import com.github._1c_syntax.bsl.mdclasses.MDCReadSettings;
@@ -45,14 +45,12 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -74,16 +72,21 @@ public class ServerContext {
   private final ObjectProvider<DocumentContext> documentContextProvider;
   private final WorkDoneProgressHelper workDoneProgressHelper;
   private final LanguageServerConfiguration languageServerConfiguration;
+  private final BslLsExecutors bslLsExecutors;
 
-  private final Map<URI, DocumentContext> documents = Collections.synchronizedMap(new HashMap<>());
+  private final Map<URI, DocumentContext> documents = new ConcurrentHashMap<>();
   private final Lazy<CF> configurationMetadata = new Lazy<>(this::computeConfigurationMetadata);
   @Nullable
   @Setter
   @Getter
   private Path configurationRoot;
-  private final Map<URI, String> mdoRefs = Collections.synchronizedMap(new HashMap<>());
+  private final Map<URI, String> mdoRefs = new ConcurrentHashMap<>();
+  /**
+   * Внутренний EnumMap не потокобезопасен; создаётся обёрнутый в
+   * {@link Collections#synchronizedMap(Map)} (см. {@link #addMdoRefByUri(URI, DocumentContext)}).
+   */
   private final Map<String, Map<ModuleType, DocumentContext>> documentsByMDORef
-    = Collections.synchronizedMap(new HashMap<>());
+    = new ConcurrentHashMap<>();
   private final Map<URI, ReadWriteLock> documentLocks = new ConcurrentHashMap<>();
 
   private final Map<DocumentContext, State> states = new ConcurrentHashMap<>();
@@ -400,13 +403,16 @@ public class ServerContext {
     var progress = workDoneProgressHelper.createProgress(0, "");
     progress.beginProgress(getMessage("computeConfigurationMetadata"));
 
-    var factory = new NamedForkJoinWorkerThreadFactory("compute-configuration-");
-    var executorService = new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(), factory, null, true);
-
     CF configuration;
     try {
-      configuration = (CF) executorService.submit(
-        () -> MDClasses.createSolution(configurationRoot, SOLUTION_READ_SETTINGS)).get();
+      // Если уже выполняемся на потоке CPU-пула — считаем inline, иначе
+      // submit + get() в тот же пул может привести к starvation/deadlock.
+      if (bslLsExecutors.isInCpuPool()) {
+        configuration = (CF) MDClasses.createSolution(configurationRoot, SOLUTION_READ_SETTINGS);
+      } else {
+        configuration = (CF) bslLsExecutors.getCpuExecutor().submit(
+          () -> MDClasses.createSolution(configurationRoot, SOLUTION_READ_SETTINGS)).get();
+      }
     } catch (ExecutionException e) {
       LOGGER.error("Can't parse configuration metadata. Execution exception: {}", e.getMessage(), e);
       configuration = (CF) MDClasses.createConfiguration();
@@ -414,8 +420,6 @@ public class ServerContext {
       LOGGER.error("Can't parse configuration metadata. Interrupted exception: {}", e.getMessage(), e);
       configuration = (CF) MDClasses.createConfiguration();
       Thread.currentThread().interrupt();
-    } finally {
-      executorService.shutdown();
     }
 
     progress.endProgress(getMessage("computeConfigurationMetadataDone"));
@@ -429,7 +433,7 @@ public class ServerContext {
     mdoRefs.put(uri, mdoRef);
     documentsByMDORef.computeIfAbsent(
       mdoRef,
-      k -> new EnumMap<>(ModuleType.class)
+      k -> Collections.synchronizedMap(new EnumMap<>(ModuleType.class))
     ).put(documentContext.getModuleType(), documentContext);
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
@@ -32,8 +32,10 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
+import java.util.stream.Stream;
 
 /**
  * Вычислитель диагностик для документа.
@@ -51,6 +53,11 @@ public abstract class DiagnosticComputer {
 
   private BslLsExecutors executors;
 
+  /**
+   * Сеттер для Spring DI; вызывается фреймворком на этапе инициализации.
+   *
+   * @param executors общий holder исполнителей
+   */
   @Autowired
   void setExecutors(BslLsExecutors executors) {
     this.executors = executors;
@@ -69,22 +76,27 @@ public abstract class DiagnosticComputer {
 
     var pool = executors == null ? ForkJoinPool.commonPool() : executors.getCpuExecutor();
     return pool.invoke(ForkJoinTask.adapt(
-      (java.util.concurrent.Callable<List<Diagnostic>>) () -> internalCompute(documentContext)
+      (Callable<List<Diagnostic>>) () -> internalCompute(documentContext)
     ));
   }
 
+  /**
+   * Параллельно (или последовательно для маленьких наборов) прогоняет все
+   * диагностики и возвращает плоский список найденных, отфильтрованный по
+   * подавлению из {@link DiagnosticIgnoranceComputer}.
+   */
   private List<Diagnostic> internalCompute(DocumentContext documentContext) {
-    DiagnosticIgnoranceComputer.Data diagnosticIgnorance = documentContext.getDiagnosticIgnorance();
+    var diagnosticIgnorance = documentContext.getDiagnosticIgnorance();
 
-    List<BSLDiagnostic> diagnostics = diagnostics(documentContext);
+    var diagnostics = diagnostics(documentContext);
     if (diagnostics.isEmpty()) {
       return List.of();
     }
 
-    boolean parallel = diagnostics.size() >= PARALLEL_DIAGNOSTICS_THRESHOLD;
+    var parallel = diagnostics.size() >= PARALLEL_DIAGNOSTICS_THRESHOLD;
     var stream = parallel ? diagnostics.parallelStream() : diagnostics.stream();
 
-    List<Diagnostic> raw = stream
+    var raw = stream
       .flatMap((BSLDiagnostic diagnostic) -> {
         try {
           return diagnostic.getDiagnostics(documentContext).stream();
@@ -94,7 +106,7 @@ public abstract class DiagnosticComputer {
             diagnostic.getInfo().getCode()
           );
           LOGGER.error(message, e);
-          return java.util.stream.Stream.empty();
+          return Stream.empty();
         }
       })
       .toList();
@@ -103,7 +115,7 @@ public abstract class DiagnosticComputer {
       return List.of();
     }
 
-    List<Diagnostic> result = new ArrayList<>(raw.size());
+    var result = new ArrayList<Diagnostic>(raw.size());
     for (Diagnostic d : raw) {
       if (!diagnosticIgnorance.diagnosticShouldBeIgnored(d)) {
         result.add(d);
@@ -112,6 +124,14 @@ public abstract class DiagnosticComputer {
     return result;
   }
 
+  /**
+   * Список диагностик, применимых к данному документу. Реализация генерируется
+   * Spring через {@link Lookup} — выбираются включённые диагностики из бина
+   * {@code diagnostics} по конфигурации.
+   *
+   * @param documentContext документ, для которого подбираются диагностики
+   * @return список диагностических правил
+   */
   @Lookup("diagnostics")
   protected abstract List<BSLDiagnostic> diagnostics(DocumentContext documentContext);
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
@@ -23,42 +23,37 @@ package com.github._1c_syntax.bsl.languageserver.context.computer;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.BSLDiagnostic;
-import com.github._1c_syntax.bsl.languageserver.utils.NamedForkJoinWorkerThreadFactory;
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.BslLsExecutors;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.Diagnostic;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Lookup;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
+import java.util.concurrent.ForkJoinTask;
 
 /**
  * Вычислитель диагностик для документа.
  * <p>
- * Абстрактный класс, обеспечивающий параллельное вычисление диагностик
- * всеми зарегистрированными анализаторами с обработкой ошибок.
+ * Параллельно прогоняет все зарегистрированные диагностики на общем CPU-пуле из
+ * {@link BslLsExecutors}. Если вызов уже происходит из этого пула, работа
+ * выполняется на текущем потоке без дополнительного {@code submit/join}.
  */
 @Component
 @Slf4j
 public abstract class DiagnosticComputer {
 
-  private ExecutorService executorService;
+  /** Минимальное число диагностик, при котором уход в parallel stream окупается. */
+  private static final int PARALLEL_DIAGNOSTICS_THRESHOLD = 8;
 
-  @PostConstruct
-  private void init() {
-    var factory = new NamedForkJoinWorkerThreadFactory("diagnostic-computer-");
-    executorService = new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(), factory, null, true);
-  }
+  private BslLsExecutors executors;
 
-  @PreDestroy
-  private void onDestroy() {
-    executorService.shutdown();
+  @Autowired
+  void setExecutors(BslLsExecutors executors) {
+    this.executors = executors;
   }
 
   /**
@@ -68,15 +63,28 @@ public abstract class DiagnosticComputer {
    * @return Список найденных диагностик
    */
   public List<Diagnostic> compute(DocumentContext documentContext) {
-    return CompletableFuture
-      .supplyAsync(() -> internalCompute(documentContext), executorService)
-      .join();
+    if (executors != null && executors.isInCpuPool()) {
+      return internalCompute(documentContext);
+    }
+
+    var pool = executors == null ? ForkJoinPool.commonPool() : executors.getCpuExecutor();
+    return pool.invoke(ForkJoinTask.adapt(
+      (java.util.concurrent.Callable<List<Diagnostic>>) () -> internalCompute(documentContext)
+    ));
   }
 
   private List<Diagnostic> internalCompute(DocumentContext documentContext) {
     DiagnosticIgnoranceComputer.Data diagnosticIgnorance = documentContext.getDiagnosticIgnorance();
 
-    return diagnostics(documentContext).parallelStream()
+    List<BSLDiagnostic> diagnostics = diagnostics(documentContext);
+    if (diagnostics.isEmpty()) {
+      return List.of();
+    }
+
+    boolean parallel = diagnostics.size() >= PARALLEL_DIAGNOSTICS_THRESHOLD;
+    var stream = parallel ? diagnostics.parallelStream() : diagnostics.stream();
+
+    List<Diagnostic> raw = stream
       .flatMap((BSLDiagnostic diagnostic) -> {
         try {
           return diagnostic.getDiagnostics(documentContext).stream();
@@ -86,13 +94,22 @@ public abstract class DiagnosticComputer {
             diagnostic.getInfo().getCode()
           );
           LOGGER.error(message, e);
-
-          return Stream.empty();
+          return java.util.stream.Stream.empty();
         }
       })
-      .filter(Predicate.not(diagnosticIgnorance::diagnosticShouldBeIgnored))
       .toList();
 
+    if (raw.isEmpty()) {
+      return List.of();
+    }
+
+    List<Diagnostic> result = new ArrayList<>(raw.size());
+    for (Diagnostic d : raw) {
+      if (!diagnosticIgnorance.diagnosticShouldBeIgnored(d)) {
+        result.add(d);
+      }
+    }
+    return result;
   }
 
   @Lookup("diagnostics")

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/LatinAndCyrillicSymbolInWordDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/LatinAndCyrillicSymbolInWordDiagnostic.java
@@ -27,7 +27,6 @@ import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticS
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticTag;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticType;
 import com.github._1c_syntax.bsl.languageserver.utils.DiagnosticHelper;
-import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
 import com.github._1c_syntax.utils.CaseInsensitivePattern;
 import org.antlr.v4.runtime.tree.ParseTree;
@@ -126,24 +125,25 @@ public class LatinAndCyrillicSymbolInWordDiagnostic extends AbstractDiagnostic {
   }
 
   private void check(int ruleID) {
-    checkTree(Trees.findAllRuleNodes(documentContext.getAst(), ruleID).stream());
+    checkTree(documentContext.getCachedRuleNodes(ruleID).stream().map(ParseTree.class::cast));
   }
 
   private void checkLValue() {
-    checkTree(Trees.findAllRuleNodes(documentContext.getAst(), BSLParser.RULE_lValue).stream()
+    checkTree(documentContext.getCachedRuleNodes(BSLParser.RULE_lValue).stream()
       .filter(ctx -> ((BSLParser.LValueContext) ctx).IDENTIFIER() != null)
       .map(ctx -> ((BSLParser.LValueContext) ctx).IDENTIFIER()));
   }
 
   private void checkParameters() {
-    checkTree(Trees.findAllRuleNodes(documentContext.getAst(), BSLParser.RULE_param).stream()
+    checkTree(documentContext.getCachedRuleNodes(BSLParser.RULE_param).stream()
       .filter(ctx -> ((BSLParser.ParamContext) ctx).IDENTIFIER() != null)
       .map(ctx -> ((BSLParser.ParamContext) ctx).IDENTIFIER()));
   }
 
   private void checkLabel() {
-    checkTree(Trees.findAllRuleNodes(documentContext.getAst(), BSLParser.RULE_labelName).stream()
-      .filter(ctx -> ctx.getParent() instanceof BSLParser.GotoStatementContext));
+    checkTree(documentContext.getCachedRuleNodes(BSLParser.RULE_labelName).stream()
+      .filter(ctx -> ctx.getParent() instanceof BSLParser.GotoStatementContext)
+      .map(ParseTree.class::cast));
   }
 
   private void checkTree(Stream<ParseTree> tree) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TransferringParametersBetweenClientAndServerDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TransferringParametersBetweenClientAndServerDiagnostic.java
@@ -155,7 +155,7 @@ public class TransferringParametersBetweenClientAndServerDiagnostic extends Abst
   }
 
   private boolean hasClientModuleVariable(String variableName) {
-    return Trees.findAllRuleNodes(documentContext.getAst(), BSLParser.RULE_moduleVar).stream()
+    return documentContext.getCachedRuleNodes(BSLParser.RULE_moduleVar).stream()
       .filter(BSLParser.ModuleVarContext.class::isInstance)
       .map(BSLParser.ModuleVarContext.class::cast)
       .filter(ctx -> hasVariableWithName(ctx, variableName))

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/BslLsExecutors.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/BslLsExecutors.java
@@ -1,0 +1,122 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.infrastructure;
+
+import com.github._1c_syntax.bsl.languageserver.utils.NamedForkJoinWorkerThreadFactory;
+import jakarta.annotation.PreDestroy;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Role;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Общие исполнители для LSP/CLI пайплайна.
+ * <p>
+ * Содержит два общих пула, переиспользуемых всеми компонентами:
+ * <ul>
+ *   <li>{@link #getCpuExecutor()} — CPU-bound задачи (диагностики, обходы AST,
+ *       семантические токены). Размер ≈ числу ядер.</li>
+ *   <li>{@link #getLspExecutor()} — обработка запросов LSP. Ограничен по числу
+ *       потоков.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+public class BslLsExecutors {
+
+  /**
+   * Верхняя граница очереди ожидающих LSP-задач. При переполнении применяется
+   * {@link ThreadPoolExecutor.CallerRunsPolicy} — задача выполняется на потоке
+   * вызывающего, что естественным образом создаёт backpressure и не даёт
+   * памяти расти бесконтрольно при всплесках запросов.
+   */
+  private static final int LSP_QUEUE_CAPACITY = 1024;
+
+  /**
+   * CPU-bound пул для параллельных вычислений анализа.
+   *
+   * @return общий CPU-пул
+   */
+  @Getter
+  private final ForkJoinPool cpuExecutor;
+
+  /**
+   * Ограниченный по числу потоков пул для обработки запросов LSP.
+   *
+   * @return пул LSP-запросов
+   */
+  @Getter
+  private final ExecutorService lspExecutor;
+
+  public BslLsExecutors() {
+    int cores = Math.max(2, Runtime.getRuntime().availableProcessors());
+
+    this.cpuExecutor = new ForkJoinPool(
+      cores,
+      new NamedForkJoinWorkerThreadFactory("bsl-cpu-"),
+      null,
+      true
+    );
+
+    int lspThreads = Math.max(4, cores);
+    this.lspExecutor = new ThreadPoolExecutor(
+      lspThreads,
+      lspThreads,
+      60L,
+      TimeUnit.SECONDS,
+      new LinkedBlockingQueue<>(LSP_QUEUE_CAPACITY),
+      new CustomizableThreadFactory("bsl-lsp-"),
+      new ThreadPoolExecutor.CallerRunsPolicy()
+    );
+    ((ThreadPoolExecutor) this.lspExecutor).allowCoreThreadTimeOut(true);
+
+    LOGGER.debug("BslLsExecutors initialized: cpu={} lsp={}", cores, lspThreads);
+  }
+
+  /**
+   * Проверка, что текущий поток принадлежит CPU-пулу.
+   * <p>
+   * Позволяет вложенным вызовам выполнять работу прямо на текущем потоке без
+   * дополнительного {@code submit/join}.
+   *
+   * @return {@code true}, если поток входит в CPU-пул
+   */
+  public boolean isInCpuPool() {
+    Thread t = Thread.currentThread();
+    return t instanceof java.util.concurrent.ForkJoinWorkerThread fj && fj.getPool() == cpuExecutor;
+  }
+
+  @PreDestroy
+  void shutdown() {
+    cpuExecutor.shutdown();
+    lspExecutor.shutdown();
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/BslLsExecutors.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/BslLsExecutors.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
 import java.util.concurrent.LinkedBlockingQueue;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
@@ -60,6 +61,15 @@ public class BslLsExecutors {
    */
   private static final int LSP_QUEUE_CAPACITY = 1024;
 
+  /** Минимальное число потоков CPU-пула (даже на одноядерных системах). */
+  private static final int MIN_CPU_THREADS = 2;
+
+  /** Минимальное число потоков пула LSP-запросов. */
+  private static final int MIN_LSP_THREADS = 4;
+
+  /** Время простоя потоков пула до выгрузки. */
+  private static final long IDLE_KEEP_ALIVE_SECONDS = 60L;
+
   /**
    * CPU-bound пул для параллельных вычислений анализа.
    *
@@ -77,7 +87,7 @@ public class BslLsExecutors {
   private final ExecutorService lspExecutor;
 
   public BslLsExecutors() {
-    int cores = Math.max(2, Runtime.getRuntime().availableProcessors());
+    var cores = Math.max(MIN_CPU_THREADS, Runtime.getRuntime().availableProcessors());
 
     this.cpuExecutor = new ForkJoinPool(
       cores,
@@ -86,17 +96,18 @@ public class BslLsExecutors {
       true
     );
 
-    int lspThreads = Math.max(4, cores);
-    this.lspExecutor = new ThreadPoolExecutor(
+    var lspThreads = Math.max(MIN_LSP_THREADS, cores);
+    var pool = new ThreadPoolExecutor(
       lspThreads,
       lspThreads,
-      60L,
+      IDLE_KEEP_ALIVE_SECONDS,
       TimeUnit.SECONDS,
       new LinkedBlockingQueue<>(LSP_QUEUE_CAPACITY),
       new CustomizableThreadFactory("bsl-lsp-"),
       new ThreadPoolExecutor.CallerRunsPolicy()
     );
-    ((ThreadPoolExecutor) this.lspExecutor).allowCoreThreadTimeOut(true);
+    pool.allowCoreThreadTimeOut(true);
+    this.lspExecutor = pool;
 
     LOGGER.debug("BslLsExecutors initialized: cpu={} lsp={}", cores, lspThreads);
   }
@@ -110,10 +121,14 @@ public class BslLsExecutors {
    * @return {@code true}, если поток входит в CPU-пул
    */
   public boolean isInCpuPool() {
-    Thread t = Thread.currentThread();
-    return t instanceof java.util.concurrent.ForkJoinWorkerThread fj && fj.getPool() == cpuExecutor;
+    return Thread.currentThread() instanceof ForkJoinWorkerThread fj
+      && fj.getPool() == cpuExecutor;
   }
 
+  /**
+   * Корректное завершение пулов при остановке Spring-контекста.
+   * Вызывается фреймворком через {@link PreDestroy}.
+   */
   @PreDestroy
   void shutdown() {
     cpuExecutor.shutdown();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
@@ -49,9 +49,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinTask;
+import java.util.function.Supplier;
 
 /**
  * Провайдер для предоставления семантических токенов.
@@ -413,7 +415,7 @@ public class SemanticTokensProvider {
       return List.of();
     }
 
-    java.util.function.Supplier<List<SemanticTokenEntry>> task = () -> {
+    Supplier<List<SemanticTokenEntry>> task = () -> {
       var stream = suppliers.size() >= PARALLEL_SUPPLIERS_THRESHOLD
         ? suppliers.parallelStream()
         : suppliers.stream();
@@ -429,7 +431,7 @@ public class SemanticTokensProvider {
 
     var pool = executors == null ? ForkJoinPool.commonPool() : executors.getCpuExecutor();
     return pool.invoke(ForkJoinTask.adapt(
-      (java.util.concurrent.Callable<List<SemanticTokenEntry>>) task::get
+      (Callable<List<SemanticTokenEntry>>) task::get
     ));
   }
 
@@ -475,8 +477,8 @@ public class SemanticTokensProvider {
     if (array.length == 0) {
       return List.of();
     }
-    Integer[] boxed = new Integer[array.length];
-    for (int i = 0; i < array.length; i++) {
+    var boxed = new Integer[array.length];
+    for (var i = 0; i < array.length; i++) {
       boxed[i] = array[i];
     }
     return Arrays.asList(boxed);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
@@ -24,11 +24,9 @@ package com.github._1c_syntax.bsl.languageserver.providers;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.BslLsExecutors;
 import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokenEntry;
 import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensSupplier;
-import com.github._1c_syntax.bsl.languageserver.utils.NamedForkJoinWorkerThreadFactory;
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokens;
@@ -51,10 +49,9 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
 
 /**
  * Провайдер для предоставления семантических токенов.
@@ -73,27 +70,19 @@ public class SemanticTokensProvider {
    */
   private static final int PARALLEL_PROCESSING_THRESHOLD = 1000;
 
-  @SuppressWarnings("NullAway.Init")
-  private ExecutorService executorService;
+  /**
+   * Минимальное число поставщиков, при котором имеет смысл идти в parallel stream.
+   */
+  private static final int PARALLEL_SUPPLIERS_THRESHOLD = 4;
 
   private final List<SemanticTokensSupplier> suppliers;
+  private final BslLsExecutors executors;
 
   /**
    * Cache for storing previous token data by resultId.
    * Key: resultId, Value: token data list
    */
   private final Map<String, CachedTokenData> tokenCache = new ConcurrentHashMap<>();
-
-  @PostConstruct
-  private void init() {
-    var factory = new NamedForkJoinWorkerThreadFactory("semantic-tokens-");
-    executorService = new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(), factory, null, true);
-  }
-
-  @PreDestroy
-  private void onDestroy() {
-    executorService.shutdown();
-  }
 
   /**
    * Cached semantic token data associated with a document.
@@ -115,13 +104,9 @@ public class SemanticTokensProvider {
     DocumentContext documentContext,
     @SuppressWarnings("unused") SemanticTokensParams params
   ) {
-    // Collect tokens from all suppliers in parallel
     var entries = collectTokens(documentContext);
-
-    // Build delta-encoded data as int array
     int[] data = toDeltaEncodedArray(entries);
 
-    // Generate a unique resultId and cache the data
     String resultId = generateResultId();
     cacheTokenData(resultId, documentContext.getUri(), data);
 
@@ -142,28 +127,19 @@ public class SemanticTokensProvider {
     String previousResultId = params.getPreviousResultId();
     CachedTokenData previousData = tokenCache.get(previousResultId);
 
-    // Collect tokens from all suppliers in parallel
     var entries = collectTokens(documentContext);
-
-    // Build delta-encoded data as int array
     int[] currentData = toDeltaEncodedArray(entries);
 
-    // Generate new resultId
     String resultId = generateResultId();
 
-    // If previous data is not available or belongs to a different document, return full tokens
     if (previousData == null || !previousData.uri().equals(documentContext.getUri())) {
       cacheTokenData(resultId, documentContext.getUri(), currentData);
       return Either.forLeft(new SemanticTokens(resultId, toList(currentData)));
     }
 
-    // Compute delta edits
     List<SemanticTokensEdit> edits = computeEdits(previousData.data(), currentData);
 
-    // Cache the new data
     cacheTokenData(resultId, documentContext.getUri(), currentData);
-
-    // Remove the old cached data
     tokenCache.remove(previousResultId);
 
     var delta = new SemanticTokensDelta();
@@ -185,16 +161,10 @@ public class SemanticTokensProvider {
   ) {
     Range range = params.getRange();
 
-    // Collect tokens from all suppliers in parallel
     var entries = collectTokens(documentContext);
-
-    // Filter tokens that fall within the specified range
     var filteredEntries = filterTokensByRange(entries, range);
-
-    // Build delta-encoded data as int array
     int[] data = toDeltaEncodedArray(filteredEntries);
 
-    // Range requests do not use resultId caching as per LSP specification
     return new SemanticTokens(toList(data));
   }
 
@@ -217,15 +187,12 @@ public class SemanticTokensProvider {
     int endLine = range.getEnd().getLine();
     int endChar = range.getEnd().getCharacter();
 
-    // Use parallel stream for large collections to leverage multiple cores
     var stream = entries.size() > PARALLEL_PROCESSING_THRESHOLD
       ? entries.parallelStream()
       : entries.stream();
 
     return stream
-      // Quick line-based pre-filter (simple integer comparison)
       .filter(token -> token.line() >= startLine && token.line() <= endLine)
-      // Detailed check for boundary lines only
       .filter(token -> isTokenInRangeDetailed(token, startLine, startChar, endLine, endChar))
       .toList();
   }
@@ -246,12 +213,10 @@ public class SemanticTokensProvider {
     int tokenStart = token.start();
     int tokenEnd = tokenStart + token.length();
 
-    // Token is on the start line - check if it ends after range start
     if (tokenLine == startLine && tokenEnd <= startChar) {
       return false;
     }
 
-    // Token is on the end line - check if it starts before range end
     return tokenLine != endLine || tokenStart < endChar;
   }
 
@@ -288,16 +253,10 @@ public class SemanticTokensProvider {
     tokenCache.entrySet().removeIf(entry -> entry.getValue().uri().equals(uri));
   }
 
-  /**
-   * Generate a unique result ID for caching.
-   */
   private static String generateResultId() {
     return UUID.randomUUID().toString();
   }
 
-  /**
-   * Cache token data with the given resultId.
-   */
   private void cacheTokenData(String resultId, URI uri, int[] data) {
     tokenCache.put(resultId, new CachedTokenData(uri, data));
   }
@@ -318,7 +277,6 @@ public class SemanticTokensProvider {
       return List.of();
     }
 
-    // Находим первый отличающийся токен и одновременно вычисляем сумму deltaLine для prefix
     int firstDiffToken = 0;
     int prefixAbsLine = 0;
     int minTokens = Math.min(prevTokenCount, currTokenCount);
@@ -332,16 +290,14 @@ public class SemanticTokensProvider {
           break outer;
         }
       }
-      prefixAbsLine += prev[base]; // накапливаем deltaLine
+      prefixAbsLine += prev[base];
       firstDiffToken = i + 1;
     }
 
-    // Если все токены одинаковые
     if (firstDiffToken == minTokens && prevTokenCount == currTokenCount) {
       return List.of();
     }
 
-    // Вычисляем смещение строк инкрементально от prefixAbsLine
     int prevSuffixAbsLine = prefixAbsLine;
     for (int i = firstDiffToken; i < prevTokenCount; i++) {
       prevSuffixAbsLine += prev[i * TOKEN_SIZE];
@@ -352,10 +308,8 @@ public class SemanticTokensProvider {
     }
     int lineOffset = currSuffixAbsLine - prevSuffixAbsLine;
 
-    // Находим последний отличающийся токен с учётом смещения строк
     int suffixMatchTokens = findSuffixMatchWithOffset(prev, curr, firstDiffToken, lineOffset, TOKEN_SIZE);
 
-    // Вычисляем границы редактирования
     int deleteEndToken = prevTokenCount - suffixMatchTokens;
     int insertEndToken = currTokenCount - suffixMatchTokens;
 
@@ -367,7 +321,6 @@ public class SemanticTokensProvider {
       return List.of();
     }
 
-    // Создаём список для вставки из среза массива
     List<Integer> insertData = toList(Arrays.copyOfRange(curr, deleteStart, insertEnd));
 
     var edit = new SemanticTokensEdit();
@@ -399,7 +352,7 @@ public class SemanticTokensProvider {
                                                int tokenSize) {
     final int DELTA_LINE_INDEX = 0;
     final int DELTA_START_INDEX = 1;
-    
+
     int prevTokenCount = prev.length / tokenSize;
     int currTokenCount = curr.length / tokenSize;
 
@@ -414,11 +367,8 @@ public class SemanticTokensProvider {
       int prevIdx = (prevTokenCount - 1 - i) * tokenSize;
       int currIdx = (currTokenCount - 1 - i) * tokenSize;
 
-      // Для граничного токена при inline-редактировании (lineOffset == 0)
-      // разрешаем различие в deltaStart
       int firstFieldToCheck = (!foundBoundary && lineOffset == 0) ? DELTA_START_INDEX + 1 : DELTA_START_INDEX;
-      
-      // Проверяем поля кроме deltaLine (и возможно deltaStart для граничного токена)
+
       boolean otherFieldsMatch = true;
       for (int j = firstFieldToCheck; j < tokenSize; j++) {
         if (prev[prevIdx + j] != curr[currIdx + j]) {
@@ -431,34 +381,22 @@ public class SemanticTokensProvider {
         break;
       }
 
-      // Теперь проверяем deltaLine
       int prevDeltaLine = prev[prevIdx + DELTA_LINE_INDEX];
       int currDeltaLine = curr[currIdx + DELTA_LINE_INDEX];
 
       if (prevDeltaLine == currDeltaLine) {
-        // Если это потенциальный граничный токен при inline-редактировании, проверяем deltaStart
         if (!foundBoundary && lineOffset == 0) {
           int prevDeltaStart = prev[prevIdx + DELTA_START_INDEX];
           int currDeltaStart = curr[currIdx + DELTA_START_INDEX];
           if (prevDeltaStart != currDeltaStart) {
-            // Граничный токен при inline-редактировании.
-            // НЕ включаем его в suffix match, чтобы он попал в edit и клиент получил
-            // обновлённое значение deltaStart. Аналогично обработке граничного токена
-            // при lineOffset != 0.
             foundBoundary = true;
             continue;
           }
         }
-        // Полное совпадение
         suffixMatch++;
       } else if (!foundBoundary && currDeltaLine - prevDeltaLine == lineOffset) {
-        // Граничный токен при вставке/удалении строк.
-        // НЕ включаем его в suffix match, чтобы он попал в edit и клиент получил
-        // обновлённое значение deltaLine. Это критично для случая, когда добавляются
-        // только пустые строки без нового кода.
         foundBoundary = true;
       } else {
-        // Не совпадает
         break;
       }
     }
@@ -467,29 +405,44 @@ public class SemanticTokensProvider {
   }
 
   /**
-   * Collect tokens from all suppliers in parallel using ForkJoinPool.
+   * Собирает токены со всех поставщиков на общем CPU-пуле из {@link BslLsExecutors}.
+   * Распараллеливается только когда поставщиков достаточно много.
    */
   private List<SemanticTokenEntry> collectTokens(DocumentContext documentContext) {
-    return CompletableFuture
-      .supplyAsync(
-        () -> suppliers.parallelStream()
-          .map(supplier -> supplier.getSemanticTokens(documentContext))
-          .flatMap(Collection::stream)
-          .toList(),
-        executorService
-      )
-      .join();
+    if (suppliers.isEmpty()) {
+      return List.of();
+    }
+
+    java.util.function.Supplier<List<SemanticTokenEntry>> task = () -> {
+      var stream = suppliers.size() >= PARALLEL_SUPPLIERS_THRESHOLD
+        ? suppliers.parallelStream()
+        : suppliers.stream();
+      return stream
+        .map(supplier -> supplier.getSemanticTokens(documentContext))
+        .flatMap(Collection::stream)
+        .toList();
+    };
+
+    if (executors != null && executors.isInCpuPool()) {
+      return task.get();
+    }
+
+    var pool = executors == null ? ForkJoinPool.commonPool() : executors.getCpuExecutor();
+    return pool.invoke(ForkJoinTask.adapt(
+      (java.util.concurrent.Callable<List<SemanticTokenEntry>>) task::get
+    ));
   }
 
   private static int[] toDeltaEncodedArray(List<SemanticTokenEntry> entries) {
-    // de-dup and sort
+    if (entries.isEmpty()) {
+      return new int[0];
+    }
     Set<SemanticTokenEntry> uniq = new HashSet<>(entries);
     List<SemanticTokenEntry> sorted = new ArrayList<>(uniq);
     sorted.sort(Comparator
       .comparingInt(SemanticTokenEntry::line)
       .thenComparingInt(SemanticTokenEntry::start));
 
-    // Use int[] to avoid boxing overhead during computation
     int[] data = new int[sorted.size() * 5];
     var prevLine = 0;
     var prevChar = 0;
@@ -515,7 +468,17 @@ public class SemanticTokensProvider {
     return data;
   }
 
+  /**
+   * Преобразует {@code int[]} в {@code List<Integer>}, обязательный для LSP4J.
+   */
   private static List<Integer> toList(int[] array) {
-    return Arrays.stream(array).boxed().toList();
+    if (array.length == 0) {
+      return List.of();
+    }
+    Integer[] boxed = new Integer[array.length];
+    for (int i = 0; i < array.length; i++) {
+      boxed[i] = array[i];
+    }
+    return Arrays.asList(boxed);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/SymbolOccurrenceRepository.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/SymbolOccurrenceRepository.java
@@ -26,7 +26,7 @@ import org.springframework.stereotype.Component;
 import java.util.Collections;
 import java.util.Map;
 import java.util.Set;
-import java.util.concurrent.ConcurrentSkipListMap;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
@@ -37,8 +37,12 @@ public class SymbolOccurrenceRepository {
 
   /**
    * Список обращений к символам в разрезе символов.
+   * <p>
+   * Внешний {@link ConcurrentHashMap} даёт O(1) на доступ по символу.
+   * Внутренний {@link ConcurrentSkipListSet} сохраняет упорядоченность по
+   * позиции — диагностики, читающие ссылки в порядке появления, опираются на это.
    */
-  private final Map<Symbol, Set<SymbolOccurrence>> occurrencesToSymbols = new ConcurrentSkipListMap<>();
+  private final Map<Symbol, Set<SymbolOccurrence>> occurrencesToSymbols = new ConcurrentHashMap<>();
 
   /**
    * Сохранить обращение к символу в хранилище.

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
@@ -45,41 +45,53 @@
  */
 package com.github._1c_syntax.bsl.languageserver.utils;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Generic object pool.
+ * Lock-free пул объектов.
  *
  * @param <T> Type T of Object in the Pool
  */
 public abstract class AbstractObjectPool<T> {
 
-  private final Set<T> available = new HashSet<>();
-  private final Set<T> inUse = new HashSet<>();
+  private final ConcurrentLinkedDeque<T> available = new ConcurrentLinkedDeque<>();
+  private final AtomicInteger inUse = new AtomicInteger(0);
 
   protected abstract T create();
 
   /**
-   * Checkout object from pool.
+   * Получить экземпляр из пула; при отсутствии свободного — создать новый.
+   *
+   * @return экземпляр пула
    */
-  public synchronized T checkOut() {
-    if (available.isEmpty()) {
-      available.add(create());
+  public T checkOut() {
+    T instance = available.pollFirst();
+    if (instance == null) {
+      instance = create();
     }
-    T instance = available.iterator().next();
-    available.remove(instance);
-    inUse.add(instance);
+    inUse.incrementAndGet();
     return instance;
   }
 
-  public synchronized void checkIn(T instance) {
-    inUse.remove(instance);
-    available.add(instance);
+  /**
+   * Вернуть экземпляр в пул.
+   * <p>
+   * {@code null} игнорируется — это снимает риск NPE из {@code finally}-веток
+   * вызывающего кода, где экземпляр мог не быть выдан.
+   *
+   * @param instance возвращаемый экземпляр
+   */
+  public void checkIn(T instance) {
+    if (instance == null) {
+      return;
+    }
+    available.offerLast(instance);
+    inUse.decrementAndGet();
   }
 
   @Override
-  public synchronized String toString() {
-    return "Pool available=%d inUse=%d".formatted(available.size(), inUse.size());
+  public String toString() {
+    return "Pool available=%d inUse=%d".formatted(available.size(), inUse.get());
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
@@ -58,6 +58,11 @@ public abstract class AbstractObjectPool<T> {
   private final ConcurrentLinkedDeque<T> available = new ConcurrentLinkedDeque<>();
   private final AtomicInteger inUse = new AtomicInteger(0);
 
+  /**
+   * Создать новый экземпляр объекта пула, когда свободных нет.
+   *
+   * @return созданный экземпляр
+   */
   protected abstract T create();
 
   /**
@@ -66,7 +71,7 @@ public abstract class AbstractObjectPool<T> {
    * @return экземпляр пула
    */
   public T checkOut() {
-    T instance = available.pollFirst();
+    var instance = available.pollFirst();
     if (instance == null) {
       instance = create();
     }
@@ -76,22 +81,16 @@ public abstract class AbstractObjectPool<T> {
 
   /**
    * Вернуть экземпляр в пул.
-   * <p>
-   * {@code null} игнорируется — это снимает риск NPE из {@code finally}-веток
-   * вызывающего кода, где экземпляр мог не быть выдан.
    *
    * @param instance возвращаемый экземпляр
    */
   public void checkIn(T instance) {
-    if (instance == null) {
-      return;
-    }
     available.offerLast(instance);
     inUse.decrementAndGet();
   }
 
   @Override
   public String toString() {
-    return "Pool available=%d inUse=%d".formatted(available.size(), inUse.get());
+    return "Pool inUse=%d".formatted(inUse.get());
   }
 }


### PR DESCRIPTION
## Описание

Набор оптимизаций горячего пути `analyze` и LSP-запросов: общая модель пулов,
инкрементальный пропуск перепарсинга, кэш узлов AST по правилу и пара
точечных правок hot-path и lock-contention.

**Конкуррентность.** Введён общий `BslLsExecutors` с двумя пулами:
- `cpuExecutor` — CPU-bound (диагностики, обходы AST, семантические токены);
- `lspExecutor` — обработка запросов LSP, ограниченный по числу потоков.

Удалены отдельные `ForkJoinPool` в `DiagnosticComputer`, `SemanticTokensProvider`,
`ServerContext.computeConfigurationMetadata`. Удалён `Executors.newCachedThreadPool`
в `BSLTextDocumentService` — заменён на общий `lspExecutor`. В `DiagnosticComputer`
и `SemanticTokensProvider` убран лишний `submit/join`, если вызов уже идёт из
CPU-пула.

**Stage-cache в `DocumentContext`.** Добавлен fingerprint содержимого (длина +
`hashCode`). При `rebuild` с идентичным контентом пропускаются перепарсинг и
пересчёт `SymbolTree`, обновляются только версия документа и зависимые от неё
данные.

**Кэш узлов AST по правилу.** В `DocumentContext` добавлен метод
`getCachedRuleNodes(int)` — кэш `Map<Integer, Collection<? extends ParseTree>>`,
инвалидируемый вместе с tokenizer/AST. Использован в:
- `LatinAndCyrillicSymbolInWordDiagnostic` (7 правил — один обход AST на правило);
- `TransferringParametersBetweenClientAndServerDiagnostic`.

`computeMetrics` переписан на однопроходный обход токенов через `BitSet` —
вместо трёх отдельных `Stream.distinct()`-проходов для NCLOC, комментариев и
общего числа строк. `getTokensFromDefaultChannel` и `getComments` переведены
со stream на прямой цикл.

**Lock contention.** В `AbstractObjectPool` снят глобальный `synchronized`,
реализация переписана на `ConcurrentLinkedDeque` + `AtomicInteger` — это
снимает точку контеншна в пуле `JLanguageTool` при параллельном `TypoDiagnostic`.
В `ServerContext` три горячие карты (`documents`, `mdoRefs`, `documentsByMDORef`)
переведены с `Collections.synchronizedMap(new HashMap<>())` на `ConcurrentHashMap`;
внутренний `EnumMap` обёрнут в `synchronizedMap` для корректных конкурентных
`put` разных типов модулей одного объекта. В `SymbolOccurrenceRepository`
внешний `ConcurrentSkipListMap` заменён на `ConcurrentHashMap` (наружу хранилище
выдаёт точные выборки по символу, упорядоченность skip-list'а не использовалась).

**Hot-path аллокации.** В `SemanticTokensProvider` убран промежуточный
`Arrays.stream(int[]).boxed().toList()` в пользу заполнения `Integer[]` напрямую.
Добавлен порог `PARALLEL_SUPPLIERS_THRESHOLD` для агрегации поставщиков.

## Связанные задачи

Closes #нет

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [x] Не применимо: новых диагностик не добавлено

## Дополнительно

Замер на SSL 3.1 (2162 `.bsl` файла, JDK 21, Windows, `-Xmx4g`):

| Метрика   | До     | После  | Разница    |
|-----------|--------|--------|------------|
| Wall time | 88,8 с | 43,2 с | в 2,06 раз |

Замер выполнен через `Measure-Command` PowerShell с одинаковыми параметрами
запуска (`analyze -s ssl/src/cf -r json -o reports -q`) и одинаковым
`-Xmx4g` для обоих прогонов.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance Improvements**
  * Reduced overhead by skipping recomputation of unchanged document content
  * Adaptive parallelization for diagnostic analysis boosts throughput
  * Enhanced semantic token processing efficiency

* **Stability & Reliability**
  * Strengthened thread-safety mechanisms in concurrent operations
  * Improved executor service coordination and resource management
<!-- end of auto-generated comment: release notes by coderabbit.ai -->