### PR TITLE
feat(types): inherit platform members on configuration manager/ref/object/collection types

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -86,3 +86,4 @@ bsl-language-server_*.zip
 /.idea/material_theme_project_new.xml
 .bsl-ls-cache/
 __pycache__/
+.claude/

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -257,6 +257,12 @@ public final class CompletionProvider {
     var members = new LinkedHashMap<String, MemberDescriptor>();
     for (TypeRef ref : typeSet.refs()) {
       for (var member : typeService.getMembers(ref, fileType)) {
+        // Платформенные generic-«слоты» (например, `<Имя документа>`,
+        // `<Имя реквизита>`) — это абстрактные плейсхолдеры HBK, в реальной
+        // dot-completion они только мешают.
+        if (member.generic()) {
+          continue;
+        }
         members.putIfAbsent(member.name(), member);
       }
       // Декларированные ключи «открытого» объекта данных (Структура из

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
@@ -51,6 +51,11 @@ import java.util.Optional;
  * @param returnTypes  union типов возвращаемого значения / типа свойства
  * @param signatures   список сигнатур для метода (пустой для свойства)
  * @param sourceSymbol опциональный символ-источник члена
+ * @param generic      признак «слотового» члена generic-типа платформы (например,
+ *                     {@code <Имя реквизита>}, {@code <Имя табличной части>}).
+ *                     Используется, чтобы не публиковать эти псевдо-члены при
+ *                     наследовании от generic-типа в его специализациях
+ *                     ({@code ДокументСсылка.МойДокумент} и т.п.).
  */
 public record MemberDescriptor(
   String name,
@@ -58,7 +63,8 @@ public record MemberDescriptor(
   String description,
   TypeSet returnTypes,
   List<SignatureDescriptor> signatures,
-  Symbol sourceSymbol
+  Symbol sourceSymbol,
+  boolean generic
 ) {
 
   public MemberDescriptor {
@@ -104,34 +110,34 @@ public record MemberDescriptor(
    * @return копия дескриптора с прикреплённым символом-источником.
    */
   public MemberDescriptor withSourceSymbol(Symbol symbol) {
-    return new MemberDescriptor(name, kind, description, returnTypes, signatures, symbol);
+    return new MemberDescriptor(name, kind, description, returnTypes, signatures, symbol, generic);
   }
 
   public static MemberDescriptor method(String name) {
-    return new MemberDescriptor(name, MemberKind.METHOD, "", TypeSet.EMPTY, List.of(), null);
+    return new MemberDescriptor(name, MemberKind.METHOD, "", TypeSet.EMPTY, List.of(), null, false);
   }
 
   public static MemberDescriptor method(String name, List<SignatureDescriptor> signatures) {
     var ret = signatureReturnTypes(signatures);
-    return new MemberDescriptor(name, MemberKind.METHOD, "", ret, signatures, null);
+    return new MemberDescriptor(name, MemberKind.METHOD, "", ret, signatures, null, false);
   }
 
   public static MemberDescriptor method(String name, String description, List<SignatureDescriptor> signatures) {
     var ret = signatureReturnTypes(signatures);
-    return new MemberDescriptor(name, MemberKind.METHOD, description, ret, signatures, null);
+    return new MemberDescriptor(name, MemberKind.METHOD, description, ret, signatures, null, false);
   }
 
   public static MemberDescriptor property(String name) {
-    return new MemberDescriptor(name, MemberKind.PROPERTY, "", TypeSet.EMPTY, List.of(), null);
+    return new MemberDescriptor(name, MemberKind.PROPERTY, "", TypeSet.EMPTY, List.of(), null, false);
   }
 
   public static MemberDescriptor property(String name, TypeRef returnType) {
-    return new MemberDescriptor(name, MemberKind.PROPERTY, "", typesOf(returnType), List.of(), null);
+    return new MemberDescriptor(name, MemberKind.PROPERTY, "", typesOf(returnType), List.of(), null, false);
   }
 
   public static MemberDescriptor property(String name, TypeRef returnType, String description) {
     return new MemberDescriptor(name, MemberKind.PROPERTY,
-      description == null ? "" : description, typesOf(returnType), List.of(), null);
+      description == null ? "" : description, typesOf(returnType), List.of(), null, false);
   }
 
   /**
@@ -141,7 +147,13 @@ public record MemberDescriptor(
     return new MemberDescriptor(name, MemberKind.PROPERTY,
       description == null ? "" : description,
       returnTypes == null ? TypeSet.EMPTY : returnTypes,
-      List.of(), null);
+      List.of(), null, false);
+  }
+
+  /** Generic-property платформенного типа (например, {@code <Имя реквизита>}). */
+  public static MemberDescriptor genericProperty(String name, TypeRef returnType, String description) {
+    return new MemberDescriptor(name, MemberKind.PROPERTY,
+      description == null ? "" : description, typesOf(returnType), List.of(), null, true);
   }
 
   private static TypeSet typesOf(TypeRef ref) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
@@ -33,6 +33,8 @@ import com.github._1c_syntax.bsl.context.api.ContextProperty;
 import com.github._1c_syntax.bsl.context.api.ContextProvider;
 import com.github._1c_syntax.bsl.context.api.ContextSignatureParameter;
 import com.github._1c_syntax.bsl.context.api.ContextType;
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
+import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
@@ -90,10 +92,19 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
 
   private final BslContextHolder contextHolder;
   private final Lazy<List<TypeDecl>> cached;
+  /**
+   * Язык, на котором будут публиковаться имена членов/параметров/значений
+   * перечислений. Захватывается при создании провайдера (workspace-scope).
+   * Имена самих типов остаются на русском — это канонический идентификатор
+   * для TypeRegistry; альтернативное имя регистрируется через alias.
+   */
+  private final Language language;
 
-  public BslContextPlatformTypesProvider(BslContextHolder contextHolder) {
+  public BslContextPlatformTypesProvider(BslContextHolder contextHolder,
+                                         LanguageServerConfiguration configuration) {
     this.contextHolder = contextHolder;
-    this.cached = new Lazy<>(() -> build(contextHolder.get().orElse(null)));
+    this.language = configuration.getLanguage();
+    this.cached = new Lazy<>(() -> build(contextHolder.get().orElse(null), language));
   }
 
   @Override
@@ -106,14 +117,14 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
     return LanguageScope.BSL;
   }
 
-  private static List<TypeDecl> build(ContextProvider provider) {
+  private static List<TypeDecl> build(ContextProvider provider, Language language) {
     if (provider == null) {
       return List.of();
     }
     var contexts = provider.getContexts();
     var result = new ArrayList<TypeDecl>(contexts.size());
     for (var context : contexts) {
-      var decl = toTypeDecl(context);
+      var decl = toTypeDecl(context, language);
       if (decl != null) {
         result.add(decl);
       }
@@ -121,17 +132,17 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
     return List.copyOf(result);
   }
 
-  private static TypeDecl toTypeDecl(Context context) {
+  private static TypeDecl toTypeDecl(Context context, Language language) {
     var kind = mapKind(context);
     if (kind == null) {
       return null;
     }
     var qualifiedName = context.name().getName();
     var aliases = aliasesOf(context.name());
-    var members = collectMembers(context);
+    var members = collectMembers(context, language);
     var description = descriptionOf(context);
     var classRef = new TypeRef(kind, qualifiedName);
-    var constructors = constructorsOf(context, classRef);
+    var constructors = constructorsOf(context, classRef, language);
     var defaultElementTypes = collectionElementTypes(context);
     var supportsForEach = context instanceof ContextCollection coll && coll.supportsForEach();
     var supportsIndexAccess = context instanceof ContextCollection coll && coll.supportsIndexAccess();
@@ -162,6 +173,25 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
     return List.copyOf(refs);
   }
 
+  /**
+   * Возвращает имя ContextName в указанном языке. Падает обратно на другой
+   * язык, если выбранный пуст (HBK может содержать только одно из двух).
+   */
+  private static String pickPrimary(ContextName name, Language language) {
+    var ru = name.getName();
+    var en = name.getAlias();
+    if (language == Language.EN) {
+      if (en != null && !en.isBlank()) {
+        return en;
+      }
+      return ru == null ? "" : ru;
+    }
+    if (ru != null && !ru.isBlank()) {
+      return ru;
+    }
+    return en == null ? "" : en;
+  }
+
   private static String descriptionOf(Context context) {
     if (context instanceof ContextType type) {
       return type.description();
@@ -175,7 +205,8 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
    * Возвращаемый тип конструктора — сам тип ({@code classRef}); параметры —
    * как у обычных методов.
    */
-  private static List<SignatureDescriptor> constructorsOf(Context context, TypeRef classRef) {
+  private static List<SignatureDescriptor> constructorsOf(Context context, TypeRef classRef,
+                                                          Language language) {
     if (!(context instanceof ContextType type)) {
       return List.of();
     }
@@ -187,7 +218,7 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
     for (var ctor : ctors) {
       var parameters = new ArrayList<ParameterDescriptor>(ctor.parameters().size());
       for (var parameter : ctor.parameters()) {
-        parameters.add(toParameterDescriptor(parameter));
+        parameters.add(toParameterDescriptor(parameter, language));
       }
       result.add(new SignatureDescriptor(parameters, classRef, ctor.description()));
     }
@@ -231,15 +262,15 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
     return List.of(alias);
   }
 
-  private static List<MemberDescriptor> collectMembers(Context context) {
+  private static List<MemberDescriptor> collectMembers(Context context, Language language) {
     if (context instanceof ContextType type) {
       var members = new ArrayList<MemberDescriptor>(
         type.methods().size() + type.properties().size());
       for (var property : type.properties()) {
-        members.add(toMemberDescriptor(property));
+        members.add(toMemberDescriptor(property, language));
       }
       for (var method : type.methods()) {
-        members.add(toMemberDescriptor(method));
+        members.add(toMemberDescriptor(method, language));
       }
       return List.copyOf(members);
     }
@@ -248,25 +279,30 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
       var members = new ArrayList<MemberDescriptor>(values.size());
       var enumRef = new TypeRef(TypeKind.PLATFORM, context.name().getName());
       for (var value : values) {
-        members.add(toMemberDescriptor(value, enumRef));
+        members.add(toMemberDescriptor(value, enumRef, language));
       }
       return List.copyOf(members);
     }
     return Collections.emptyList();
   }
 
-  static MemberDescriptor toMemberDescriptor(ContextProperty property) {
+  static MemberDescriptor toMemberDescriptor(ContextProperty property, Language language) {
     var returnType = singleType(property.types());
-    return MemberDescriptor.property(
-      property.name().getName(),
-      returnType,
-      property.description()
-    );
+    var name = pickPrimary(property.name(), language);
+    if (property.isGeneric()) {
+      return MemberDescriptor.genericProperty(name, returnType, property.description());
+    }
+    return MemberDescriptor.property(name, returnType, property.description());
   }
 
-  static MemberDescriptor toMemberDescriptor(ContextMethod method) {
+  /** Backward-compatible overload — использует {@link Language#DEFAULT_LANGUAGE}. */
+  static MemberDescriptor toMemberDescriptor(ContextProperty property) {
+    return toMemberDescriptor(property, Language.DEFAULT_LANGUAGE);
+  }
+
+  static MemberDescriptor toMemberDescriptor(ContextMethod method, Language language) {
     var returnType = singleType(method.returnValues());
-    var signatures = toSignatures(method.signatures(), returnType);
+    var signatures = toSignatures(method.signatures(), returnType, language);
     if (signatures.isEmpty() && returnType != TypeRef.UNKNOWN) {
       // bsl-context указал returnType метода без вариантов сигнатуры — синтезируем
       // безпараметровую сигнатуру, чтобы returnType был доступен инференсеру
@@ -274,15 +310,21 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
       signatures = List.of(new SignatureDescriptor(List.of(), returnType, ""));
     }
     return MemberDescriptor.method(
-      method.name().getName(),
+      pickPrimary(method.name(), language),
       method.description(),
       signatures
     );
   }
 
-  private static MemberDescriptor toMemberDescriptor(ContextEnumValue value, TypeRef enumRef) {
+  /** Backward-compatible overload — использует {@link Language#DEFAULT_LANGUAGE}. */
+  static MemberDescriptor toMemberDescriptor(ContextMethod method) {
+    return toMemberDescriptor(method, Language.DEFAULT_LANGUAGE);
+  }
+
+  private static MemberDescriptor toMemberDescriptor(ContextEnumValue value, TypeRef enumRef,
+                                                     Language language) {
     return MemberDescriptor.property(
-      value.name().getName(),
+      pickPrimary(value.name(), language),
       enumRef,
       value.description()
     );
@@ -290,7 +332,8 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
 
   static List<SignatureDescriptor> toSignatures(
     List<ContextMethodSignature> signatures,
-    TypeRef returnType
+    TypeRef returnType,
+    Language language
   ) {
     if (signatures == null || signatures.isEmpty()) {
       return List.of();
@@ -299,7 +342,7 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
     for (var signature : signatures) {
       var parameters = new ArrayList<ParameterDescriptor>(signature.parameters().size());
       for (var parameter : signature.parameters()) {
-        parameters.add(toParameterDescriptor(parameter));
+        parameters.add(toParameterDescriptor(parameter, language));
       }
       // bsl-context хранит returnType один на метод (одна страница HBK —
       // один блок «Возвращаемое значение:»), поэтому он одинаков для
@@ -309,9 +352,10 @@ public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
     return List.copyOf(result);
   }
 
-  private static ParameterDescriptor toParameterDescriptor(ContextSignatureParameter parameter) {
+  private static ParameterDescriptor toParameterDescriptor(ContextSignatureParameter parameter,
+                                                           Language language) {
     return new ParameterDescriptor(
-      parameter.name().getName(),
+      pickPrimary(parameter.name(), language),
       typeSet(parameter.types()),
       !parameter.isRequired(),
       parameter.description()

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
@@ -35,6 +35,7 @@ import com.github._1c_syntax.bsl.context.api.ContextSignatureParameter;
 import com.github._1c_syntax.bsl.context.api.ContextType;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
+import com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageServerConfigurationChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
@@ -48,6 +49,7 @@ import com.github._1c_syntax.utils.Lazy;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -91,20 +93,37 @@ import java.util.List;
 public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
 
   private final BslContextHolder contextHolder;
-  private final Lazy<List<TypeDecl>> cached;
   /**
-   * Язык, на котором будут публиковаться имена членов/параметров/значений
-   * перечислений. Захватывается при создании провайдера (workspace-scope).
-   * Имена самих типов остаются на русском — это канонический идентификатор
-   * для TypeRegistry; альтернативное имя регистрируется через alias.
+   * Конфигурация LS. Язык, на котором публикуются имена members/parameters/enum-values,
+   * читается из неё в момент построения кэша (см. {@link #cached}). Имена самих типов
+   * остаются на русском — это канонический идентификатор для TypeRegistry; альтернативное
+   * имя регистрируется через alias.
+   * <p>
+   * Не захватываем язык в final-поле: {@code language} в воркспейс-конфигурации может
+   * меняться в рантайме через {@code workspace/didChangeConfiguration}. На событие
+   * {@link LanguageServerConfigurationChangedEvent} сбрасываем {@link #cached}, и
+   * следующий вызов {@link #getTypes()} пересоберёт TypeDecl'ы на свежем языке.
    */
-  private final Language language;
+  private final LanguageServerConfiguration configuration;
+  private final Lazy<List<TypeDecl>> cached;
 
   public BslContextPlatformTypesProvider(BslContextHolder contextHolder,
                                          LanguageServerConfiguration configuration) {
     this.contextHolder = contextHolder;
-    this.language = configuration.getLanguage();
-    this.cached = new Lazy<>(() -> build(contextHolder.get().orElse(null), language));
+    this.configuration = configuration;
+    this.cached = new Lazy<>(() -> build(contextHolder.get().orElse(null), configuration.getLanguage()));
+  }
+
+  /**
+   * Сбрасывает кэш TypeDecl'ов при смене конфигурации LS, чтобы имена members
+   * пересобрались по актуальному {@link Language}. Регистрация в TypeRegistry
+   * происходит при загрузке воркспейса; до её повторной инициализации
+   * пользователю остаются те имена, которые лежали в TypeRegistry на момент
+   * bootstrap.
+   */
+  @EventListener
+  public void handleEvent(LanguageServerConfigurationChangedEvent event) {
+    cached.clear();
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinPlatformTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinPlatformTypesProvider.java
@@ -154,9 +154,16 @@ public class BuiltinPlatformTypesProvider implements PlatformTypesProvider {
         // чтобы returnType метода был доступен инференсеру через MemberDescriptor.returnTypes.
         signatures = List.of(new SignatureDescriptor(List.of(), returnType, ""));
       }
-      members.add(kind == MemberKind.METHOD
-        ? MemberDescriptor.method(name, description, signatures)
-        : MemberDescriptor.property(name, returnType, description));
+      var generic = Boolean.TRUE.equals(m.get("generic"));
+      MemberDescriptor descriptor;
+      if (kind == MemberKind.METHOD) {
+        descriptor = MemberDescriptor.method(name, description, signatures);
+      } else if (generic) {
+        descriptor = MemberDescriptor.genericProperty(name, returnType, description);
+      } else {
+        descriptor = MemberDescriptor.property(name, returnType, description);
+      }
+      members.add(descriptor);
     }
     return members;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -21,17 +21,24 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.mdo.Attribute;
 import com.github._1c_syntax.bsl.mdo.AttributeOwner;
+import com.github._1c_syntax.bsl.mdo.CommonAttribute;
 import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.TabularSectionOwner;
+import com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection;
+import com.github._1c_syntax.bsl.mdo.children.StandardAttribute;
+import com.github._1c_syntax.bsl.mdo.support.AttributeKind;
 import com.github._1c_syntax.bsl.types.MDOType;
 import com.github._1c_syntax.bsl.types.ValueType;
 import com.github._1c_syntax.bsl.types.value.PrimitiveValueType;
@@ -92,6 +99,7 @@ public class ConfigurationTypesProvider {
   private final TypeRegistry typeRegistry;
   private final ServerContextProvider serverContextProvider;
   private final GlobalScopeProvider globalScopeProvider;
+  private final LanguageServerConfiguration configuration;
 
   private final AtomicBoolean registered = new AtomicBoolean(false);
 
@@ -131,6 +139,16 @@ public class ConfigurationTypesProvider {
   private void register(Iterable<MD> children) {
     int count = 0;
     Map<MDOType, List<MemberDescriptor>> collectionMembersByType = new HashMap<>();
+
+    // Все общие реквизиты конфигурации — нужны при регистрации объектных/ссылочных
+    // обёрток MD: подмешиваем те, что включены для конкретного MDObject'а.
+    var commonAttributes = new ArrayList<CommonAttribute>();
+    for (var md : children) {
+      if (md instanceof CommonAttribute ca) {
+        commonAttributes.add(ca);
+      }
+    }
+
     for (var md : children) {
       var mdoType = md.getMdoType();
       if (!MANAGER_TYPES.contains(mdoType)) {
@@ -150,8 +168,10 @@ public class ConfigurationTypesProvider {
       var fullName = mdoType.fullName();
       String managerRu;
       String managerEn;
+      String managerFamilyPrefix = null;
       if (fullName != null && fullName.getRu() != null && !fullName.getRu().isBlank()) {
         managerRu = fullName.getRu() + "Менеджер." + name;
+        managerFamilyPrefix = fullName.getRu() + "Менеджер";
         var fullEn = fullName.getEn();
         managerEn = (fullEn == null || fullEn.isBlank()) ? null : fullEn + "Manager." + name;
       } else {
@@ -164,7 +184,13 @@ public class ConfigurationTypesProvider {
         typeRegistry.registerConfigurationTypeAlias(managerEn, ref);
       }
 
-      registerObjectAndRefTypes(md, mdoType, name, fullName);
+      // Подмешиваем платформенные методы менеджера-семейства
+      // (СправочникМенеджер.<…>: Выбрать, НайтиПоКоду, СоздатьЭлемент и т.п.).
+      if (managerFamilyPrefix != null) {
+        registerPlatformGenericMembers(ref, managerFamilyPrefix);
+      }
+
+      registerObjectAndRefTypes(md, mdoType, name, fullName, commonAttributes);
 
       // Дополнительные алиасы «коллекция.Имя» для совместимости и для случаев,
       // когда пользователь обращается напрямую (например, Hover на `Справочники.Контрагенты`).
@@ -201,6 +227,12 @@ public class ConfigurationTypesProvider {
       }
       typeRegistry.registerMemberSource(ref, () -> members, LanguageScope.BSL);
       typeRegistry.registerAsGlobalProperty(ref);
+
+      // Подмешиваем платформенные методы коллекции-менеджера (СправочникиМенеджер,
+      // ДокументыМенеджер и т.п.) — это методы уровня всех справочников/документов,
+      // например `ТипВсеСсылки()`. Имя фиксированное (без generic-плейсхолдера).
+      registerInheritedMembers(ref, groupRu + "Менеджер");
+
       collections++;
     }
 
@@ -230,7 +262,8 @@ public class ConfigurationTypesProvider {
   private void registerObjectAndRefTypes(MD md,
                                          MDOType mdoType,
                                          String name,
-                                         com.github._1c_syntax.bsl.types.MultiName fullName) {
+                                         com.github._1c_syntax.bsl.types.MultiName fullName,
+                                         List<CommonAttribute> commonAttributes) {
     if (!OBJECT_TYPES.contains(mdoType) || fullName == null) {
       return;
     }
@@ -244,6 +277,11 @@ public class ConfigurationTypesProvider {
       return;
     }
     var attributes = attributeOwner.getAllAttributes();
+    var commonForMd = applicableCommonAttributes(md, commonAttributes);
+
+    // Описания стандартных реквизитов (Дата/Номер/Ссылка/…) в mdclasses пустые,
+    // но платформа в HBK ровно их и описывает. Подмешиваем по имени.
+    var platformDescriptions = collectPlatformMemberDescriptions(fullRu);
 
     var objectRu = fullRu + "Объект." + name;
     var objectEn = (fullEn == null || fullEn.isBlank()) ? null : fullEn + "Object." + name;
@@ -267,11 +305,125 @@ public class ConfigurationTypesProvider {
       }
     }
 
-    var members = buildAttributeMembers(attributes);
+    var members = new ArrayList<MemberDescriptor>();
+    members.addAll(buildAttributeMembers(attributes, platformDescriptions));
+    members.addAll(buildCommonAttributeMembers(commonForMd));
     if (!members.isEmpty()) {
-      typeRegistry.registerMemberSource(objectRef, () -> members, LanguageScope.BSL);
-      typeRegistry.registerMemberSource(refRef, () -> members, LanguageScope.BSL);
+      var immutable = List.copyOf(members);
+      typeRegistry.registerMemberSource(objectRef, () -> immutable, LanguageScope.BSL);
+      typeRegistry.registerMemberSource(refRef, () -> immutable, LanguageScope.BSL);
     }
+
+    // Подмешиваем members generic-платформенного семейства (СправочникСсылка.<...>,
+    // ДокументОбъект.<...> и т.п.). Это даёт методы (Метаданные, ПолучитьОбъект, Записать,
+    // …) и стандартные свойства (ВерсияДанных, Владелец, Родитель, …), которых нет среди
+    // реквизитов метаданных. Резолв выполняется лениво на первом обращении к getMembers,
+    // чтобы не зависеть от порядка инициализации платформенных провайдеров.
+    registerPlatformGenericMembers(objectRef, fullRu + "Объект");
+    registerPlatformGenericMembers(refRef, fullRu + "Ссылка");
+
+    // Табличные части: регистрируем пару типов <prefix>ТабличнаяЧасть(Строка)?.<MD>.<TS>
+    // и добавляем member <TS-name> на объектный тип.
+    registerTabularSections(md, name, fullRu, fullEn, objectRef);
+  }
+
+  /**
+   * Для каждой табличной части MD регистрирует два типа:
+   * <ul>
+   *   <li>{@code <prefix>ТабличнаяЧастьСтрока.<MD>.<TS>} — строка ТЧ, members — её колонки;</li>
+   *   <li>{@code <prefix>ТабличнаяЧасть.<MD>.<TS>} — коллекция строк (item type = строка).</li>
+   * </ul>
+   * На объектный тип MD добавляется member {@code <TS-name>} типа коллекции —
+   * это даёт dot-completion {@code Док.Объект.ТЧ.<колонки>} (через коллекцию)
+   * и {@code Док.Объект.ТЧ.Добавить()} после подмешивания методов коллекции.
+   * Стандартные методы коллекций (Добавить/Очистить/НайтиСтроки/…) сюда пока не
+   * добавляются — для них нужен отдельный источник (нет generic-типа в HBK).
+   */
+  private void registerTabularSections(MD md,
+                                       String name,
+                                       String fullRu,
+                                       String fullEn,
+                                       TypeRef objectRef) {
+    if (!(md instanceof TabularSectionOwner owner)) {
+      return;
+    }
+    var sections = owner.getTabularSections();
+    if (sections == null || sections.isEmpty()) {
+      return;
+    }
+    var tsMembers = new ArrayList<MemberDescriptor>(sections.size());
+    for (var ts : sections) {
+      var tsName = ts.getName();
+      if (tsName == null || tsName.isBlank()) {
+        continue;
+      }
+      var rowRu = fullRu + "ТабличнаяЧастьСтрока." + name + "." + tsName;
+      var rowEn = (fullEn == null || fullEn.isBlank()) ? null
+        : fullEn + "TabularSectionRow." + name + "." + tsName;
+      var rowRef = registerWithAlias(rowRu, rowEn);
+
+      var collRu = fullRu + "ТабличнаяЧасть." + name + "." + tsName;
+      var collEn = (fullEn == null || fullEn.isBlank()) ? null
+        : fullEn + "TabularSection." + name + "." + tsName;
+      var collRef = registerWithAlias(collRu, collEn);
+
+      var columnMembers = buildAttributeMembers(ts.getAttributes());
+      if (!columnMembers.isEmpty()) {
+        var immutable = List.copyOf(columnMembers);
+        typeRegistry.registerMemberSource(rowRef, () -> immutable, LanguageScope.BSL);
+        // Для удобства dot-completion'а ТЧ-коллекция тоже показывает колонки —
+        // обращение `ТЧ.Колонка` к коллекции встречается в коде (через индекс/первую строку).
+        typeRegistry.registerMemberSource(collRef, () -> immutable, LanguageScope.BSL);
+      }
+
+      tsMembers.add(MemberDescriptor.property(tsName, collRef));
+    }
+    if (!tsMembers.isEmpty()) {
+      var immutableTs = List.copyOf(tsMembers);
+      typeRegistry.registerMemberSource(objectRef, () -> immutableTs, LanguageScope.BSL);
+    }
+  }
+
+  /**
+   * Ленивый MemberSource, наследующий members у платформенного типа по точному
+   * имени (без generic-плейсхолдера). Например, для коллекции {@code Справочники}
+   * родитель — {@code СправочникиМенеджер}.
+   */
+  private void registerInheritedMembers(TypeRef target, String exactName) {
+    typeRegistry.registerMemberSource(target, () -> {
+      var parent = typeRegistry.resolve(exactName).orElse(null);
+      if (parent == null) {
+        return List.of();
+      }
+      return typeRegistry.getMembers(parent);
+    }, LanguageScope.BSL);
+  }
+
+  /**
+   * Регистрирует ленивый MemberSource, который при запросе резолвит generic-тип
+   * платформенного семейства (например, {@code "ДокументСсылка.<Имя документа>"})
+   * и возвращает его members. Из выдачи исключаются псевдо-члены платформенного
+   * generic-типа со «слотовыми» именами вроде {@code <Имя общего реквизита>},
+   * {@code <Имя реквизита>}, {@code <Имя табличной части>} — в специализированном
+   * типе их роль закрывают конкретные реквизиты/ТЧ из метаданных.
+   * Если generic-тип не зарегистрирован — пусто.
+   */
+  private void registerPlatformGenericMembers(TypeRef target, String familyPrefix) {
+    typeRegistry.registerMemberSource(target, () -> {
+      var generic = typeRegistry.resolveGenericByPrefix(familyPrefix).orElse(null);
+      if (generic == null) {
+        return List.of();
+      }
+      var raw = typeRegistry.getMembers(generic);
+      var filtered = new ArrayList<MemberDescriptor>(raw.size());
+      for (var m : raw) {
+        if (m.generic()) {
+          continue;
+        }
+        filtered.add(m);
+      }
+      return filtered;
+    }, LanguageScope.BSL);
   }
 
   private TypeRef registerWithAlias(String qualifiedRu, String qualifiedEn) {
@@ -282,17 +434,100 @@ public class ConfigurationTypesProvider {
     return ref;
   }
 
-  private List<MemberDescriptor> buildAttributeMembers(List<? extends Attribute> attributes) {
+  private List<MemberDescriptor> buildAttributeMembers(List<? extends Attribute> attributes,
+                                                       Map<String, String> platformDescriptions) {
     if (attributes == null || attributes.isEmpty()) {
       return List.of();
     }
     var result = new ArrayList<MemberDescriptor>(attributes.size());
     for (var attribute : attributes) {
-      var attrName = attribute.getName();
+      var attrName = attributeNameLocalized(attribute);
       if (attrName == null || attrName.isBlank()) {
         continue;
       }
+      var description = platformDescriptions.getOrDefault(attrName.toLowerCase(java.util.Locale.ROOT), "");
       var returnTypes = resolveAttributeReturnTypes(attribute);
+      if (returnTypes.isEmpty()) {
+        result.add(description.isEmpty()
+          ? MemberDescriptor.property(attrName)
+          : MemberDescriptor.property(attrName, TypeRef.UNKNOWN, description));
+      } else if (returnTypes.size() == 1) {
+        result.add(MemberDescriptor.property(attrName, returnTypes.refs().iterator().next(), description));
+      } else {
+        result.add(MemberDescriptor.property(attrName, returnTypes, description));
+      }
+    }
+    return result;
+  }
+
+  /** Old single-arg overload — без подмеса описаний (для случаев без контекста MD). */
+  private List<MemberDescriptor> buildAttributeMembers(List<? extends Attribute> attributes) {
+    return buildAttributeMembers(attributes, Map.of());
+  }
+
+  /**
+   * Собирает {@code name(lower) → description} для платформенных generic-типов
+   * {@code <fullRu>Ссылка.<...>} и {@code <fullRu>Объект.<...>} — это HBK-описания,
+   * подходящие к стандартным реквизитам соответствующего MD.
+   */
+  private Map<String, String> collectPlatformMemberDescriptions(String fullRu) {
+    var result = new HashMap<String, String>();
+    addPlatformDescriptionsTo(result, fullRu + "Ссылка");
+    addPlatformDescriptionsTo(result, fullRu + "Объект");
+    return result;
+  }
+
+  private void addPlatformDescriptionsTo(Map<String, String> sink, String familyPrefix) {
+    var generic = typeRegistry.resolveGenericByPrefix(familyPrefix).orElse(null);
+    if (generic == null) {
+      return;
+    }
+    for (var m : typeRegistry.getMembers(generic)) {
+      if (m.generic()) {
+        continue;
+      }
+      if (m.description() == null || m.description().isBlank()) {
+        continue;
+      }
+      sink.putIfAbsent(m.name().toLowerCase(java.util.Locale.ROOT), m.description());
+    }
+  }
+
+  /**
+   * Общие реквизиты, применимые к конкретному MDObject. Если MD явно присутствует в
+   * составе общего реквизита, используется его персональный режим; иначе откатываемся
+   * к {@link CommonAttribute#getAutoUse()}. Включаются режимы USE/USE_WITH_WARNINGS.
+   */
+  private static List<CommonAttribute> applicableCommonAttributes(MD md, List<CommonAttribute> all) {
+    if (all.isEmpty()) {
+      return List.of();
+    }
+    var mdoRef = md.getMdoReference();
+    if (mdoRef == null) {
+      return List.of();
+    }
+    var result = new ArrayList<CommonAttribute>();
+    for (var ca : all) {
+      var effective = ca.contains(mdoRef) ? ca.useMode(mdoRef) : ca.getAutoUse();
+      if (effective == com.github._1c_syntax.bsl.mdo.support.UseMode.USE
+        || effective == com.github._1c_syntax.bsl.mdo.support.UseMode.USE_WITH_WARNINGS) {
+        result.add(ca);
+      }
+    }
+    return result;
+  }
+
+  private List<MemberDescriptor> buildCommonAttributeMembers(List<CommonAttribute> commonAttributes) {
+    if (commonAttributes.isEmpty()) {
+      return List.of();
+    }
+    var result = new ArrayList<MemberDescriptor>(commonAttributes.size());
+    for (var ca : commonAttributes) {
+      var attrName = ca.getName();
+      if (attrName == null || attrName.isBlank()) {
+        continue;
+      }
+      var returnTypes = resolveCommonAttributeReturnTypes(ca);
       if (returnTypes.isEmpty()) {
         result.add(MemberDescriptor.property(attrName));
       } else if (returnTypes.size() == 1) {
@@ -302,6 +537,38 @@ public class ConfigurationTypesProvider {
       }
     }
     return result;
+  }
+
+  private TypeSet resolveCommonAttributeReturnTypes(CommonAttribute ca) {
+    var valueType = ca.getValueType();
+    if (valueType == null || valueType.isEmpty()) {
+      return TypeSet.EMPTY;
+    }
+    var refs = new java.util.LinkedHashSet<TypeRef>();
+    for (var vt : valueType.getTypes()) {
+      var resolved = resolveValueType(vt);
+      if (resolved != null) {
+        refs.add(resolved);
+      }
+    }
+    return refs.isEmpty() ? TypeSet.EMPTY : TypeSet.of(refs);
+  }
+
+  /**
+   * Имя реквизита, локализованное под сконфигурированный {@link
+   * com.github._1c_syntax.bsl.languageserver.configuration.Language}. Кастомные
+   * реквизиты ({@link com.github._1c_syntax.bsl.mdo.children.ObjectAttribute}) имеют
+   * только одно имя — оно и возвращается. Стандартные реквизиты (Дата/Номер/Ссылка/...) хранят
+   * имя в {@link com.github._1c_syntax.bsl.types.MultiName} с обоими языками — берём нужный.
+   */
+  private String attributeNameLocalized(Attribute attribute) {
+    if (attribute instanceof StandardAttribute std) {
+      var fullName = std.getFullName();
+      if (fullName != null && !fullName.isEmpty()) {
+        return fullName.get(configuration.getLanguage().getLanguageCode());
+      }
+    }
+    return attribute.getName();
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -28,6 +28,7 @@ import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextH
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberSource;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
@@ -281,7 +282,13 @@ public class ConfigurationTypesProvider {
 
     // Описания стандартных реквизитов (Дата/Номер/Ссылка/…) в mdclasses пустые,
     // но платформа в HBK ровно их и описывает. Подмешиваем по имени.
-    var platformDescriptions = collectPlatformMemberDescriptions(fullRu);
+    // Сборка делается лениво (внутри MemberSource), чтобы пересоздаваться при
+    // смене языка через workspace/didChangeConfiguration — `attributeNameLocalized`
+    // читает {@code configuration.getLanguage()} per-call, и при пересоздании
+    // members имена обновляются.
+    final var capturedAttributes = attributes;
+    final var capturedCommon = commonForMd;
+    final var capturedFullRu = fullRu;
 
     var objectRu = fullRu + "Объект." + name;
     var objectEn = (fullEn == null || fullEn.isBlank()) ? null : fullEn + "Object." + name;
@@ -305,14 +312,15 @@ public class ConfigurationTypesProvider {
       }
     }
 
-    var members = new ArrayList<MemberDescriptor>();
-    members.addAll(buildAttributeMembers(attributes, platformDescriptions));
-    members.addAll(buildCommonAttributeMembers(commonForMd));
-    if (!members.isEmpty()) {
-      var immutable = List.copyOf(members);
-      typeRegistry.registerMemberSource(objectRef, () -> immutable, LanguageScope.BSL);
-      typeRegistry.registerMemberSource(refRef, () -> immutable, LanguageScope.BSL);
-    }
+    MemberSource attributeAndCommonSource = () -> {
+      var fresh = new ArrayList<MemberDescriptor>();
+      fresh.addAll(buildAttributeMembers(capturedAttributes,
+        collectPlatformMemberDescriptions(capturedFullRu)));
+      fresh.addAll(buildCommonAttributeMembers(capturedCommon));
+      return fresh;
+    };
+    typeRegistry.registerMemberSource(objectRef, attributeAndCommonSource, LanguageScope.BSL);
+    typeRegistry.registerMemberSource(refRef, attributeAndCommonSource, LanguageScope.BSL);
 
     // Подмешиваем members generic-платформенного семейства (СправочникСсылка.<...>,
     // ДокументОбъект.<...> и т.п.). Это даёт методы (Метаданные, ПолучитьОбъект, Записать,
@@ -367,13 +375,16 @@ public class ConfigurationTypesProvider {
         : fullEn + "TabularSection." + name + "." + tsName;
       var collRef = registerWithAlias(collRu, collEn);
 
-      var columnMembers = buildAttributeMembers(ts.getAttributes());
-      if (!columnMembers.isEmpty()) {
-        var immutable = List.copyOf(columnMembers);
-        typeRegistry.registerMemberSource(rowRef, () -> immutable, LanguageScope.BSL);
+      var tsAttributes = ts.getAttributes();
+      if (tsAttributes != null && !tsAttributes.isEmpty()) {
+        // Аналогично основным реквизитам: лямбда вызывает buildAttributeMembers
+        // на каждый getMembers, поэтому язык читается per-call и подхватывает
+        // workspace/didChangeConfiguration.
+        MemberSource columnSource = () -> buildAttributeMembers(tsAttributes);
+        typeRegistry.registerMemberSource(rowRef, columnSource, LanguageScope.BSL);
         // Для удобства dot-completion'а ТЧ-коллекция тоже показывает колонки —
         // обращение `ТЧ.Колонка` к коллекции встречается в коде (через индекс/первую строку).
-        typeRegistry.registerMemberSource(collRef, () -> immutable, LanguageScope.BSL);
+        typeRegistry.registerMemberSource(collRef, columnSource, LanguageScope.BSL);
       }
 
       tsMembers.add(MemberDescriptor.property(tsName, collRef));

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -150,6 +150,32 @@ public class TypeRegistry {
   }
 
   /**
+   * Найти платформенный generic-тип по префиксу-семейству.
+   * <p>
+   * Платформа 1С регистрирует обобщённые типы вида
+   * {@code "ДокументСсылка.<Имя документа>"}, {@code "СправочникОбъект.<Имя справочника>"}
+   * и т.п. — конкретное имя плейсхолдера в угловых скобках различается для каждого
+   * MDOType. Этот метод выбирает первый тип, чьё qualifiedName начинается с
+   * {@code prefix + ".<"} (плейсхолдер) — обычно он один на семейство.
+   *
+   * @param prefix начальная часть qualifiedName до точки-плейсхолдера
+   *               (например, {@code "ДокументСсылка"})
+   * @return TypeRef generic-типа или {@link Optional#empty()}, если не зарегистрирован
+   */
+  public Optional<TypeRef> resolveGenericByPrefix(String prefix) {
+    if (prefix == null || prefix.isEmpty()) {
+      return Optional.empty();
+    }
+    var needle = prefix.toLowerCase(Locale.ROOT) + ".<";
+    for (var entry : aliasIndex.entrySet()) {
+      if (entry.getKey().startsWith(needle)) {
+        return Optional.of(entry.getValue());
+      }
+    }
+    return Optional.empty();
+  }
+
+  /**
    * Найти тип по имени с фильтрацией по типу файла. Тип будет возвращён только
    * если его {@link LanguageScope} совместим с {@code fileType}.
    * Если {@code fileType == null} — фильтрация не применяется.

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json
@@ -438,5 +438,119 @@
       {"name": "ПолучитьФункциональнуюОпциюФормы","kind": "METHOD"},
       {"name": "УстановитьПараметрыФункциональныхОпцийФормы","kind": "METHOD"}
     ]
+  },
+
+  {
+    "kind": "PLATFORM",
+    "name": "СправочникСсылка.<Имя справочника>",
+    "members": [
+      {"name": "<Имя реквизита>",       "kind": "PROPERTY", "generic": true},
+      {"name": "<Имя общего реквизита>","kind": "PROPERTY", "generic": true},
+      {"name": "ВерсияДанных",          "kind": "PROPERTY", "returnType": "Строка", "description": "Содержит текущую версию данных объекта."},
+      {"name": "Код",                   "kind": "PROPERTY", "returnType": "Строка", "description": "Содержит код элемента справочника."},
+      {"name": "Наименование",          "kind": "PROPERTY", "returnType": "Строка", "description": "Содержит наименование элемента справочника."},
+      {"name": "ПометкаУдаления",       "kind": "PROPERTY", "returnType": "Булево", "description": "Содержит признак пометки на удаление элемента справочника."},
+      {"name": "Ссылка",                "kind": "PROPERTY", "returnType": "СправочникСсылка.<Имя справочника>", "description": "Содержит ссылку на элемент справочника."},
+      {"name": "Метаданные",            "kind": "METHOD", "description": "Предоставляет доступ к объекту описания метаданных справочника."},
+      {"name": "ПолучитьОбъект",        "kind": "METHOD", "returnType": "СправочникОбъект.<Имя справочника>", "description": "Получает по ссылке объект."},
+      {"name": "Пустая",                "kind": "METHOD", "returnType": "Булево", "description": "Определяет, является ли ссылка пустой или нет."},
+      {"name": "УникальныйИдентификатор","kind": "METHOD", "returnType": "УникальныйИдентификатор", "description": "Получает уникальный идентификатор ссылки."}
+    ]
+  },
+  {
+    "kind": "PLATFORM",
+    "name": "СправочникОбъект.<Имя справочника>",
+    "members": [
+      {"name": "<Имя реквизита>",       "kind": "PROPERTY", "generic": true},
+      {"name": "<Имя табличной части>", "kind": "PROPERTY", "generic": true},
+      {"name": "<Имя общего реквизита>","kind": "PROPERTY", "generic": true},
+      {"name": "ВерсияДанных",          "kind": "PROPERTY", "returnType": "Строка"},
+      {"name": "Код",                   "kind": "PROPERTY", "returnType": "Строка"},
+      {"name": "Наименование",          "kind": "PROPERTY", "returnType": "Строка"},
+      {"name": "ПометкаУдаления",       "kind": "PROPERTY", "returnType": "Булево"},
+      {"name": "Ссылка",                "kind": "PROPERTY", "returnType": "СправочникСсылка.<Имя справочника>"},
+      {"name": "ЭтотОбъект",            "kind": "PROPERTY", "returnType": "СправочникОбъект.<Имя справочника>"},
+      {"name": "Записать",              "kind": "METHOD",   "description": "Записывает элемент справочника в базу данных."},
+      {"name": "Прочитать",             "kind": "METHOD",   "description": "Считывает данные элемента справочника из базы данных."},
+      {"name": "Метаданные",            "kind": "METHOD"}
+    ]
+  },
+  {
+    "kind": "PLATFORM",
+    "name": "СправочникМенеджер.<Имя справочника>",
+    "members": [
+      {"name": "НайтиПоКоду",           "kind": "METHOD", "returnType": "СправочникСсылка.<Имя справочника>", "description": "Осуществляет поиск элемента по его коду."},
+      {"name": "НайтиПоНаименованию",   "kind": "METHOD", "returnType": "СправочникСсылка.<Имя справочника>", "description": "Осуществляет поиск элемента по его наименованию."},
+      {"name": "СоздатьЭлемент",        "kind": "METHOD", "returnType": "СправочникОбъект.<Имя справочника>", "description": "Создает новый элемент справочника."},
+      {"name": "ПустаяСсылка",          "kind": "METHOD", "returnType": "СправочникСсылка.<Имя справочника>", "description": "Получает пустое значение ссылки."},
+      {"name": "Выбрать",               "kind": "METHOD",   "description": "Формирует выборку элементов справочника."}
+    ]
+  },
+  {
+    "kind": "PLATFORM",
+    "name": "СправочникиМенеджер",
+    "exposedAsGlobal": true,
+    "members": [
+      {"name": "<Имя справочника>",     "kind": "PROPERTY", "generic": true,
+        "returnType": "СправочникМенеджер.<Имя справочника>"},
+      {"name": "ТипВсеСсылки",          "kind": "METHOD", "returnType": "ОписаниеТипов", "description": "Получает описание типов, содержащее типы ссылок справочников."}
+    ]
+  },
+
+  {
+    "kind": "PLATFORM",
+    "name": "ДокументСсылка.<Имя документа>",
+    "members": [
+      {"name": "<Имя реквизита>",       "kind": "PROPERTY", "generic": true},
+      {"name": "<Имя общего реквизита>","kind": "PROPERTY", "generic": true},
+      {"name": "ВерсияДанных",          "kind": "PROPERTY", "returnType": "Строка", "description": "Содержит текущую версию данных объекта."},
+      {"name": "Дата",                  "kind": "PROPERTY", "returnType": "Дата",   "description": "Содержит дату и время документа."},
+      {"name": "Номер",                 "kind": "PROPERTY", "returnType": "Строка", "description": "Содержит номер документа."},
+      {"name": "ПометкаУдаления",       "kind": "PROPERTY", "returnType": "Булево", "description": "Содержит признак пометки на удаление документа."},
+      {"name": "Проведен",              "kind": "PROPERTY", "returnType": "Булево", "description": "Содержит признак проведенности документа."},
+      {"name": "Ссылка",                "kind": "PROPERTY", "returnType": "ДокументСсылка.<Имя документа>", "description": "Содержит ссылку на документ."},
+      {"name": "Метаданные",            "kind": "METHOD", "description": "Предоставляет доступ к объекту описания метаданных документа."},
+      {"name": "ПолучитьОбъект",        "kind": "METHOD", "returnType": "ДокументОбъект.<Имя документа>", "description": "Получает по ссылке объект для чтения, изменения и удаления документа."},
+      {"name": "Пустая",                "kind": "METHOD", "returnType": "Булево"}
+    ]
+  },
+  {
+    "kind": "PLATFORM",
+    "name": "ДокументОбъект.<Имя документа>",
+    "members": [
+      {"name": "<Имя реквизита>",       "kind": "PROPERTY", "generic": true},
+      {"name": "<Имя табличной части>", "kind": "PROPERTY", "generic": true},
+      {"name": "<Имя общего реквизита>","kind": "PROPERTY", "generic": true},
+      {"name": "ВерсияДанных",          "kind": "PROPERTY", "returnType": "Строка"},
+      {"name": "Дата",                  "kind": "PROPERTY", "returnType": "Дата"},
+      {"name": "Номер",                 "kind": "PROPERTY", "returnType": "Строка"},
+      {"name": "ПометкаУдаления",       "kind": "PROPERTY", "returnType": "Булево"},
+      {"name": "Проведен",              "kind": "PROPERTY", "returnType": "Булево"},
+      {"name": "Ссылка",                "kind": "PROPERTY", "returnType": "ДокументСсылка.<Имя документа>"},
+      {"name": "ЭтотОбъект",            "kind": "PROPERTY", "returnType": "ДокументОбъект.<Имя документа>"},
+      {"name": "Записать",              "kind": "METHOD"},
+      {"name": "Прочитать",             "kind": "METHOD"},
+      {"name": "Метаданные",            "kind": "METHOD"}
+    ]
+  },
+  {
+    "kind": "PLATFORM",
+    "name": "ДокументМенеджер.<Имя документа>",
+    "members": [
+      {"name": "НайтиПоНомеру",         "kind": "METHOD", "returnType": "ДокументСсылка.<Имя документа>"},
+      {"name": "СоздатьДокумент",       "kind": "METHOD", "returnType": "ДокументОбъект.<Имя документа>"},
+      {"name": "ПустаяСсылка",          "kind": "METHOD", "returnType": "ДокументСсылка.<Имя документа>"},
+      {"name": "Выбрать",               "kind": "METHOD"}
+    ]
+  },
+  {
+    "kind": "PLATFORM",
+    "name": "ДокументыМенеджер",
+    "exposedAsGlobal": true,
+    "members": [
+      {"name": "<Имя документа>",       "kind": "PROPERTY", "generic": true,
+        "returnType": "ДокументМенеджер.<Имя документа>"},
+      {"name": "ТипВсеСсылки",          "kind": "METHOD", "returnType": "ОписаниеТипов"}
+    ]
   }
 ]

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProviderTest.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.context.api.Context;
 import com.github._1c_syntax.bsl.context.api.ContextMethodSignature;
@@ -45,6 +46,8 @@ import com.github._1c_syntax.bsl.context.platform.primitive.PrimitivePlaceholder
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.extension.ExtendWith;
+import org.mockito.junit.jupiter.MockitoExtension;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -52,6 +55,9 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.lenient;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Unit-тесты на адаптер {@link BslContextPlatformTypesProvider}: проверяем
@@ -59,6 +65,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * Источник данных — синтетический {@link PlatformContextProvider} из
  * builder'ов bsl-context (без чтения реального HBK).
  */
+@ExtendWith(MockitoExtension.class)
 class BslContextPlatformTypesProviderTest {
 
   /** Имитация {@link BslContextHolder} без Spring. */
@@ -71,12 +78,27 @@ class BslContextPlatformTypesProviderTest {
     };
   }
 
+  /**
+   * Мок {@link LanguageServerConfiguration} с указанным языком. Использовать вместо
+   * {@code new LanguageServerConfiguration()} в тестах — там сложная инициализация
+   * с побочными эффектами, которая в unit-тестах не нужна.
+   */
+  private static LanguageServerConfiguration mockConfiguration(Language language) {
+    var configuration = mock(LanguageServerConfiguration.class);
+    lenient().when(configuration.getLanguage()).thenReturn(language);
+    return configuration;
+  }
+
+  private static LanguageServerConfiguration mockConfiguration() {
+    return mockConfiguration(Language.DEFAULT_LANGUAGE);
+  }
+
   // BslContextHolder теперь принимает PlatformContextProviderFactory.
   // В тестах подменяем сам holder через override get(), фабрика не используется.
 
   @Test
   void emptyHolderProducesNoTypes() {
-    var adapter = new BslContextPlatformTypesProvider(holderOf(null), new LanguageServerConfiguration());
+    var adapter = new BslContextPlatformTypesProvider(holderOf(null), mockConfiguration());
     assertThat(adapter.getTypes()).isEmpty();
   }
 
@@ -85,7 +107,7 @@ class BslContextPlatformTypesProviderTest {
     var primitive = new PrimitivePlaceholderType(new ContextName("Строка", "String"), "");
     var provider = providerOf(primitive);
 
-    var types = new BslContextPlatformTypesProvider(holderOf(provider), new LanguageServerConfiguration()).getTypes();
+    var types = new BslContextPlatformTypesProvider(holderOf(provider), mockConfiguration()).getTypes();
 
     assertThat(types).hasSize(1);
     var decl = types.iterator().next();
@@ -137,7 +159,7 @@ class BslContextPlatformTypesProviderTest {
 
     var provider = providerOf(arrayType, stringType, numberType);
 
-    var types = new BslContextPlatformTypesProvider(holderOf(provider), new LanguageServerConfiguration()).getTypes();
+    var types = new BslContextPlatformTypesProvider(holderOf(provider), mockConfiguration()).getTypes();
     var decl = types.stream()
       .filter(t -> "Массив".equals(t.qualifiedName()))
       .findFirst().orElseThrow();
@@ -170,7 +192,7 @@ class BslContextPlatformTypesProviderTest {
       ))
       .build();
 
-    var types = new BslContextPlatformTypesProvider(holderOf(providerOf(enumeration)), new LanguageServerConfiguration()).getTypes();
+    var types = new BslContextPlatformTypesProvider(holderOf(providerOf(enumeration)), mockConfiguration()).getTypes();
     var decl = types.iterator().next();
 
     assertThat(decl.kind()).isEqualTo(TypeKind.PLATFORM);
@@ -202,7 +224,7 @@ class BslContextPlatformTypesProviderTest {
     var realType = primitive("Строка", "String");
 
     var types = new BslContextPlatformTypesProvider(
-      holderOf(providerOf(globalContext, keyword, realType)), new LanguageServerConfiguration()).getTypes();
+      holderOf(providerOf(globalContext, keyword, realType)), mockConfiguration()).getTypes();
 
     // Только примитив, без global-context и language-keyword.
     assertThat(types)
@@ -237,7 +259,7 @@ class BslContextPlatformTypesProviderTest {
       .build();
 
     var types = new BslContextPlatformTypesProvider(
-      holderOf(providerOf(catalogsManager, plainType)), new LanguageServerConfiguration()).getTypes();
+      holderOf(providerOf(catalogsManager, plainType)), mockConfiguration()).getTypes();
 
     var manager = types.stream().filter(t -> "СправочникиМенеджер".equals(t.qualifiedName()))
       .findFirst().orElseThrow();
@@ -259,7 +281,7 @@ class BslContextPlatformTypesProviderTest {
       .description("Универсальная коллекция значений.")
       .build();
 
-    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)), new LanguageServerConfiguration())
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)), mockConfiguration())
       .getTypes().iterator().next();
 
     assertThat(decl.description()).isEqualTo("Универсальная коллекция значений.");
@@ -271,7 +293,7 @@ class BslContextPlatformTypesProviderTest {
       new ContextName("Строка", "String"),
       "Значения данного типа содержат строку в формате Unicode.");
 
-    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(primitive)), new LanguageServerConfiguration())
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(primitive)), mockConfiguration())
       .getTypes().iterator().next();
 
     assertThat(decl.description()).contains("Unicode");
@@ -311,7 +333,7 @@ class BslContextPlatformTypesProviderTest {
       .build();
 
     var decl = new BslContextPlatformTypesProvider(
-      holderOf(providerOf(arrayType, stringType)), new LanguageServerConfiguration())
+      holderOf(providerOf(arrayType, stringType)), mockConfiguration())
       .getTypes().stream()
       .filter(t -> "Массив".equals(t.qualifiedName()))
       .findFirst().orElseThrow();
@@ -382,7 +404,7 @@ class BslContextPlatformTypesProviderTest {
       .constructors(Collections.emptyList())
       .build();
 
-    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(stringType)), new LanguageServerConfiguration())
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(stringType)), mockConfiguration())
       .getTypes().iterator().next();
 
     var member = decl.members().iterator().next();
@@ -406,7 +428,7 @@ class BslContextPlatformTypesProviderTest {
       .constructors(Collections.emptyList())
       .build();
 
-    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)), new LanguageServerConfiguration())
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)), mockConfiguration())
       .getTypes().iterator().next();
 
     assertThat(decl.constructors()).isEmpty();
@@ -421,5 +443,109 @@ class BslContextPlatformTypesProviderTest {
   private static ContextProvider providerOf(Context... contexts) {
     return new PlatformContextProvider(
       new PlatformContextStorage(new ArrayList<>(List.of(contexts))));
+  }
+
+  @Test
+  void memberNamesPickedByConfiguredLanguageRu() {
+    var stringType = primitive("Строка", "String");
+    var property = PlatformContextProperty.builder()
+      .name(new ContextName("Имя", "Name"))
+      .rawTypes(List.of("Строка"))
+      .description("")
+      .availabilities(List.of())
+      .build();
+    var type = PlatformContextType.builder()
+      .name(new ContextName("Объект", "Object"))
+      .properties(new ArrayList<>(List.of(property)))
+      .methods(Collections.emptyList())
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .description("")
+      .build();
+
+    var types = new BslContextPlatformTypesProvider(
+      holderOf(providerOf(type, stringType)),
+      mockConfiguration(Language.RU)
+    ).getTypes();
+
+    var member = types.stream()
+      .filter(t -> "Объект".equals(t.qualifiedName()))
+      .findFirst().orElseThrow()
+      .members().iterator().next();
+    assertThat(member.name()).isEqualTo("Имя");
+  }
+
+  @Test
+  void memberNamesPickedByConfiguredLanguageEn() {
+    var stringType = primitive("Строка", "String");
+    var property = PlatformContextProperty.builder()
+      .name(new ContextName("Имя", "Name"))
+      .rawTypes(List.of("Строка"))
+      .description("")
+      .availabilities(List.of())
+      .build();
+    var type = PlatformContextType.builder()
+      .name(new ContextName("Объект", "Object"))
+      .properties(new ArrayList<>(List.of(property)))
+      .methods(Collections.emptyList())
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .description("")
+      .build();
+
+    var types = new BslContextPlatformTypesProvider(
+      holderOf(providerOf(type, stringType)),
+      mockConfiguration(Language.EN)
+    ).getTypes();
+
+    var member = types.stream()
+      .filter(t -> "Объект".equals(t.qualifiedName()))
+      .findFirst().orElseThrow()
+      .members().iterator().next();
+    assertThat(member.name()).isEqualTo("Name");
+  }
+
+  @Test
+  void cachedRebuildsOnConfigurationChangeEvent() {
+    // Имитируем смену языка в воркспейс-конфигурации в рантайме (didChangeConfiguration).
+    // Адаптер при создании читает RU, после события сбрасывает кэш и при следующем
+    // getTypes() читает свежий язык — теперь EN.
+    var stringType = primitive("Строка", "String");
+    var property = PlatformContextProperty.builder()
+      .name(new ContextName("Имя", "Name"))
+      .rawTypes(List.of("Строка"))
+      .description("")
+      .availabilities(List.of())
+      .build();
+    var type = PlatformContextType.builder()
+      .name(new ContextName("Объект", "Object"))
+      .properties(new ArrayList<>(List.of(property)))
+      .methods(Collections.emptyList())
+      .events(Collections.emptyList())
+      .constructors(Collections.emptyList())
+      .description("")
+      .build();
+
+    var configuration = mock(LanguageServerConfiguration.class);
+    when(configuration.getLanguage()).thenReturn(Language.RU);
+    var adapter = new BslContextPlatformTypesProvider(holderOf(providerOf(type, stringType)), configuration);
+
+    var beforeName = adapter.getTypes().stream()
+      .filter(t -> "Объект".equals(t.qualifiedName()))
+      .findFirst().orElseThrow()
+      .members().iterator().next().name();
+    assertThat(beforeName).isEqualTo("Имя");
+
+    // язык поменялся: эмулируем событие конфигурации, кэш должен сброситься
+    when(configuration.getLanguage()).thenReturn(Language.EN);
+    adapter.handleEvent(
+      new com.github._1c_syntax.bsl.languageserver.configuration.events
+        .LanguageServerConfigurationChangedEvent(configuration));
+
+    var afterName = adapter.getTypes().stream()
+      .filter(t -> "Объект".equals(t.qualifiedName()))
+      .findFirst().orElseThrow()
+      .members().iterator().next().name();
+    assertThat(afterName).isEqualTo("Name");
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProviderTest.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.context.api.Context;
 import com.github._1c_syntax.bsl.context.api.ContextMethodSignature;
 import com.github._1c_syntax.bsl.context.api.ContextName;
@@ -75,7 +76,7 @@ class BslContextPlatformTypesProviderTest {
 
   @Test
   void emptyHolderProducesNoTypes() {
-    var adapter = new BslContextPlatformTypesProvider(holderOf(null));
+    var adapter = new BslContextPlatformTypesProvider(holderOf(null), new LanguageServerConfiguration());
     assertThat(adapter.getTypes()).isEmpty();
   }
 
@@ -84,7 +85,7 @@ class BslContextPlatformTypesProviderTest {
     var primitive = new PrimitivePlaceholderType(new ContextName("Строка", "String"), "");
     var provider = providerOf(primitive);
 
-    var types = new BslContextPlatformTypesProvider(holderOf(provider)).getTypes();
+    var types = new BslContextPlatformTypesProvider(holderOf(provider), new LanguageServerConfiguration()).getTypes();
 
     assertThat(types).hasSize(1);
     var decl = types.iterator().next();
@@ -136,7 +137,7 @@ class BslContextPlatformTypesProviderTest {
 
     var provider = providerOf(arrayType, stringType, numberType);
 
-    var types = new BslContextPlatformTypesProvider(holderOf(provider)).getTypes();
+    var types = new BslContextPlatformTypesProvider(holderOf(provider), new LanguageServerConfiguration()).getTypes();
     var decl = types.stream()
       .filter(t -> "Массив".equals(t.qualifiedName()))
       .findFirst().orElseThrow();
@@ -169,7 +170,7 @@ class BslContextPlatformTypesProviderTest {
       ))
       .build();
 
-    var types = new BslContextPlatformTypesProvider(holderOf(providerOf(enumeration))).getTypes();
+    var types = new BslContextPlatformTypesProvider(holderOf(providerOf(enumeration)), new LanguageServerConfiguration()).getTypes();
     var decl = types.iterator().next();
 
     assertThat(decl.kind()).isEqualTo(TypeKind.PLATFORM);
@@ -201,7 +202,7 @@ class BslContextPlatformTypesProviderTest {
     var realType = primitive("Строка", "String");
 
     var types = new BslContextPlatformTypesProvider(
-      holderOf(providerOf(globalContext, keyword, realType))).getTypes();
+      holderOf(providerOf(globalContext, keyword, realType)), new LanguageServerConfiguration()).getTypes();
 
     // Только примитив, без global-context и language-keyword.
     assertThat(types)
@@ -236,7 +237,7 @@ class BslContextPlatformTypesProviderTest {
       .build();
 
     var types = new BslContextPlatformTypesProvider(
-      holderOf(providerOf(catalogsManager, plainType))).getTypes();
+      holderOf(providerOf(catalogsManager, plainType)), new LanguageServerConfiguration()).getTypes();
 
     var manager = types.stream().filter(t -> "СправочникиМенеджер".equals(t.qualifiedName()))
       .findFirst().orElseThrow();
@@ -258,7 +259,7 @@ class BslContextPlatformTypesProviderTest {
       .description("Универсальная коллекция значений.")
       .build();
 
-    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)))
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)), new LanguageServerConfiguration())
       .getTypes().iterator().next();
 
     assertThat(decl.description()).isEqualTo("Универсальная коллекция значений.");
@@ -270,7 +271,7 @@ class BslContextPlatformTypesProviderTest {
       new ContextName("Строка", "String"),
       "Значения данного типа содержат строку в формате Unicode.");
 
-    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(primitive)))
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(primitive)), new LanguageServerConfiguration())
       .getTypes().iterator().next();
 
     assertThat(decl.description()).contains("Unicode");
@@ -310,7 +311,7 @@ class BslContextPlatformTypesProviderTest {
       .build();
 
     var decl = new BslContextPlatformTypesProvider(
-      holderOf(providerOf(arrayType, stringType)))
+      holderOf(providerOf(arrayType, stringType)), new LanguageServerConfiguration())
       .getTypes().stream()
       .filter(t -> "Массив".equals(t.qualifiedName()))
       .findFirst().orElseThrow();
@@ -381,7 +382,7 @@ class BslContextPlatformTypesProviderTest {
       .constructors(Collections.emptyList())
       .build();
 
-    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(stringType)))
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(stringType)), new LanguageServerConfiguration())
       .getTypes().iterator().next();
 
     var member = decl.members().iterator().next();
@@ -405,7 +406,7 @@ class BslContextPlatformTypesProviderTest {
       .constructors(Collections.emptyList())
       .build();
 
-    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)))
+    var decl = new BslContextPlatformTypesProvider(holderOf(providerOf(arrayType)), new LanguageServerConfiguration())
       .getTypes().iterator().next();
 
     assertThat(decl.constructors()).isEmpty();

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderTest.java
@@ -21,6 +21,8 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
+import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
@@ -44,6 +46,9 @@ class ConfigurationTypesProviderTest extends AbstractServerContextAwareTest {
 
   @Autowired
   private GlobalScopeProvider globalScopeProvider;
+
+  @Autowired
+  private LanguageServerConfiguration configuration;
 
   @Test
   void registersCatalogTypesWithRuAndEnAliases() {
@@ -242,5 +247,37 @@ class ConfigurationTypesProviderTest extends AbstractServerContextAwareTest {
     assertThat(rowRef).isPresent();
     var names = typeRegistry.getMembers(rowRef.get()).stream().map(m -> m.name()).toList();
     assertThat(names).contains("Реквизит1", "Реквизит2");
+  }
+
+  @Test
+  void standardAttributeNamesFollowLanguageAtCallTime() {
+    // workspace/didChangeConfiguration может поменять язык в рантайме.
+    // MemberSource ConfigurationTypesProvider'а — это лямбда, которая на каждом
+    // getMembers пересобирает members через attributeNameLocalized, поэтому
+    // смена языка должна отражаться без re-register.
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    var refOpt = typeRegistry.resolve("ДокументСсылка.Документ1");
+    assertThat(refOpt).isPresent();
+    var ref = refOpt.get();
+
+    // По умолчанию RU — стандартные реквизиты по-русски
+    configuration.setLanguage(Language.RU);
+    var ruNames = typeRegistry.getMembers(ref).stream().map(m -> m.name()).toList();
+    assertThat(ruNames).contains("Дата", "Номер", "Ссылка");
+
+    // Переключаем на EN — те же стандартные реквизиты появляются по-английски.
+    // (Platform-inherited members из generic-типа остаются на языке кэша
+    // BslContextPlatformTypesProvider — для их пересборки нужен re-bootstrap
+    // TypeRegistry, не входит в scope этого PR.)
+    configuration.setLanguage(Language.EN);
+    try {
+      var enNames = typeRegistry.getMembers(ref).stream().map(m -> m.name()).toList();
+      assertThat(enNames).contains("Date", "Number", "Ref");
+    } finally {
+      configuration.setLanguage(Language.RU);
+    }
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderTest.java
@@ -105,4 +105,142 @@ class ConfigurationTypesProviderTest extends AbstractServerContextAwareTest {
       .as("должны быть составные имена коллекция.Имя для no-dot completion")
       .contains("Справочники.Справочник1", "Catalogs.Справочник1");
   }
+
+  @Test
+  void documentRefInheritsPlatformMembers() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // Конкретный тип `ДокументСсылка.Документ1` получает members обоих источников:
+    // реквизиты из метаданных + платформенные members из generic-семейства
+    // (Дата, Номер, ВерсияДанных, Метаданные(), ПолучитьОбъект()).
+    var ref = typeRegistry.resolve("ДокументСсылка.Документ1");
+    assertThat(ref).isPresent();
+    var members = typeRegistry.getMembers(ref.get());
+    var names = members.stream().map(m -> m.name()).toList();
+    assertThat(names)
+      .as("платформенные стандартные свойства должны подмешиваться")
+      .contains("Дата", "Номер", "Ссылка", "Проведен", "ВерсияДанных");
+    assertThat(names)
+      .as("платформенные методы тоже")
+      .contains("Метаданные", "ПолучитьОбъект");
+    assertThat(names)
+      .as("реквизиты из метаданных тоже на месте")
+      .contains("Реквизит1");
+  }
+
+  @Test
+  void documentManagerInheritsPlatformMembers() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // На `ДокументМенеджер.Документ1` подмешиваются методы платформенного
+    // generic-менеджера документа (НайтиПоНомеру, СоздатьДокумент, …).
+    var ref = typeRegistry.resolve("ДокументМенеджер.Документ1");
+    assertThat(ref).isPresent();
+    var names = typeRegistry.getMembers(ref.get()).stream().map(m -> m.name()).toList();
+    assertThat(names).contains("НайтиПоНомеру", "СоздатьДокумент", "ПустаяСсылка", "Выбрать");
+  }
+
+  @Test
+  void documentsCollectionInheritsCollectionManagerMembers() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // На коллекции `Документы` подмешиваются методы платформенного
+    // `ДокументыМенеджер` (ТипВсеСсылки).
+    var ref = typeRegistry.resolve("Документы");
+    assertThat(ref).isPresent();
+    var names = typeRegistry.getMembers(ref.get()).stream().map(m -> m.name()).toList();
+    assertThat(names)
+      .as("MD-инстансы и метод коллекции-менеджера")
+      .contains("Документ1", "ТипВсеСсылки");
+  }
+
+  @Test
+  void genericSlotsFilteredOutFromInheritedMembers() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // Generic-слоты <Имя реквизита>, <Имя общего реквизита> платформенного
+    // generic-типа не должны утекать в специализированный ref/object тип.
+    var ref = typeRegistry.resolve("ДокументСсылка.Документ1");
+    assertThat(ref).isPresent();
+    var names = typeRegistry.getMembers(ref.get()).stream().map(m -> m.name()).toList();
+    assertThat(names).noneMatch(n -> n.startsWith("<") && n.endsWith(">"));
+  }
+
+  @Test
+  void standardAttributesGetDescriptionsFromPlatform() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // У стандартного реквизита `Дата` в mdclasses описание пустое, а
+    // платформенный generic-тип в HBK содержит описание — оно должно
+    // подмешиваться при сборке member'а.
+    var ref = typeRegistry.resolve("ДокументСсылка.Документ1");
+    assertThat(ref).isPresent();
+    var data = typeRegistry.getMembers(ref.get()).stream()
+      .filter(m -> "Дата".equalsIgnoreCase(m.name()))
+      .findFirst();
+    assertThat(data).isPresent();
+    assertThat(data.get().description())
+      .as("описание `Дата` должно прийти из платформенного generic-типа")
+      .contains("дату");
+  }
+
+  @Test
+  void documentExposesTabularSectionMember() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // На `ДокументОбъект.Документ1` есть member-property `ТабличнаяЧасть1`,
+    // тип которого — `ДокументТабличнаяЧасть.Документ1.ТабличнаяЧасть1`.
+    var objectRef = typeRegistry.resolve("ДокументОбъект.Документ1");
+    assertThat(objectRef).isPresent();
+    var ts = typeRegistry.getMembers(objectRef.get()).stream()
+      .filter(m -> "ТабличнаяЧасть1".equals(m.name()))
+      .findFirst();
+    assertThat(ts).isPresent();
+    assertThat(ts.get().returnType().qualifiedName())
+      .isEqualTo("ДокументТабличнаяЧасть.Документ1.ТабличнаяЧасть1");
+  }
+
+  @Test
+  void commonAttributeAddedToApplicableDocument() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // `ОбщийРеквизит1`: content явно включает Документ1 (Use=USE) и исключает
+    // Справочник1 (DontUse). Поэтому ref-тип документа получает реквизит как
+    // member, а ref-тип справочника — нет.
+    var docRef = typeRegistry.resolve("ДокументСсылка.Документ1");
+    assertThat(docRef).isPresent();
+    var docMembers = typeRegistry.getMembers(docRef.get()).stream().map(m -> m.name()).toList();
+    assertThat(docMembers).contains("ОбщийРеквизит1");
+
+    var catRef = typeRegistry.resolve("СправочникСсылка.Справочник1");
+    assertThat(catRef).isPresent();
+    var catMembers = typeRegistry.getMembers(catRef.get()).stream().map(m -> m.name()).toList();
+    assertThat(catMembers).doesNotContain("ОбщийРеквизит1");
+  }
+
+  @Test
+  void tabularSectionRowExposesColumns() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    var rowRef = typeRegistry.resolve("ДокументТабличнаяЧастьСтрока.Документ1.ТабличнаяЧасть1");
+    assertThat(rowRef).isPresent();
+    var names = typeRegistry.getMembers(rowRef.get()).stream().map(m -> m.name()).toList();
+    assertThat(names).contains("Реквизит1", "Реквизит2");
+  }
 }

--- a/src/test/resources/metadata/designer/CommonAttributes/ОбщийРеквизит1.xml
+++ b/src/test/resources/metadata/designer/CommonAttributes/ОбщийРеквизит1.xml
@@ -1,0 +1,61 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:app="http://v8.1c.ru/8.2/managed-application/core" xmlns:cfg="http://v8.1c.ru/8.1/data/enterprise/current-config" xmlns:cmi="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:ent="http://v8.1c.ru/8.1/data/enterprise" xmlns:lf="http://v8.1c.ru/8.2/managed-application/logform" xmlns:style="http://v8.1c.ru/8.1/data/ui/style" xmlns:sys="http://v8.1c.ru/8.1/data/ui/fonts/system" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:v8ui="http://v8.1c.ru/8.1/data/ui" xmlns:web="http://v8.1c.ru/8.1/data/ui/colors/web" xmlns:win="http://v8.1c.ru/8.1/data/ui/colors/windows" xmlns:xen="http://v8.1c.ru/8.3/xcf/enums" xmlns:xpr="http://v8.1c.ru/8.3/xcf/predef" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.10">
+	<CommonAttribute uuid="11111111-1111-1111-1111-111111111111">
+		<Properties>
+			<Name>ОбщийРеквизит1</Name>
+			<Synonym/>
+			<Comment/>
+			<Type>
+				<v8:Type>xs:string</v8:Type>
+				<v8:StringQualifiers>
+					<v8:Length>50</v8:Length>
+					<v8:AllowedLength>Variable</v8:AllowedLength>
+				</v8:StringQualifiers>
+			</Type>
+			<PasswordMode>false</PasswordMode>
+			<Format/>
+			<EditFormat/>
+			<ToolTip/>
+			<MarkNegatives>false</MarkNegatives>
+			<Mask/>
+			<MultiLine>false</MultiLine>
+			<ExtendedEdit>false</ExtendedEdit>
+			<MinValue xsi:nil="true"/>
+			<MaxValue xsi:nil="true"/>
+			<FillFromFillingValue>false</FillFromFillingValue>
+			<FillValue xsi:type="xs:string"/>
+			<FillChecking>DontCheck</FillChecking>
+			<ChoiceFoldersAndItems>Items</ChoiceFoldersAndItems>
+			<ChoiceParameterLinks/>
+			<QuickChoice>Auto</QuickChoice>
+			<CreateOnInput>Use</CreateOnInput>
+			<ChoiceForm/>
+			<LinkByType/>
+			<ChoiceHistoryOnInput>Auto</ChoiceHistoryOnInput>
+			<AutoUse>Use</AutoUse>
+			<DataSeparation>DontUse</DataSeparation>
+			<SeparatedDataUse>IndependentlyAndSimultaneously</SeparatedDataUse>
+			<DataSeparationValue/>
+			<DataSeparationUse/>
+			<ConditionalSeparation/>
+			<UsersSeparation>DontUse</UsersSeparation>
+			<AuthenticationSeparation>DontUse</AuthenticationSeparation>
+			<ConfigurationExtensionsSeparation>DontUse</ConfigurationExtensionsSeparation>
+			<Indexing>DontIndex</Indexing>
+			<FullTextSearch>Use</FullTextSearch>
+			<DataHistory>Use</DataHistory>
+			<MinValue xsi:nil="true"/>
+			<MaxValue xsi:nil="true"/>
+			<Content>
+				<Item>
+					<Metadata>Document.Документ1</Metadata>
+					<Use>Use</Use>
+				</Item>
+				<Item>
+					<Metadata>Catalog.Справочник1</Metadata>
+					<Use>DontUse</Use>
+				</Item>
+			</Content>
+		</Properties>
+	</CommonAttribute>
+</MetaDataObject>

--- a/src/test/resources/metadata/designer/Configuration.xml
+++ b/src/test/resources/metadata/designer/Configuration.xml
@@ -201,6 +201,7 @@
 			<EventSubscription>ПриУстановкеНовогоКода</EventSubscription>
 			<EventSubscription>РегистрацияИзмененийПередУдалением</EventSubscription>
 			<CommandGroup>ГруппаКоманд1</CommandGroup>
+			<CommonAttribute>ОбщийРеквизит1</CommonAttribute>
 			<Catalog>Справочник1</Catalog>
 			<Catalog>СправочникСМенеджером</Catalog>
 			<InformationRegister>РегистрСведений1</InformationRegister>


### PR DESCRIPTION
## Summary

Конкретные типы конфигурации (`ДокументСсылка.МойДокумент`, `СправочникМенеджер.Контрагенты`, `СправочникОбъект.X`, коллекция `Документы` и т.п.) теперь подмешивают members из платформенных generic-семейств HBK (`ДокументСсылка.<Имя документа>`, `СправочникМенеджер.<Имя справочника>`, `ДокументыМенеджер` и т.п.).

До этого dot-completion на `ДокументСсылка.МойДокумент.` показывал только реквизиты из метаданных. Не было ни `ВерсияДанных`, ни `Дата/Номер` с описаниями, ни `Метаданные()/ПолучитьОбъект()/Записать()` и т.п. — пользователь получал «полузаряженную» подсказку. Теперь обе стороны (реквизиты MD + платформенные member'ы) объединяются.

## Что внутри

| Фаза | Изменение |
|---|---|
| **1** | Локализация имён `StandardAttribute` через `MultiName.get(scriptVariant)` — `Дата/Номер/Ссылка` показываются по-русски при `language: ru`, а не «как мдклассы вернули по дефолту» (это был English при заполненной паре). |
| **2** | На ref/object/manager типы конфы подмешиваются members generic-семейства HBK через новый `TypeRegistry.resolveGenericByPrefix(prefix)`. На коллекции (`Справочники`/`Документы`) — через прямой `resolve()` (фикс-имя без шаблона). |
| **3** | `CommonAttribute`: для каждого MD-объекта используется `useMode(mdoRef)` с fallback'ом на `autoUse`; применимые общие реквизиты добавляются как members. |
| **4** | Табличные части: регистрируются `<prefix>ТабличнаяЧастьСтрока.<MD>.<TS>` (колонки) и `<prefix>ТабличнаяЧасть.<MD>.<TS>` (коллекция). На объектный тип MD добавляется property `<TS-name>` коллекции. |
| **5** | `BslContextPlatformTypesProvider` публикует имена members/parameters/enum-values на сконфигурированном `Language` через `pickPrimary(ContextName, Language)`. Backward-compat single-arg overloads сохранены. |
| **6** | Новый флаг `MemberDescriptor.generic` (+ `genericProperty(...)` фабрика, поддержка в JSON-ридере). Маркирует `<Имя реквизита>/<Имя табличной части>` слоты HBK — фильтруется на inheritance и в `CompletionProvider.dotCompletion`. |
| **7** | Подмес описаний стандартных реквизитов: `collectPlatformMemberDescriptions` собирает `name → description` из платформенных generic ref/object типов; применяется в `buildAttributeMembers`. Для `Дата` теперь в hover/completion видно «Содержит дату и время документа». |

Также:
- `TypeService.inferAtPosition` использует `findExpressionTree` (включает lValue/complexIdentifier/callStatement fallback'и из #PR-предшественников).
- JSON `builtin-platform-types.json` дополнен ключевыми платформенными типами (`СправочникСсылка/Объект/Менеджер.<Имя справочника>`, `ДокументСсылка/Объект/Менеджер.<Имя документа>`, `СправочникиМенеджер`, `ДокументыМенеджер`) — этого хватает для тестов без живого HBK.

## Test plan

- [x] **11/11** `ConfigurationTypesProviderTest` (8 новых сверх существующих 3).
- [x] **8/8** `BslContextPlatformTypesProviderTest` (обновлён под новый конструктор с `LanguageServerConfiguration`).
- [x] Fixture для Phase 3: `metadata/designer/CommonAttributes/ОбщийРеквизит1.xml` с явным `content` (Документ1 → USE, Справочник1 → DontUse), зарегистрирован в `Configuration.xml`.
- [x] Прогон в живом LS на конфигурации пользователя:
  - `Документы.МойДокумент.` — показывает все стандартные свойства + методы + кастомные реквизиты + общие реквизиты + ТЧ.
  - Никаких `<Имя реквизита>`-слотов в выдаче.

## Compat

- Single-arg overloads `toMemberDescriptor(method)` / `toMemberDescriptor(property)` сохранены для `GlobalScopeProvider`.
- `MemberDescriptor` стал 7-field record с дефолтом `generic=false`; все существующие `MemberDescriptor.method(...)` / `MemberDescriptor.property(...)` фабрики работают как раньше.