### PR TITLE
feat(types): bsl-context cb4c721 — ContextCollection (kind=COLLECTION) + Linux/macOS bin/ fix

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
     api("io.github.1c-syntax:supportconf:0.16.0")
     // Парсер синтакс-помощника платформы (.hbk). Подключён по SHA коммита
     // master до выпуска первого релизного тэга — после замены на тэг.
-    api("io.github.1c-syntax:bsl-context:b8d0ce5")
+    api("io.github.1c-syntax:bsl-context:cb4c721")
 
     // nullability annotations
     api("org.jspecify:jspecify:1.0.0")

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
@@ -189,7 +189,7 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
   private static TypeKind mapKind(Context context) {
     return switch (context.kind()) {
       case PRIMITIVE_TYPE -> TypeKind.PRIMITIVE;
-      case TYPE, ENUM -> TypeKind.PLATFORM;
+      case TYPE, COLLECTION, ENUM -> TypeKind.PLATFORM;
       // GLOBAL_CONTEXT и LANGUAGE_KEYWORD типами не являются — обрабатываются
       // отдельно (GlobalScopeProvider).
       case GLOBAL_CONTEXT, LANGUAGE_KEYWORD -> null;
@@ -313,7 +313,7 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
   private static TypeKind mapRefKind(Context context) {
     return switch (context.kind()) {
       case PRIMITIVE_TYPE -> TypeKind.PRIMITIVE;
-      case TYPE, ENUM -> TypeKind.PLATFORM;
+      case TYPE, COLLECTION, ENUM -> TypeKind.PLATFORM;
       case GLOBAL_CONTEXT, LANGUAGE_KEYWORD -> TypeKind.UNKNOWN;
     };
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
@@ -773,7 +773,7 @@ public class GlobalScopeProvider {
     var first = types.get(0);
     var kind = switch (first.kind()) {
       case PRIMITIVE_TYPE -> TypeKind.PRIMITIVE;
-      case TYPE, ENUM -> TypeKind.PLATFORM;
+      case TYPE, COLLECTION, ENUM -> TypeKind.PLATFORM;
       case GLOBAL_CONTEXT, LANGUAGE_KEYWORD -> TypeKind.UNKNOWN;
     };
     return new TypeRef(kind, first.name().getName());


### PR DESCRIPTION
## Summary

Бамп `bsl-context` до `cb4c721`. Два значимых пункта:

### 1. Linux/macOS autoDetect (закрывает #3909)

`PlatformFinder` ожидал `{version}/bin/shcntx_ru.hbk` на всех ОС, но на Linux/macOS платформа 1С раскладывается **без** подкаталога `bin/`:

| OS | HBK |
|---|---|
| Windows | `<v>/bin/shcntx_ru.hbk` |
| Linux | `/opt/1cv8/{i386,x86_64}/<v>/shcntx_ru.hbk` либо `/opt/1C/v8.<X>/{i386,x86_64}/<v>/shcntx_ru.hbk` |
| macOS | `/opt/1cv8/<v>/shcntx_ru.hbk` |

До фикса `BslContextHolder.get()` возвращал `Optional.empty()` на любой не-Windows-машине и адаптер тихо уходил в JSON-fallback. Сверено с [v8find/СоздательВерсииПлатформы.os](https://github.com/oscript-library/v8find).

> Этот PR заменяет/закрывает #3909.

### 2. ContextCollection (kind=COLLECTION)

Платформенные коллекции (`Массив`, `Соответствие`, `Структура`, `ТаблицаЗначений`, `ЭлементыФормы` и др. — **306 штук** на 8.3.27.1786) теперь публикуются как `ContextCollection extends ContextType`:

```java
public interface ContextCollection extends ContextType {
    List<Context> collectionElementTypes();
    boolean supportsForEach();
    String forEachDescription();
    boolean supportsIndexAccess();
    String indexAccessDescription();
}
```

Источник — блок «Элементы коллекции:» на главной HTML-странице типа в `shcntx_*.hbk`. Парсер обрабатывает обе разметки имени (`<a href>` как у `Соответствие` и текст-до-`<br>` как у `Массив` с «Произвольный») и достаёт сведения о поддержке `Для каждого … Из … Цикл` и индексатора `[...]` с их описаниями (boilerplate-prefix отрезан).

`ContextKind.COLLECTION` — отдельный enum-value, по аналогии с `ENUM` (не смешиваем разные семантики в один `TYPE`).

## Что меняется в LS

- Три `switch (kind())` (`BslContextPlatformTypesProvider.mapKind` / `mapRefKind`, `GlobalScopeProvider.firstTypeRef`) расширены case'ом `COLLECTION → TypeKind.PLATFORM`.
- Семантически для type-system v2 коллекция — это всё ещё `PLATFORM`-тип со своими методами/свойствами. Различение `ContextCollection` идёт по `instanceof` на стороне адаптера.

## Что НЕ моделируется в LS (потенциал для будущего PR)

`TypeDecl` пока не носит собственного поля для типов элементов коллекции. Данные `ContextCollection.collectionElementTypes()` остаются в bsl-context и могут быть проброшены в LS отдельным PR (например, через `TypeDecl.collectionElementTypes` или decoration в `MemberDescriptor`). После этого LS сможет автоматически заполнять `TypeSet.elementTypes` для платформенных коллекций в hover/completion.

## Test plan

- [x] `./gradlew compileJava test --tests \"*BslContext*\"` — зелёный
- [x] bsl-context smoke на реальной 8.3.27.1786 — 7 кейсов коллекций (Соответствие→КлючИЗначение, Массив→Произвольный, Структура, ТаблицаЗначений, ЭлементыФормы→5 типов, БуферДвоичныхДанных→Число, ФиксированныйМассив без блока)
- [ ] Smoke на реальной Linux/macOS с установленной 1С — нет под рукой, но логика покрыта в bsl-context

🤖 Generated with [Claude Code](https://claude.com/claude-code)