### PR TITLE
feat: add textDocument/onTypeFormatting support

### DIFF
--- a/docs/en/index.md
+++ b/docs/en/index.md
@@ -36,6 +36,7 @@ Perfomance measurement - [SSL 3.1](../bench/index.html)
 
 * File formatting
 * Selected region formatting
+* On-type formatting (on Enter and `;`)
 * Symbol definition for current file (regions, procedures, functions, variables, defined via `Var` keyword)
 * Folding regions definition `#Region`, `#If`, procedures and functions, code blocks, queries
 * Methods "Cognitive Complexity" and "Cyclomatic Complexity" scores
@@ -107,7 +108,7 @@ Perfomance measurement - [SSL 3.1](../bench/index.html)
     | [colorPresentation](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_colorPresentation) | <img src="./assets/images/checkmark.svg" alt="yes" width="20">    |                                                              |                  |
     | [formatting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting) | <img src="./assets/images/checkmark.svg" alt="yes" width="20"> |                                                              |                  |
     | [rangeFormatting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting) | <img src="./assets/images/checkmark.svg" alt="yes" width="20"> |                                                              |                  |
-    | [onTypeFormatting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_onTypeFormatting) | <img src="./assets/images/cross.svg" alt="no" width="20">    |                                                              |                  |
+    | [onTypeFormatting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_onTypeFormatting) | <img src="./assets/images/checkmark.svg" alt="yes" width="20"> | firstTriggerCharacter = `\n`<br />moreTriggerCharacter = `;` |                  |
     | [rename](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename) | <img src="./assets/images/checkmark.svg" alt="yes" width="20">    |                                                              |                  |
     | [prepareRename](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_prepareRename) | <img src="./assets/images/checkmark.svg" alt="yes" width="20">    |                                                              |                  |
     | [foldingRange](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_foldingRange) | <img src="./assets/images/checkmark.svg" alt="yes" width="20"> |                                                              |                  |

--- a/docs/index.md
+++ b/docs/index.md
@@ -36,6 +36,7 @@
 
 * Форматирование файла
 * Форматирование выбранного диапазона
+* Форматирование при наборе (по Enter и `;`)
 * Определение символов текущего файла (области, процедуры, функции, переменные, объявленные через `Перем`)
 * Определение сворачиваемых областей - `#Область`, `#Если`, процедуры и функции, блоки кода, пакеты запросов
 * Показ когнитивной и цикломатической сложности метода
@@ -107,7 +108,7 @@
     | [colorPresentation](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_colorPresentation) | <img src="./assets/images/checkmark.svg" alt="yes" width="20">    |                                                              |                  |
     | [formatting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting) | <img src="./assets/images/checkmark.svg" alt="yes" width="20"> |                                                              |                  |
     | [rangeFormatting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting) | <img src="./assets/images/checkmark.svg" alt="yes" width="20"> |                                                              |                  |
-    | [onTypeFormatting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_onTypeFormatting) | <img src="./assets/images/cross.svg" alt="no" width="20">    |                                                              |                  |
+    | [onTypeFormatting](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_onTypeFormatting) | <img src="./assets/images/checkmark.svg" alt="yes" width="20"> | firstTriggerCharacter = `\n`<br />moreTriggerCharacter = `;` |                  |
     | [rename](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rename) | <img src="./assets/images/checkmark.svg" alt="yes" width="20">    |                                                              |                  |
     | [prepareRename](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_prepareRename) | <img src="./assets/images/checkmark.svg" alt="yes" width="20">    |                                                              |                  |
     | [foldingRange](https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_foldingRange) | <img src="./assets/images/checkmark.svg" alt="yes" width="20"> |                                                              |                  |

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -43,6 +43,7 @@ import org.eclipse.lsp4j.DiagnosticRegistrationOptions;
 import org.eclipse.lsp4j.DocumentFormattingOptions;
 import org.eclipse.lsp4j.DocumentHighlightOptions;
 import org.eclipse.lsp4j.DocumentLinkOptions;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
 import org.eclipse.lsp4j.DocumentRangeFormattingOptions;
 import org.eclipse.lsp4j.DocumentSymbolOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
@@ -125,6 +126,7 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
     capabilities.setTextDocumentSync(getTextDocumentSyncOptions());
     capabilities.setDocumentRangeFormattingProvider(getDocumentRangeFormattingProvider());
     capabilities.setDocumentFormattingProvider(getDocumentFormattingProvider());
+    capabilities.setDocumentOnTypeFormattingProvider(getDocumentOnTypeFormattingProvider());
     capabilities.setFoldingRangeProvider(getFoldingRangeProvider());
     capabilities.setDocumentSymbolProvider(getDocumentSymbolProvider());
     capabilities.setCodeActionProvider(getCodeActionProvider());
@@ -308,6 +310,13 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
     var documentRangeFormattingOptions = new DocumentRangeFormattingOptions();
     documentRangeFormattingOptions.setWorkDoneProgress(Boolean.FALSE);
     return documentRangeFormattingOptions;
+  }
+
+  private static DocumentOnTypeFormattingOptions getDocumentOnTypeFormattingProvider() {
+    var options = new DocumentOnTypeFormattingOptions();
+    options.setFirstTriggerCharacter("\n");
+    options.setMoreTriggerCharacter(List.of(";"));
+    return options;
   }
 
   private static CodeLensOptions getCodeLensProvider() {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -82,6 +82,7 @@ import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.DocumentLink;
 import org.eclipse.lsp4j.DocumentLinkParams;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
@@ -334,6 +335,20 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
     return withFreshDocumentContext(
       documentContext,
       () -> formatProvider.getRangeFormatting(params, documentContext)
+    );
+  }
+
+  @Override
+  public CompletableFuture<List<? extends TextEdit>> onTypeFormatting(DocumentOnTypeFormattingParams params) {
+    var maybeDocument = serverContextProvider.getDocumentUnsafe(params.getTextDocument().getUri());
+    if (maybeDocument.isEmpty()) {
+      return CompletableFuture.completedFuture(Collections.emptyList());
+    }
+    var documentContext = maybeDocument.get();
+
+    return withFreshDocumentContext(
+      documentContext,
+      () -> formatProvider.getOnTypeFormatting(params, documentContext)
     );
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -41,6 +41,7 @@ import org.eclipse.lsp4j.TextEdit;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.HashMap;
@@ -163,27 +164,40 @@ public final class FormatProvider {
 
     int antlrLine = targetLineLsp + 1;
 
-    List<Token> tokens = documentContext.getTokens().stream()
-      .filter((Token token) -> {
-        if (token.getLine() != antlrLine) {
-          return false;
-        }
-        // Конец токена должен укладываться в диапазон до позиции курсора, иначе токены,
-        // выходящие за курсор (например многострочные литералы), дублируют свой хвост в replace.
-        long endColumn = (long) token.getCharPositionInLine() + token.getText().length();
-        return endColumn <= cutoffCharacter;
-      })
-      .toList();
-
-    boolean hasContent = tokens.stream()
-      .anyMatch(token -> token.getChannel() == Token.DEFAULT_CHANNEL
-        || token.getType() == BSLLexer.LINE_COMMENT);
-    if (!hasContent) {
-      return Collections.emptyList();
+    // На горячем пути (каждый Enter/`;`) обходить весь поток токенов дорого.
+    // Токены отсортированы по line — находим начало нужной строки бинарным поиском
+    // и обходим только её хвост до первого токена со следующей линии.
+    List<Token> allTokens = documentContext.getTokens();
+    List<Token> tokens = new ArrayList<>();
+    for (int i = firstTokenIndexOnLine(allTokens, antlrLine); i < allTokens.size(); i++) {
+      Token token = allTokens.get(i);
+      if (token.getLine() != antlrLine) {
+        break;
+      }
+      // Конец токена должен укладываться в диапазон до позиции курсора, иначе токены,
+      // выходящие за курсор (например многострочные литералы), дублируют свой хвост в replace.
+      long endColumn = (long) token.getCharPositionInLine() + token.getText().length();
+      if (endColumn <= cutoffCharacter) {
+        tokens.add(token);
+      }
     }
 
     return getTextEdits(
       tokens, documentContext.getScriptVariantLocale(), editRange, 0, params.getOptions());
+  }
+
+  private static int firstTokenIndexOnLine(List<Token> tokens, int line) {
+    int lo = 0;
+    int hi = tokens.size();
+    while (lo < hi) {
+      int mid = (lo + hi) >>> 1;
+      if (tokens.get(mid).getLine() < line) {
+        lo = mid + 1;
+      } else {
+        hi = mid;
+      }
+    }
+    return lo;
   }
 
   public List<TextEdit> getRangeFormatting(

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -32,6 +32,7 @@ import org.antlr.v4.runtime.Token;
 import org.apache.commons.lang3.StringUtils;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Position;
@@ -57,6 +58,7 @@ import java.util.stream.Collectors;
  *
  * @see <a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting">Document Formatting Request specification</a>
  * @see <a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting">Document Range Formatting Request specification</a>
+ * @see <a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_onTypeFormatting">Document On Type Formatting Request specification</a>
  */
 @Component
 @RequiredArgsConstructor
@@ -116,6 +118,65 @@ public final class FormatProvider {
       locale,
       Ranges.create(firstToken, lastToken), firstToken.getCharPositionInLine(), params.getOptions()
     );
+  }
+
+  /**
+   * Возвращает правки форматирования при наборе указанного символа.
+   * <p>
+   * Поддерживаются триггеры:
+   * <ul>
+   *   <li>{@code "\n"} (Enter) — переформатирование предыдущей строки;</li>
+   *   <li>{@code ";"} — переформатирование завершённого оператора текущей строки до позиции курсора.</li>
+   * </ul>
+   * Диапазон правки никогда не пересекает позицию ввода, чтобы не «дёргать» курсор пользователя.
+   *
+   * @param params          параметры запроса onTypeFormatting
+   * @param documentContext контекст текущего документа
+   * @return список правок (одна-единственная замена соответствующего диапазона) или пустой список,
+   * если форматировать нечего
+   */
+  public List<TextEdit> getOnTypeFormatting(
+    DocumentOnTypeFormattingParams params,
+    DocumentContext documentContext
+  ) {
+    String ch = params.getCh();
+    Position position = params.getPosition();
+
+    int targetLineLsp;
+    Range editRange;
+    int cutoffCharacter;
+
+    if ("\n".equals(ch)) {
+      if (position.getLine() == 0) {
+        return Collections.emptyList();
+      }
+      targetLineLsp = position.getLine() - 1;
+      editRange = Ranges.create(targetLineLsp, 0, position.getLine(), 0);
+      cutoffCharacter = Integer.MAX_VALUE;
+    } else if (";".equals(ch)) {
+      targetLineLsp = position.getLine();
+      editRange = Ranges.create(targetLineLsp, 0, position.getLine(), position.getCharacter());
+      cutoffCharacter = position.getCharacter();
+    } else {
+      return Collections.emptyList();
+    }
+
+    int antlrLine = targetLineLsp + 1;
+
+    List<Token> tokens = documentContext.getTokens().stream()
+      .filter((Token token) -> token.getLine() == antlrLine
+        && token.getCharPositionInLine() < cutoffCharacter)
+      .collect(Collectors.toList());
+
+    boolean hasContent = tokens.stream()
+      .anyMatch(token -> token.getChannel() == Token.DEFAULT_CHANNEL
+        || token.getType() == BSLLexer.LINE_COMMENT);
+    if (!hasContent) {
+      return Collections.emptyList();
+    }
+
+    return getTextEdits(
+      tokens, documentContext.getScriptVariantLocale(), editRange, 0, params.getOptions());
   }
 
   public List<TextEdit> getRangeFormatting(

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -164,8 +164,15 @@ public final class FormatProvider {
     int antlrLine = targetLineLsp + 1;
 
     List<Token> tokens = documentContext.getTokens().stream()
-      .filter((Token token) -> token.getLine() == antlrLine
-        && token.getCharPositionInLine() < cutoffCharacter)
+      .filter((Token token) -> {
+        if (token.getLine() != antlrLine) {
+          return false;
+        }
+        // Конец токена должен укладываться в диапазон до позиции курсора, иначе токены,
+        // выходящие за курсор (например многострочные литералы), дублируют свой хвост в replace.
+        long endColumn = (long) token.getCharPositionInLine() + token.getText().length();
+        return endColumn <= cutoffCharacter;
+      })
       .collect(Collectors.toList());
 
     boolean hasContent = tokens.stream()

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -140,7 +140,7 @@ public final class FormatProvider {
     DocumentContext documentContext
   ) {
     String ch = params.getCh();
-    Position position = params.getPosition();
+    var position = params.getPosition();
 
     int targetLineLsp;
     Range editRange;
@@ -173,7 +173,7 @@ public final class FormatProvider {
         long endColumn = (long) token.getCharPositionInLine() + token.getText().length();
         return endColumn <= cutoffCharacter;
       })
-      .collect(Collectors.toList());
+      .toList();
 
     boolean hasContent = tokens.stream()
       .anyMatch(token -> token.getChannel() == Token.DEFAULT_CHANNEL

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -28,8 +28,11 @@ import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.lsp4j.DocumentFormattingParams;
+import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
 import org.eclipse.lsp4j.FormattingOptions;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.eclipse.lsp4j.TextEdit;
 import org.junit.jupiter.api.Test;
@@ -282,6 +285,133 @@ class FormatProviderTest {
     assertThat(textEdits).hasSize(1);
     assertThat(textEdits.getFirst().getNewText()).isEqualTo("Возврат -1 > -2");
 
+  }
+
+  @Test
+  void testOnTypeFormattingEnterNormalizesPreviousLine() {
+    // given: пользователь нажал Enter после `если х=1 тогда`
+    String fileContent = "если х=1 тогда\n\n";
+    var params = onTypeParams("\n", 1, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    assertThat(edit.getRange()).isEqualTo(new Range(new Position(0, 0), new Position(1, 0)));
+    assertThat(edit.getNewText()).isEqualTo("Если х = 1 Тогда\n");
+  }
+
+  @Test
+  void testOnTypeFormattingEnterPreservesIndent() {
+    // given: внутри процедуры пользователь набрал кривую строку и нажал Enter
+    String fileContent = "Процедура П()\n    возврат;\nКонецПроцедуры\n";
+    // Enter был нажат в конце второй строки (LSP-line 1), курсор перешёл на line 2
+    var params = onTypeParams("\n", 2, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    assertThat(edit.getRange()).isEqualTo(new Range(new Position(1, 0), new Position(2, 0)));
+    assertThat(edit.getNewText()).isEqualTo("    Возврат;\n");
+  }
+
+  @Test
+  void testOnTypeFormattingEnterOnEmptyPreviousLineReturnsNoEdits() {
+    // given
+    String fileContent = "\n\n";
+    var params = onTypeParams("\n", 1, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).isEmpty();
+  }
+
+  @Test
+  void testOnTypeFormattingEnterAtFirstLineReturnsNoEdits() {
+    // given: предыдущей строки не существует
+    String fileContent = "Процедура П()\nКонецПроцедуры\n";
+    var params = onTypeParams("\n", 0, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).isEmpty();
+  }
+
+  @Test
+  void testOnTypeFormattingSemicolonFormatsCurrentLineUpToCursor() {
+    // given: пользователь набрал `х=1;` — курсор сразу после `;` (column 4)
+    String fileContent = "х=1;";
+    var params = onTypeParams(";", 0, 4);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    assertThat(edit.getRange()).isEqualTo(new Range(new Position(0, 0), new Position(0, 4)));
+    assertThat(edit.getNewText()).isEqualTo("х = 1;");
+  }
+
+  @Test
+  void testOnTypeFormattingUnknownTriggerReturnsNoEdits() {
+    // given
+    String fileContent = "х=1\n";
+    var params = onTypeParams(".", 0, 3);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).isEmpty();
+  }
+
+  private DocumentOnTypeFormattingParams onTypeParams(String ch, int line, int character) {
+    var params = new DocumentOnTypeFormattingParams();
+    params.setTextDocument(getTextDocumentIdentifier());
+    params.setOptions(new FormattingOptions(4, true));
+    params.setCh(ch);
+    params.setPosition(new Position(line, character));
+    return params;
   }
 
   private File getTestFile() {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -388,6 +388,26 @@ class FormatProviderTest {
   }
 
   @Test
+  void testOnTypeFormattingSemicolonExcludesTokensExtendingPastCursor() {
+    // given: пользователь набрал `;` внутри строкового литерала: было `"abc"`, стало `"a;bc"`.
+    // STRING-токен начинается на col 0, длина 6 — выходит за курсор (col 3).
+    // Такой токен не должен попадать в правку, иначе хвост литерала задублируется.
+    String fileContent = "\"a;bc\"";
+    var params = onTypeParams(";", 0, 3);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then: единственный токен строки выходит за курсор и отфильтрован, форматировать нечего
+    assertThat(textEdits).isEmpty();
+  }
+
+  @Test
   void testOnTypeFormattingUnknownTriggerReturnsNoEdits() {
     // given
     String fileContent = "х=1\n";


### PR DESCRIPTION
## Summary

Реализует LSP-метод `textDocument/onTypeFormatting` поверх существующего токен-based `FormatProvider`.

Триггеры:
- `"\n"` (Enter) — переформатирует **предыдущую** строку: нормализация регистра ключевых слов, расстановка пробелов вокруг операторов. Edit range — `(L, 0)..(L+1, 0)`, не пересекает позицию курсора.
- `";"` — форматирует текущую строку **до позиции курсора включительно**.
- Неподдерживаемые триггеры / Enter на первой строке / пустые строки → пустой список правок (no-op).

Реализация переиспользует существующий `getTextEdits` / `getNewText`, поэтому «бесплатно» получает корректную обработку унарного минуса, ASSIGN-индента, fluent-цепочек, локалей (RU/EN) и канонизации ключевых слов.

## Changes

- `FormatProvider.getOnTypeFormatting(...)` — новая точка входа (~60 строк).
- `BSLTextDocumentService.onTypeFormatting(...)` — override LSP-метода по шаблону `formatting`/`rangeFormatting`.
- `BSLLanguageServer.initialize` — объявление `DocumentOnTypeFormattingOptions("\n", [";"])`.

## Test plan

- [x] `FormatProviderTest` — 6 новых юнит-тестов (все зелёные):
  - Enter после `если х=1 тогда` → `Если х = 1 Тогда\n`;
  - Enter внутри процедуры — отступ сохраняется, регистр нормализуется;
  - Enter на пустой строке → `[]`;
  - Enter на первой строке файла → `[]`;
  - `;` после `х=1;` → `х = 1;` (range до курсора);
  - неизвестный триггер → `[]`.
- [x] `./gradlew test --tests FormatProviderTest` — 14/14 passed.
- [x] `./gradlew compileJava compileTestJava` — успешно.

## Notes

Существующая реализация в `vsc-language-1c-bsl` (`DocumentFormattingEditProvider.provideOnTypeFormattingEdits`) — регексп-фолбэк, регистрируется только при отключённом LS. Здесь — токен-based реализация в самом LS, поэтому она активна всегда и переиспользует уже отлаженный движок форматирования.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added on-type automatic formatting: pressing Enter reformats the previous line; typing semicolon reformats the current line up to the cursor. The language server now advertises and supports on-type formatting requests with newline and semicolon triggers.
* **Tests**
  * Added tests covering on-type formatting behaviors (Enter, semicolon, unknown triggers) and edge cases to ensure correct edits and no-op conditions.
* **Documentation**
  * Updated docs to list on-type formatting and show supported trigger characters (\n and ;).

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3908?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->