### PR TITLE
fix(context): контракт addWorkspace(URI) — нормализованный через Absolute.uri

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -85,7 +85,8 @@ public class ServerContextProvider {
   /**
    * Добавить workspace по URI и создать для нее контекст сервера.
    *
-   * @param workspaceUri URI корня workspace
+   * @param workspaceUri нормализованный через {@link Absolute#uri(URI)} URI
+   *                     корня workspace
    * @return созданный контекст сервера
    */
   public ServerContext addWorkspace(URI workspaceUri) {
@@ -94,8 +95,13 @@ public class ServerContextProvider {
 
   /**
    * Добавить workspace по URI и создать для нее контекст сервера.
+   * <p>
+   * {@code workspaceUri} должен быть нормализован через
+   * {@link Absolute#uri(URI)} — иначе {@link #clear()} /
+   * {@link #removeWorkspace(WorkspaceFolder)} не смогут найти запись по
+   * ключу (они ищут через {@code Absolute.uri(...)} ещё раз).
    *
-   * @param workspaceUri URI корня workspace
+   * @param workspaceUri  нормализованный URI корня workspace
    * @param workspaceName имя workspace (если null — извлекается из URI)
    * @return созданный контекст сервера
    */

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/AnalyzeProjectOnStartTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/AnalyzeProjectOnStartTest.java
@@ -28,6 +28,7 @@ import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopu
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.utils.Absolute;
 import org.eclipse.lsp4j.services.LanguageClient;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
@@ -48,7 +49,7 @@ import static org.mockito.Mockito.verify;
 @CleanupContextBeforeClassAndAfterEachTestMethod
 class AnalyzeProjectOnStartTest {
 
-  private static final URI TEST_WORKSPACE_URI = URI.create("file:///test-analyze-workspace");
+  private static final URI TEST_WORKSPACE_URI = Absolute.uri("file:///test-analyze-workspace");
 
   @Autowired
   private AnalyzeProjectOnStart analyzeProjectOnStart;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/AbstractServerContextAwareTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/AbstractServerContextAwareTest.java
@@ -138,7 +138,7 @@ public abstract class AbstractServerContextAwareTest {
   protected void initServerContext(Path configurationRoot, boolean populate) {
     cleanupAfterClass = false;
     serverContextProvider.clear();
-    var uri = configurationRoot.toUri();
+    var uri = Absolute.uri(configurationRoot.toUri());
     context = serverContextProvider.addWorkspace(uri);
     context.setConfigurationRoot(configurationRoot);
     WorkspaceContextHolder.set(context.getWorkspaceUri());

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/util/TestUtils.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/util/TestUtils.java
@@ -80,29 +80,17 @@ public class TestUtils {
    * Получить ServerContext для файла.
    * <p>
    * Логика:
-   * - prefix-match: если файл попадает под уже зарегистрированный workspace —
-   *   используется он, независимо от того, сколько других workspace'ов есть;
-   * - 0 контекстов → создаётся новый для родительской директории файла;
-   * - 1 контекст → используется он (тесты с явно подготовленным workspace'ом,
-   *   которые загружают файлы вне его директории, на это рассчитывают);
-   * - {@literal >}1 контекстов и ни один не содержит файл → fall back на
-   *   default metadata workspace. Исторически здесь бросалось исключение, но
-   *   оно делало вызов чувствительным к порядку выполнения тестов и валило
-   *   сборку на macOS/Windows (см. {@code getServerContextForUri} с
-   *   FAKE_*_DOCUMENT_URI). Для синтетических URI default workspace —
-   *   корректный «дай хоть какой-нибудь» выбор.
+   * - 0 контекстов в провайдере → создаёт новый для родительской директории файла
+   * - 1 контекст → возвращает его (файл будет добавлен туда)
+   * - >1 контекстов → выбрасывает исключение (тест должен явно указать контекст)
    */
   private static ServerContext getServerContextForFile(Path filePath) {
     var provider = TestApplicationContext.getBean(ServerContextProvider.class);
-
-    var absolutePath = Absolute.path(filePath);
-    var existing = provider.getServerContext(absolutePath.toUri());
-    if (existing.isPresent()) {
-      return existing.get();
-    }
-
     var allContexts = provider.getAllContexts();
+
     if (allContexts.isEmpty()) {
+      // No contexts registered - create new one for parent directory
+      var absolutePath = Absolute.path(filePath);
       var parentDir = absolutePath.getParent();
       if (parentDir == null) {
         parentDir = absolutePath;
@@ -110,9 +98,13 @@ public class TestUtils {
       var workspaceFolder = new WorkspaceFolder(parentDir.toUri().toString(), "test-" + parentDir.getFileName());
       return provider.addWorkspace(workspaceFolder);
     } else if (allContexts.size() == 1) {
+      // Single context - use it
       return allContexts.values().iterator().next();
     } else {
-      return getServerContext();
+      // Multiple contexts - test must explicitly specify which one to use
+      throw new IllegalStateException(
+        "Multiple ServerContexts registered. Use getDocumentContextFromFile(path, serverContext) to specify target context."
+      );
     }
   }
 


### PR DESCRIPTION
## Summary

- `AbstractServerContextAwareTest.initServerContext(Path, boolean)` — оборачивает `configurationRoot.toUri()` в `Absolute.uri(...)` перед `addWorkspace`. Это центральный путь инициализации тестового workspace'а; callsite-ы передают сюда в том числе не-канонизованные `Path` (`@TempDir` от JUnit, относительные `Path.of("./...")`).
- `AnalyzeProjectOnStartTest.TEST_WORKSPACE_URI` инициализируется через `Absolute.uri("file:///test-analyze-workspace")` — фикспойнт нормализации на JVM-инициализации.
- `ServerContextProvider.addWorkspace(URI, ?)` — короткая Javadoc-нота: URI должен быть нормализован через `Absolute.uri`, иначе `clear()` / `removeWorkspace` не найдут запись по ключу.
- `TestUtils.getServerContextForFile` — старый `throw on >1 contexts` восстановлен (отменяет test-only смягчение из `2e19715c93`).

## Why

Симптом на macOS: `Multiple ServerContexts registered. Use getDocumentContextFromFile(path, serverContext) ...` валит 7 тест-классов через `FAKE_DOCUMENT_URI`.

Корневая утечка — на macOS JUnit `@TempDir` создаёт путь под `/var/folders/...`, а это симлинк на `/private/var/folders/...`. Цепочка:

```
@TempDir Path tempDir            # = /var/folders/.../junit-NNN/  (через симлинк)
initServerContext(tempDir, ...)  # configurationRoot.toUri() = file:///var/folders/.../
addWorkspace(uri)                # contexts.put(non-canonical-uri)
...
provider.clear()                 # removeWorkspace(WF(uri.toString()))
  → Absolute.uri(uri.toString()) # внутри File.getCanonicalFile() резолвит симлинк
                                 # → file:///private/var/folders/.../
  → contexts.remove(canonical)   # промах: stored key != canonical
                                 # workspace переживает cleanup
```

Дальше leak копится в `contexts`, и в следующем тест-классе `initServerContext(PATH_TO_METADATA)` делает `contexts.size()` ≥ 2. `TestUtils.getServerContextForFile` ловит это `throw'ом`.

На Linux то же `@TempDir` лежит под `/tmp/junit-NNN/`, `/tmp` — обычная директория, не симлинк, `Absolute.uri` round-trip identity, утечки нет.

Фикс — нормализовать URI в одной точке (`initServerContext`), через которую идут все callsite-ы с произвольным `Path`. Тогда ключ в `contexts` всегда фикспойнт `Absolute.uri`, и `clear()` стабильно находит и удаляет.

## Test plan

- [x] `./gradlew test -PmaxParallelForks=2` локально (Linux) — все 1664 теста зелёные.
- [ ] Java CI matrix (Ubuntu/macOS/Windows × JDK 21/25) — проверить, что 7 ранее упавших Mac/Win-тестов (`ExpressionTreeComparersTest`, `ExpressionTreeBuildingVisitorTest`, `ExpressionParseTreeRewriterTest`, `ModuleReferenceTest`, `UseDirectiveScannerTest`, `BlockKeywordMatcherTest`, `ConfigurationModuleMembersProviderTest`) теперь зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)