### PR TITLE
chore(types): bsl-context b8d0ce5 — PlatformFinder fix для Linux/macOS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
     api("io.github.1c-syntax:supportconf:0.16.0")
     // Парсер синтакс-помощника платформы (.hbk). Подключён по SHA коммита
     // master до выпуска первого релизного тэга — после замены на тэг.
-    api("io.github.1c-syntax:bsl-context:76cbe38")
+    api("io.github.1c-syntax:bsl-context:b8d0ce5")
 
     // nullability annotations
     api("org.jspecify:jspecify:1.0.0")


### PR DESCRIPTION
## Summary

`PlatformFinder.autoDetect()` в bsl-context ожидал `{version}/bin/shcntx_ru.hbk` на всех ОС, но на **Linux** и **macOS** платформа 1С раскладывается без подкаталога `bin/` — HBK лежит **прямо в version-каталоге**:

| OS | Раскладка | Где HBK |
|---|---|---|
| Windows | `C:\Program Files\1Cv8\<v>\bin\` | `<v>/bin/shcntx_ru.hbk` |
| Linux | `/opt/1cv8/{i386,x86_64}/<v>/` либо `/opt/1C/v8.<X>/{i386,x86_64}/<v>/` | `<v>/shcntx_ru.hbk` |
| macOS | `/opt/1cv8/<v>/` | `<v>/shcntx_ru.hbk` |

Из-за этого `BslContextPlatformTypesProvider` / `GlobalScopeProvider` на не-Windows машинах получали `Optional.empty()` и тихо уходили в JSON-fallback.

Сверено с `v8find/СоздательВерсииПлатформы.os → ПолучитьПутьКФайлу` — ветка `ЭтоWindows / Иначе`.

## Changes

- `build.gradle.kts`: `bsl-context:76cbe38` → `bsl-context:b8d0ce5`

Изменений на стороне LS не требуется — `PlatformInstall.binDir()` теперь указывает на каталог, в котором фактически лежат HBK, без подкаталога.

## Test plan

- [x] `./gradlew compileJava test --tests \"*BslContext*\"` — зелёный (19 unit-тестов адаптера)
- [x] bsl-context smoke на реальной Windows-платформе 8.3.27.1786 проходит
- [ ] Smoke на Linux/macOS машинах с реальной 1С (нет под рукой)

🤖 Generated with [Claude Code](https://claude.com/claude-code)