### PR TITLE
feat(types): bump bsl-context — fix Linux path-separator + storage collision

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -94,7 +94,7 @@ dependencies {
     api("io.github.1c-syntax:supportconf:0.16.0")
     // Парсер синтакс-помощника платформы (.hbk). Подключён по SHA коммита
     // master до выпуска первого релизного тэга — после замены на тэг.
-    api("io.github.1c-syntax:bsl-context:cb4c721")
+    api("io.github.1c-syntax:bsl-context:e5f9917")
 
     // nullability annotations
     api("org.jspecify:jspecify:1.0.0")


### PR DESCRIPTION
## Summary

Bump `bsl-context` до `e5f9917` — два связанных фикса под капотом, внешний API не менялся.

### 1. Path-separator в путях HBK (Linux-баг)

У пользователя на Linux в логах:

```
[WARN] Failed to load platform contexts from 1C syntax helper:
  page not found in memory: /objects\catalog213\catalog2171\QuerySchemaQueryBatch\/methods/Add4584.html
```

HBK создаётся 1С на Windows, в TOC PackBlock пути могут храниться в windows-style (`\`). При конкатенации parent+child получалась смесь `\` и `/`, lookup в `PageSource.InMemory` промахивался. На Windows-машинах это «случайно» работало — в зависимости от того, какой стиль использует конкретный HBK.

Лечится централизованной нормализацией: `PageSource.normalize()` теперь делает `\` → `/`, схлопывает `//`, срезает ведущий `/`. Применяется и при заливке ZIP-entries в map, и при lookup'е, и во всех предикатах на `htmlPath()` (`.contains("/properties/")`, `.split("/")`).

### 2. Коллизия имён в `PlatformContextStorage`

В HBK реально есть **два разных типа** с одинаковым русским именем — например, `ЭлементыФормы`:
- `FormItems` — управляемые формы (`ContextCollection`)
- `Controls` — обычные формы, устаревшие (`ContextType`)

Раньше `contextsByNames.put(name, ctx)` молча затирал первого вторым → результат `getContextByName(\"ЭлементыФормы\")` зависел от порядка обхода `parallelStream` (флэк в смок-тесте). Теперь `putIfAbsent` — первый-побеждает (документировано в комменте, для гарантированного выбора используйте уникальный en-алиас).

Внутри bsl-context на полном HBK 8.3.27 — 0/10 падений в 10× прогоне.

## Test plan

- [x] \`./gradlew compileJava\` зелёный в LS на этой ветке
- [ ] CI — прогон стандартного теста-сьюта (адаптер не меняется, только бамп зависимости)