### PR TITLE
feat(formatting): add useOnTypeFormatting config flag

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/formating/FormattingOptions.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/formating/FormattingOptions.java
@@ -46,4 +46,9 @@ public class FormattingOptions {
    * Использовать форматирование ключевых слов.
    */
   private boolean useKeywordsFormatting = true;
+  /**
+   * Включить форматирование по нажатию символа-триггера (textDocument/onTypeFormatting).
+   * Триггеры — Enter и {@code ;}.
+   */
+  private boolean useOnTypeFormatting = true;
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -140,6 +140,10 @@ public final class FormatProvider {
     DocumentOnTypeFormattingParams params,
     DocumentContext documentContext
   ) {
+    if (!configuration.getFormattingOptions().isUseOnTypeFormatting()) {
+      return Collections.emptyList();
+    }
+
     String ch = params.getCh();
     var position = params.getPosition();
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -425,6 +425,26 @@ class FormatProviderTest {
     assertThat(textEdits).isEmpty();
   }
 
+  @Test
+  void testOnTypeFormattingDisabledByConfig() throws IOException {
+    // given: настройка useOnTypeFormatting = false должна полностью отключать провайдер
+    configuration.update(new File("./src/test/resources/.bsl-language-server-format-on-type-off.json"));
+
+    String fileContent = "если х=1 тогда\n\n";
+    var params = onTypeParams("\n", 1, 0);
+
+    var documentContext = TestUtils.getDocumentContext(
+      URI.create(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).isEmpty();
+  }
+
   private DocumentOnTypeFormattingParams onTypeParams(String ch, int line, int character) {
     var params = new DocumentOnTypeFormattingParams();
     params.setTextDocument(getTextDocumentIdentifier());

--- a/src/test/resources/.bsl-language-server-format-on-type-off.json
+++ b/src/test/resources/.bsl-language-server-format-on-type-off.json
@@ -1,0 +1,9 @@
+{
+  "language": "ru",
+  "formatting": {
+    "useOnTypeFormatting": false
+  },
+  "useDevSite": true,
+  "traceLog": "build/.trace.log",
+  "configurationRoot": "src/test/resources/metadata/designer"
+}


### PR DESCRIPTION
## Summary

Конфигурационный флаг `formatting.useOnTypeFormatting` (по умолчанию `true`), позволяющий пользователю отключить on-type-форматтер. Когда флаг выключен, `FormatProvider.getOnTypeFormatting` рано возвращает пустой список правок и не вмешивается в ввод пользователя.

Server capability при этом не меняется — клиент-расширение (vsc-language-1c-bsl) по-прежнему видит объявленную поддержку on-type через LSP-контракт и может корректно решить, нужен ли его собственный встроенный fallback. Управление включением/выключением остаётся за пользователем через стандартный механизм конфигурации LS.

## Changes

- `FormattingOptions.useOnTypeFormatting` — новое поле, default `true`.
- `FormatProvider.getOnTypeFormatting` — early return пустого списка при выключенном флаге.

## Test plan

- [x] Добавлен `testOnTypeFormattingDisabledByConfig` — настройка из `.bsl-language-server-format-on-type-off.json` отключает фичу.
- [x] `./gradlew test --tests FormatProviderTest` — 15/15 passed.

## Related

Дополняет #3908 (фича) и #3916 (фикс регрессии перевода строки на Enter).