### PR TITLE
fix(onTypeFormatting): preserve typed newline + add useOnTypeFormatting config flag

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/formating/FormattingOptions.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/formating/FormattingOptions.java
@@ -46,4 +46,9 @@ public class FormattingOptions {
    * Использовать форматирование ключевых слов.
    */
   private boolean useKeywordsFormatting = true;
+  /**
+   * Включить форматирование по нажатию символа-триггера (textDocument/onTypeFormatting).
+   * Триггеры — Enter и {@code ;}.
+   */
+  private boolean useOnTypeFormatting = true;
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/BlockKeywordMatcher.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/BlockKeywordMatcher.java
@@ -1,0 +1,107 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.providers;
+
+import com.github._1c_syntax.bsl.parser.BSLLexer;
+import org.antlr.v4.runtime.Token;
+import org.jspecify.annotations.Nullable;
+
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+
+/**
+ * Поиск парных открывающих/закрывающих ключевых слов BSL: `Если`/`КонецЕсли`,
+ * `Процедура`/`КонецПроцедуры`, `Цикл`/`КонецЦикла` и т.п.
+ */
+final class BlockKeywordMatcher {
+
+  private record ScopePair(Set<Integer> openers, Set<Integer> closers) {
+  }
+
+  private static final ScopePair IF_SCOPE =
+    new ScopePair(Set.of(BSLLexer.IF_KEYWORD), Set.of(BSLLexer.ENDIF_KEYWORD));
+  private static final ScopePair DO_SCOPE =
+    new ScopePair(Set.of(BSLLexer.WHILE_KEYWORD, BSLLexer.FOR_KEYWORD), Set.of(BSLLexer.ENDDO_KEYWORD));
+  private static final ScopePair TRY_SCOPE =
+    new ScopePair(Set.of(BSLLexer.TRY_KEYWORD), Set.of(BSLLexer.ENDTRY_KEYWORD));
+  private static final ScopePair PROCEDURE_SCOPE =
+    new ScopePair(Set.of(BSLLexer.PROCEDURE_KEYWORD), Set.of(BSLLexer.ENDPROCEDURE_KEYWORD));
+  private static final ScopePair FUNCTION_SCOPE =
+    new ScopePair(Set.of(BSLLexer.FUNCTION_KEYWORD), Set.of(BSLLexer.ENDFUNCTION_KEYWORD));
+
+  private static final Map<Integer, ScopePair> SCOPE_BY_CLOSER_TYPE = Map.ofEntries(
+    Map.entry(BSLLexer.ENDIF_KEYWORD, IF_SCOPE),
+    Map.entry(BSLLexer.ELSE_KEYWORD, IF_SCOPE),
+    Map.entry(BSLLexer.ELSIF_KEYWORD, IF_SCOPE),
+    Map.entry(BSLLexer.ENDDO_KEYWORD, DO_SCOPE),
+    Map.entry(BSLLexer.ENDTRY_KEYWORD, TRY_SCOPE),
+    Map.entry(BSLLexer.EXCEPT_KEYWORD, TRY_SCOPE),
+    Map.entry(BSLLexer.ENDPROCEDURE_KEYWORD, PROCEDURE_SCOPE),
+    Map.entry(BSLLexer.ENDFUNCTION_KEYWORD, FUNCTION_SCOPE)
+  );
+
+  private BlockKeywordMatcher() {
+    // utility class
+  }
+
+  /**
+   * Ищет парный открывающий токен для закрывающего ключевого слова.
+   *
+   * Возвращает null, если переданный токен не относится к парным закрывающим
+   * или парный открывающий не найден (несбалансированный код).
+   */
+  static @Nullable Token findMatchingOpener(List<Token> allTokens, int closerIndex) {
+    if (closerIndex < 0 || closerIndex >= allTokens.size()) {
+      return null;
+    }
+    var closer = allTokens.get(closerIndex);
+    var scope = SCOPE_BY_CLOSER_TYPE.get(closer.getType());
+    if (scope == null) {
+      return null;
+    }
+    // Для настоящих закрывашек (КонецЕсли/КонецЦикла и т.п.) стартуем с балансом 1
+    // и ищем opener, сводящий его в 0. Для промежуточных (Иначе/ИначеЕсли/Исключение)
+    // стартуем с 0 — родитель найдётся при первом opener без перекрывающего closer
+    // (баланс = -1).
+    var balance = scope.closers.contains(closer.getType()) ? 1 : 0;
+    var target = balance - 1;
+    for (var i = closerIndex - 1; i >= 0; i--) {
+      var t = allTokens.get(i);
+      if (t.getChannel() != Token.DEFAULT_CHANNEL) {
+        continue;
+      }
+      var type = t.getType();
+      if (scope.closers.contains(type)) {
+        balance++;
+      } else if (scope.openers.contains(type)) {
+        balance--;
+        if (balance == target) {
+          return t;
+        }
+      } else {
+        // no-op: токен вне рассматриваемой скобочной структуры.
+      }
+    }
+    return null;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -181,6 +181,8 @@ public final class FormatProvider {
     // и обходим только её хвост до первого токена со следующей линии.
     List<Token> allTokens = documentContext.getTokens();
     List<Token> tokens = new ArrayList<>();
+    Token firstSignificant = null;
+    int firstSignificantIndex = -1;
     for (int i = firstTokenIndexOnLine(allTokens, antlrLine); i < allTokens.size(); i++) {
       Token token = allTokens.get(i);
       if (token.getLine() != antlrLine) {
@@ -189,13 +191,136 @@ public final class FormatProvider {
       // Конец токена должен укладываться в диапазон до позиции курсора, иначе токены,
       // выходящие за курсор (например многострочные литералы), дублируют свой хвост в replace.
       long endColumn = (long) token.getCharPositionInLine() + token.getText().length();
-      if (endColumn <= cutoffCharacter) {
-        tokens.add(token);
+      if (endColumn > cutoffCharacter) {
+        continue;
+      }
+      tokens.add(token);
+      if (firstSignificant == null
+        && (token.getChannel() == Token.DEFAULT_CHANNEL || token.getType() == BSLLexer.LINE_COMMENT)) {
+        firstSignificant = token;
+        firstSignificantIndex = i;
       }
     }
 
-    return getTextEdits(
-      tokens, documentContext.getScriptVariantLocale(), editRange, 0, params.getOptions());
+    if (firstSignificant == null) {
+      return Collections.emptyList();
+    }
+
+    // Решаем, каким должен быть отступ строки:
+    // - если первый значимый токен — закрывающее ключевое слово, выравниваем по парному
+    //   открывающему (`КонецЕсли` → `Если`, `КонецПроцедуры` → `Процедура` и т.п.);
+    // - иначе сохраняем фактический leading whitespace строки — это не даёт «съедать»
+    //   табуляции у строк, начинающихся с decrement-keyword'а, и не трогает руками
+    //   проставленный отступ для прочих строк.
+    String currentLineText = documentContext.getContentList()[targetLineLsp];
+    String targetIndent = leadingWhitespace(currentLineText);
+    Token matchingOpener = findMatchingOpener(allTokens, firstSignificantIndex);
+    if (matchingOpener != null) {
+      String openerLineText = documentContext.getContentList()[matchingOpener.getLine() - 1];
+      targetIndent = leadingWhitespace(openerLineText);
+    }
+
+    // Заменяем строку от колонки 0 до cutoff'а целиком: ведущий whitespace должен быть
+    // под нашим контролем (чтобы выровнять при необходимости).
+    Range adjustedRange = Ranges.create(
+      editRange.getStart().getLine(),
+      0,
+      editRange.getEnd().getLine(),
+      editRange.getEnd().getCharacter()
+    );
+
+    // startCharacter = колонка первого значимого токена → currentIndentLevel = 0 внутри
+    // getNewText. Возможный decrement у первого токена не уйдёт «в плюс», и при выводе
+    // первого токена индент будет пустым — мы сами добавим targetIndent ниже.
+    List<TextEdit> baseEdits = getTextEdits(
+      tokens,
+      documentContext.getScriptVariantLocale(),
+      adjustedRange,
+      firstSignificant.getCharPositionInLine(),
+      params.getOptions()
+    );
+    if (baseEdits.isEmpty()) {
+      return baseEdits;
+    }
+
+    TextEdit base = baseEdits.getFirst();
+    return List.of(new TextEdit(base.getRange(), targetIndent + base.getNewText()));
+  }
+
+  private static String leadingWhitespace(String line) {
+    int i = 0;
+    while (i < line.length()) {
+      char c = line.charAt(i);
+      if (c != ' ' && c != '\t') {
+        break;
+      }
+      i++;
+    }
+    return line.substring(0, i);
+  }
+
+  /**
+   * Ищет парный открывающий токен для закрывающего ключевого слова (`КонецЕсли`/`Иначе`/
+   * `Исключение`/`КонецЦикла`/`КонецПопытки`/`КонецПроцедуры`/`КонецФункции`).
+   * Возвращает null, если токен не закрывающий или парный открывающий не найден.
+   */
+  private static Token findMatchingOpener(List<Token> allTokens, int closerIndex) {
+    if (closerIndex < 0 || closerIndex >= allTokens.size()) {
+      return null;
+    }
+    Token closer = allTokens.get(closerIndex);
+    int closerType = closer.getType();
+    Set<Integer> openers;
+    Set<Integer> closers;
+    switch (closerType) {
+      case BSLLexer.ENDIF_KEYWORD:
+      case BSLLexer.ELSE_KEYWORD:
+      case BSLLexer.ELSIF_KEYWORD:
+        openers = Set.of(BSLLexer.IF_KEYWORD);
+        closers = Set.of(BSLLexer.ENDIF_KEYWORD);
+        break;
+      case BSLLexer.ENDDO_KEYWORD:
+        openers = Set.of(BSLLexer.WHILE_KEYWORD, BSLLexer.FOR_KEYWORD);
+        closers = Set.of(BSLLexer.ENDDO_KEYWORD);
+        break;
+      case BSLLexer.ENDTRY_KEYWORD:
+      case BSLLexer.EXCEPT_KEYWORD:
+        openers = Set.of(BSLLexer.TRY_KEYWORD);
+        closers = Set.of(BSLLexer.ENDTRY_KEYWORD);
+        break;
+      case BSLLexer.ENDPROCEDURE_KEYWORD:
+        openers = Set.of(BSLLexer.PROCEDURE_KEYWORD);
+        closers = Set.of(BSLLexer.ENDPROCEDURE_KEYWORD);
+        break;
+      case BSLLexer.ENDFUNCTION_KEYWORD:
+        openers = Set.of(BSLLexer.FUNCTION_KEYWORD);
+        closers = Set.of(BSLLexer.ENDFUNCTION_KEYWORD);
+        break;
+      default:
+        return null;
+    }
+    // Для «настоящих» закрывашек (КонецЕсли/КонецЦикла/…) стартуем с балансом 1
+    // и ищем opener, который сводит его в 0. Для «промежуточных» (Иначе, ИначеЕсли,
+    // Исключение) стартуем с 0 — родитель найдётся при первом IF/TRY без перекрывающего
+    // ENDIF/ENDTRY (баланс = -1).
+    int balance = closers.contains(closerType) ? 1 : 0;
+    int target = balance - 1;
+    for (int i = closerIndex - 1; i >= 0; i--) {
+      Token t = allTokens.get(i);
+      if (t.getChannel() != Token.DEFAULT_CHANNEL) {
+        continue;
+      }
+      int type = t.getType();
+      if (closers.contains(type)) {
+        balance++;
+      } else if (openers.contains(type)) {
+        balance--;
+        if (balance == target) {
+          return t;
+        }
+      }
+    }
+    return null;
   }
 
   private static int firstTokenIndexOnLine(List<Token> tokens, int line) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageSer
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.utils.Keywords;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.languageserver.utils.bsl.BlockKeywordMatcher;
 import com.github._1c_syntax.bsl.parser.BSLLexer;
 import com.github._1c_syntax.bsl.types.MultiName;
 import org.antlr.v4.runtime.Token;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -152,8 +152,16 @@ public final class FormatProvider {
         return Collections.emptyList();
       }
       targetLineLsp = position.getLine() - 1;
-      editRange = Ranges.create(targetLineLsp, 0, position.getLine(), 0);
-      cutoffCharacter = Integer.MAX_VALUE;
+      String[] contentList = documentContext.getContentList();
+      if (targetLineLsp >= contentList.length) {
+        return Collections.emptyList();
+      }
+      // Ограничиваем диапазон концом строки (без `\n`), чтобы только что набранный
+      // пользователем перевод строки не оказался внутри replace-range — иначе при
+      // отсутствии в newText хвостового `\n` editor удаляет только что добавленную строку.
+      int lineLength = contentList[targetLineLsp].length();
+      editRange = Ranges.create(targetLineLsp, 0, targetLineLsp, lineLength);
+      cutoffCharacter = lineLength;
     } else if (";".equals(ch)) {
       targetLineLsp = position.getLine();
       editRange = Ranges.create(targetLineLsp, 0, position.getLine(), position.getCharacter());

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -140,6 +140,10 @@ public final class FormatProvider {
     DocumentOnTypeFormattingParams params,
     DocumentContext documentContext
   ) {
+    if (!configuration.getFormattingOptions().isUseOnTypeFormatting()) {
+      return Collections.emptyList();
+    }
+
     String ch = params.getCh();
     var position = params.getPosition();
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -38,6 +38,7 @@ import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
+import org.jspecify.annotations.Nullable;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -144,113 +145,126 @@ public final class FormatProvider {
       return Collections.emptyList();
     }
 
-    String ch = params.getCh();
-    var position = params.getPosition();
-
-    int targetLineLsp;
-    Range editRange;
-    int cutoffCharacter;
-
-    if ("\n".equals(ch)) {
-      if (position.getLine() == 0) {
-        return Collections.emptyList();
-      }
-      targetLineLsp = position.getLine() - 1;
-      String[] contentList = documentContext.getContentList();
-      if (targetLineLsp >= contentList.length) {
-        return Collections.emptyList();
-      }
-      // Ограничиваем диапазон концом строки (без `\n`), чтобы только что набранный
-      // пользователем перевод строки не оказался внутри replace-range — иначе при
-      // отсутствии в newText хвостового `\n` editor удаляет только что добавленную строку.
-      int lineLength = contentList[targetLineLsp].length();
-      editRange = Ranges.create(targetLineLsp, 0, targetLineLsp, lineLength);
-      cutoffCharacter = lineLength;
-    } else if (";".equals(ch)) {
-      targetLineLsp = position.getLine();
-      editRange = Ranges.create(targetLineLsp, 0, position.getLine(), position.getCharacter());
-      cutoffCharacter = position.getCharacter();
-    } else {
+    var window = resolveEditWindow(params.getCh(), params.getPosition(), documentContext);
+    if (window == null) {
       return Collections.emptyList();
     }
 
-    int antlrLine = targetLineLsp + 1;
-
-    // На горячем пути (каждый Enter/`;`) обходить весь поток токенов дорого.
-    // Токены отсортированы по line — находим начало нужной строки бинарным поиском
-    // и обходим только её хвост до первого токена со следующей линии.
-    List<Token> allTokens = documentContext.getTokens();
-    List<Token> tokens = new ArrayList<>();
-    Token firstSignificant = null;
-    int firstSignificantIndex = -1;
-    for (int i = firstTokenIndexOnLine(allTokens, antlrLine); i < allTokens.size(); i++) {
-      Token token = allTokens.get(i);
-      if (token.getLine() != antlrLine) {
-        break;
-      }
-      // Конец токена должен укладываться в диапазон до позиции курсора, иначе токены,
-      // выходящие за курсор (например многострочные литералы), дублируют свой хвост в replace.
-      long endColumn = (long) token.getCharPositionInLine() + token.getText().length();
-      if (endColumn > cutoffCharacter) {
-        continue;
-      }
-      tokens.add(token);
-      if (firstSignificant == null
-        && (token.getChannel() == Token.DEFAULT_CHANNEL || token.getType() == BSLLexer.LINE_COMMENT)) {
-        firstSignificant = token;
-        firstSignificantIndex = i;
-      }
-    }
-
-    if (firstSignificant == null) {
+    var allTokens = documentContext.getTokens();
+    var lineTokens = collectLineTokens(allTokens, window.antlrLine, window.cutoffCharacter);
+    if (lineTokens.firstSignificant == null) {
       return Collections.emptyList();
     }
 
-    // Решаем, каким должен быть отступ строки:
-    // - если первый значимый токен — закрывающее ключевое слово, выравниваем по парному
-    //   открывающему (`КонецЕсли` → `Если`, `КонецПроцедуры` → `Процедура` и т.п.);
-    // - иначе сохраняем фактический leading whitespace строки — это не даёт «съедать»
-    //   табуляции у строк, начинающихся с decrement-keyword'а, и не трогает руками
-    //   проставленный отступ для прочих строк.
-    String currentLineText = documentContext.getContentList()[targetLineLsp];
-    String targetIndent = leadingWhitespace(currentLineText);
-    Token matchingOpener = findMatchingOpener(allTokens, firstSignificantIndex);
-    if (matchingOpener != null) {
-      String openerLineText = documentContext.getContentList()[matchingOpener.getLine() - 1];
-      targetIndent = leadingWhitespace(openerLineText);
-    }
+    var targetIndent = resolveTargetIndent(
+      documentContext, window.targetLineLsp, allTokens, lineTokens.firstSignificantIndex);
 
-    // Заменяем строку от колонки 0 до cutoff'а целиком: ведущий whitespace должен быть
-    // под нашим контролем (чтобы выровнять при необходимости).
-    Range adjustedRange = Ranges.create(
-      editRange.getStart().getLine(),
+    var adjustedRange = Ranges.create(
+      window.editRange.getStart().getLine(),
       0,
-      editRange.getEnd().getLine(),
-      editRange.getEnd().getCharacter()
+      window.editRange.getEnd().getLine(),
+      window.editRange.getEnd().getCharacter()
     );
 
-    // startCharacter = колонка первого значимого токена → currentIndentLevel = 0 внутри
-    // getNewText. Возможный decrement у первого токена не уйдёт «в плюс», и при выводе
-    // первого токена индент будет пустым — мы сами добавим targetIndent ниже.
-    List<TextEdit> baseEdits = getTextEdits(
-      tokens,
+    // startCharacter = колонка первого значимого токена, чтобы getNewText считал
+    // currentIndentLevel от него. Decrement у первого токена даст 0, а ведущий
+    // отступ мы подставим сами ниже.
+    var baseEdits = getTextEdits(
+      lineTokens.tokens,
       documentContext.getScriptVariantLocale(),
       adjustedRange,
-      firstSignificant.getCharPositionInLine(),
+      lineTokens.firstSignificant.getCharPositionInLine(),
       params.getOptions()
     );
     if (baseEdits.isEmpty()) {
       return baseEdits;
     }
 
-    TextEdit base = baseEdits.getFirst();
+    var base = baseEdits.getFirst();
     return List.of(new TextEdit(base.getRange(), targetIndent + base.getNewText()));
   }
 
+  private record EditWindow(int targetLineLsp, int antlrLine, Range editRange, int cutoffCharacter) {
+  }
+
+  private static @Nullable EditWindow resolveEditWindow(
+    String ch, Position position, DocumentContext documentContext
+  ) {
+    if ("\n".equals(ch)) {
+      if (position.getLine() == 0) {
+        return null;
+      }
+      var targetLineLsp = position.getLine() - 1;
+      var contentList = documentContext.getContentList();
+      if (targetLineLsp >= contentList.length) {
+        return null;
+      }
+      // Ограничиваем диапазон концом строки без переноса: только что набранный пользователем
+      // перевод строки не должен попасть внутрь replace-range, иначе editor может проглотить
+      // новую строку при отсутствии хвостового переноса в newText.
+      var lineLength = contentList[targetLineLsp].length();
+      var range = Ranges.create(targetLineLsp, 0, targetLineLsp, lineLength);
+      return new EditWindow(targetLineLsp, targetLineLsp + 1, range, lineLength);
+    }
+    if (";".equals(ch)) {
+      var targetLineLsp = position.getLine();
+      var range = Ranges.create(targetLineLsp, 0, targetLineLsp, position.getCharacter());
+      return new EditWindow(targetLineLsp, targetLineLsp + 1, range, position.getCharacter());
+    }
+    return null;
+  }
+
+  private record LineTokens(List<Token> tokens, @Nullable Token firstSignificant, int firstSignificantIndex) {
+  }
+
+  private static LineTokens collectLineTokens(List<Token> allTokens, int antlrLine, int cutoffCharacter) {
+    // Токены отсортированы по line — находим начало нужной строки бинарным поиском
+    // и идём пока line совпадает. Все условия выхода — в заголовке while, поэтому
+    // в теле цикла нет break/continue.
+    var tokens = new ArrayList<Token>();
+    @Nullable Token firstSignificant = null;
+    var firstSignificantIndex = -1;
+    var i = firstTokenIndexOnLine(allTokens, antlrLine);
+    while (i < allTokens.size() && allTokens.get(i).getLine() == antlrLine) {
+      var token = allTokens.get(i);
+      // Конец токена должен укладываться в диапазон до позиции курсора — иначе токены,
+      // выходящие за курсор (например многострочные литералы), дублируют свой хвост в replace.
+      long endColumn = (long) token.getCharPositionInLine() + token.getText().length();
+      if (endColumn <= cutoffCharacter) {
+        tokens.add(token);
+        if (firstSignificant == null
+          && (token.getChannel() == Token.DEFAULT_CHANNEL || token.getType() == BSLLexer.LINE_COMMENT)) {
+          firstSignificant = token;
+          firstSignificantIndex = i;
+        }
+      }
+      i++;
+    }
+    return new LineTokens(tokens, firstSignificant, firstSignificantIndex);
+  }
+
+  private static String resolveTargetIndent(
+    DocumentContext documentContext,
+    int targetLineLsp,
+    List<Token> allTokens,
+    int firstSignificantIndex
+  ) {
+    // Если первый значимый токен — закрывающее ключевое слово, выравниваем строку
+    // по парному открывающему. Иначе сохраняем фактический leading whitespace строки:
+    // это не даёт форматтеру срезать табуляцию у строк с decrement-keyword'ом и не
+    // трогает руками проставленный отступ прочих строк.
+    var contentList = documentContext.getContentList();
+    var opener = findMatchingOpener(allTokens, firstSignificantIndex);
+    if (opener != null) {
+      return leadingWhitespace(contentList[opener.getLine() - 1]);
+    }
+    return leadingWhitespace(contentList[targetLineLsp]);
+  }
+
   private static String leadingWhitespace(String line) {
-    int i = 0;
+    var i = 0;
     while (i < line.length()) {
-      char c = line.charAt(i);
+      var c = line.charAt(i);
       if (c != ' ' && c != '\t') {
         break;
       }
@@ -259,65 +273,67 @@ public final class FormatProvider {
     return line.substring(0, i);
   }
 
+  private record ScopePair(Set<Integer> openers, Set<Integer> closers) {
+  }
+
+  private static final ScopePair IF_SCOPE =
+    new ScopePair(Set.of(BSLLexer.IF_KEYWORD), Set.of(BSLLexer.ENDIF_KEYWORD));
+  private static final ScopePair DO_SCOPE =
+    new ScopePair(Set.of(BSLLexer.WHILE_KEYWORD, BSLLexer.FOR_KEYWORD), Set.of(BSLLexer.ENDDO_KEYWORD));
+  private static final ScopePair TRY_SCOPE =
+    new ScopePair(Set.of(BSLLexer.TRY_KEYWORD), Set.of(BSLLexer.ENDTRY_KEYWORD));
+  private static final ScopePair PROCEDURE_SCOPE =
+    new ScopePair(Set.of(BSLLexer.PROCEDURE_KEYWORD), Set.of(BSLLexer.ENDPROCEDURE_KEYWORD));
+  private static final ScopePair FUNCTION_SCOPE =
+    new ScopePair(Set.of(BSLLexer.FUNCTION_KEYWORD), Set.of(BSLLexer.ENDFUNCTION_KEYWORD));
+
+  private static final Map<Integer, ScopePair> SCOPE_BY_CLOSER_TYPE = Map.ofEntries(
+    Map.entry(BSLLexer.ENDIF_KEYWORD, IF_SCOPE),
+    Map.entry(BSLLexer.ELSE_KEYWORD, IF_SCOPE),
+    Map.entry(BSLLexer.ELSIF_KEYWORD, IF_SCOPE),
+    Map.entry(BSLLexer.ENDDO_KEYWORD, DO_SCOPE),
+    Map.entry(BSLLexer.ENDTRY_KEYWORD, TRY_SCOPE),
+    Map.entry(BSLLexer.EXCEPT_KEYWORD, TRY_SCOPE),
+    Map.entry(BSLLexer.ENDPROCEDURE_KEYWORD, PROCEDURE_SCOPE),
+    Map.entry(BSLLexer.ENDFUNCTION_KEYWORD, FUNCTION_SCOPE)
+  );
+
   /**
-   * Ищет парный открывающий токен для закрывающего ключевого слова (`КонецЕсли`/`Иначе`/
-   * `Исключение`/`КонецЦикла`/`КонецПопытки`/`КонецПроцедуры`/`КонецФункции`).
-   * Возвращает null, если токен не закрывающий или парный открывающий не найден.
+   * Ищет парный открывающий токен для закрывающего ключевого слова.
+   *
+   * Возвращает null, если переданный токен не относится к парным закрывающим
+   * или парный открывающий не найден (несбалансированный код).
    */
-  private static Token findMatchingOpener(List<Token> allTokens, int closerIndex) {
+  private static @Nullable Token findMatchingOpener(List<Token> allTokens, int closerIndex) {
     if (closerIndex < 0 || closerIndex >= allTokens.size()) {
       return null;
     }
-    Token closer = allTokens.get(closerIndex);
-    int closerType = closer.getType();
-    Set<Integer> openers;
-    Set<Integer> closers;
-    switch (closerType) {
-      case BSLLexer.ENDIF_KEYWORD:
-      case BSLLexer.ELSE_KEYWORD:
-      case BSLLexer.ELSIF_KEYWORD:
-        openers = Set.of(BSLLexer.IF_KEYWORD);
-        closers = Set.of(BSLLexer.ENDIF_KEYWORD);
-        break;
-      case BSLLexer.ENDDO_KEYWORD:
-        openers = Set.of(BSLLexer.WHILE_KEYWORD, BSLLexer.FOR_KEYWORD);
-        closers = Set.of(BSLLexer.ENDDO_KEYWORD);
-        break;
-      case BSLLexer.ENDTRY_KEYWORD:
-      case BSLLexer.EXCEPT_KEYWORD:
-        openers = Set.of(BSLLexer.TRY_KEYWORD);
-        closers = Set.of(BSLLexer.ENDTRY_KEYWORD);
-        break;
-      case BSLLexer.ENDPROCEDURE_KEYWORD:
-        openers = Set.of(BSLLexer.PROCEDURE_KEYWORD);
-        closers = Set.of(BSLLexer.ENDPROCEDURE_KEYWORD);
-        break;
-      case BSLLexer.ENDFUNCTION_KEYWORD:
-        openers = Set.of(BSLLexer.FUNCTION_KEYWORD);
-        closers = Set.of(BSLLexer.ENDFUNCTION_KEYWORD);
-        break;
-      default:
-        return null;
+    var closer = allTokens.get(closerIndex);
+    var scope = SCOPE_BY_CLOSER_TYPE.get(closer.getType());
+    if (scope == null) {
+      return null;
     }
-    // Для «настоящих» закрывашек (КонецЕсли/КонецЦикла/…) стартуем с балансом 1
-    // и ищем opener, который сводит его в 0. Для «промежуточных» (Иначе, ИначеЕсли,
-    // Исключение) стартуем с 0 — родитель найдётся при первом IF/TRY без перекрывающего
-    // ENDIF/ENDTRY (баланс = -1).
-    int balance = closers.contains(closerType) ? 1 : 0;
-    int target = balance - 1;
-    for (int i = closerIndex - 1; i >= 0; i--) {
-      Token t = allTokens.get(i);
+    // Для настоящих закрывашек (КонецЕсли/КонецЦикла и т.п.) стартуем с балансом 1
+    // и ищем opener, сводящий его в 0. Для промежуточных (Иначе/ИначеЕсли/Исключение)
+    // стартуем с 0 — родитель найдётся при первом opener без перекрывающего closer
+    // (баланс = -1).
+    var balance = scope.closers.contains(closer.getType()) ? 1 : 0;
+    var target = balance - 1;
+    for (var i = closerIndex - 1; i >= 0; i--) {
+      var t = allTokens.get(i);
       if (t.getChannel() != Token.DEFAULT_CHANNEL) {
         continue;
       }
-      int type = t.getType();
-      if (closers.contains(type)) {
+      var type = t.getType();
+      if (scope.closers.contains(type)) {
         balance++;
-      } else if (openers.contains(type)) {
+      } else if (scope.openers.contains(type)) {
         balance--;
         if (balance == target) {
           return t;
         }
+      } else {
+        // no-op: токен вне рассматриваемой скобочной структуры.
       }
     }
     return null;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -156,9 +156,6 @@ public final class FormatProvider {
       return Collections.emptyList();
     }
 
-    var targetIndent = resolveTargetIndent(
-      documentContext, window.targetLineLsp, allTokens, lineTokens.firstSignificantIndex);
-
     var adjustedRange = Ranges.create(
       window.editRange.getStart().getLine(),
       0,
@@ -180,6 +177,8 @@ public final class FormatProvider {
       return baseEdits;
     }
 
+    var targetIndent = resolveTargetIndent(
+      documentContext, window.targetLineLsp, allTokens, lineTokens.firstSignificantIndex);
     var base = baseEdits.getFirst();
     return List.of(new TextEdit(base.getRange(), targetIndent + base.getNewText()));
   }
@@ -254,7 +253,7 @@ public final class FormatProvider {
     // это не даёт форматтеру срезать табуляцию у строк с decrement-keyword'ом и не
     // трогает руками проставленный отступ прочих строк.
     var contentList = documentContext.getContentList();
-    var opener = findMatchingOpener(allTokens, firstSignificantIndex);
+    var opener = BlockKeywordMatcher.findMatchingOpener(allTokens, firstSignificantIndex);
     if (opener != null) {
       return leadingWhitespace(contentList[opener.getLine() - 1]);
     }
@@ -273,71 +272,6 @@ public final class FormatProvider {
     return line.substring(0, i);
   }
 
-  private record ScopePair(Set<Integer> openers, Set<Integer> closers) {
-  }
-
-  private static final ScopePair IF_SCOPE =
-    new ScopePair(Set.of(BSLLexer.IF_KEYWORD), Set.of(BSLLexer.ENDIF_KEYWORD));
-  private static final ScopePair DO_SCOPE =
-    new ScopePair(Set.of(BSLLexer.WHILE_KEYWORD, BSLLexer.FOR_KEYWORD), Set.of(BSLLexer.ENDDO_KEYWORD));
-  private static final ScopePair TRY_SCOPE =
-    new ScopePair(Set.of(BSLLexer.TRY_KEYWORD), Set.of(BSLLexer.ENDTRY_KEYWORD));
-  private static final ScopePair PROCEDURE_SCOPE =
-    new ScopePair(Set.of(BSLLexer.PROCEDURE_KEYWORD), Set.of(BSLLexer.ENDPROCEDURE_KEYWORD));
-  private static final ScopePair FUNCTION_SCOPE =
-    new ScopePair(Set.of(BSLLexer.FUNCTION_KEYWORD), Set.of(BSLLexer.ENDFUNCTION_KEYWORD));
-
-  private static final Map<Integer, ScopePair> SCOPE_BY_CLOSER_TYPE = Map.ofEntries(
-    Map.entry(BSLLexer.ENDIF_KEYWORD, IF_SCOPE),
-    Map.entry(BSLLexer.ELSE_KEYWORD, IF_SCOPE),
-    Map.entry(BSLLexer.ELSIF_KEYWORD, IF_SCOPE),
-    Map.entry(BSLLexer.ENDDO_KEYWORD, DO_SCOPE),
-    Map.entry(BSLLexer.ENDTRY_KEYWORD, TRY_SCOPE),
-    Map.entry(BSLLexer.EXCEPT_KEYWORD, TRY_SCOPE),
-    Map.entry(BSLLexer.ENDPROCEDURE_KEYWORD, PROCEDURE_SCOPE),
-    Map.entry(BSLLexer.ENDFUNCTION_KEYWORD, FUNCTION_SCOPE)
-  );
-
-  /**
-   * Ищет парный открывающий токен для закрывающего ключевого слова.
-   *
-   * Возвращает null, если переданный токен не относится к парным закрывающим
-   * или парный открывающий не найден (несбалансированный код).
-   */
-  private static @Nullable Token findMatchingOpener(List<Token> allTokens, int closerIndex) {
-    if (closerIndex < 0 || closerIndex >= allTokens.size()) {
-      return null;
-    }
-    var closer = allTokens.get(closerIndex);
-    var scope = SCOPE_BY_CLOSER_TYPE.get(closer.getType());
-    if (scope == null) {
-      return null;
-    }
-    // Для настоящих закрывашек (КонецЕсли/КонецЦикла и т.п.) стартуем с балансом 1
-    // и ищем opener, сводящий его в 0. Для промежуточных (Иначе/ИначеЕсли/Исключение)
-    // стартуем с 0 — родитель найдётся при первом opener без перекрывающего closer
-    // (баланс = -1).
-    var balance = scope.closers.contains(closer.getType()) ? 1 : 0;
-    var target = balance - 1;
-    for (var i = closerIndex - 1; i >= 0; i--) {
-      var t = allTokens.get(i);
-      if (t.getChannel() != Token.DEFAULT_CHANNEL) {
-        continue;
-      }
-      var type = t.getType();
-      if (scope.closers.contains(type)) {
-        balance++;
-      } else if (scope.openers.contains(type)) {
-        balance--;
-        if (balance == target) {
-          return t;
-        }
-      } else {
-        // no-op: токен вне рассматриваемой скобочной структуры.
-      }
-    }
-    return null;
-  }
 
   private static int firstTokenIndexOnLine(List<Token> tokens, int line) {
     int lo = 0;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/bsl/BlockKeywordMatcher.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/bsl/BlockKeywordMatcher.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with BSL Language Server.
  */
-package com.github._1c_syntax.bsl.languageserver.providers;
+package com.github._1c_syntax.bsl.languageserver.utils.bsl;
 
 import com.github._1c_syntax.bsl.parser.BSLLexer;
 import org.antlr.v4.runtime.Token;
@@ -33,7 +33,7 @@ import java.util.Set;
  * Поиск парных открывающих/закрывающих ключевых слов BSL: `Если`/`КонецЕсли`,
  * `Процедура`/`КонецПроцедуры`, `Цикл`/`КонецЦикла` и т.п.
  */
-final class BlockKeywordMatcher {
+public final class BlockKeywordMatcher {
 
   private record ScopePair(Set<Integer> openers, Set<Integer> closers) {
   }
@@ -70,7 +70,7 @@ final class BlockKeywordMatcher {
    * Возвращает null, если переданный токен не относится к парным закрывающим
    * или парный открывающий не найден (несбалансированный код).
    */
-  static @Nullable Token findMatchingOpener(List<Token> allTokens, int closerIndex) {
+  public static @Nullable Token findMatchingOpener(List<Token> allTokens, int closerIndex) {
     if (closerIndex < 0 || closerIndex >= allTokens.size()) {
       return null;
     }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -544,6 +544,32 @@ class FormatProviderTest {
     assertThat(edit.getNewText()).isEqualTo("    Иначе");
   }
 
+  @Test
+  void testOnTypeFormattingEnterAlignsClosingKeywordThroughNestedBlock() {
+    // На LSP-line 4 кривой `КонецЕсли` — он закрывает ВНЕШНЕЕ `Если` на line 0,
+    // несмотря на вложенный `Если/КонецЕсли` на line 1-3.
+    String fileContent = ""
+      + "Если А Тогда\n"
+      + "  Если Б Тогда\n"
+      + "    Возврат;\n"
+      + "  КонецЕсли;\n"
+      + "        КонецЕсли\n"
+      + "\n";
+    var params = onTypeParams("\n", 5, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    // внешнее `Если` на col 0 → закрывающий КонецЕсли тоже на col 0
+    assertThat(edit.getNewText()).isEqualTo("КонецЕсли");
+  }
+
   private DocumentOnTypeFormattingParams onTypeParams(String ch, int line, int character) {
     var params = new DocumentOnTypeFormattingParams();
     params.setTextDocument(getTextDocumentIdentifier());

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -348,6 +348,8 @@ class FormatProviderTest {
     assertThat(textEdits).hasSize(1);
     TextEdit edit = textEdits.getFirst();
     assertThat(edit.getRange().getEnd().getLine()).isEqualTo(0);
+    // граница диапазона — конец исходной строки "А = 1;" (6 UTF-16 единиц)
+    assertThat(edit.getRange().getEnd().getCharacter()).isEqualTo(6);
     assertThat(edit.getNewText()).doesNotEndWith("\n");
     assertThat(edit.getNewText()).doesNotEndWith("\r");
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -304,8 +304,8 @@ class FormatProviderTest {
     // then
     assertThat(textEdits).hasSize(1);
     TextEdit edit = textEdits.getFirst();
-    assertThat(edit.getRange()).isEqualTo(new Range(new Position(0, 0), new Position(1, 0)));
-    assertThat(edit.getNewText()).isEqualTo("Если х = 1 Тогда\n");
+    assertThat(edit.getRange()).isEqualTo(new Range(new Position(0, 0), new Position(0, 14)));
+    assertThat(edit.getNewText()).isEqualTo("Если х = 1 Тогда");
   }
 
   @Test
@@ -326,8 +326,30 @@ class FormatProviderTest {
     // then
     assertThat(textEdits).hasSize(1);
     TextEdit edit = textEdits.getFirst();
-    assertThat(edit.getRange()).isEqualTo(new Range(new Position(1, 0), new Position(2, 0)));
-    assertThat(edit.getNewText()).isEqualTo("    Возврат;\n");
+    assertThat(edit.getRange()).isEqualTo(new Range(new Position(1, 0), new Position(1, 12)));
+    assertThat(edit.getNewText()).isEqualTo("    Возврат;");
+  }
+
+  @Test
+  void testOnTypeFormattingEnterPreservesTrailingNewline() {
+    // регрессия PR #3908: edit покрывал только что набранный перевод строки,
+    // и при отсутствии хвостового переноса в newText editor удалял новую строку.
+    String fileContent = "А = 1;\n";
+    var params = onTypeParams("\n", 1, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // диапазон правки не должен переходить на следующую строку
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    assertThat(edit.getRange().getEnd().getLine()).isEqualTo(0);
+    assertThat(edit.getNewText()).doesNotEndWith("\n");
+    assertThat(edit.getNewText()).doesNotEndWith("\r");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -548,13 +548,14 @@ class FormatProviderTest {
   void testOnTypeFormattingEnterAlignsClosingKeywordThroughNestedBlock() {
     // На LSP-line 4 кривой `КонецЕсли` — он закрывает ВНЕШНЕЕ `Если` на line 0,
     // несмотря на вложенный `Если/КонецЕсли` на line 1-3.
-    String fileContent = ""
-      + "Если А Тогда\n"
-      + "  Если Б Тогда\n"
-      + "    Возврат;\n"
-      + "  КонецЕсли;\n"
-      + "        КонецЕсли\n"
-      + "\n";
+    String fileContent = """
+      Если А Тогда
+        Если Б Тогда
+          Возврат;
+        КонецЕсли;
+              КонецЕсли
+
+      """;
     var params = onTypeParams("\n", 5, 0);
 
     var documentContext = TestUtils.getDocumentContext(

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -347,7 +347,7 @@ class FormatProviderTest {
     // диапазон правки не должен переходить на следующую строку
     assertThat(textEdits).hasSize(1);
     TextEdit edit = textEdits.getFirst();
-    assertThat(edit.getRange().getEnd().getLine()).isEqualTo(0);
+    assertThat(edit.getRange().getEnd().getLine()).isZero();
     // граница диапазона — конец исходной строки "А = 1;" (6 UTF-16 единиц)
     assertThat(edit.getRange().getEnd().getCharacter()).isEqualTo(6);
     assertThat(edit.getNewText()).doesNotEndWith("\n");
@@ -450,7 +450,7 @@ class FormatProviderTest {
   }
 
   @Test
-  void testOnTypeFormattingDisabledByConfig() throws IOException {
+  void testOnTypeFormattingDisabledByConfig() {
     // given: настройка useOnTypeFormatting = false должна полностью отключать провайдер
     configuration.update(new File("./src/test/resources/.bsl-language-server-format-on-type-off.json"));
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -449,6 +449,26 @@ class FormatProviderTest {
     assertThat(textEdits).isEmpty();
   }
 
+  @Test
+  void testOnTypeFormattingDisabledByConfig() throws IOException {
+    // given: настройка useOnTypeFormatting = false должна полностью отключать провайдер
+    configuration.update(new File("./src/test/resources/.bsl-language-server-format-on-type-off.json"));
+
+    String fileContent = "если х=1 тогда\n\n";
+    var params = onTypeParams("\n", 1, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).isEmpty();
+  }
+
   private DocumentOnTypeFormattingParams onTypeParams(String ch, int line, int character) {
     var params = new DocumentOnTypeFormattingParams();
     params.setTextDocument(getTextDocumentIdentifier());

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -469,6 +469,81 @@ class FormatProviderTest {
     assertThat(textEdits).isEmpty();
   }
 
+  @Test
+  void testOnTypeFormattingSemicolonPreservesLeadingTab() {
+    // регрессия: `\tконецесли` + `;` ранее съедал ведущую табуляцию, потому что
+    // первый токен — decrement-keyword и getNewText сбрасывал indentLevel в 0.
+    // Теперь ведущий whitespace вне replace-диапазона и подменяется явно.
+    String fileContent = "\tконецесли;";
+    var params = onTypeParams(";", 0, 11);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    // Парного `Если` нет → fallback: сохраняем фактический отступ строки.
+    assertThat(edit.getNewText()).isEqualTo("\tКонецЕсли;");
+  }
+
+  @Test
+  void testOnTypeFormattingEnterAlignsClosingKeywordToOpener() {
+    // фича: `КонецЕсли` с криво проставленным отступом выравнивается по `Если`.
+    String fileContent = "Если Истина Тогда\n        КонецЕсли\n\n";
+    var params = onTypeParams("\n", 2, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    // Если на col 0 → КонецЕсли подтягивается к col 0
+    assertThat(edit.getNewText()).isEqualTo("КонецЕсли");
+  }
+
+  @Test
+  void testOnTypeFormattingEnterAlignsEndProcedureToProcedure() {
+    String fileContent = "    Процедура П()\n  КонецПроцедуры\n\n";
+    var params = onTypeParams("\n", 2, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    // ведущий отступ `Процедура` = 4 пробела → `КонецПроцедуры` тоже 4 пробела
+    assertThat(edit.getNewText()).isEqualTo("    КонецПроцедуры");
+  }
+
+  @Test
+  void testOnTypeFormattingEnterAlignsElseToIf() {
+    String fileContent = "    Если Истина Тогда\nИначе\n\n";
+    var params = onTypeParams("\n", 2, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    assertThat(edit.getNewText()).isEqualTo("    Иначе");
+  }
+
   private DocumentOnTypeFormattingParams onTypeParams(String ch, int line, int character) {
     var params = new DocumentOnTypeFormattingParams();
     params.setTextDocument(getTextDocumentIdentifier());

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/bsl/BlockKeywordMatcherTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/bsl/BlockKeywordMatcherTest.java
@@ -1,0 +1,128 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.utils.bsl;
+
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.parser.BSLLexer;
+import org.antlr.v4.runtime.Token;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@CleanupContextBeforeClassAndAfterEachTestMethod
+class BlockKeywordMatcherTest {
+
+  @Test
+  void returnsNullForNegativeIndex() {
+    var tokens = tokensOf("Если Истина Тогда\nКонецЕсли;");
+    assertThat(BlockKeywordMatcher.findMatchingOpener(tokens, -1)).isNull();
+  }
+
+  @Test
+  void returnsNullForOutOfBoundsIndex() {
+    var tokens = tokensOf("Если Истина Тогда\nКонецЕсли;");
+    assertThat(BlockKeywordMatcher.findMatchingOpener(tokens, tokens.size())).isNull();
+    assertThat(BlockKeywordMatcher.findMatchingOpener(tokens, tokens.size() + 10)).isNull();
+  }
+
+  @Test
+  void returnsNullForNonClosingToken() {
+    var tokens = tokensOf("А = 1;");
+    var assignIndex = indexOfType(tokens, BSLLexer.ASSIGN);
+    assertThat(BlockKeywordMatcher.findMatchingOpener(tokens, assignIndex)).isNull();
+  }
+
+  @Test
+  void findsOpenerForSimpleEndIf() {
+    var tokens = tokensOf("Если Истина Тогда\nКонецЕсли;");
+    var endifIndex = indexOfType(tokens, BSLLexer.ENDIF_KEYWORD);
+    var opener = BlockKeywordMatcher.findMatchingOpener(tokens, endifIndex);
+    assertThat(opener).isNotNull();
+    assertThat(opener.getType()).isEqualTo(BSLLexer.IF_KEYWORD);
+    assertThat(opener.getLine()).isEqualTo(1);
+  }
+
+  @Test
+  void findsOuterOpenerThroughNestedBlock() {
+    var source = "Если А Тогда\n  Если Б Тогда\n    Возврат;\n  КонецЕсли;\nКонецЕсли;";
+    var tokens = tokensOf(source);
+    var outerEndifIndex = lastIndexOfType(tokens, BSLLexer.ENDIF_KEYWORD);
+    var opener = BlockKeywordMatcher.findMatchingOpener(tokens, outerEndifIndex);
+    assertThat(opener).isNotNull();
+    assertThat(opener.getType()).isEqualTo(BSLLexer.IF_KEYWORD);
+    // должно быть внешнее `Если` на первой строке, а не вложенное со второй
+    assertThat(opener.getLine()).isEqualTo(1);
+  }
+
+  @Test
+  void findsContainingTryForExceptKeyword() {
+    var tokens = tokensOf("Попытка\n  Возврат;\nИсключение\nКонецПопытки;");
+    var exceptIndex = indexOfType(tokens, BSLLexer.EXCEPT_KEYWORD);
+    var opener = BlockKeywordMatcher.findMatchingOpener(tokens, exceptIndex);
+    assertThat(opener).isNotNull();
+    assertThat(opener.getType()).isEqualTo(BSLLexer.TRY_KEYWORD);
+  }
+
+  @Test
+  void findsContainingLoopForEnddo() {
+    var tokens = tokensOf("Для Сч = 1 По 3 Цикл\n  Возврат;\nКонецЦикла;");
+    var enddoIndex = indexOfType(tokens, BSLLexer.ENDDO_KEYWORD);
+    var opener = BlockKeywordMatcher.findMatchingOpener(tokens, enddoIndex);
+    assertThat(opener).isNotNull();
+    assertThat(opener.getType()).isEqualTo(BSLLexer.FOR_KEYWORD);
+  }
+
+  @Test
+  void returnsNullWhenOpenerMissing() {
+    // несбалансированный КонецЕсли без парного Если
+    var tokens = tokensOf("КонецЕсли;");
+    var endifIndex = indexOfType(tokens, BSLLexer.ENDIF_KEYWORD);
+    assertThat(BlockKeywordMatcher.findMatchingOpener(tokens, endifIndex)).isNull();
+  }
+
+  private static List<Token> tokensOf(String source) {
+    return TestUtils.getDocumentContext(source).getTokens();
+  }
+
+  private static int indexOfType(List<Token> tokens, int type) {
+    for (var i = 0; i < tokens.size(); i++) {
+      if (tokens.get(i).getType() == type) {
+        return i;
+      }
+    }
+    throw new AssertionError("token of type " + type + " not found");
+  }
+
+  private static int lastIndexOfType(List<Token> tokens, int type) {
+    for (var i = tokens.size() - 1; i >= 0; i--) {
+      if (tokens.get(i).getType() == type) {
+        return i;
+      }
+    }
+    throw new AssertionError("token of type " + type + " not found");
+  }
+}

--- a/src/test/resources/.bsl-language-server-format-on-type-off.json
+++ b/src/test/resources/.bsl-language-server-format-on-type-off.json
@@ -1,0 +1,9 @@
+{
+  "language": "ru",
+  "formatting": {
+    "useOnTypeFormatting": false
+  },
+  "useDevSite": true,
+  "traceLog": "build/.trace.log",
+  "configurationRoot": "src/test/resources/metadata/designer"
+}


### PR DESCRIPTION
Объединяет #3916 (fix) и #3917 (feat) в один PR.

---

## 1. fix: preserve newline typed by user on Enter

Регрессия из #3908. Пользователи на пререлизе сообщают, что при Enter в конце строки editor добавляет новую строку — и она тут же удаляется.

**Причина.** Range правки для триггера `"\n"` покрывал `(L, 0)..(L+1, 0)`, то есть включал только что набранный пользователем перевод строки. Хвостовой `\n` в `newText` зависел от эвристики `getNewText` (append `\n`, если последний токен заканчивается на `\n`). В юнит-тестах WS-токен с переводом строки попадал в фильтрованный список, поэтому случай выглядел рабочим. В реальной среде (CRLF, лексер не всегда даёт «удобный» WS-токен на нужной строке) хвостовой `\n` мог не появиться — editor применял edit без него, и строка схлопывалась.

**Фикс.** Для `\n` ограничиваем range концом строки: `(L, 0)..(L, lineLength)`, где `lineLength = documentContext.getContentList()[L].length()`. `cutoffCharacter` = `lineLength`, поэтому WS-токен с `\n` автоматически отфильтровывается. Только что набранный `\n` физически вне replace-range — гарантированно не теряется независимо от того, что вернёт `getNewText`.

## 2. feat: add useOnTypeFormatting config flag

Конфигурационный флаг `formatting.useOnTypeFormatting` (по умолчанию `true`), позволяющий пользователю отключить on-type-форматтер. Когда флаг выключен, `FormatProvider.getOnTypeFormatting` рано возвращает пустой список правок и не вмешивается в ввод пользователя.

Server capability при этом не меняется — клиент-расширение (vsc-language-1c-bsl) по-прежнему видит объявленную поддержку on-type через LSP-контракт и может корректно решить, нужен ли его собственный встроенный fallback. Управление включением/выключением остаётся за пользователем через стандартный механизм конфигурации LS.

## Test plan

- [x] Обновлены `testOnTypeFormattingEnterNormalizesPreviousLine` и `testOnTypeFormattingEnterPreservesIndent` под новый range/newText.
- [x] Добавлен регресс `testOnTypeFormattingEnterPreservesTrailingNewline` — проверяет, что edit не переходит на следующую строку и не заканчивается на `\n`/`\r` (включая жёсткую проверку `end.character`).
- [x] Добавлен `testOnTypeFormattingDisabledByConfig` — настройка из `.bsl-language-server-format-on-type-off.json` отключает фичу.
- [x] `./gradlew test --tests FormatProviderTest` — 16/16 passed.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Workspace toggle to enable/disable on-type formatting (Enter/`;`).
  * Added block-keyword matching utility to improve paired-keyword handling.

* **Bug Fixes**
  * On-Type Enter formatting constrained to the original line and no longer includes trailing newline.
  * Improved on-type behavior for `;` and indentation alignment of closing keywords.

* **Tests**
  * Updated and added tests covering on-type cases and the new configuration.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3916?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->