### PR TITLE
perf: ServerContext: synchronizedMap -> ConcurrentHashMap

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -45,7 +45,6 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.EnumMap;
-import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -75,15 +74,19 @@ public class ServerContext {
   private final WorkDoneProgressHelper workDoneProgressHelper;
   private final LanguageServerConfiguration languageServerConfiguration;
 
-  private final Map<URI, DocumentContext> documents = Collections.synchronizedMap(new HashMap<>());
+  private final Map<URI, DocumentContext> documents = new ConcurrentHashMap<>();
   private final Lazy<CF> configurationMetadata = new Lazy<>(this::computeConfigurationMetadata);
   @Nullable
   @Setter
   @Getter
   private Path configurationRoot;
-  private final Map<URI, String> mdoRefs = Collections.synchronizedMap(new HashMap<>());
+  private final Map<URI, String> mdoRefs = new ConcurrentHashMap<>();
+  /**
+   * Внутренний EnumMap не потокобезопасен; создаётся обёрнутый в
+   * {@link Collections#synchronizedMap(Map)} (см. {@link #addMdoRefByUri(URI, DocumentContext)}).
+   */
   private final Map<String, Map<ModuleType, DocumentContext>> documentsByMDORef
-    = Collections.synchronizedMap(new HashMap<>());
+    = new ConcurrentHashMap<>();
   private final Map<URI, ReadWriteLock> documentLocks = new ConcurrentHashMap<>();
 
   private final Map<DocumentContext, State> states = new ConcurrentHashMap<>();
@@ -423,13 +426,19 @@ public class ServerContext {
     return configuration;
   }
 
+  /**
+   * Регистрирует документ в индексе по {@code mdoRef}.
+   * Внутренний {@link EnumMap} оборачивается в
+   * {@link Collections#synchronizedMap(Map)}, чтобы конкурентные {@code put}
+   * для разных типов модулей одного объекта были безопасны.
+   */
   private void addMdoRefByUri(URI uri, DocumentContext documentContext) {
     var mdoRef = documentContext.getMdoRef();
 
     mdoRefs.put(uri, mdoRef);
     documentsByMDORef.computeIfAbsent(
       mdoRef,
-      k -> new EnumMap<>(ModuleType.class)
+      k -> Collections.synchronizedMap(new EnumMap<>(ModuleType.class))
     ).put(documentContext.getModuleType(), documentContext);
   }
 


### PR DESCRIPTION
## Описание

Три горячие карты `ServerContext` (`documents`, `mdoRefs`, `documentsByMDORef`)
переведены с `Collections.synchronizedMap(new HashMap<>())` на
`ConcurrentHashMap`. Это снимает глобальную блокировку при каждом get/put
на путях с конкурентным доступом из диагностик и LSP-обработчиков.

Внутренний `EnumMap` внутри `documentsByMDORef` не потокобезопасен —
оборачивается в `Collections.synchronizedMap(...)` при создании, чтобы
конкурентные `put` разных типов модулей одного объекта были безопасны.
Сам `computeIfAbsent` на `ConcurrentHashMap` атомарен.

## Связанные задачи

Часть #3871 (разбит на три независимых PR по запросу @nixel2007).

## Чеклист
- [x] Ветка PR обновлена из develop
- [x] Отладочные комментарии удалены
- [x] Изменения покрыты тестами
- [x] `gradlew precommit`

## Дополнительно

Ветка независима от #3872 и #3874, мерджить можно в любом порядке.