### PR TITLE
perf: AbstractObjectPool: lock-free на ConcurrentLinkedDeque

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
@@ -45,41 +45,53 @@
  */
 package com.github._1c_syntax.bsl.languageserver.utils;
 
-import java.util.HashSet;
-import java.util.Set;
+import java.util.concurrent.ConcurrentLinkedDeque;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
- * Generic object pool.
+ * Lock-free пул объектов.
  *
  * @param <T> Type T of Object in the Pool
  */
 public abstract class AbstractObjectPool<T> {
 
-  private final Set<T> available = new HashSet<>();
-  private final Set<T> inUse = new HashSet<>();
+  private final ConcurrentLinkedDeque<T> available = new ConcurrentLinkedDeque<>();
+  private final AtomicInteger inUse = new AtomicInteger(0);
 
+  /**
+   * Создать новый экземпляр объекта пула, когда свободных нет.
+   *
+   * @return созданный экземпляр
+   */
   protected abstract T create();
 
   /**
-   * Checkout object from pool.
+   * Получить экземпляр из пула; при отсутствии свободного — создать новый.
+   *
+   * @return экземпляр пула
    */
-  public synchronized T checkOut() {
-    if (available.isEmpty()) {
-      available.add(create());
+  public T checkOut() {
+    var instance = available.pollFirst();
+    if (instance == null) {
+      instance = create();
     }
-    T instance = available.iterator().next();
-    available.remove(instance);
-    inUse.add(instance);
+    inUse.incrementAndGet();
     return instance;
   }
 
-  public synchronized void checkIn(T instance) {
-    inUse.remove(instance);
-    available.add(instance);
+  /**
+   * Вернуть экземпляр в пул.
+   *
+   * @param instance возвращаемый экземпляр
+   */
+  public void checkIn(T instance) {
+    available.offerLast(instance);
+    inUse.decrementAndGet();
   }
 
   @Override
-  public synchronized String toString() {
-    return "Pool available=%d inUse=%d".formatted(available.size(), inUse.size());
+  @SuppressWarnings("java:S2250") // toString вызывается только для отладки/логов, O(n) size() тут приемлемо
+  public String toString() {
+    return "Pool available=%d inUse=%d".formatted(available.size(), inUse.get());
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
@@ -45,8 +45,9 @@
  */
 package com.github._1c_syntax.bsl.languageserver.utils;
 
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ConcurrentLinkedDeque;
-import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Lock-free пул объектов.
@@ -56,7 +57,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 public abstract class AbstractObjectPool<T> {
 
   private final ConcurrentLinkedDeque<T> available = new ConcurrentLinkedDeque<>();
-  private final AtomicInteger inUse = new AtomicInteger(0);
+  private final Set<T> inUse = ConcurrentHashMap.newKeySet();
 
   /**
    * Создать новый экземпляр объекта пула, когда свободных нет.
@@ -71,12 +72,15 @@ public abstract class AbstractObjectPool<T> {
    * @return экземпляр пула
    */
   public T checkOut() {
-    var instance = available.pollFirst();
-    if (instance == null) {
-      instance = create();
+    while (true) {
+      var instance = available.pollFirst();
+      if (instance == null) {
+        instance = create();
+      }
+      if (inUse.add(instance)) {
+        return instance;
+      }
     }
-    inUse.incrementAndGet();
-    return instance;
   }
 
   /**
@@ -85,13 +89,15 @@ public abstract class AbstractObjectPool<T> {
    * @param instance возвращаемый экземпляр
    */
   public void checkIn(T instance) {
+    if (!inUse.remove(instance)) {
+      return;
+    }
     available.offerLast(instance);
-    inUse.decrementAndGet();
   }
 
   @Override
   @SuppressWarnings("java:S2250") // toString вызывается только для отладки/логов, O(n) size() тут приемлемо
   public String toString() {
-    return "Pool available=%d inUse=%d".formatted(available.size(), inUse.get());
+    return "Pool available=%d inUse=%d".formatted(available.size(), inUse.size());
   }
 }


### PR DESCRIPTION
Выделено в отдельный PR из #3874 по запросу @nixel2007.



<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved performance and concurrency handling in internal object pool management.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->