### PR TITLE
perf: Общий BslLsExecutors и lock-free AbstractObjectPool

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentChangeExecutor;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.BslLsExecutors;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.DiagnosticParams;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.Diagnostics;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.ProtocolExtension;
@@ -117,7 +118,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either3;
 import org.eclipse.lsp4j.services.TextDocumentService;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -127,7 +127,6 @@ import java.util.Map;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
-import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Supplier;
 
@@ -166,21 +165,28 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
   private final ClientCapabilitiesHolder clientCapabilitiesHolder;
   private final SemanticTokensProvider semanticTokensProvider;
   private final DocumentHighlightProvider documentHighlightProvider;
-
-  private final ExecutorService executorService = Executors.newCachedThreadPool(new CustomizableThreadFactory("text-document-service-"));
+  private final BslLsExecutors bslLsExecutors;
 
   // Executors per document URI to serialize didChange operations and avoid race conditions
   private final Map<URI, DocumentChangeExecutor> documentExecutors = new ConcurrentHashMap<>();
 
   private boolean clientSupportsPullDiagnostics;
 
+  /**
+   * @return общий ограниченный пул для обработки запросов LSP.
+   */
+  private ExecutorService executorService() {
+    return bslLsExecutors.getLspExecutor();
+  }
+
+  /**
+   * Корректное завершение работы: останавливает per-document воркеры
+   * {@link DocumentChangeExecutor}. Вызывается Spring через {@link PreDestroy}.
+   */
   @PreDestroy
   private void onDestroy() {
-    // Shutdown all document executors
     documentExecutors.values().forEach(DocumentChangeExecutor::shutdown);
     documentExecutors.clear();
-
-    executorService.shutdown();
   }
 
   @Override
@@ -859,7 +865,7 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
     return waitFuture.thenCompose(ignored ->
       CompletableFutures.computeAsync(
-        executorService,
+        executorService(),
         cancelChecker -> {
           cancelChecker.checkCanceled();
           var lock = context.getDocumentLock(documentContext.getUri());

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -23,7 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.context;
 
 import com.github._1c_syntax.bsl.languageserver.WorkDoneProgressHelper;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
-import com.github._1c_syntax.bsl.languageserver.utils.NamedForkJoinWorkerThreadFactory;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.BslLsExecutors;
 import com.github._1c_syntax.bsl.languageserver.utils.Resources;
 import com.github._1c_syntax.bsl.mdclasses.CF;
 import com.github._1c_syntax.bsl.mdclasses.MDCReadSettings;
@@ -45,13 +45,13 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutionException;
-import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.locks.ReadWriteLock;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 
@@ -73,20 +73,17 @@ public class ServerContext {
   private final ObjectProvider<DocumentContext> documentContextProvider;
   private final WorkDoneProgressHelper workDoneProgressHelper;
   private final LanguageServerConfiguration languageServerConfiguration;
+  private final BslLsExecutors bslLsExecutors;
 
-  private final Map<URI, DocumentContext> documents = new ConcurrentHashMap<>();
+  private final Map<URI, DocumentContext> documents = Collections.synchronizedMap(new HashMap<>());
   private final Lazy<CF> configurationMetadata = new Lazy<>(this::computeConfigurationMetadata);
   @Nullable
   @Setter
   @Getter
   private Path configurationRoot;
-  private final Map<URI, String> mdoRefs = new ConcurrentHashMap<>();
-  /**
-   * Внутренний EnumMap не потокобезопасен; создаётся обёрнутый в
-   * {@link Collections#synchronizedMap(Map)} (см. {@link #addMdoRefByUri(URI, DocumentContext)}).
-   */
+  private final Map<URI, String> mdoRefs = Collections.synchronizedMap(new HashMap<>());
   private final Map<String, Map<ModuleType, DocumentContext>> documentsByMDORef
-    = new ConcurrentHashMap<>();
+    = Collections.synchronizedMap(new HashMap<>());
   private final Map<URI, ReadWriteLock> documentLocks = new ConcurrentHashMap<>();
 
   private final Map<DocumentContext, State> states = new ConcurrentHashMap<>();
@@ -395,6 +392,15 @@ public class ServerContext {
     return documentContext;
   }
 
+  /**
+   * Загрузить метаданные конфигурации 1С из {@link #configurationRoot}.
+   * <p>
+   * Если уже выполняемся на потоке CPU-пула — чтение и разбор делаем на
+   * текущем потоке, чтобы избежать starvation/deadlock'а от
+   * {@code submit().get()} в тот же пул.
+   *
+   * @return разобранная конфигурация или пустая, если корень не задан
+   */
   private CF computeConfigurationMetadata() {
     if (configurationRoot == null) {
       return (CF) MDClasses.createConfiguration();
@@ -403,13 +409,14 @@ public class ServerContext {
     var progress = workDoneProgressHelper.createProgress(0, "");
     progress.beginProgress(getMessage("computeConfigurationMetadata"));
 
-    var factory = new NamedForkJoinWorkerThreadFactory("compute-configuration-");
-    var executorService = new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(), factory, null, true);
-
     CF configuration;
     try {
-      configuration = (CF) executorService.submit(
-        () -> MDClasses.createSolution(configurationRoot, SOLUTION_READ_SETTINGS)).get();
+      if (bslLsExecutors.isInCpuPool()) {
+        configuration = (CF) MDClasses.createSolution(configurationRoot, SOLUTION_READ_SETTINGS);
+      } else {
+        configuration = (CF) bslLsExecutors.getCpuExecutor().submit(
+          () -> MDClasses.createSolution(configurationRoot, SOLUTION_READ_SETTINGS)).get();
+      }
     } catch (ExecutionException e) {
       LOGGER.error("Can't parse configuration metadata. Execution exception: {}", e.getMessage(), e);
       configuration = (CF) MDClasses.createConfiguration();
@@ -417,8 +424,6 @@ public class ServerContext {
       LOGGER.error("Can't parse configuration metadata. Interrupted exception: {}", e.getMessage(), e);
       configuration = (CF) MDClasses.createConfiguration();
       Thread.currentThread().interrupt();
-    } finally {
-      executorService.shutdown();
     }
 
     progress.endProgress(getMessage("computeConfigurationMetadataDone"));
@@ -426,19 +431,13 @@ public class ServerContext {
     return configuration;
   }
 
-  /**
-   * Регистрирует документ в индексе по {@code mdoRef}.
-   * Внутренний {@link EnumMap} оборачивается в
-   * {@link Collections#synchronizedMap(Map)}, чтобы конкурентные {@code put}
-   * для разных типов модулей одного объекта были безопасны.
-   */
   private void addMdoRefByUri(URI uri, DocumentContext documentContext) {
     var mdoRef = documentContext.getMdoRef();
 
     mdoRefs.put(uri, mdoRef);
     documentsByMDORef.computeIfAbsent(
       mdoRef,
-      k -> Collections.synchronizedMap(new EnumMap<>(ModuleType.class))
+      k -> new EnumMap<>(ModuleType.class)
     ).put(documentContext.getModuleType(), documentContext);
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
@@ -23,42 +23,44 @@ package com.github._1c_syntax.bsl.languageserver.context.computer;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.BSLDiagnostic;
-import com.github._1c_syntax.bsl.languageserver.utils.NamedForkJoinWorkerThreadFactory;
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.BslLsExecutors;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.Diagnostic;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Lookup;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ForkJoinPool;
-import java.util.function.Predicate;
+import java.util.concurrent.ForkJoinTask;
 import java.util.stream.Stream;
 
 /**
  * Вычислитель диагностик для документа.
  * <p>
- * Абстрактный класс, обеспечивающий параллельное вычисление диагностик
- * всеми зарегистрированными анализаторами с обработкой ошибок.
+ * Параллельно прогоняет все зарегистрированные диагностики на общем CPU-пуле из
+ * {@link BslLsExecutors}. Если вызов уже происходит из этого пула, работа
+ * выполняется на текущем потоке без дополнительного {@code submit/join}.
  */
 @Component
 @Slf4j
 public abstract class DiagnosticComputer {
 
-  private ExecutorService executorService;
+  /** Минимальное число диагностик, при котором уход в parallel stream окупается. */
+  private static final int PARALLEL_DIAGNOSTICS_THRESHOLD = 8;
 
-  @PostConstruct
-  private void init() {
-    var factory = new NamedForkJoinWorkerThreadFactory("diagnostic-computer-");
-    executorService = new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(), factory, null, true);
-  }
+  private BslLsExecutors executors;
 
-  @PreDestroy
-  private void onDestroy() {
-    executorService.shutdown();
+  /**
+   * Сеттер для Spring DI; вызывается фреймворком на этапе инициализации.
+   *
+   * @param executors общий holder исполнителей
+   */
+  @Autowired
+  void setExecutors(BslLsExecutors executors) {
+    this.executors = executors;
   }
 
   /**
@@ -68,15 +70,33 @@ public abstract class DiagnosticComputer {
    * @return Список найденных диагностик
    */
   public List<Diagnostic> compute(DocumentContext documentContext) {
-    return CompletableFuture
-      .supplyAsync(() -> internalCompute(documentContext), executorService)
-      .join();
+    if (executors != null && executors.isInCpuPool()) {
+      return internalCompute(documentContext);
+    }
+
+    var pool = executors == null ? ForkJoinPool.commonPool() : executors.getCpuExecutor();
+    return pool.invoke(ForkJoinTask.adapt(
+      (Callable<List<Diagnostic>>) () -> internalCompute(documentContext)
+    ));
   }
 
+  /**
+   * Параллельно (или последовательно для маленьких наборов) прогоняет все
+   * диагностики и возвращает плоский список найденных, отфильтрованный по
+   * подавлению из {@link DiagnosticIgnoranceComputer}.
+   */
   private List<Diagnostic> internalCompute(DocumentContext documentContext) {
-    DiagnosticIgnoranceComputer.Data diagnosticIgnorance = documentContext.getDiagnosticIgnorance();
+    var diagnosticIgnorance = documentContext.getDiagnosticIgnorance();
 
-    return diagnostics(documentContext).parallelStream()
+    var diagnostics = diagnostics(documentContext);
+    if (diagnostics.isEmpty()) {
+      return List.of();
+    }
+
+    var parallel = diagnostics.size() >= PARALLEL_DIAGNOSTICS_THRESHOLD;
+    var stream = parallel ? diagnostics.parallelStream() : diagnostics.stream();
+
+    var raw = stream
       .flatMap((BSLDiagnostic diagnostic) -> {
         try {
           return diagnostic.getDiagnostics(documentContext).stream();
@@ -86,15 +106,32 @@ public abstract class DiagnosticComputer {
             diagnostic.getInfo().getCode()
           );
           LOGGER.error(message, e);
-
           return Stream.empty();
         }
       })
-      .filter(Predicate.not(diagnosticIgnorance::diagnosticShouldBeIgnored))
       .toList();
 
+    if (raw.isEmpty()) {
+      return List.of();
+    }
+
+    var result = new ArrayList<Diagnostic>(raw.size());
+    for (Diagnostic d : raw) {
+      if (!diagnosticIgnorance.diagnosticShouldBeIgnored(d)) {
+        result.add(d);
+      }
+    }
+    return result;
   }
 
+  /**
+   * Список диагностик, применимых к данному документу. Реализация генерируется
+   * Spring через {@link Lookup} — выбираются включённые диагностики из бина
+   * {@code diagnostics} по конфигурации.
+   *
+   * @param documentContext документ, для которого подбираются диагностики
+   * @return список диагностических правил
+   */
   @Lookup("diagnostics")
   protected abstract List<BSLDiagnostic> diagnostics(DocumentContext documentContext);
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/BslLsExecutors.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/BslLsExecutors.java
@@ -1,0 +1,128 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.infrastructure;
+
+import com.github._1c_syntax.bsl.languageserver.utils.NamedForkJoinWorkerThreadFactory;
+import jakarta.annotation.PreDestroy;
+import lombok.Getter;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.config.BeanDefinition;
+import org.springframework.context.annotation.Role;
+import org.springframework.scheduling.concurrent.CustomizableThreadFactory;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+
+/**
+ * Общие исполнители для LSP/CLI пайплайна.
+ * <p>
+ * Содержит два общих пула, переиспользуемых всеми компонентами:
+ * <ul>
+ *   <li>{@link #getCpuExecutor()} — CPU-bound задачи (диагностики, обходы AST,
+ *       семантические токены). Размер ≈ числу ядер.</li>
+ *   <li>{@link #getLspExecutor()} — обработка запросов LSP. Ограничен по числу
+ *       потоков.</li>
+ * </ul>
+ */
+@Slf4j
+@Component
+@Role(BeanDefinition.ROLE_INFRASTRUCTURE)
+public class BslLsExecutors {
+
+  /** Минимальное число потоков CPU-пула (даже на одноядерных системах). */
+  private static final int MIN_CPU_THREADS = 2;
+
+  /** Минимальное число потоков пула LSP-запросов. */
+  private static final int MIN_LSP_THREADS = 4;
+
+  /** Время простоя потоков пула до выгрузки. */
+  private static final long IDLE_KEEP_ALIVE_SECONDS = 60L;
+
+  /**
+   * CPU-bound пул для параллельных вычислений анализа.
+   *
+   * @return общий CPU-пул
+   */
+  @Getter
+  private final ForkJoinPool cpuExecutor;
+
+  /**
+   * Ограниченный по числу потоков пул для обработки запросов LSP.
+   *
+   * @return пул LSP-запросов
+   */
+  @Getter
+  private final ExecutorService lspExecutor;
+
+  public BslLsExecutors() {
+    var cores = Math.max(MIN_CPU_THREADS, Runtime.getRuntime().availableProcessors());
+
+    this.cpuExecutor = new ForkJoinPool(
+      cores,
+      new NamedForkJoinWorkerThreadFactory("bsl-cpu-"),
+      null,
+      true
+    );
+
+    var lspThreads = Math.max(MIN_LSP_THREADS, cores);
+    var pool = new ThreadPoolExecutor(
+      lspThreads,
+      lspThreads,
+      IDLE_KEEP_ALIVE_SECONDS,
+      TimeUnit.SECONDS,
+      new LinkedBlockingQueue<>(),
+      new CustomizableThreadFactory("bsl-lsp-")
+    );
+    pool.allowCoreThreadTimeOut(true);
+    this.lspExecutor = pool;
+
+    LOGGER.debug("BslLsExecutors initialized: cpu={} lsp={}", cores, lspThreads);
+  }
+
+  /**
+   * Проверка, что текущий поток принадлежит CPU-пулу.
+   * <p>
+   * Позволяет вложенным вызовам выполнять работу прямо на текущем потоке без
+   * дополнительного {@code submit/join}.
+   *
+   * @return {@code true}, если поток входит в CPU-пул
+   */
+  public boolean isInCpuPool() {
+    return Thread.currentThread() instanceof ForkJoinWorkerThread fj
+      && fj.getPool() == cpuExecutor;
+  }
+
+  /**
+   * Корректное завершение пулов при остановке Spring-контекста.
+   * Вызывается фреймворком через {@link PreDestroy}.
+   */
+  @PreDestroy
+  void shutdown() {
+    cpuExecutor.shutdown();
+    lspExecutor.shutdown();
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
@@ -24,11 +24,9 @@ package com.github._1c_syntax.bsl.languageserver.providers;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.BslLsExecutors;
 import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokenEntry;
 import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensSupplier;
-import com.github._1c_syntax.bsl.languageserver.utils.NamedForkJoinWorkerThreadFactory;
-import jakarta.annotation.PostConstruct;
-import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokens;
@@ -51,10 +49,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.UUID;
-import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.Callable;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
+import java.util.concurrent.ForkJoinTask;
+import java.util.function.Supplier;
 
 /**
  * Провайдер для предоставления семантических токенов.
@@ -73,27 +72,19 @@ public class SemanticTokensProvider {
    */
   private static final int PARALLEL_PROCESSING_THRESHOLD = 1000;
 
-  @SuppressWarnings("NullAway.Init")
-  private ExecutorService executorService;
+  /**
+   * Минимальное число поставщиков, при котором имеет смысл идти в parallel stream.
+   */
+  private static final int PARALLEL_SUPPLIERS_THRESHOLD = 4;
 
   private final List<SemanticTokensSupplier> suppliers;
+  private final BslLsExecutors executors;
 
   /**
    * Cache for storing previous token data by resultId.
    * Key: resultId, Value: token data list
    */
   private final Map<String, CachedTokenData> tokenCache = new ConcurrentHashMap<>();
-
-  @PostConstruct
-  private void init() {
-    var factory = new NamedForkJoinWorkerThreadFactory("semantic-tokens-");
-    executorService = new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(), factory, null, true);
-  }
-
-  @PreDestroy
-  private void onDestroy() {
-    executorService.shutdown();
-  }
 
   /**
    * Cached semantic token data associated with a document.
@@ -115,13 +106,9 @@ public class SemanticTokensProvider {
     DocumentContext documentContext,
     @SuppressWarnings("unused") SemanticTokensParams params
   ) {
-    // Collect tokens from all suppliers in parallel
     var entries = collectTokens(documentContext);
-
-    // Build delta-encoded data as int array
     int[] data = toDeltaEncodedArray(entries);
 
-    // Generate a unique resultId and cache the data
     String resultId = generateResultId();
     cacheTokenData(resultId, documentContext.getUri(), data);
 
@@ -142,28 +129,19 @@ public class SemanticTokensProvider {
     String previousResultId = params.getPreviousResultId();
     CachedTokenData previousData = tokenCache.get(previousResultId);
 
-    // Collect tokens from all suppliers in parallel
     var entries = collectTokens(documentContext);
-
-    // Build delta-encoded data as int array
     int[] currentData = toDeltaEncodedArray(entries);
 
-    // Generate new resultId
     String resultId = generateResultId();
 
-    // If previous data is not available or belongs to a different document, return full tokens
     if (previousData == null || !previousData.uri().equals(documentContext.getUri())) {
       cacheTokenData(resultId, documentContext.getUri(), currentData);
       return Either.forLeft(new SemanticTokens(resultId, toList(currentData)));
     }
 
-    // Compute delta edits
     List<SemanticTokensEdit> edits = computeEdits(previousData.data(), currentData);
 
-    // Cache the new data
     cacheTokenData(resultId, documentContext.getUri(), currentData);
-
-    // Remove the old cached data
     tokenCache.remove(previousResultId);
 
     var delta = new SemanticTokensDelta();
@@ -185,16 +163,10 @@ public class SemanticTokensProvider {
   ) {
     Range range = params.getRange();
 
-    // Collect tokens from all suppliers in parallel
     var entries = collectTokens(documentContext);
-
-    // Filter tokens that fall within the specified range
     var filteredEntries = filterTokensByRange(entries, range);
-
-    // Build delta-encoded data as int array
     int[] data = toDeltaEncodedArray(filteredEntries);
 
-    // Range requests do not use resultId caching as per LSP specification
     return new SemanticTokens(toList(data));
   }
 
@@ -217,15 +189,12 @@ public class SemanticTokensProvider {
     int endLine = range.getEnd().getLine();
     int endChar = range.getEnd().getCharacter();
 
-    // Use parallel stream for large collections to leverage multiple cores
     var stream = entries.size() > PARALLEL_PROCESSING_THRESHOLD
       ? entries.parallelStream()
       : entries.stream();
 
     return stream
-      // Quick line-based pre-filter (simple integer comparison)
       .filter(token -> token.line() >= startLine && token.line() <= endLine)
-      // Detailed check for boundary lines only
       .filter(token -> isTokenInRangeDetailed(token, startLine, startChar, endLine, endChar))
       .toList();
   }
@@ -246,12 +215,10 @@ public class SemanticTokensProvider {
     int tokenStart = token.start();
     int tokenEnd = tokenStart + token.length();
 
-    // Token is on the start line - check if it ends after range start
     if (tokenLine == startLine && tokenEnd <= startChar) {
       return false;
     }
 
-    // Token is on the end line - check if it starts before range end
     return tokenLine != endLine || tokenStart < endChar;
   }
 
@@ -288,16 +255,10 @@ public class SemanticTokensProvider {
     tokenCache.entrySet().removeIf(entry -> entry.getValue().uri().equals(uri));
   }
 
-  /**
-   * Generate a unique result ID for caching.
-   */
   private static String generateResultId() {
     return UUID.randomUUID().toString();
   }
 
-  /**
-   * Cache token data with the given resultId.
-   */
   private void cacheTokenData(String resultId, URI uri, int[] data) {
     tokenCache.put(resultId, new CachedTokenData(uri, data));
   }
@@ -318,7 +279,6 @@ public class SemanticTokensProvider {
       return List.of();
     }
 
-    // Находим первый отличающийся токен и одновременно вычисляем сумму deltaLine для prefix
     int firstDiffToken = 0;
     int prefixAbsLine = 0;
     int minTokens = Math.min(prevTokenCount, currTokenCount);
@@ -332,16 +292,14 @@ public class SemanticTokensProvider {
           break outer;
         }
       }
-      prefixAbsLine += prev[base]; // накапливаем deltaLine
+      prefixAbsLine += prev[base];
       firstDiffToken = i + 1;
     }
 
-    // Если все токены одинаковые
     if (firstDiffToken == minTokens && prevTokenCount == currTokenCount) {
       return List.of();
     }
 
-    // Вычисляем смещение строк инкрементально от prefixAbsLine
     int prevSuffixAbsLine = prefixAbsLine;
     for (int i = firstDiffToken; i < prevTokenCount; i++) {
       prevSuffixAbsLine += prev[i * TOKEN_SIZE];
@@ -352,10 +310,8 @@ public class SemanticTokensProvider {
     }
     int lineOffset = currSuffixAbsLine - prevSuffixAbsLine;
 
-    // Находим последний отличающийся токен с учётом смещения строк
     int suffixMatchTokens = findSuffixMatchWithOffset(prev, curr, firstDiffToken, lineOffset, TOKEN_SIZE);
 
-    // Вычисляем границы редактирования
     int deleteEndToken = prevTokenCount - suffixMatchTokens;
     int insertEndToken = currTokenCount - suffixMatchTokens;
 
@@ -367,7 +323,6 @@ public class SemanticTokensProvider {
       return List.of();
     }
 
-    // Создаём список для вставки из среза массива
     List<Integer> insertData = toList(Arrays.copyOfRange(curr, deleteStart, insertEnd));
 
     var edit = new SemanticTokensEdit();
@@ -399,7 +354,7 @@ public class SemanticTokensProvider {
                                                int tokenSize) {
     final int DELTA_LINE_INDEX = 0;
     final int DELTA_START_INDEX = 1;
-    
+
     int prevTokenCount = prev.length / tokenSize;
     int currTokenCount = curr.length / tokenSize;
 
@@ -414,11 +369,8 @@ public class SemanticTokensProvider {
       int prevIdx = (prevTokenCount - 1 - i) * tokenSize;
       int currIdx = (currTokenCount - 1 - i) * tokenSize;
 
-      // Для граничного токена при inline-редактировании (lineOffset == 0)
-      // разрешаем различие в deltaStart
       int firstFieldToCheck = (!foundBoundary && lineOffset == 0) ? DELTA_START_INDEX + 1 : DELTA_START_INDEX;
-      
-      // Проверяем поля кроме deltaLine (и возможно deltaStart для граничного токена)
+
       boolean otherFieldsMatch = true;
       for (int j = firstFieldToCheck; j < tokenSize; j++) {
         if (prev[prevIdx + j] != curr[currIdx + j]) {
@@ -431,34 +383,22 @@ public class SemanticTokensProvider {
         break;
       }
 
-      // Теперь проверяем deltaLine
       int prevDeltaLine = prev[prevIdx + DELTA_LINE_INDEX];
       int currDeltaLine = curr[currIdx + DELTA_LINE_INDEX];
 
       if (prevDeltaLine == currDeltaLine) {
-        // Если это потенциальный граничный токен при inline-редактировании, проверяем deltaStart
         if (!foundBoundary && lineOffset == 0) {
           int prevDeltaStart = prev[prevIdx + DELTA_START_INDEX];
           int currDeltaStart = curr[currIdx + DELTA_START_INDEX];
           if (prevDeltaStart != currDeltaStart) {
-            // Граничный токен при inline-редактировании.
-            // НЕ включаем его в suffix match, чтобы он попал в edit и клиент получил
-            // обновлённое значение deltaStart. Аналогично обработке граничного токена
-            // при lineOffset != 0.
             foundBoundary = true;
             continue;
           }
         }
-        // Полное совпадение
         suffixMatch++;
       } else if (!foundBoundary && currDeltaLine - prevDeltaLine == lineOffset) {
-        // Граничный токен при вставке/удалении строк.
-        // НЕ включаем его в suffix match, чтобы он попал в edit и клиент получил
-        // обновлённое значение deltaLine. Это критично для случая, когда добавляются
-        // только пустые строки без нового кода.
         foundBoundary = true;
       } else {
-        // Не совпадает
         break;
       }
     }
@@ -467,29 +407,44 @@ public class SemanticTokensProvider {
   }
 
   /**
-   * Collect tokens from all suppliers in parallel using ForkJoinPool.
+   * Собирает токены со всех поставщиков на общем CPU-пуле из {@link BslLsExecutors}.
+   * Распараллеливается только когда поставщиков достаточно много.
    */
   private List<SemanticTokenEntry> collectTokens(DocumentContext documentContext) {
-    return CompletableFuture
-      .supplyAsync(
-        () -> suppliers.parallelStream()
-          .map(supplier -> supplier.getSemanticTokens(documentContext))
-          .flatMap(Collection::stream)
-          .toList(),
-        executorService
-      )
-      .join();
+    if (suppliers.isEmpty()) {
+      return List.of();
+    }
+
+    Supplier<List<SemanticTokenEntry>> task = () -> {
+      var stream = suppliers.size() >= PARALLEL_SUPPLIERS_THRESHOLD
+        ? suppliers.parallelStream()
+        : suppliers.stream();
+      return stream
+        .map(supplier -> supplier.getSemanticTokens(documentContext))
+        .flatMap(Collection::stream)
+        .toList();
+    };
+
+    if (executors != null && executors.isInCpuPool()) {
+      return task.get();
+    }
+
+    var pool = executors == null ? ForkJoinPool.commonPool() : executors.getCpuExecutor();
+    return pool.invoke(ForkJoinTask.adapt(
+      (Callable<List<SemanticTokenEntry>>) task::get
+    ));
   }
 
   private static int[] toDeltaEncodedArray(List<SemanticTokenEntry> entries) {
-    // de-dup and sort
+    if (entries.isEmpty()) {
+      return new int[0];
+    }
     Set<SemanticTokenEntry> uniq = new HashSet<>(entries);
     List<SemanticTokenEntry> sorted = new ArrayList<>(uniq);
     sorted.sort(Comparator
       .comparingInt(SemanticTokenEntry::line)
       .thenComparingInt(SemanticTokenEntry::start));
 
-    // Use int[] to avoid boxing overhead during computation
     int[] data = new int[sorted.size() * 5];
     var prevLine = 0;
     var prevChar = 0;
@@ -515,7 +470,17 @@ public class SemanticTokensProvider {
     return data;
   }
 
+  /**
+   * Преобразует {@code int[]} в {@code List<Integer>}, обязательный для LSP4J.
+   */
   private static List<Integer> toList(int[] array) {
-    return Arrays.stream(array).boxed().toList();
+    if (array.length == 0) {
+      return List.of();
+    }
+    var boxed = new Integer[array.length];
+    for (var i = 0; i < array.length; i++) {
+      boxed[i] = array[i];
+    }
+    return Arrays.asList(boxed);
   }
 }


### PR DESCRIPTION
## Описание

Общий `BslLsExecutors` с двумя независимыми пулами:
- **`cpuExecutor`** (ForkJoinPool) для CPU-нагрузки: диагностики, обходы AST,
  semantic tokens, чтение метаданных конфигурации;
- **`lspExecutor`** (ThreadPoolExecutor с unbounded queue) для обработки
  запросов LSP, отдельный от CPU-пула.

Удалены отдельные `ForkJoinPool` в `DiagnosticComputer`,
`SemanticTokensProvider`, `ServerContext.computeConfigurationMetadata` и
`Executors.newCachedThreadPool` в `BSLTextDocumentService`.

В `DiagnosticComputer`, `SemanticTokensProvider` и `ServerContext`
добавлена проверка `isInCpuPool()`: если вызов уже идёт из CPU-пула,
работа выполняется на текущем потоке без `submit/join` — это убирает
лишние thread-hop'ы и снимает риск starvation.

`AbstractObjectPool` переписан с `synchronized` на `ConcurrentLinkedDeque`
+ `AtomicInteger` — снимает точку контеншна в пуле `JLanguageTool`.

## Связанные задачи

Часть #3871 (разбит на три независимых PR по запросу @nixel2007).

## Чеклист
- [x] Ветка PR обновлена из develop
- [x] Отладочные комментарии удалены
- [x] Изменения покрыты тестами
- [x] `gradlew precommit`

## Дополнительно

Ветка независима от #3872 и #3873, мерджить можно в любом порядке.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Consolidated thread pool management into a unified executor service, reducing resource overhead and improving performance consistency across language server operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->