### PR TITLE
feat(types): подключение bsl-context — платформенные типы и глобалы из СП

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -27,11 +27,14 @@ plugins {
 }
 
 repositories {
-    mavenLocal()
     mavenCentral()
     maven(url = "https://projectlombok.org/edge-releases")
     maven("https://central.sonatype.com/repository/maven-snapshots")
+    // bsl-context (1С platform syntax-helper parser) поставляется через jitpack
+    // до выпуска первого релизного тэга. После — заменить на mavenCentral.
+    maven(url = "https://jitpack.io")
 }
+
 
 group = "io.github.1c-syntax"
 gitVersioning.apply {
@@ -89,6 +92,9 @@ dependencies {
     api("io.github.1c-syntax:mdclasses:0.18.0")
     api("io.github.1c-syntax:bsl-common-library:0.10.0")
     api("io.github.1c-syntax:supportconf:0.16.0")
+    // Парсер синтакс-помощника платформы (.hbk). Подключён по SHA коммита
+    // master до выпуска первого релизного тэга — после замены на тэг.
+    api("io.github.1c-syntax:bsl-context:76cbe38")
 
     // nullability annotations
     api("org.jspecify:jspecify:1.0.0")

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfiguration.java
@@ -32,6 +32,8 @@ import com.github._1c_syntax.bsl.languageserver.configuration.documentlink.Docum
 import com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageServerConfigurationChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.configuration.formating.FormattingOptions;
 import com.github._1c_syntax.bsl.languageserver.configuration.inlayhints.InlayHintOptions;
+import com.github._1c_syntax.bsl.languageserver.configuration.oscript.OScriptOptions;
+import com.github._1c_syntax.bsl.languageserver.configuration.platform.V8PlatformOptions;
 import com.github._1c_syntax.bsl.languageserver.configuration.references.ReferencesOptions;
 import com.github._1c_syntax.bsl.languageserver.configuration.semantictokens.SemanticTokensOptions;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
@@ -117,8 +119,11 @@ public class LanguageServerConfiguration {
 
   @JsonProperty("oscript")
   @Setter(value = AccessLevel.NONE)
-  private com.github._1c_syntax.bsl.languageserver.configuration.oscript.OScriptOptions oscriptOptions =
-    new com.github._1c_syntax.bsl.languageserver.configuration.oscript.OScriptOptions();
+  private OScriptOptions oscriptOptions = new OScriptOptions();
+
+  @JsonProperty("platform")
+  @Setter(value = AccessLevel.NONE)
+  private V8PlatformOptions platformOptions = new V8PlatformOptions();
 
   private String siteRoot = "https://1c-syntax.github.io/bsl-language-server";
   private boolean useDevSite;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/platform/V8PlatformOptions.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/platform/V8PlatformOptions.java
@@ -1,0 +1,50 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.configuration.platform;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import lombok.Getter;
+import lombok.Setter;
+import org.jspecify.annotations.Nullable;
+
+import java.nio.file.Path;
+
+/**
+ * Workspace-scoped настройки для подсистемы платформенных типов
+ * (см. {@code BslContextPlatformTypesProvider}).
+ */
+@Getter
+@Setter
+public class V8PlatformOptions {
+
+  /**
+   * Путь к каталогу {@code bin} установленной платформы 1С — там, где лежат
+   * файлы синтакс-помощника ({@code shcntx_*.hbk}, {@code shlang_*.hbk}).
+   * Если не задан (по умолчанию), используется автодетект самой свежей
+   * установки на машине.
+   * <p>
+   * Пример: {@code C:\Program Files\1cv8\8.3.27.1786\bin}.
+   */
+  @JsonProperty("binPath")
+  @Nullable
+  private Path binPath;
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextHolder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextHolder.java
@@ -1,0 +1,80 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.context.api.ContextProvider;
+import com.github._1c_syntax.bsl.languageserver.configuration.platform.V8PlatformOptions;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
+import com.github._1c_syntax.utils.Lazy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+
+import java.util.Optional;
+
+/**
+ * Workspace-scoped lazy-кэш {@link ContextProvider} от {@code bsl-context}.
+ * Парсинг HBK-справки занимает порядка двух секунд и выполняется один раз
+ * за время жизни scope; результат шарится между потребителями
+ * ({@link BslContextPlatformTypesProvider} для типов и {@link GlobalScopeProvider}
+ * для глобального контекста, keyword'ов и системных перечислений).
+ * <p>
+ * Источник выбирается по {@link V8PlatformOptions#getBinPath()}: если задан —
+ * берётся явный каталог {@code bin} платформы, иначе — автодетект самой
+ * свежей установки на машине через {@code PlatformFinder}.
+ * <p>
+ * Если 1С не установлена или парсинг падает — {@link #get()} возвращает
+ * {@link Optional#empty()}, потребители работают через JSON-fallback.
+ * Повторных попыток инициализации не делается.
+ */
+@Slf4j
+@Component
+@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class BslContextHolder {
+
+  private final PlatformContextProviderFactory factory;
+  private final Lazy<Optional<ContextProvider>> cached;
+
+  public BslContextHolder(PlatformContextProviderFactory factory) {
+    this.factory = factory;
+    this.cached = new Lazy<>(this::load);
+  }
+
+  /**
+   * Возвращает {@link ContextProvider}, инициализируя его при первом вызове.
+   * Если источник недоступен — возвращает {@link Optional#empty()}; повторных
+   * попыток не делает.
+   */
+  public Optional<ContextProvider> get() {
+    return cached.getOrCompute();
+  }
+
+  private Optional<ContextProvider> load() {
+    try {
+      return factory.create();
+    } catch (Exception e) {
+      LOGGER.warn("Failed to load platform contexts from 1C syntax helper: {}", e.getMessage());
+      return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
@@ -1,0 +1,320 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.context.api.Context;
+import com.github._1c_syntax.bsl.context.api.ContextConstructor;
+import com.github._1c_syntax.bsl.context.api.ContextEnum;
+import com.github._1c_syntax.bsl.context.api.ContextEnumValue;
+import com.github._1c_syntax.bsl.context.api.ContextMethod;
+import com.github._1c_syntax.bsl.context.api.ContextMethodSignature;
+import com.github._1c_syntax.bsl.context.api.ContextName;
+import com.github._1c_syntax.bsl.context.api.ContextProperty;
+import com.github._1c_syntax.bsl.context.api.ContextProvider;
+import com.github._1c_syntax.bsl.context.api.ContextSignatureParameter;
+import com.github._1c_syntax.bsl.context.api.ContextType;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
+import com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.utils.Lazy;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+
+/**
+ * Поставщик платформенных типов на основе синтакс-помощника установленной
+ * платформы 1С (через библиотеку {@code bsl-context}). Источник
+ * {@link ContextProvider} берётся из {@link BslContextHolder} — общий
+ * workspace-scoped кэш парсинга HBK.
+ * <p>
+ * Соответствие категорий bsl-context → {@link TypeKind} type-system v2:
+ * <ul>
+ *   <li>{@code PRIMITIVE_TYPE} → {@link TypeKind#PRIMITIVE} — примитивы языка
+ *       (Строка, Число, Дата, Булево, Тип, Null, Неопределено, Произвольный);</li>
+ *   <li>{@code TYPE} → {@link TypeKind#PLATFORM} — платформенные типы со
+ *       свойствами и методами;</li>
+ *   <li>{@code ENUM} → {@link TypeKind#PLATFORM} — системные перечисления;
+ *       значения публикуются как {@link MemberKind#PROPERTY} с типом самого
+ *       перечисления (для dot-completion'а);</li>
+ *   <li>{@code GLOBAL_CONTEXT} и {@code LANGUAGE_KEYWORD} — типами не являются,
+ *       пропускаются. Глобальный контекст и языковые keyword'ы потребляет
+ *       {@link GlobalScopeProvider}.</li>
+ * </ul>
+ * <p>
+ * Что из членов типа сейчас НЕ публикуется (type-system v2 моделирует только
+ * {@link MemberKind#METHOD} / {@link MemberKind#PROPERTY}): события
+ * ({@code ContextType.events()}). Также не публикуются метаданные
+ * методов/свойств/конструкторов ({@code sinceVersion},
+ * {@code deprecatedSinceVersion}, {@code recommendedReplacements},
+ * {@code availabilities}, {@code accessMode}, {@code syntaxText},
+ * {@code defaultValue} и т.п.) — они доступны в bsl-context, но
+ * соответствующие LS-дескрипторы их пока не носят. См. {@code tmp/PLAN.md}
+ * в bsl-context.
+ */
+@Slf4j
+@Component
+@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
+
+  private final BslContextHolder contextHolder;
+  private final Lazy<List<TypeDecl>> cached;
+
+  public BslContextPlatformTypesProvider(BslContextHolder contextHolder) {
+    this.contextHolder = contextHolder;
+    this.cached = new Lazy<>(() -> build(contextHolder.get().orElse(null)));
+  }
+
+  @Override
+  public Collection<TypeDecl> getTypes() {
+    return cached.getOrCompute();
+  }
+
+  @Override
+  public LanguageScope getLanguageScope() {
+    return LanguageScope.BSL;
+  }
+
+  private static List<TypeDecl> build(ContextProvider provider) {
+    if (provider == null) {
+      return List.of();
+    }
+    var contexts = provider.getContexts();
+    var result = new ArrayList<TypeDecl>(contexts.size());
+    for (var context : contexts) {
+      var decl = toTypeDecl(context);
+      if (decl != null) {
+        result.add(decl);
+      }
+    }
+    return List.copyOf(result);
+  }
+
+  private static TypeDecl toTypeDecl(Context context) {
+    var kind = mapKind(context);
+    if (kind == null) {
+      return null;
+    }
+    var qualifiedName = context.name().getName();
+    var aliases = aliasesOf(context.name());
+    var members = collectMembers(context);
+    var description = descriptionOf(context);
+    var classRef = new TypeRef(kind, qualifiedName);
+    var constructors = constructorsOf(context, classRef);
+    return new TypeDecl(kind, qualifiedName, aliases, members,
+      isExposedAsGlobal(context), description, constructors);
+  }
+
+  private static String descriptionOf(Context context) {
+    if (context instanceof ContextType type) {
+      return type.description();
+    }
+    return "";
+  }
+
+  /**
+   * Маппит конструкторы платформенного типа из bsl-context
+   * ({@link ContextConstructor}) в {@link SignatureDescriptor} type-system v2.
+   * Возвращаемый тип конструктора — сам тип ({@code classRef}); параметры —
+   * как у обычных методов.
+   */
+  private static List<SignatureDescriptor> constructorsOf(Context context, TypeRef classRef) {
+    if (!(context instanceof ContextType type)) {
+      return List.of();
+    }
+    var ctors = type.constructors();
+    if (ctors == null || ctors.isEmpty()) {
+      return List.of();
+    }
+    var result = new ArrayList<SignatureDescriptor>(ctors.size());
+    for (var ctor : ctors) {
+      var parameters = new ArrayList<ParameterDescriptor>(ctor.parameters().size());
+      for (var parameter : ctor.parameters()) {
+        parameters.add(toParameterDescriptor(parameter));
+      }
+      result.add(new SignatureDescriptor(parameters, classRef, ctor.description()));
+    }
+    return List.copyOf(result);
+  }
+
+  /**
+   * Помечает тип как «возможный ресивер dot-выражения через глобальное имя»
+   * по эвристике: внутри типа есть generic-property вида {@code <Имя X>}.
+   * Это резервный сигнал для LS — основной путь связывания
+   * {@code Справочники} ↔ {@code СправочникиМенеджер} идёт через
+   * {@link GlobalScopeProvider} из свойств глобального контекста.
+   */
+  private static boolean isExposedAsGlobal(Context context) {
+    if (!(context instanceof ContextType type)) {
+      return false;
+    }
+    for (var p : type.properties()) {
+      if (p.isGeneric()) {
+        return true;
+      }
+    }
+    return false;
+  }
+
+  private static TypeKind mapKind(Context context) {
+    return switch (context.kind()) {
+      case PRIMITIVE_TYPE -> TypeKind.PRIMITIVE;
+      case TYPE, ENUM -> TypeKind.PLATFORM;
+      // GLOBAL_CONTEXT и LANGUAGE_KEYWORD типами не являются — обрабатываются
+      // отдельно (GlobalScopeProvider).
+      case GLOBAL_CONTEXT, LANGUAGE_KEYWORD -> null;
+    };
+  }
+
+  private static List<String> aliasesOf(ContextName name) {
+    var alias = name.getAlias();
+    if (alias == null || alias.isBlank() || alias.equalsIgnoreCase(name.getName())) {
+      return List.of();
+    }
+    return List.of(alias);
+  }
+
+  private static List<MemberDescriptor> collectMembers(Context context) {
+    if (context instanceof ContextType type) {
+      var members = new ArrayList<MemberDescriptor>(
+        type.methods().size() + type.properties().size());
+      for (var property : type.properties()) {
+        members.add(toMemberDescriptor(property));
+      }
+      for (var method : type.methods()) {
+        members.add(toMemberDescriptor(method));
+      }
+      return List.copyOf(members);
+    }
+    if (context instanceof ContextEnum enumeration) {
+      var values = enumeration.values();
+      var members = new ArrayList<MemberDescriptor>(values.size());
+      var enumRef = new TypeRef(TypeKind.PLATFORM, context.name().getName());
+      for (var value : values) {
+        members.add(toMemberDescriptor(value, enumRef));
+      }
+      return List.copyOf(members);
+    }
+    return Collections.emptyList();
+  }
+
+  static MemberDescriptor toMemberDescriptor(ContextProperty property) {
+    var returnType = singleType(property.types());
+    return new MemberDescriptor(
+      property.name().getName(),
+      MemberKind.PROPERTY,
+      property.description(),
+      returnType,
+      List.of()
+    );
+  }
+
+  static MemberDescriptor toMemberDescriptor(ContextMethod method) {
+    var returnType = singleType(method.returnValues());
+    var signatures = toSignatures(method.signatures(), returnType);
+    return new MemberDescriptor(
+      method.name().getName(),
+      MemberKind.METHOD,
+      method.description(),
+      returnType,
+      signatures
+    );
+  }
+
+  private static MemberDescriptor toMemberDescriptor(ContextEnumValue value, TypeRef enumRef) {
+    return new MemberDescriptor(
+      value.name().getName(),
+      MemberKind.PROPERTY,
+      value.description(),
+      enumRef,
+      List.of()
+    );
+  }
+
+  static List<SignatureDescriptor> toSignatures(
+    List<ContextMethodSignature> signatures,
+    TypeRef returnType
+  ) {
+    if (signatures == null || signatures.isEmpty()) {
+      return List.of();
+    }
+    var result = new ArrayList<SignatureDescriptor>(signatures.size());
+    for (var signature : signatures) {
+      var parameters = new ArrayList<ParameterDescriptor>(signature.parameters().size());
+      for (var parameter : signature.parameters()) {
+        parameters.add(toParameterDescriptor(parameter));
+      }
+      // bsl-context хранит returnType один на метод (одна страница HBK —
+      // один блок «Возвращаемое значение:»), поэтому он одинаков для
+      // всех вариантов сигнатуры.
+      result.add(new SignatureDescriptor(parameters, returnType, signature.description()));
+    }
+    return List.copyOf(result);
+  }
+
+  private static ParameterDescriptor toParameterDescriptor(ContextSignatureParameter parameter) {
+    return new ParameterDescriptor(
+      parameter.name().getName(),
+      typeSet(parameter.types()),
+      !parameter.isRequired(),
+      parameter.description()
+    );
+  }
+
+  static TypeRef singleType(List<Context> contexts) {
+    if (contexts == null || contexts.isEmpty()) {
+      return TypeRef.UNKNOWN;
+    }
+    var first = contexts.get(0);
+    return new TypeRef(mapRefKind(first), first.name().getName());
+  }
+
+  private static TypeSet typeSet(List<Context> contexts) {
+    if (contexts == null || contexts.isEmpty()) {
+      return TypeSet.EMPTY;
+    }
+    var refs = new ArrayList<TypeRef>(contexts.size());
+    for (var c : contexts) {
+      refs.add(new TypeRef(mapRefKind(c), c.name().getName()));
+    }
+    return TypeSet.of(refs);
+  }
+
+  private static TypeKind mapRefKind(Context context) {
+    return switch (context.kind()) {
+      case PRIMITIVE_TYPE -> TypeKind.PRIMITIVE;
+      case TYPE, ENUM -> TypeKind.PLATFORM;
+      case GLOBAL_CONTEXT, LANGUAGE_KEYWORD -> TypeKind.UNKNOWN;
+    };
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinPlatformTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinPlatformTypesProvider.java
@@ -42,15 +42,12 @@ import java.util.List;
 import java.util.Map;
 
 /**
- * Bootstrap-провайдер платформенных типов на основе JSON-ресурса,
- * упакованного вместе с bsl-language-server.
- * <p>
- * Содержит минимальный набор примитивов и ключевых коллекций — этого
- * достаточно для базового вывода типов из литералов и {@code Новый X()}.
- * Полный набор членов платформенных типов в дальнейшем будет приходить
- * из внешнего {@code platform-context} либо JSON синтакс-помощника
- * установленной платформы. Точка расширения — реализация
- * {@link PlatformTypesProvider} как отдельный Spring {@code @Component}.
+ * Fallback-провайдер платформенных типов из JSON-ресурса, упакованного
+ * вместе с bsl-language-server. Используется, когда полноценный источник
+ * через {@link BslContextPlatformTypesProvider} (синтакс-помощник
+ * установленной платформы) недоступен — например, на CI или у пользователя
+ * без 1С. Содержит минимальный набор примитивов и ключевых коллекций для
+ * базового вывода типов из литералов и {@code Новый X()}.
  */
 @Slf4j
 @Component
@@ -61,13 +58,26 @@ public class BuiltinPlatformTypesProvider implements PlatformTypesProvider {
     "com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json";
 
   private final List<TypeDecl> types;
+  private final BslContextHolder bslContextHolder;
 
-  public BuiltinPlatformTypesProvider() {
+  public BuiltinPlatformTypesProvider(BslContextHolder bslContextHolder) {
+    this.bslContextHolder = bslContextHolder;
     this.types = loadFromResource(RESOURCE_PATH);
   }
 
+  /**
+   * Возвращает встроенный JSON-fallback только тогда, когда полноценный
+   * {@code bsl-context}-источник недоступен (платформа 1С не установлена
+   * либо парсинг HBK не удался). Если bsl-context дал данные —
+   * {@link BslContextPlatformTypesProvider} полностью покрывает то же
+   * множество типов, поэтому здесь возвращаем пустой список, чтобы
+   * избежать дублей и устаревшей JSON-разметки.
+   */
   @Override
   public Collection<TypeDecl> getTypes() {
+    if (bslContextHolder.get().isPresent()) {
+      return List.of();
+    }
     return types;
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
@@ -21,6 +21,13 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
+import com.github._1c_syntax.bsl.context.api.ContextEnum;
+import com.github._1c_syntax.bsl.context.api.ContextLanguageKeyword;
+import com.github._1c_syntax.bsl.context.api.ContextProperty;
+import com.github._1c_syntax.bsl.context.api.ContextProvider;
+import com.github._1c_syntax.bsl.context.api.ContextType;
+import com.github._1c_syntax.bsl.context.api.LanguageKeywordCategory;
+import com.github._1c_syntax.bsl.context.api.LanguageKeywordSnippet;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope;
@@ -46,11 +53,18 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicBoolean;
 
 /**
  * Workspace-scoped реестр глобальной области видимости:
@@ -82,31 +96,45 @@ public class GlobalScopeProvider {
   private final Map<String, LanguageScope> keywordScopes;
   /** lowercased имя платформенной переменной → языковой скоуп. */
   private final Map<String, LanguageScope> platformVariableScopes;
+  /**
+   * lowercased имя BSL-keyword'а (canonical или alias) → двуязычный сниппет
+   * автодополнения с плейсхолдерами {@code <?>}. Заполняется при загрузке
+   * из bsl-context. Для keyword'ов из JSON-fallback — пустая мапа.
+   */
+  private final Map<String, LanguageKeywordSnippet> keywordSnippets;
   /** lowercased имя глобального свойства (через registerGlobalProperty) → языковой скоуп. */
-  private final Map<String, LanguageScope> globalPropertyScopes = new java.util.concurrent.ConcurrentHashMap<>();
+  private final Map<String, LanguageScope> globalPropertyScopes = new ConcurrentHashMap<>();
   /** Имена library-модулей OneScript (lowercased) → TypeRef модуля. */
-  private final Map<String, TypeRef> libraryModules = new java.util.concurrent.ConcurrentHashMap<>();
+  private final Map<String, TypeRef> libraryModules = new ConcurrentHashMap<>();
   /** Имена library-классов OneScript (lowercased) → сигнатуры конструктора. */
-  private final Map<String, List<SignatureDescriptor>> libraryClasses = new java.util.concurrent.ConcurrentHashMap<>();
+  private final Map<String, List<SignatureDescriptor>> libraryClasses = new ConcurrentHashMap<>();
   /** Хранит исходные написания имён library-сущностей для отображения. */
-  private final Map<String, String> libraryNamesDisplay = new java.util.concurrent.ConcurrentHashMap<>();
+  private final Map<String, String> libraryNamesDisplay = new ConcurrentHashMap<>();
   /**
    * Имя library-сущности (lowercased) → имя библиотеки-источника (lowercased,
    * например, имя каталога с {@code lib.config} или {@code oscript_modules/<name>}).
    * Используется для фильтрации видимости по {@code #Использовать <libName>}.
    */
-  private final Map<String, String> libraryEntryOrigin = new java.util.concurrent.ConcurrentHashMap<>();
+  private final Map<String, String> libraryEntryOrigin = new ConcurrentHashMap<>();
   /**
    * Каноничные «составные» имена MD-объектов конфигурации в коллекционной
    * форме ({@code Справочники.Контрагенты}, {@code Documents.Документ1}).
    * Поддерживается no-dot completion: пользователь печатает {@code Докум} —
    * подсказывается и {@code Документы}, и {@code Документы.Документ1}.
    */
-  private final java.util.Set<String> configurationQualifiedNames =
-    java.util.Collections.newSetFromMap(new java.util.concurrent.ConcurrentHashMap<>());
+  private final Set<String> configurationQualifiedNames =
+    Collections.newSetFromMap(new ConcurrentHashMap<>());
 
-  public GlobalScopeProvider() {
-    var loaded = load();
+  /**
+   * @param bslContextHolder источник BSL-глобалов из синтакс-помощника
+   *                         установленной платформы 1С (через {@code bsl-context}).
+   *                         Если платформа найдена — её содержимое заменяет
+   *                         встроенный {@code builtin-globals.json} для BSL-части
+   *                         (OS-часть всегда из ресурса). Если платформа недоступна —
+   *                         fallback на JSON-ресурс.
+   */
+  public GlobalScopeProvider(BslContextHolder bslContextHolder) {
+    var loaded = load(bslContextHolder);
     this.functions = loaded.functions;
     this.classes = loaded.classes;
     this.keywords = loaded.keywords;
@@ -115,6 +143,21 @@ public class GlobalScopeProvider {
     this.classScopes = loaded.classScopes;
     this.keywordScopes = loaded.keywordScopes;
     this.platformVariableScopes = loaded.platformVariableScopes;
+    this.keywordSnippets = loaded.keywordSnippets;
+  }
+
+  /**
+   * Двуязычный сниппет автодополнения для BSL-keyword'а (например,
+   * {@code Если <?> Тогда\nИначеЕсли\nКонецЕсли;}). Источник —
+   * парные {@code .st}-файлы из {@code shlang_*.hbk}; если bsl-context
+   * недоступен или у keyword'а сниппета нет — {@link Optional#empty()}.
+   * Поиск по lowercased имени, как ru, так и en.
+   */
+  public Optional<LanguageKeywordSnippet> findKeywordSnippet(String name) {
+    if (name == null || name.isBlank()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(keywordSnippets.get(name.toLowerCase(Locale.ROOT)));
   }
 
   /**
@@ -127,8 +170,7 @@ public class GlobalScopeProvider {
   @Autowired(required = false)
   private GlobalSymbolScope globalSymbolScope;
 
-  private final java.util.concurrent.atomic.AtomicBoolean globalsPublished =
-    new java.util.concurrent.atomic.AtomicBoolean(false);
+  private final AtomicBoolean globalsPublished = new AtomicBoolean(false);
 
   /**
    * Поиск symbol'а в глобальной области (globals + library entries).
@@ -187,7 +229,7 @@ public class GlobalScopeProvider {
       return;
     }
     // Регистрируем глобальные функции в GlobalSymbolScope как synthetic-методы.
-    var alreadyRegistered = new java.util.HashSet<MemberDescriptor>();
+    var alreadyRegistered = new HashSet<MemberDescriptor>();
     for (var entry : functions.entrySet()) {
       var descriptor = entry.getValue();
       if (!alreadyRegistered.add(descriptor)) {
@@ -291,7 +333,7 @@ public class GlobalScopeProvider {
     if (fileType == null) {
       return getFunctions();
     }
-    var result = new java.util.LinkedHashSet<MemberDescriptor>();
+    var result = new LinkedHashSet<MemberDescriptor>();
     for (var entry : functions.entrySet()) {
       var s = functionScopes.get(entry.getKey());
       if (s == null || s.matches(fileType)) {
@@ -664,7 +706,7 @@ public class GlobalScopeProvider {
    * @return Каноничные составные имена MD-объектов в исходном написании.
    */
   public Collection<String> getConfigurationQualifiedNames() {
-    return java.util.List.copyOf(configurationQualifiedNames);
+    return List.copyOf(configurationQualifiedNames);
   }
 
   /**
@@ -682,15 +724,214 @@ public class GlobalScopeProvider {
     // (например, OScriptLibraryIndex перед reindex).
   }
 
-  private static Loaded load() {
-    var bsl = loadFromResource(RESOURCE_PATH, LanguageScope.BSL);
+  /**
+   * Загружает наполнение глобальной области:
+   * <ul>
+   *   <li>OneScript (OS) — всегда из ресурса {@link #OSCRIPT_RESOURCE_PATH};</li>
+   *   <li>BSL — целиком из bsl-context, если платформа 1С установлена и парсинг
+   *       прошёл (функции из глобального контекста, классы для {@code Новый} —
+   *       из ContextType, ключевые слова — из {@code LANGUAGE_KEYWORD}
+   *       категорий LITERAL/STATEMENT/OPERATOR/DECLARATION, платформенные
+   *       переменные — из {@code ContextEnum}). JSON в этом случае не читается.
+   *       Если bsl-context недоступен — fallback на ресурс {@link #RESOURCE_PATH}.</li>
+   * </ul>
+   */
+  private static Loaded load(BslContextHolder bslContextHolder) {
     var os = loadFromResource(OSCRIPT_RESOURCE_PATH, LanguageScope.OS);
+    var bsl = loadBsl(bslContextHolder);
     return merge(bsl, os);
+  }
+
+  /**
+   * BSL-часть глобальной области: либо из bsl-context (если есть), либо
+   * из {@link #RESOURCE_PATH} JSON (fallback). JSON не читается, когда
+   * bsl-context дал результат — иначе данные дублируются.
+   */
+  private static Loaded loadBsl(BslContextHolder bslContextHolder) {
+    var providerOpt = bslContextHolder.get();
+    if (providerOpt.isPresent()) {
+      return buildBslFromContext(providerOpt.get());
+    }
+    return loadFromResource(RESOURCE_PATH, LanguageScope.BSL);
+  }
+
+  private static Loaded buildBslFromContext(ContextProvider provider) {
+    var globalContext = provider.getGlobalContext();
+
+    var functions = new LinkedHashMap<String, MemberDescriptor>();
+    var functionScopes = new HashMap<String, LanguageScope>();
+    if (globalContext != null) {
+      for (var method : globalContext.methods()) {
+        var descriptor = BslContextPlatformTypesProvider.toMemberDescriptor(method);
+        putFunction(functions, functionScopes, method.name().getName(), descriptor);
+        putFunction(functions, functionScopes, method.name().getAlias(), descriptor);
+      }
+    }
+
+    var classes = new ArrayList<String>();
+    var classScopes = new HashMap<String, LanguageScope>();
+    var classSeen = new HashSet<String>();
+    var keywords = new ArrayList<String>();
+    var keywordScopes = new HashMap<String, LanguageScope>();
+    var keywordSeen = new HashSet<String>();
+    var keywordSnippets = new HashMap<String, LanguageKeywordSnippet>();
+    var variables = new ArrayList<PlatformVariable>();
+    var variableScopes = new HashMap<String, LanguageScope>();
+    var variableSeen = new HashSet<String>();
+
+    // Глобальные свойства (Документы, Справочники, БиблиотекаКартинок и т.п.) —
+    // top-level имена, доступные без префикса. Тип берём первый из объявленных
+    // в СП (типа СправочникиМенеджер) — для dot-completion'а к коллекции.
+    if (globalContext != null) {
+      for (var property : globalContext.properties()) {
+        if (property.isGeneric()) {
+          continue; // generic-плейсхолдеры (<Имя справочника>) — не имена.
+        }
+        var name = property.name().getName();
+        var alias = property.name().getAlias();
+        var lc = name.toLowerCase(Locale.ROOT);
+        if (!variableSeen.add(lc)) {
+          continue;
+        }
+        var aliases = alias == null || alias.isBlank() ? List.<String>of() : List.of(alias);
+        var typeRef = firstTypeRef(property);
+        variables.add(new PlatformVariable(name, aliases, property.description(), typeRef));
+        variableScopes.put(lc, LanguageScope.BSL);
+        if (!aliases.isEmpty()) {
+          variableScopes.put(alias.toLowerCase(Locale.ROOT), LanguageScope.BSL);
+        }
+      }
+    }
+
+    for (var ctx : provider.getContexts()) {
+      if (ctx instanceof ContextType type && !type.isGeneric()) {
+        addNameWithAlias(classes, classScopes, classSeen, type.name().getName(), type.name().getAlias());
+      } else if (ctx instanceof ContextEnum enumeration) {
+        // Системное перечисление платформы — публикуется как глобальная
+        // переменная: «КодировкаТекста» как имя, тип — ссылка на само
+        // перечисление (для dot-completion'а с его значениями).
+        var name = enumeration.name().getName();
+        var alias = enumeration.name().getAlias();
+        var lc = name.toLowerCase(Locale.ROOT);
+        if (variableSeen.add(lc)) {
+          var aliases = alias == null || alias.isBlank() ? List.<String>of() : List.of(alias);
+          var typeRef = new TypeRef(TypeKind.PLATFORM, name);
+          variables.add(new PlatformVariable(name, aliases, "", typeRef));
+          variableScopes.put(lc, LanguageScope.BSL);
+          if (!aliases.isEmpty()) {
+            variableScopes.put(alias.toLowerCase(Locale.ROOT), LanguageScope.BSL);
+          }
+        }
+      } else if (ctx instanceof ContextLanguageKeyword kw) {
+        if (KEYWORD_CATEGORIES.contains(kw.category())) {
+          var added = addNameWithAlias(keywords, keywordScopes, keywordSeen,
+            kw.name().getName(), kw.name().getAlias());
+          if (added && !kw.snippet().isEmpty()) {
+            // Сниппет по обоим написаниям — пользователь может ввести любое.
+            keywordSnippets.put(kw.name().getName().toLowerCase(Locale.ROOT), kw.snippet());
+            if (kw.name().getAlias() != null && !kw.name().getAlias().isBlank()) {
+              keywordSnippets.put(kw.name().getAlias().toLowerCase(Locale.ROOT), kw.snippet());
+            }
+          }
+        }
+      }
+    }
+
+    return new Loaded(
+      Collections.unmodifiableMap(functions),
+      List.copyOf(classes),
+      List.copyOf(keywords),
+      List.copyOf(variables),
+      new ConcurrentHashMap<>(functionScopes),
+      new ConcurrentHashMap<>(classScopes),
+      new ConcurrentHashMap<>(keywordScopes),
+      new ConcurrentHashMap<>(variableScopes),
+      Map.copyOf(keywordSnippets)
+    );
+  }
+
+  /**
+   * Берёт первый тип из {@link ContextProperty#types()} и заворачивает в
+   * {@link TypeRef}. Если список пуст — {@link TypeRef#UNKNOWN}.
+   * Используется при публикации глобальных свойств — у property может быть
+   * один или несколько объявленных типов, для resolve dot-completion'а
+   * нам достаточно первого.
+   */
+  private static TypeRef firstTypeRef(ContextProperty property) {
+    var types = property.types();
+    if (types == null || types.isEmpty()) {
+      return TypeRef.UNKNOWN;
+    }
+    var first = types.get(0);
+    var kind = switch (first.kind()) {
+      case PRIMITIVE_TYPE -> TypeKind.PRIMITIVE;
+      case TYPE, ENUM -> TypeKind.PLATFORM;
+      case GLOBAL_CONTEXT, LANGUAGE_KEYWORD -> TypeKind.UNKNOWN;
+    };
+    return new TypeRef(kind, first.name().getName());
+  }
+
+  /**
+   * Категории {@link LanguageKeywordCategory}, пригодные для no-dot completion
+   * как «keywords». PRAGMA / ANNOTATION / PREPROCESSOR_INSTRUCTION
+   * предваряются специальными префиксами ({@code &} / {@code #}) и
+   * обрабатываются другим completion-flow.
+   */
+  private static final Set<LanguageKeywordCategory> KEYWORD_CATEGORIES =
+    EnumSet.of(
+      LanguageKeywordCategory.LITERAL,
+      LanguageKeywordCategory.STATEMENT,
+      LanguageKeywordCategory.OPERATOR,
+      LanguageKeywordCategory.DECLARATION
+    );
+
+  /**
+   * Добавляет ru-имя и en-алиас в общий список с дедупликацией по lowercase.
+   * @return {@code true}, если хотя бы одно из имён было добавлено впервые
+   *         (нужно для маппинга «ключ → snippet» — он привязывается только
+   *         к новым именам).
+   */
+  private static boolean addNameWithAlias(List<String> sink,
+                                          Map<String, LanguageScope> scopes,
+                                          Set<String> seen,
+                                          String name, String alias) {
+    var added = false;
+    if (name != null && !name.isBlank()) {
+      var lc = name.toLowerCase(Locale.ROOT);
+      if (seen.add(lc)) {
+        sink.add(name);
+        scopes.put(lc, LanguageScope.BSL);
+        added = true;
+      }
+    }
+    if (alias != null && !alias.isBlank()) {
+      var lc = alias.toLowerCase(Locale.ROOT);
+      if (seen.add(lc)) {
+        sink.add(alias);
+        scopes.put(lc, LanguageScope.BSL);
+        added = true;
+      }
+    }
+    return added;
+  }
+
+  private static void putFunction(
+    Map<String, MemberDescriptor> functions,
+    Map<String, LanguageScope> functionScopes,
+    String name,
+    MemberDescriptor descriptor
+  ) {
+    if (name == null || name.isBlank()) {
+      return;
+    }
+    var lc = name.toLowerCase(Locale.ROOT);
+    functions.putIfAbsent(lc, descriptor);
+    functionScopes.merge(lc, LanguageScope.BSL, LanguageScope::merge);
   }
 
   private static Loaded merge(Loaded a, Loaded b) {
     var functions = new LinkedHashMap<String, MemberDescriptor>(a.functions);
-    var functionScopes = new java.util.HashMap<String, LanguageScope>(a.functionScopes);
+    var functionScopes = new HashMap<String, LanguageScope>(a.functionScopes);
     for (var e : b.functions.entrySet()) {
       functions.putIfAbsent(e.getKey(), e.getValue());
     }
@@ -698,8 +939,8 @@ public class GlobalScopeProvider {
       functionScopes.merge(e.getKey(), e.getValue(), LanguageScope::merge);
     }
     var classes = new ArrayList<String>(a.classes.size() + b.classes.size());
-    var classScopes = new java.util.HashMap<String, LanguageScope>(a.classScopes);
-    var seenClass = new java.util.HashSet<String>();
+    var classScopes = new HashMap<String, LanguageScope>(a.classScopes);
+    var seenClass = new HashSet<String>();
     for (var c : a.classes) {
       if (seenClass.add(c.toLowerCase(Locale.ROOT))) classes.add(c);
     }
@@ -710,8 +951,8 @@ public class GlobalScopeProvider {
       classScopes.merge(e.getKey(), e.getValue(), LanguageScope::merge);
     }
     var keywords = new ArrayList<String>(a.keywords.size() + b.keywords.size());
-    var keywordScopes = new java.util.HashMap<String, LanguageScope>(a.keywordScopes);
-    var seenKw = new java.util.HashSet<String>();
+    var keywordScopes = new HashMap<String, LanguageScope>(a.keywordScopes);
+    var seenKw = new HashSet<String>();
     for (var k : a.keywords) {
       if (seenKw.add(k.toLowerCase(Locale.ROOT))) keywords.add(k);
     }
@@ -722,8 +963,8 @@ public class GlobalScopeProvider {
       keywordScopes.merge(e.getKey(), e.getValue(), LanguageScope::merge);
     }
     var vars = new ArrayList<PlatformVariable>(a.platformVariables.size() + b.platformVariables.size());
-    var varScopes = new java.util.HashMap<String, LanguageScope>(a.platformVariableScopes);
-    var seenVar = new java.util.HashSet<String>();
+    var varScopes = new HashMap<String, LanguageScope>(a.platformVariableScopes);
+    var seenVar = new HashSet<String>();
     for (var v : a.platformVariables) {
       if (seenVar.add(v.name().toLowerCase(Locale.ROOT))) vars.add(v);
     }
@@ -733,15 +974,19 @@ public class GlobalScopeProvider {
     for (var e : b.platformVariableScopes.entrySet()) {
       varScopes.merge(e.getKey(), e.getValue(), LanguageScope::merge);
     }
+    var snippets = new HashMap<String, LanguageKeywordSnippet>();
+    snippets.putAll(a.keywordSnippets);
+    b.keywordSnippets.forEach(snippets::putIfAbsent);
     return new Loaded(
       Collections.unmodifiableMap(functions),
       List.copyOf(classes),
       List.copyOf(keywords),
       List.copyOf(vars),
-      new java.util.concurrent.ConcurrentHashMap<>(functionScopes),
-      new java.util.concurrent.ConcurrentHashMap<>(classScopes),
-      new java.util.concurrent.ConcurrentHashMap<>(keywordScopes),
-      new java.util.concurrent.ConcurrentHashMap<>(varScopes)
+      new ConcurrentHashMap<>(functionScopes),
+      new ConcurrentHashMap<>(classScopes),
+      new ConcurrentHashMap<>(keywordScopes),
+      new ConcurrentHashMap<>(varScopes),
+      Map.copyOf(snippets)
     );
   }
 
@@ -756,23 +1001,23 @@ public class GlobalScopeProvider {
       @SuppressWarnings("unchecked")
       var keywords = (List<String>) root.getOrDefault("keywords", Collections.emptyList());
       var variables = readVariables(root);
-      var fnScopes = new java.util.HashMap<String, LanguageScope>();
+      var fnScopes = new HashMap<String, LanguageScope>();
       functions.keySet().forEach(k -> fnScopes.put(k, scope));
-      var clsScopes = new java.util.HashMap<String, LanguageScope>();
+      var clsScopes = new HashMap<String, LanguageScope>();
       classes.forEach(c -> clsScopes.put(c.toLowerCase(Locale.ROOT), scope));
-      var kwScopes = new java.util.HashMap<String, LanguageScope>();
+      var kwScopes = new HashMap<String, LanguageScope>();
       keywords.forEach(k -> kwScopes.put(k.toLowerCase(Locale.ROOT), scope));
-      var varScopes = new java.util.HashMap<String, LanguageScope>();
+      var varScopes = new HashMap<String, LanguageScope>();
       for (var v : variables) {
         varScopes.put(v.name().toLowerCase(Locale.ROOT), scope);
         v.aliases().forEach(a -> varScopes.put(a.toLowerCase(Locale.ROOT), scope));
       }
       return new Loaded(functions, List.copyOf(classes), List.copyOf(keywords), variables,
-        fnScopes, clsScopes, kwScopes, varScopes);
+        fnScopes, clsScopes, kwScopes, varScopes, Map.of());
     } catch (IOException e) {
       LOGGER.error("Failed to load builtin globals resource: {}", resourcePath, e);
       return new Loaded(Collections.emptyMap(), List.of(), List.of(), List.of(),
-        Map.of(), Map.of(), Map.of(), Map.of());
+        Map.of(), Map.of(), Map.of(), Map.of(), Map.of());
     }
   }
 
@@ -861,7 +1106,8 @@ public class GlobalScopeProvider {
     Map<String, LanguageScope> functionScopes,
     Map<String, LanguageScope> classScopes,
     Map<String, LanguageScope> keywordScopes,
-    Map<String, LanguageScope> platformVariableScopes
+    Map<String, LanguageScope> platformVariableScopes,
+    Map<String, LanguageKeywordSnippet> keywordSnippets
   ) {
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformContextProviderFactory.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformContextProviderFactory.java
@@ -1,0 +1,77 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.context.PlatformContextGrabber;
+import com.github._1c_syntax.bsl.context.api.ContextProvider;
+import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.stereotype.Component;
+
+import java.io.IOException;
+import java.util.Optional;
+
+/**
+ * Фабрика {@link ContextProvider} от {@code bsl-context}: создаёт парсер
+ * синтакс-помощника установленной 1С и возвращает готовый провайдер. Подходящий
+ * каталог {@code bin} платформы выбирается по
+ * {@link com.github._1c_syntax.bsl.languageserver.configuration.platform.V8PlatformOptions#getBinPath()}
+ * либо через {@code PlatformFinder.autoDetect()} (самая свежая установка на машине).
+ * <p>
+ * Stateless — кэш живёт в {@link BslContextHolder}. Здесь только factory,
+ * чтобы инкапсулировать статическую фабрику {@link PlatformContextGrabber}
+ * в Spring-компонент.
+ */
+@Slf4j
+@Component
+@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@RequiredArgsConstructor
+public class PlatformContextProviderFactory {
+
+  private final LanguageServerConfiguration configuration;
+
+  /**
+   * Создаёт новый {@link ContextProvider}, прочитав HBK-файлы платформы.
+   *
+   * @return полностью инициализированный провайдер, либо {@link Optional#empty()},
+   *   если платформа не найдена / HBK не открылся
+   * @throws IOException если парсинг упал на IO-ошибке (для логирования в caller'е)
+   */
+  public Optional<ContextProvider> create() throws IOException {
+    var binPath = configuration.getPlatformOptions().getBinPath();
+    var grabber = binPath != null
+      ? PlatformContextGrabber.fromPlatformBin(binPath)
+      : PlatformContextGrabber.autoDetect();
+    grabber.parse();
+    var provider = grabber.getProvider();
+    if (provider == null) {
+      return Optional.empty();
+    }
+    LOGGER.info("Loaded {} platform contexts from 1C syntax helper",
+      provider.getContexts().size());
+    return Optional.of(provider);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProviderTest.java
@@ -1,0 +1,424 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.context.api.Context;
+import com.github._1c_syntax.bsl.context.api.ContextMethodSignature;
+import com.github._1c_syntax.bsl.context.api.ContextName;
+import com.github._1c_syntax.bsl.context.api.ContextProvider;
+import com.github._1c_syntax.bsl.context.api.ContextSignatureParameter;
+import com.github._1c_syntax.bsl.context.api.LanguageKeywordCategory;
+import com.github._1c_syntax.bsl.context.api.ContextConstructor;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextConstructor;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextEnum;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextEnumValue;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextMethod;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextMethodSignature;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextProperty;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextProvider;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextSignatureParameter;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextType;
+import com.github._1c_syntax.bsl.context.platform.PlatformGlobalContext;
+import com.github._1c_syntax.bsl.context.platform.PlatformLanguageKeyword;
+import com.github._1c_syntax.bsl.context.platform.internal.PlatformContextStorage;
+import com.github._1c_syntax.bsl.context.platform.primitive.PrimitivePlaceholderType;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit-тесты на адаптер {@link BslContextPlatformTypesProvider}: проверяем
+ * правильность маппинга {@code Context} → {@code TypeDecl}/{@code MemberDescriptor}.
+ * Источник данных — синтетический {@link PlatformContextProvider} из
+ * builder'ов bsl-context (без чтения реального HBK).
+ */
+class BslContextPlatformTypesProviderTest {
+
+  /** Имитация {@link BslContextHolder} без Spring. */
+  private static BslContextHolder holderOf(ContextProvider provider) {
+    return new BslContextHolder(null) {
+      @Override
+      public Optional<ContextProvider> get() {
+        return Optional.ofNullable(provider);
+      }
+    };
+  }
+
+  // BslContextHolder теперь принимает PlatformContextProviderFactory.
+  // В тестах подменяем сам holder через override get(), фабрика не используется.
+
+  @Test
+  void emptyHolderProducesNoTypes() {
+    var adapter = new BslContextPlatformTypesProvider(holderOf(null));
+    assertThat(adapter.getTypes()).isEmpty();
+  }
+
+  @Test
+  void primitiveBecomesPrimitiveTypeDecl() {
+    var primitive = new PrimitivePlaceholderType(new ContextName("Строка", "String"), "");
+    var provider = providerOf(primitive);
+
+    var types = new BslContextPlatformTypesProvider(holderOf(provider)).getTypes();
+
+    assertThat(types).hasSize(1);
+    var decl = types.iterator().next();
+    assertThat(decl.kind()).isEqualTo(TypeKind.PRIMITIVE);
+    assertThat(decl.qualifiedName()).isEqualTo("Строка");
+    assertThat(decl.aliases()).containsExactly("String");
+    assertThat(decl.members()).isEmpty();
+  }
+
+  @Test
+  void platformTypePublishesMethodsAndPropertiesAsMembers() {
+    var stringType = primitive("Строка", "String");
+    var numberType = primitive("Число", "Number");
+
+    var addedParam = PlatformContextSignatureParameter.builder()
+      .name(new ContextName("Значение", ""))
+      .isRequired(true)
+      .rawTypes(List.of("Строка"))
+      .description("Добавляемое значение")
+      .build();
+    var addSig = PlatformContextMethodSignature.builder()
+      .name(new ContextName("", ""))
+      .parameters(new ArrayList<>(List.of((ContextSignatureParameter) addedParam)))
+      .description("")
+      .build();
+    var addMethod = PlatformContextMethod.builder()
+      .name(new ContextName("Добавить", "Add"))
+      .description("Добавляет элемент.")
+      .availabilities(List.of())
+      .rawReturnValues(List.of())
+      .signatures(new ArrayList<>(List.of((ContextMethodSignature) addSig)))
+      .build();
+
+    var countProperty = PlatformContextProperty.builder()
+      .name(new ContextName("Количество", "Count"))
+      .rawTypes(List.of("Число"))
+      .description("Количество элементов.")
+      .availabilities(List.of())
+      .build();
+
+    var arrayType = PlatformContextType.builder()
+      .name(new ContextName("Массив", "Array"))
+      .methods(new ArrayList<>(List.of(addMethod)))
+      .properties(new ArrayList<>(List.of(countProperty)))
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .description("Универсальная коллекция.")
+      .build();
+
+    var provider = providerOf(arrayType, stringType, numberType);
+
+    var types = new BslContextPlatformTypesProvider(holderOf(provider)).getTypes();
+    var decl = types.stream()
+      .filter(t -> "Массив".equals(t.qualifiedName()))
+      .findFirst().orElseThrow();
+
+    assertThat(decl.kind()).isEqualTo(TypeKind.PLATFORM);
+    assertThat(decl.aliases()).containsExactly("Array");
+    // Порядок: properties → methods.
+    var members = List.copyOf(decl.members());
+    assertThat(members).hasSize(2);
+    assertThat(members.get(0).name()).isEqualTo("Количество");
+    assertThat(members.get(0).kind()).isEqualTo(MemberKind.PROPERTY);
+    assertThat(members.get(0).returnType().qualifiedName()).isEqualTo("Число");
+    assertThat(members.get(1).name()).isEqualTo("Добавить");
+    assertThat(members.get(1).kind()).isEqualTo(MemberKind.METHOD);
+    assertThat(members.get(1).signatures()).hasSize(1);
+    var param = members.get(1).signatures().get(0).parameters().get(0);
+    assertThat(param.name()).isEqualTo("Значение");
+    assertThat(param.optional()).isFalse();
+  }
+
+  @Test
+  void enumValuesPublishedAsPropertiesOfEnumType() {
+    var enumeration = PlatformContextEnum.builder()
+      .name(new ContextName("КодировкаТекста", "TextEncoding"))
+      .values(List.of(
+        new PlatformContextEnumValue(new ContextName("UTF8", "UTF8"),
+          "Кодировка UTF-8.", "", "", List.of()),
+        new PlatformContextEnumValue(new ContextName("ANSI", "ANSI"),
+          "ANSI-кодировка.", "", "", List.of())
+      ))
+      .build();
+
+    var types = new BslContextPlatformTypesProvider(holderOf(providerOf(enumeration))).getTypes();
+    var decl = types.iterator().next();
+
+    assertThat(decl.kind()).isEqualTo(TypeKind.PLATFORM);
+    assertThat(decl.qualifiedName()).isEqualTo("КодировкаТекста");
+    assertThat(decl.members()).hasSize(2);
+    decl.members().forEach(m -> {
+      assertThat(m.kind()).isEqualTo(MemberKind.PROPERTY);
+      // Тип значения = сам enum (для dot-completion'а с его именами).
+      assertThat(m.returnType().qualifiedName()).isEqualTo("КодировкаТекста");
+    });
+  }
+
+  @Test
+  void globalContextAndLanguageKeywordAreSkippedAsTypes() {
+    var globalContext = PlatformGlobalContext.builder()
+      .methods(Collections.emptyList())
+      .properties(Collections.emptyList())
+      .applicationEvents(Collections.emptyList())
+      .ordinaryApplicationEvents(Collections.emptyList())
+      .sessionModuleEvents(Collections.emptyList())
+      .externalConnectionModuleEvents(Collections.emptyList())
+      .build();
+    var keyword = PlatformLanguageKeyword.builder()
+      .name(new ContextName("Если", "If"))
+      .category(LanguageKeywordCategory.STATEMENT)
+      .description("")
+      .snippet(com.github._1c_syntax.bsl.context.api.LanguageKeywordSnippet.EMPTY)
+      .build();
+    var realType = primitive("Строка", "String");
+
+    var types = new BslContextPlatformTypesProvider(
+      holderOf(providerOf(globalContext, keyword, realType))).getTypes();
+
+    // Только примитив, без global-context и language-keyword.
+    assertThat(types)
+      .extracting(t -> t.qualifiedName())
+      .containsExactly("Строка");
+  }
+
+  @Test
+  void exposedAsGlobalHeuristicTriggersOnGenericProperty() {
+    // Универсальный менеджер с generic-property — должен быть помечен exposedAsGlobal=true.
+    var genericProp = PlatformContextProperty.builder()
+      .name(new ContextName("<Имя справочника>", ""))
+      .rawTypes(List.of())
+      .description("")
+      .availabilities(List.of())
+      .build();
+    var catalogsManager = PlatformContextType.builder()
+      .name(new ContextName("СправочникиМенеджер", "CatalogsManager"))
+      .methods(Collections.emptyList())
+      .properties(new ArrayList<>(List.of(genericProp)))
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .build();
+
+    // Обычный тип без generic — exposedAsGlobal=false.
+    var plainType = PlatformContextType.builder()
+      .name(new ContextName("ТаблицаЗначений", "ValueTable"))
+      .methods(Collections.emptyList())
+      .properties(Collections.emptyList())
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .build();
+
+    var types = new BslContextPlatformTypesProvider(
+      holderOf(providerOf(catalogsManager, plainType))).getTypes();
+
+    var manager = types.stream().filter(t -> "СправочникиМенеджер".equals(t.qualifiedName()))
+      .findFirst().orElseThrow();
+    var plain = types.stream().filter(t -> "ТаблицаЗначений".equals(t.qualifiedName()))
+      .findFirst().orElseThrow();
+
+    assertThat(manager.exposedAsGlobal()).isTrue();
+    assertThat(plain.exposedAsGlobal()).isFalse();
+  }
+
+  @Test
+  void typeDescriptionPropagatedFromContextType() {
+    var arrayType = PlatformContextType.builder()
+      .name(new ContextName("Массив", "Array"))
+      .methods(Collections.emptyList())
+      .properties(Collections.emptyList())
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .description("Универсальная коллекция значений.")
+      .build();
+
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)))
+      .getTypes().iterator().next();
+
+    assertThat(decl.description()).isEqualTo("Универсальная коллекция значений.");
+  }
+
+  @Test
+  void primitiveDescriptionPropagatedFromShlangPage() {
+    var primitive = new PrimitivePlaceholderType(
+      new ContextName("Строка", "String"),
+      "Значения данного типа содержат строку в формате Unicode.");
+
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(primitive)))
+      .getTypes().iterator().next();
+
+    assertThat(decl.description()).contains("Unicode");
+  }
+
+  @Test
+  void constructorsMappedToSignatureDescriptors() {
+    var stringType = primitive("Строка", "String");
+
+    var defaultCtor = PlatformContextConstructor.builder()
+      .name(new ContextName("По умолчанию", "Default"))
+      .description("Создаёт пустой массив.")
+      .parameters(Collections.emptyList())
+      .build();
+
+    var capacityParam = PlatformContextSignatureParameter.builder()
+      .name(new ContextName("ФиксированныйРазмер", "FixedSize"))
+      .isRequired(true)
+      .rawTypes(List.of("Строка"))
+      .description("Начальная вместимость массива.")
+      .build();
+    var byCapacityCtor = PlatformContextConstructor.builder()
+      .name(new ContextName("По размеру", "ByCapacity"))
+      .description("Создаёт массив с заданной вместимостью.")
+      .parameters(List.of(capacityParam))
+      .build();
+
+    var arrayType = PlatformContextType.builder()
+      .name(new ContextName("Массив", "Array"))
+      .methods(Collections.emptyList())
+      .properties(Collections.emptyList())
+      .events(Collections.emptyList())
+      .constructors(new ArrayList<>(List.of(
+        (ContextConstructor) defaultCtor,
+        (ContextConstructor) byCapacityCtor)))
+      .description("")
+      .build();
+
+    var decl = new BslContextPlatformTypesProvider(
+      holderOf(providerOf(arrayType, stringType)))
+      .getTypes().stream()
+      .filter(t -> "Массив".equals(t.qualifiedName()))
+      .findFirst().orElseThrow();
+
+    var ctors = decl.constructors();
+    assertThat(ctors).hasSize(2);
+    // 1. По умолчанию: без параметров.
+    assertThat(ctors.get(0).description()).isEqualTo("Создаёт пустой массив.");
+    assertThat(ctors.get(0).parameters()).isEmpty();
+    assertThat(ctors.get(0).returnType().qualifiedName())
+      .as("returnType конструктора — сам тип Массив")
+      .isEqualTo("Массив");
+    // 2. По размеру: один обязательный параметр с резолвом типа.
+    assertThat(ctors.get(1).description()).isEqualTo("Создаёт массив с заданной вместимостью.");
+    assertThat(ctors.get(1).parameters()).hasSize(1);
+    var param = ctors.get(1).parameters().get(0);
+    assertThat(param.name()).isEqualTo("ФиксированныйРазмер");
+    assertThat(param.optional()).isFalse();
+    assertThat(ctors.get(1).returnType().qualifiedName()).isEqualTo("Массив");
+  }
+
+  @Test
+  void multiVariantMethodPublishesMultipleSignatures() {
+    // Метод с двумя вариантами синтаксиса — например, Найти(Подстрока)
+    // и Найти(Подстрока, НомерСимвола). LS теперь умеет выбирать вариант
+    // по фактическому числу аргументов (HoverProvider /
+    // SignatureSelection.pickIndexByArity), поэтому важно публиковать все
+    // варианты как разные SignatureDescriptor с одним returnType метода.
+    var substringParam = PlatformContextSignatureParameter.builder()
+      .name(new ContextName("Подстрока", "SearchString"))
+      .isRequired(true)
+      .rawTypes(List.of())
+      .description("")
+      .build();
+    var sig1 = PlatformContextMethodSignature.builder()
+      .name(new ContextName("Основной", ""))
+      .parameters(new ArrayList<>(List.of((ContextSignatureParameter) substringParam)))
+      .description("Поиск с начала строки.")
+      .build();
+
+    var fromParam = PlatformContextSignatureParameter.builder()
+      .name(new ContextName("НомерСимвола", "CharNumber"))
+      .isRequired(true)
+      .rawTypes(List.of())
+      .description("")
+      .build();
+    var sig2 = PlatformContextMethodSignature.builder()
+      .name(new ContextName("СНачалаПоиска", ""))
+      .parameters(new ArrayList<>(List.of(
+        (ContextSignatureParameter) substringParam,
+        (ContextSignatureParameter) fromParam)))
+      .description("Поиск начиная с указанной позиции.")
+      .build();
+
+    var findMethod = PlatformContextMethod.builder()
+      .name(new ContextName("Найти", "Find"))
+      .description("Ищет вхождение подстроки.")
+      .availabilities(List.of())
+      .rawReturnValues(List.of())
+      .signatures(new ArrayList<>(List.of(
+        (ContextMethodSignature) sig1, (ContextMethodSignature) sig2)))
+      .build();
+    var stringType = PlatformContextType.builder()
+      .name(new ContextName("Строка", "String"))
+      .methods(new ArrayList<>(List.of(findMethod)))
+      .properties(Collections.emptyList())
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .build();
+
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(stringType)))
+      .getTypes().iterator().next();
+
+    var member = decl.members().iterator().next();
+    assertThat(member.signatures())
+      .as("Оба варианта синтаксиса должны быть опубликованы")
+      .hasSize(2);
+    assertThat(member.signatures().get(0).parameters()).hasSize(1);
+    assertThat(member.signatures().get(0).description()).isEqualTo("Поиск с начала строки.");
+    assertThat(member.signatures().get(1).parameters()).hasSize(2);
+    assertThat(member.signatures().get(1).description())
+      .isEqualTo("Поиск начиная с указанной позиции.");
+  }
+
+  @Test
+  void typeWithoutConstructorsHasEmptyConstructorList() {
+    var arrayType = PlatformContextType.builder()
+      .name(new ContextName("Массив", "Array"))
+      .methods(Collections.emptyList())
+      .properties(Collections.emptyList())
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .build();
+
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)))
+      .getTypes().iterator().next();
+
+    assertThat(decl.constructors()).isEmpty();
+  }
+
+  // --- builders ---
+
+  private static PrimitivePlaceholderType primitive(String ru, String en) {
+    return new PrimitivePlaceholderType(new ContextName(ru, en), "");
+  }
+
+  private static ContextProvider providerOf(Context... contexts) {
+    return new PlatformContextProvider(
+      new PlatformContextStorage(new ArrayList<>(List.of(contexts))));
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProviderBslContextTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProviderBslContextTest.java
@@ -1,0 +1,266 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.context.api.Context;
+import com.github._1c_syntax.bsl.context.api.ContextMethodSignature;
+import com.github._1c_syntax.bsl.context.api.ContextName;
+import com.github._1c_syntax.bsl.context.api.ContextProvider;
+import com.github._1c_syntax.bsl.context.api.ContextSignatureParameter;
+import com.github._1c_syntax.bsl.context.api.LanguageKeywordCategory;
+import com.github._1c_syntax.bsl.context.api.LanguageKeywordSnippet;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextEnum;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextEnumValue;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextMethod;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextMethodSignature;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextProperty;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextProvider;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextSignatureParameter;
+import com.github._1c_syntax.bsl.context.platform.PlatformContextType;
+import com.github._1c_syntax.bsl.context.platform.PlatformGlobalContext;
+import com.github._1c_syntax.bsl.context.platform.PlatformLanguageKeyword;
+import com.github._1c_syntax.bsl.context.platform.internal.PlatformContextStorage;
+import org.junit.jupiter.api.Test;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Unit-тесты на загрузку BSL-части {@link GlobalScopeProvider} из bsl-context:
+ * глобальные функции, классы для {@code Новый}, ключевые слова, платформенные
+ * переменные (системные перечисления + свойства глобального контекста),
+ * сниппеты автодополнения. Источник — синтетический {@link PlatformContextProvider}
+ * без чтения реального HBK.
+ */
+class GlobalScopeProviderBslContextTest {
+
+  private static BslContextHolder holderOf(ContextProvider provider) {
+    return new BslContextHolder(null) {
+      @Override
+      public Optional<ContextProvider> get() {
+        return Optional.ofNullable(provider);
+      }
+    };
+  }
+
+  @Test
+  void globalFunctionsLoadedFromContext() {
+    var globalContext = PlatformGlobalContext.builder()
+      .methods(new ArrayList<>(List.of(
+        method("Сообщить", "Message", "Выводит сообщение."),
+        method("СтрДлина", "StrLen", "Длина строки.")
+      )))
+      .properties(Collections.emptyList())
+      .applicationEvents(Collections.emptyList())
+      .ordinaryApplicationEvents(Collections.emptyList())
+      .sessionModuleEvents(Collections.emptyList())
+      .externalConnectionModuleEvents(Collections.emptyList())
+      .build();
+
+    var scope = new GlobalScopeProvider(holderOf(providerOf(globalContext)));
+
+    assertThat(scope.findFunction("Сообщить")).isPresent();
+    assertThat(scope.findFunction("Message")).isPresent();
+    assertThat(scope.findFunction("СтрДлина").orElseThrow().description())
+      .isEqualTo("Длина строки.");
+  }
+
+  @Test
+  void classesForNewLoadedFromPlatformTypes() {
+    var array = type("Массив", "Array");
+    var table = type("ТаблицаЗначений", "ValueTable");
+
+    var scope = new GlobalScopeProvider(holderOf(providerOf(array, table)));
+
+    assertThat(scope.getClasses()).contains("Массив", "Array", "ТаблицаЗначений", "ValueTable");
+  }
+
+  @Test
+  void genericTypesNotPublishedAsClasses() {
+    // Тип с угловыми скобками в имени — это шаблон, не реальный класс для Новый.
+    var generic = type("СправочникСсылка.<Имя справочника>",
+      "CatalogRef.<Catalog name>");
+    var plain = type("Массив", "Array");
+
+    var scope = new GlobalScopeProvider(holderOf(providerOf(generic, plain)));
+
+    assertThat(scope.getClasses()).contains("Массив", "Array");
+    assertThat(scope.getClasses()).doesNotContain("СправочникСсылка.<Имя справочника>");
+  }
+
+  @Test
+  void languageKeywordsByCategory() {
+    var ifKw = keyword("Если", "If", LanguageKeywordCategory.STATEMENT,
+      "Если <?> Тогда\nКонецЕсли;", "If <?> Then\nEndIf;");
+    var trueKw = keyword("Истина", "True", LanguageKeywordCategory.LITERAL,
+      "Истина", "True");
+    var procKw = keyword("Процедура", "Procedure", LanguageKeywordCategory.DECLARATION,
+      "Процедура <?>()\nКонецПроцедуры", "Procedure <?>()\nEndProcedure");
+    // PRAGMA / ANNOTATION / PREPROCESSOR_INSTRUCTION в keywords не идут.
+    var pragma = keyword("НаКлиенте", "AtClient", LanguageKeywordCategory.PRAGMA, "", "");
+    var annotation = keyword("Перед", "Before", LanguageKeywordCategory.ANNOTATION, "", "");
+    var pre = keyword("Область", "Region", LanguageKeywordCategory.PREPROCESSOR_INSTRUCTION, "", "");
+
+    var scope = new GlobalScopeProvider(holderOf(providerOf(
+      ifKw, trueKw, procKw, pragma, annotation, pre)));
+
+    assertThat(scope.getKeywords()).contains("Если", "If", "Истина", "True", "Процедура", "Procedure");
+    assertThat(scope.getKeywords()).doesNotContain("НаКлиенте", "Перед", "Область");
+  }
+
+  @Test
+  void keywordSnippetIsBilingualAndAccessibleByEitherName() {
+    var ifKw = keyword("Если", "If", LanguageKeywordCategory.STATEMENT,
+      "Если <?> Тогда\nКонецЕсли;", "If <?> Then\nEndIf;");
+    var scope = new GlobalScopeProvider(holderOf(providerOf(ifKw)));
+
+    var byRu = scope.findKeywordSnippet("Если").orElseThrow();
+    assertThat(byRu.ru()).isEqualTo("Если <?> Тогда\nКонецЕсли;");
+    assertThat(byRu.en()).isEqualTo("If <?> Then\nEndIf;");
+
+    // Тот же сниппет доступен по en-алиасу.
+    var byEn = scope.findKeywordSnippet("If").orElseThrow();
+    assertThat(byEn).isEqualTo(byRu);
+  }
+
+  @Test
+  void contextEnumPublishedAsPlatformVariable() {
+    var encoding = PlatformContextEnum.builder()
+      .name(new ContextName("КодировкаТекста", "TextEncoding"))
+      .values(List.of(
+        new PlatformContextEnumValue(new ContextName("UTF8", "UTF8"),
+          "", "", "", List.of())
+      ))
+      .build();
+
+    var scope = new GlobalScopeProvider(holderOf(providerOf(encoding)));
+
+    assertThat(scope.getPlatformVariableNames()).contains("КодировкаТекста");
+    var type = scope.findPlatformVariableType("КодировкаТекста").orElseThrow();
+    assertThat(type.qualifiedName()).isEqualTo("КодировкаТекста");
+    // Поиск по en-алиасу тоже работает.
+    assertThat(scope.findPlatformVariableType("TextEncoding")).isPresent();
+  }
+
+  @Test
+  void globalContextPropertiesPublishedAsPlatformVariables() {
+    var catalogsManager = type("СправочникиМенеджер", "CatalogsManager");
+
+    var catalogsProperty = PlatformContextProperty.builder()
+      .name(new ContextName("Справочники", "Catalogs"))
+      .rawTypes(List.of("СправочникиМенеджер"))
+      .description("Глобальное свойство для доступа к справочникам.")
+      .availabilities(List.of())
+      .build();
+
+    var globalContext = PlatformGlobalContext.builder()
+      .methods(Collections.emptyList())
+      .properties(new ArrayList<>(List.of(catalogsProperty)))
+      .applicationEvents(Collections.emptyList())
+      .ordinaryApplicationEvents(Collections.emptyList())
+      .sessionModuleEvents(Collections.emptyList())
+      .externalConnectionModuleEvents(Collections.emptyList())
+      .build();
+
+    var scope = new GlobalScopeProvider(holderOf(providerOf(catalogsManager, globalContext)));
+
+    assertThat(scope.getPlatformVariableNames()).contains("Справочники");
+    // Тип «Справочники» — это СправочникиМенеджер (для dot-completion'а).
+    assertThat(scope.findPlatformVariableType("Справочники").orElseThrow().qualifiedName())
+      .isEqualTo("СправочникиМенеджер");
+    // En-алиас тоже находит.
+    assertThat(scope.findPlatformVariableType("Catalogs")).isPresent();
+  }
+
+  @Test
+  void genericGlobalPropertyIsSkipped() {
+    // У СправочникиМенеджер есть generic-property «<Имя справочника>» — это
+    // плейсхолдер, а не реальное глобальное имя; не должен попадать в platformVariables.
+    var genericProp = PlatformContextProperty.builder()
+      .name(new ContextName("<Имя справочника>", "<Catalog name>"))
+      .rawTypes(List.of())
+      .description("")
+      .availabilities(List.of())
+      .build();
+
+    var globalContext = PlatformGlobalContext.builder()
+      .methods(Collections.emptyList())
+      .properties(new ArrayList<>(List.of(genericProp)))
+      .applicationEvents(Collections.emptyList())
+      .ordinaryApplicationEvents(Collections.emptyList())
+      .sessionModuleEvents(Collections.emptyList())
+      .externalConnectionModuleEvents(Collections.emptyList())
+      .build();
+
+    var scope = new GlobalScopeProvider(holderOf(providerOf(globalContext)));
+    assertThat(scope.getPlatformVariableNames()).doesNotContain("<Имя справочника>");
+  }
+
+  // --- builders ---
+
+  private static PlatformContextType type(String ru, String en) {
+    return PlatformContextType.builder()
+      .name(new ContextName(ru, en))
+      .methods(Collections.emptyList())
+      .properties(Collections.emptyList())
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .build();
+  }
+
+  private static PlatformContextMethod method(String ru, String en, String description) {
+    var sig = PlatformContextMethodSignature.builder()
+      .name(new ContextName("", ""))
+      .parameters(new ArrayList<ContextSignatureParameter>())
+      .description("")
+      .build();
+    return PlatformContextMethod.builder()
+      .name(new ContextName(ru, en))
+      .description(description)
+      .availabilities(List.of())
+      .rawReturnValues(List.of())
+      .signatures(new ArrayList<>(List.of((ContextMethodSignature) sig)))
+      .build();
+  }
+
+  private static PlatformLanguageKeyword keyword(String ru, String en,
+                                                 LanguageKeywordCategory category,
+                                                 String snippetRu, String snippetEn) {
+    return PlatformLanguageKeyword.builder()
+      .name(new ContextName(ru, en))
+      .category(category)
+      .description("")
+      .snippet(snippetRu.isEmpty() && snippetEn.isEmpty()
+        ? LanguageKeywordSnippet.EMPTY
+        : new LanguageKeywordSnippet(snippetRu, snippetEn))
+      .build();
+  }
+
+  private static ContextProvider providerOf(Context... contexts) {
+    return new PlatformContextProvider(
+      new PlatformContextStorage(new ArrayList<>(List.of(contexts))));
+  }
+}


### PR DESCRIPTION
## Summary

Подключение [`bsl-context`](https://github.com/1c-syntax/bsl-context) — Java-парсера синтакс-помощника платформы 1С (`.hbk`-файлов) — к type-system v2. Позволяет получать **полную модель платформенных типов и глобалов** из синтакс-помощника установленной на машине 1С, а не из укороченного `builtin-globals.json` / `builtin-platform-types.json` ресурсов.

При наличии установленной 1С (или явно заданного `platformOptions.binPath`):
- сотни платформенных типов с реальными методами / свойствами / описаниями / конструкторами;
- глобальные функции, классы для `Новый`, ключевые слова BSL, `platformVariables` (`Документы` → `СправочникиМенеджер`, `КодировкаТекста` → enum) — всё из СП с двуязычными именами;
- двуязычные сниппеты автодополнения для keyword'ов (`Если <?> Тогда\nКонецЕсли;` / `If <?> Then\nEndIf;`).

При отсутствии 1С / неудачном парсинге — провайдеры молча уходят в JSON-fallback (текущее поведение).

## Что добавлено

| Компонент | Роль |
|---|---|
| `BslContextHolder` | workspace-scoped lazy-кэш `ContextProvider`. Источник: `platformOptions.binPath` или `PlatformFinder.autoDetect()`. |
| `PlatformOptions` (`@platform.binPath`) | новая секция конфигурации — явный путь к каталогу `bin` платформы. |
| `BslContextPlatformTypesProvider` | `PlatformTypesProvider`-адаптер: маппит `ContextType` / `ContextEnum` в `TypeDecl` (members, description, constructors, exposedAsGlobal). |
| `BslContextPlatformTypesProviderTest` (10 unit) | покрывают маппинг `Context` → `TypeDecl`/`MemberDescriptor`/constructors. |
| `GlobalScopeProviderBslContextTest` (8 unit) | покрывают сборку BSL-части из bsl-context: функции, классы, keywords-по-категориям, snippets, ContextEnum / globalContext.properties → `PlatformVariable`. |

## Что изменено

- `BuiltinPlatformTypesProvider` — отключается (возвращает пустой список), если bsl-context дал данные. Иначе — JSON-fallback как раньше.
- `GlobalScopeProvider` — при наличии bsl-context BSL-часть собирается **целиком** из него: глобальные функции и свойства из `PlatformGlobalContext`, классы из `ContextType`, ключевые слова из `ContextLanguageKeyword` (категории `LITERAL`/`STATEMENT`/`OPERATOR`/`DECLARATION`), `platformVariables` из `ContextEnum` + `globalContext.properties()`. JSON `builtin-globals.json` в этом случае не читается. Добавлен публичный метод `findKeywordSnippet(name): Optional<LanguageKeywordSnippet>`.
- `LanguageServerConfiguration` — поле `platformOptions`.

## Зависимость

```kotlin
api(\"io.github.1c-syntax:bsl-context:76cbe38\")
```

через jitpack (используется группа `io.github.1c-syntax` — канонический namespace 1c-syntax). Привязка по SHA, потому что API ещё может развиваться по ходу интеграции; после стабилизации заменим на тэг `0.1.0` через Maven Central.

## Что НЕ моделируется (потенциал для будущих PR)

- События типов (`ContextType.events`) — type-system v2 не носит `EVENT` member-kind.
- Метаданные методов / свойств / конструкторов: `sinceVersion`, `deprecatedSinceVersion`, `recommendedReplacements`, `availabilities`, `accessMode`, `defaultValue`, `notes`, `examples`, `seeAlso`. В bsl-context они есть — нужно только расширить `MemberDescriptor`/`ParameterDescriptor`/`SignatureDescriptor`.
- Категории `PRAGMA` / `ANNOTATION` / `PREPROCESSOR_INSTRUCTION` keyword'ов — для них в LS своя completion-flow.

См. [`tmp/PLAN.md`](https://github.com/1c-syntax/bsl-context/blob/master/tmp/PLAN.md) в bsl-context.

## Test plan

- [x] `./gradlew compileJava` — зелёный
- [x] `./gradlew test --tests \"*BslContext*\"` — 18 unit-тестов passed (10 + 8)
- [x] Локальный запуск с реальной 1С (8.3.27.1786): completion подсказывает платформенные типы, методы, глобальные свойства; snippets для `Если`/`Для`/`Попытка` работают; `КодировкаТекста.UTF8` резолвится в системное перечисление; `Документы` резолвится в `СправочникиМенеджер`.
- [ ] Полный test suite на CI (timeout локально >5min, не запускал)

🤖 Generated with [Claude Code](https://claude.com/claude-code)