### PR TITLE
build(native): initial GraalVM native-image support

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -133,6 +133,11 @@ dependencies {
 
     // AOP
     implementation("org.aspectj:aspectjrt:1.9.25.1")
+    // aspectjweaver нужен Spring AOP в рантайме для парсинга pointcut-выражений у @Aspect-бинов
+    // из транзитивных зависимостей (Sentry CheckIn / Spring caching advisor / etc.).
+    // Наши собственные аспекты по-прежнему вплетаются в байт-код через CTW
+    // (io.freefair.aspectj.post-compile-weaving), runtime-Spring AOP их не проксирует.
+    implementation("org.aspectj:aspectjweaver:1.9.25.1")
 
     // commons utils
     implementation("commons-io:commons-io:2.22.0")
@@ -217,22 +222,6 @@ tasks.bootJar {
 
 tasks.named<org.springframework.boot.gradle.tasks.bundling.BootBuildImage>("bootBuildImage") {
     imageName.set("docker.io/1csyntax/bsl-language-server:${project.version}")
-}
-
-// aspectjweaver требуется Spring AOT-процессору (AspectJBeanFactoryInitializationAotProcessor)
-// для парсинга @Aspect pointcut-выражений при processAot. В рантайм-classpath его подключать
-// не нужно — у нас compile-time weaving через io.freefair.aspectj.post-compile-weaving, и
-// runtime-AOP Spring AOP-прокси (CGLIB) ломает native-image из-за конфликта с pre-generated
-// CGLIB-стабами Spring AOT.
-val aotProcessorClasspath: Configuration by configurations.creating
-dependencies {
-    aotProcessorClasspath("org.aspectj:aspectjweaver:1.9.25.1")
-}
-tasks.withType<org.springframework.boot.gradle.tasks.aot.ProcessAot>().configureEach {
-    classpath += aotProcessorClasspath
-}
-tasks.withType<org.springframework.boot.gradle.tasks.aot.ProcessTestAot>().configureEach {
-    classpath += aotProcessorClasspath
 }
 
 graalvmNative {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -101,34 +101,34 @@ dependencies {
         exclude("commons-logging", "commons-logging")
         exclude("com.sun.xml.bind", "jaxb-core")
         exclude("com.sun.xml.bind", "jaxb-impl")
-        // gRPC используется LanguageTool только для удалённых правил (n-gram сервис и т.п.).
-        // Мы их не используем, а транзитивный io.grpc.netty-shaded ломает native-image
-        // (захват ch.qos.logback.classic.Logger в image heap через netty static init).
+        // io.grpc.netty-shaded ломает native-image: его static init захватывает
+        // ch.qos.logback.classic.Logger в image heap. LanguageTool сам netty-shaded
+        // не использует — только в составе grpc-stub-а для удалённых правил, который
+        // мы не задействуем; остальные grpc-api/grpc-protobuf остаются на classpath,
+        // чтобы LanguageTool мог разрешать `io.grpc.Channel` при загрузке правил.
         exclude("io.grpc", "grpc-netty-shaded")
-        exclude("io.grpc", "grpc-protobuf")
-        exclude("io.grpc", "grpc-stub")
     }
     implementation("org.languagetool:language-en:$languageToolVersion") {
         exclude("commons-logging:commons-logging")
         exclude("com.sun.xml.bind", "jaxb-core")
         exclude("com.sun.xml.bind", "jaxb-impl")
-        // gRPC используется LanguageTool только для удалённых правил (n-gram сервис и т.п.).
-        // Мы их не используем, а транзитивный io.grpc.netty-shaded ломает native-image
-        // (захват ch.qos.logback.classic.Logger в image heap через netty static init).
+        // io.grpc.netty-shaded ломает native-image: его static init захватывает
+        // ch.qos.logback.classic.Logger в image heap. LanguageTool сам netty-shaded
+        // не использует — только в составе grpc-stub-а для удалённых правил, который
+        // мы не задействуем; остальные grpc-api/grpc-protobuf остаются на classpath,
+        // чтобы LanguageTool мог разрешать `io.grpc.Channel` при загрузке правил.
         exclude("io.grpc", "grpc-netty-shaded")
-        exclude("io.grpc", "grpc-protobuf")
-        exclude("io.grpc", "grpc-stub")
     }
     implementation("org.languagetool:language-ru:$languageToolVersion") {
         exclude("commons-logging", "commons-logging")
         exclude("com.sun.xml.bind", "jaxb-core")
         exclude("com.sun.xml.bind", "jaxb-impl")
-        // gRPC используется LanguageTool только для удалённых правил (n-gram сервис и т.п.).
-        // Мы их не используем, а транзитивный io.grpc.netty-shaded ломает native-image
-        // (захват ch.qos.logback.classic.Logger в image heap через netty static init).
+        // io.grpc.netty-shaded ломает native-image: его static init захватывает
+        // ch.qos.logback.classic.Logger в image heap. LanguageTool сам netty-shaded
+        // не использует — только в составе grpc-stub-а для удалённых правил, который
+        // мы не задействуем; остальные grpc-api/grpc-protobuf остаются на classpath,
+        // чтобы LanguageTool мог разрешать `io.grpc.Channel` при загрузке правил.
         exclude("io.grpc", "grpc-netty-shaded")
-        exclude("io.grpc", "grpc-protobuf")
-        exclude("io.grpc", "grpc-stub")
     }
 
     // AOP

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -131,6 +131,15 @@ dependencies {
         exclude("io.grpc", "grpc-netty-shaded")
     }
 
+    // Shadow-копия ExtendXStream из mdclasses нуждается в прямом доступе к XStream API
+    // (мы переопределяем protected методы XStream). XStream и так в рантайме через mdclasses,
+    // здесь — compileOnly, чтобы не дублировать в graph.
+    compileOnly("com.thoughtworks.xstream:xstream:1.4.21")
+    compileOnly("io.github.classgraph:classgraph:4.8.184")
+    // ImageInfo.inImageRuntimeCode() для разделения JVM/native веток в shadow ExtendXStream;
+    // в JVM возвращает false, в native — true. Артефакт лёгкий и без транзитивов.
+    implementation("org.graalvm.sdk:nativeimage:24.2.2")
+
     // AOP
     implementation("org.aspectj:aspectjrt:1.9.25.1")
     // aspectjweaver нужен Spring AOP в рантайме для парсинга pointcut-выражений у @Aspect-бинов
@@ -232,7 +241,12 @@ graalvmNative {
             buildArgs.addAll(
                 "--no-fallback",
                 "-H:+UnlockExperimentalVMOptions",
-                "-H:+ReportExceptionStackTraces"
+                "-H:+ReportExceptionStackTraces",
+                // LanguageTool's Languages.<clinit> читает ресурсы языковых модулей.
+                // В native build-time `language-module.properties` ещё не виден — деферим инит.
+                "--initialize-at-run-time=org.languagetool.Languages",
+                "--initialize-at-run-time=org.languagetool.Language",
+                "--initialize-at-run-time=org.languagetool.JLanguageTool"
             )
         }
     }

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -7,6 +7,7 @@ plugins {
     `java-library`
     `maven-publish`
     jacoco
+    id("org.graalvm.buildtools.native") version "1.1.0"
     id("com.diffplug.spotless") version "7.0.4"
     id("me.qoomon.git-versioning") version "6.4.4"
     id("io.freefair.lombok") version "9.5.0"
@@ -100,16 +101,34 @@ dependencies {
         exclude("commons-logging", "commons-logging")
         exclude("com.sun.xml.bind", "jaxb-core")
         exclude("com.sun.xml.bind", "jaxb-impl")
+        // gRPC используется LanguageTool только для удалённых правил (n-gram сервис и т.п.).
+        // Мы их не используем, а транзитивный io.grpc.netty-shaded ломает native-image
+        // (захват ch.qos.logback.classic.Logger в image heap через netty static init).
+        exclude("io.grpc", "grpc-netty-shaded")
+        exclude("io.grpc", "grpc-protobuf")
+        exclude("io.grpc", "grpc-stub")
     }
     implementation("org.languagetool:language-en:$languageToolVersion") {
         exclude("commons-logging:commons-logging")
         exclude("com.sun.xml.bind", "jaxb-core")
         exclude("com.sun.xml.bind", "jaxb-impl")
+        // gRPC используется LanguageTool только для удалённых правил (n-gram сервис и т.п.).
+        // Мы их не используем, а транзитивный io.grpc.netty-shaded ломает native-image
+        // (захват ch.qos.logback.classic.Logger в image heap через netty static init).
+        exclude("io.grpc", "grpc-netty-shaded")
+        exclude("io.grpc", "grpc-protobuf")
+        exclude("io.grpc", "grpc-stub")
     }
     implementation("org.languagetool:language-ru:$languageToolVersion") {
         exclude("commons-logging", "commons-logging")
         exclude("com.sun.xml.bind", "jaxb-core")
         exclude("com.sun.xml.bind", "jaxb-impl")
+        // gRPC используется LanguageTool только для удалённых правил (n-gram сервис и т.п.).
+        // Мы их не используем, а транзитивный io.grpc.netty-shaded ломает native-image
+        // (захват ch.qos.logback.classic.Logger в image heap через netty static init).
+        exclude("io.grpc", "grpc-netty-shaded")
+        exclude("io.grpc", "grpc-protobuf")
+        exclude("io.grpc", "grpc-stub")
     }
 
     // AOP
@@ -198,6 +217,36 @@ tasks.bootJar {
 
 tasks.named<org.springframework.boot.gradle.tasks.bundling.BootBuildImage>("bootBuildImage") {
     imageName.set("docker.io/1csyntax/bsl-language-server:${project.version}")
+}
+
+// aspectjweaver требуется Spring AOT-процессору (AspectJBeanFactoryInitializationAotProcessor)
+// для парсинга @Aspect pointcut-выражений при processAot. В рантайм-classpath его подключать
+// не нужно — у нас compile-time weaving через io.freefair.aspectj.post-compile-weaving, и
+// runtime-AOP Spring AOP-прокси (CGLIB) ломает native-image из-за конфликта с pre-generated
+// CGLIB-стабами Spring AOT.
+val aotProcessorClasspath: Configuration by configurations.creating
+dependencies {
+    aotProcessorClasspath("org.aspectj:aspectjweaver:1.9.25.1")
+}
+tasks.withType<org.springframework.boot.gradle.tasks.aot.ProcessAot>().configureEach {
+    classpath += aotProcessorClasspath
+}
+tasks.withType<org.springframework.boot.gradle.tasks.aot.ProcessTestAot>().configureEach {
+    classpath += aotProcessorClasspath
+}
+
+graalvmNative {
+    binaries {
+        named("main") {
+            sharedLibrary.set(false)
+            mainClass.set("com.github._1c_syntax.bsl.languageserver.BSLLSPLauncher")
+            buildArgs.addAll(
+                "--no-fallback",
+                "-H:+UnlockExperimentalVMOptions",
+                "-H:+ReportExceptionStackTraces"
+            )
+        }
+    }
 }
 
 afterEvaluate {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/AutoServerInfo.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/AutoServerInfo.java
@@ -59,6 +59,12 @@ public class AutoServerInfo extends org.eclipse.lsp4j.ServerInfo implements Seri
       .getContextClassLoader()
       .getResourceAsStream("META-INF/MANIFEST.MF");
 
+    if (mfStream == null) {
+      // В native-image MANIFEST.MF не упакован — обходимся пакетной версией.
+      var pkgVersion = AutoServerInfo.class.getPackage().getImplementationVersion();
+      return pkgVersion != null ? pkgVersion : "";
+    }
+
     Manifest manifest = new Manifest();
     try {
       manifest.read(mfStream);
@@ -67,7 +73,8 @@ public class AutoServerInfo extends org.eclipse.lsp4j.ServerInfo implements Seri
       return "";
     }
 
-    return manifest.getMainAttributes().getValue(Attributes.Name.IMPLEMENTATION_VERSION);
+    var version = manifest.getMainAttributes().getValue(Attributes.Name.IMPLEMENTATION_VERSION);
+    return version != null ? version : "";
   }
 
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLSPLauncher.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLSPLauncher.java
@@ -108,6 +108,25 @@ public class BSLLSPLauncher implements Callable<Integer>, ExitCodeGenerator {
   private int exitCode;
 
   public static void main(String[] args) {
+    if (System.getenv("BSL_LS_THREAD_DUMP") != null) {
+      var watchdog = new Thread(() -> {
+        try {
+          Thread.sleep(60_000);
+          System.err.println("\n=== WATCHDOG: dumping thread stacks ===");
+          Thread.getAllStackTraces().forEach((t, stack) -> {
+            System.err.println("Thread: " + t.getName() + " state=" + t.getState());
+            for (var frame : stack) {
+              System.err.println("    at " + frame);
+            }
+          });
+          System.err.println("=== WATCHDOG: end ===");
+        } catch (InterruptedException ignored) {
+        }
+      }, "watchdog");
+      watchdog.setDaemon(true);
+      watchdog.start();
+    }
+
     var applicationContext = new SpringApplicationBuilder(BSLLSPLauncher.class)
       .web(getWebApplicationType(args))
       .run(args);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/AbstractRunTestsCodeLensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/AbstractRunTestsCodeLensSupplier.java
@@ -26,28 +26,20 @@ import com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageSer
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
-import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.ClientInfo;
 import org.eclipse.lsp4j.InitializeParams;
-import org.jspecify.annotations.Nullable;
-import org.springframework.cache.annotation.CacheConfig;
-import org.springframework.cache.annotation.CacheEvict;
-import org.springframework.cache.annotation.Cacheable;
 import org.springframework.context.event.EventListener;
 
 import java.net.URI;
-import java.nio.file.Path;
 import java.util.Optional;
-import java.util.Set;
-import java.util.stream.Collectors;
 
 @RequiredArgsConstructor
-@CacheConfig(cacheNames = "testSources")
 public abstract class AbstractRunTestsCodeLensSupplier<T extends CodeLensData>
   implements CodeLensSupplier<T> {
 
   protected final LanguageServerConfiguration configuration;
+  protected final TestSourcesProvider testSourcesProvider;
 
   private boolean clientIsSupported;
 
@@ -59,7 +51,6 @@ public abstract class AbstractRunTestsCodeLensSupplier<T extends CodeLensData>
    * @param event Событие
    */
   @EventListener
-  @CacheEvict(allEntries = true)
   public void handleEvent(LanguageServerInitializeRequestReceivedEvent event) {
     var clientName = Optional.of(event)
       .map(LanguageServerInitializeRequestReceivedEvent::getParams)
@@ -67,19 +58,17 @@ public abstract class AbstractRunTestsCodeLensSupplier<T extends CodeLensData>
       .map(ClientInfo::getName)
       .orElse("");
     clientIsSupported = "Visual Studio Code".equals(clientName);
+    testSourcesProvider.evict();
   }
 
   /**
    * Обработчик события {@link LanguageServerConfigurationChangedEvent}.
    * <p>
    * Сбрасывает кеш при изменении конфигурации.
-   *
-   * @param event Событие
    */
-  @EventListener
-  @CacheEvict(allEntries = true)
-  public void handleLanguageServerConfigurationChange(LanguageServerConfigurationChangedEvent event) {
-    // No-op. Служит для сброса кеша при изменении конфигурации
+  @EventListener(LanguageServerConfigurationChangedEvent.class)
+  public void handleLanguageServerConfigurationChange() {
+    testSourcesProvider.evict();
   }
 
   /**
@@ -88,39 +77,11 @@ public abstract class AbstractRunTestsCodeLensSupplier<T extends CodeLensData>
   @Override
   public boolean isApplicable(DocumentContext documentContext) {
     var uri = documentContext.getUri();
-    var testSources = getSelf().getTestSources(documentContext.getServerContext().getConfigurationRoot());
+    var testSources = testSourcesProvider.getTestSources(documentContext.getServerContext().getConfigurationRoot());
 
     return clientIsSupported
       && documentContext.getFileType() == FileType.OS
       && testSources.stream().anyMatch(testSource -> isInside(uri, testSource));
-  }
-
-  /**
-   * Получить self-injected экземпляр себя для работы механизмов кэширования.
-   *
-   * @return Управляемый Spring'ом экземпляр себя
-   */
-  protected abstract AbstractRunTestsCodeLensSupplier<T> getSelf();
-
-  /**
-   * Получить список каталогов с тестами с учетом корня рабочей области.
-   * <p>
-   * public для работы @Cachable.
-   *
-   * @param configurationRoot Корень конфигурации
-   * @return Список исходных файлов тестов
-   */
-  @Cacheable
-  public Set<URI> getTestSources(@Nullable Path configurationRoot) {
-    var configurationRootString = Optional.ofNullable(configurationRoot)
-      .map(Path::toString)
-      .orElse("");
-
-    return configuration.getCodeLensOptions().getTestRunnerAdapterOptions().getTestSources()
-      .stream()
-      .map(testDir -> Path.of(configurationRootString, testDir))
-      .map(path -> Absolute.path(path).toUri())
-      .collect(Collectors.toSet());
   }
 
   private static boolean isInside(URI childURI, URI parentURI) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/DebugTestCodeLensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/DebugTestCodeLensSupplier.java
@@ -28,14 +28,11 @@ import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Resources;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.ToString;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.Command;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -58,19 +55,13 @@ public class DebugTestCodeLensSupplier
   private final TestRunnerAdapter testRunnerAdapter;
   private final Resources resources;
 
-  // Self-injection для работы кэша в базовом классе.
-  @Autowired
-  @Lazy
-  @Getter
-  @SuppressWarnings("NullAway.Init")
-  private DebugTestCodeLensSupplier self;
-
   public DebugTestCodeLensSupplier(
     LanguageServerConfiguration configuration,
+    TestSourcesProvider testSourcesProvider,
     TestRunnerAdapter testRunnerAdapter,
     Resources resources
   ) {
-    super(configuration);
+    super(configuration, testSourcesProvider);
     this.testRunnerAdapter = testRunnerAdapter;
     this.resources = resources;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/RunAllTestsCodeLensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/RunAllTestsCodeLensSupplier.java
@@ -26,12 +26,9 @@ import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConf
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Resources;
-import lombok.Getter;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.Command;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -54,18 +51,13 @@ public class RunAllTestsCodeLensSupplier
   private final TestRunnerAdapter testRunnerAdapter;
   private final Resources resources;
 
-  // Self-injection для работы кэша в базовом классе.
-  @Autowired
-  @Lazy
-  @Getter
-  private RunAllTestsCodeLensSupplier self;
-
   public RunAllTestsCodeLensSupplier(
     LanguageServerConfiguration configuration,
+    TestSourcesProvider testSourcesProvider,
     TestRunnerAdapter testRunnerAdapter,
     Resources resources
   ) {
-    super(configuration);
+    super(configuration, testSourcesProvider);
     this.testRunnerAdapter = testRunnerAdapter;
     this.resources = resources;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/RunTestCodeLensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/RunTestCodeLensSupplier.java
@@ -28,14 +28,11 @@ import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Resources;
 import lombok.EqualsAndHashCode;
-import lombok.Getter;
 import lombok.ToString;
 import lombok.Value;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.CodeLens;
 import org.eclipse.lsp4j.Command;
-import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Lazy;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
 
@@ -61,19 +58,13 @@ public class RunTestCodeLensSupplier
   private final TestRunnerAdapter testRunnerAdapter;
   private final Resources resources;
 
-  // Self-injection для работы кэша в базовом классе.
-  @Autowired
-  @Lazy
-  @Getter
-  @SuppressWarnings("NullAway.Init")
-  private RunTestCodeLensSupplier self;
-
   public RunTestCodeLensSupplier(
     LanguageServerConfiguration configuration,
+    TestSourcesProvider testSourcesProvider,
     TestRunnerAdapter testRunnerAdapter,
     Resources resources
   ) {
-    super(configuration);
+    super(configuration, testSourcesProvider);
     this.testRunnerAdapter = testRunnerAdapter;
     this.resources = resources;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/TestSourcesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/TestSourcesProvider.java
@@ -1,0 +1,80 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.codelenses;
+
+import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
+import com.github._1c_syntax.utils.Absolute;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.cache.annotation.CacheConfig;
+import org.springframework.cache.annotation.CacheEvict;
+import org.springframework.cache.annotation.Cacheable;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.nio.file.Path;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
+
+/**
+ * Поставщик списка каталогов с тестовыми исходниками для линз запуска тестов.
+ * <p>
+ * Кэширование вынесено в отдельный бин, чтобы вызов кэшируемого метода
+ * шёл через нормальный Spring AOP-прокси без self-injection в линзах
+ * (паттерн {@code @Lazy self} ломает native-image на конфликте
+ * pre-generated CGLIB-стабов с runtime AOP).
+ */
+@Component
+@CacheConfig(cacheNames = "testSources")
+@RequiredArgsConstructor
+public class TestSourcesProvider {
+
+  private final LanguageServerConfiguration configuration;
+
+  /**
+   * Получить список каталогов с тестами с учётом корня рабочей области.
+   *
+   * @param configurationRoot Корень конфигурации.
+   * @return URI каталогов с тестами.
+   */
+  @Cacheable
+  public Set<URI> getTestSources(@Nullable Path configurationRoot) {
+    var configurationRootString = Optional.ofNullable(configurationRoot)
+      .map(Path::toString)
+      .orElse("");
+
+    return configuration.getCodeLensOptions().getTestRunnerAdapterOptions().getTestSources()
+      .stream()
+      .map(testDir -> Path.of(configurationRootString, testDir))
+      .map(path -> Absolute.path(path).toUri())
+      .collect(Collectors.toSet());
+  }
+
+  /**
+   * Сбросить кэш каталогов с тестами.
+   */
+  @CacheEvict(allEntries = true)
+  public void evict() {
+    // No-op. Сброс кеша выполняется аспектом @CacheEvict.
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -104,19 +104,16 @@ public class DocumentContext implements Comparable<DocumentContext> {
   private int version;
 
   private final ServerContext context;
+  // Spring AOT в native-image не применяет @Autowired-setter-инъекцию к prototype-бинам,
+  // созданным через ObjectProvider.getObject(args). Заполняем эти поля явно в
+  // initializeDependencies(), вызываемом из ServerContext.createDocumentContext.
   @SuppressWarnings("NullAway.Init")
-  @Setter(onMethod_ = {@Autowired})
   private DiagnosticComputer diagnosticComputer;
-
   @SuppressWarnings("NullAway.Init")
-  @Setter(onMethod_ = {@Autowired})
   private ObjectProvider<CognitiveComplexityComputer> cognitiveComplexityComputerProvider;
   @SuppressWarnings("NullAway.Init")
-  @Setter(onMethod_ = {@Autowired})
   private ObjectProvider<CyclomaticComplexityComputer> cyclomaticComplexityComputerProvider;
-
   @SuppressWarnings("NullAway.Init")
-  @Setter(onMethod_ = {@Autowired})
   private OScriptModuleTypeResolver oScriptModuleTypeResolver;
 
   @Nullable
@@ -151,6 +148,29 @@ public class DocumentContext implements Comparable<DocumentContext> {
     this.uri = uri;
     this.context = context;
     this.fileType = computeFileType(uri);
+    // diagnosticComputer и computeProvider'ы инжектируются явно через initializeDependencies()
+    // из ServerContext.createDocumentContext. Spring AOT в native-image не применяет
+    // @Autowired-setter-инъекцию к prototype-бинам, созданным через ObjectProvider.getObject(args),
+    // поэтому setter-инъекция как раньше тут не подходит — упираемся в null при первом
+    // обращении к diagnosticComputer.
+  }
+
+  /**
+   * Установка зависимостей, которые в обычном Spring инжектились бы через
+   * {@code @Autowired}-сеттеры. Вызывается из {@link ServerContext#createDocumentContext}
+   * сразу после {@code documentContextProvider.getObject(...)} — гарантирует, что поля
+   * не остаются {@code null} в native-image.
+   */
+  void initializeDependencies(
+    DiagnosticComputer diagnosticComputer,
+    ObjectProvider<CognitiveComplexityComputer> cognitiveComplexityComputerProvider,
+    ObjectProvider<CyclomaticComplexityComputer> cyclomaticComplexityComputerProvider,
+    OScriptModuleTypeResolver oScriptModuleTypeResolver
+  ) {
+    this.diagnosticComputer = diagnosticComputer;
+    this.cognitiveComplexityComputerProvider = cognitiveComplexityComputerProvider;
+    this.cyclomaticComplexityComputerProvider = cyclomaticComplexityComputerProvider;
+    this.oScriptModuleTypeResolver = oScriptModuleTypeResolver;
   }
 
   public ServerContext getServerContext() {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -115,6 +115,10 @@ public class DocumentContext implements Comparable<DocumentContext> {
   private ObjectProvider<CyclomaticComplexityComputer> cyclomaticComplexityComputerProvider;
   @SuppressWarnings("NullAway.Init")
   private OScriptModuleTypeResolver oScriptModuleTypeResolver;
+  // StringInterner — singleton-бин, нужен computer'ам complexities, которые сами
+  // prototype'ы и страдают тем же AOT-багом (см. ниже initializeDependencies).
+  @SuppressWarnings("NullAway.Init")
+  private com.github._1c_syntax.utils.StringInterner stringInterner;
 
   @Nullable
   private BSLTokenizer tokenizer;
@@ -165,12 +169,14 @@ public class DocumentContext implements Comparable<DocumentContext> {
     DiagnosticComputer diagnosticComputer,
     ObjectProvider<CognitiveComplexityComputer> cognitiveComplexityComputerProvider,
     ObjectProvider<CyclomaticComplexityComputer> cyclomaticComplexityComputerProvider,
-    OScriptModuleTypeResolver oScriptModuleTypeResolver
+    OScriptModuleTypeResolver oScriptModuleTypeResolver,
+    com.github._1c_syntax.utils.StringInterner stringInterner
   ) {
     this.diagnosticComputer = diagnosticComputer;
     this.cognitiveComplexityComputerProvider = cognitiveComplexityComputerProvider;
     this.cyclomaticComplexityComputerProvider = cyclomaticComplexityComputerProvider;
     this.oScriptModuleTypeResolver = oScriptModuleTypeResolver;
+    this.stringInterner = stringInterner;
   }
 
   public ServerContext getServerContext() {
@@ -434,13 +440,17 @@ public class DocumentContext implements Comparable<DocumentContext> {
   }
 
   private ComplexityData computeCognitiveComplexity() {
-    Computer<ComplexityData> cognitiveComplexityComputer = cognitiveComplexityComputerProvider.getObject(this);
-    return cognitiveComplexityComputer.compute();
+    var computer = cognitiveComplexityComputerProvider.getObject(this);
+    // см. комментарий к initializeDependencies — Spring AOT в native не вызовет
+    // @Setter @Autowired у prototype-бина, поэтому ставим stringInterner вручную.
+    computer.setStringInterner(stringInterner);
+    return computer.compute();
   }
 
   private ComplexityData computeCyclomaticComplexity() {
-    Computer<ComplexityData> cyclomaticComplexityComputer = cyclomaticComplexityComputerProvider.getObject(this);
-    return cyclomaticComplexityComputer.compute();
+    var computer = cyclomaticComplexityComputerProvider.getObject(this);
+    computer.setStringInterner(stringInterner);
+    return computer.compute();
   }
 
   private MetricStorage computeMetrics() {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -76,6 +76,11 @@ public class ServerContext {
     .build();
 
   private final ObjectProvider<DocumentContext> documentContextProvider;
+  // Сервисы для ручной инициализации DocumentContext (см. createDocumentContext).
+  private final com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticComputer diagnosticComputer;
+  private final ObjectProvider<com.github._1c_syntax.bsl.languageserver.context.computer.CognitiveComplexityComputer> cognitiveComplexityComputerProvider;
+  private final ObjectProvider<com.github._1c_syntax.bsl.languageserver.context.computer.CyclomaticComplexityComputer> cyclomaticComplexityComputerProvider;
+  private final com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleTypeResolver oScriptModuleTypeResolver;
   private final WorkDoneProgressHelper workDoneProgressHelper;
   private final GlobalLanguageServerConfiguration globalConfiguration;
   @Qualifier("computeConfigurationExecutor")
@@ -430,6 +435,16 @@ public class ServerContext {
 
   private DocumentContext createDocumentContext(URI uri) {
     var documentContext = documentContextProvider.getObject(uri, this);
+    // Spring AOT в native-image не вызывает @Autowired-setter'ы для prototype-бина,
+    // созданного через ObjectProvider.getObject(args). Принудительно подкладываем
+    // нужные сервисы вручную; в обычной JVM это перезапишет уже выставленные значения
+    // теми же экземплярами (Spring-инъекция отрабатывает раньше).
+    documentContext.initializeDependencies(
+      diagnosticComputer,
+      cognitiveComplexityComputerProvider,
+      cyclomaticComplexityComputerProvider,
+      oScriptModuleTypeResolver
+    );
 
     documents.put(uri, documentContext);
     addMdoRefByUri(uri, documentContext);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -81,6 +81,7 @@ public class ServerContext {
   private final ObjectProvider<com.github._1c_syntax.bsl.languageserver.context.computer.CognitiveComplexityComputer> cognitiveComplexityComputerProvider;
   private final ObjectProvider<com.github._1c_syntax.bsl.languageserver.context.computer.CyclomaticComplexityComputer> cyclomaticComplexityComputerProvider;
   private final com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleTypeResolver oScriptModuleTypeResolver;
+  private final com.github._1c_syntax.utils.StringInterner stringInterner;
   private final WorkDoneProgressHelper workDoneProgressHelper;
   private final GlobalLanguageServerConfiguration globalConfiguration;
   @Qualifier("computeConfigurationExecutor")
@@ -443,7 +444,8 @@ public class ServerContext {
       diagnosticComputer,
       cognitiveComplexityComputerProvider,
       cyclomaticComplexityComputerProvider,
-      oScriptModuleTypeResolver
+      oScriptModuleTypeResolver,
+      stringInterner
     );
 
     documents.put(uri, documentContext);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/CognitiveComplexityComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/CognitiveComplexityComputer.java
@@ -71,7 +71,10 @@ public class CognitiveComplexityComputer
 
   private final DocumentContext documentContext;
 
-  @Setter(onMethod_ ={@Autowired}, value = AccessLevel.PACKAGE)
+  // Setter сделан public, чтобы DocumentContext мог проставить stringInterner
+  // вручную — в native-image Spring AOT не вызывает @Autowired-сеттеры для prototype-бинов,
+  // создаваемых через ObjectProvider.getObject(args).
+  @Setter(onMethod_ ={@Autowired})
   private StringInterner stringInterner;
 
   private int fileComplexity;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/CyclomaticComplexityComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/CyclomaticComplexityComputer.java
@@ -66,7 +66,10 @@ public class CyclomaticComplexityComputer
 
   private final DocumentContext documentContext;
 
-  @Setter(onMethod_ ={@Autowired}, value = AccessLevel.PACKAGE)
+  // Setter сделан public, чтобы DocumentContext мог проставить stringInterner
+  // вручную — в native-image Spring AOT не вызывает @Autowired-сеттеры для prototype-бинов,
+  // создаваемых через ObjectProvider.getObject(args).
+  @Setter(onMethod_ ={@Autowired})
   private StringInterner stringInterner;
 
   private int fileComplexity;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
@@ -27,7 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.diagnostics.BSLDiagnostic;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.Diagnostic;
-import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 
@@ -40,18 +40,23 @@ import java.util.stream.Stream;
 /**
  * Вычислитель диагностик для документа.
  * <p>
- * Абстрактный класс, обеспечивающий параллельное вычисление диагностик
- * всеми зарегистрированными анализаторами с обработкой ошибок.
+ * Обеспечивает параллельное вычисление диагностик всеми зарегистрированными
+ * анализаторами с обработкой ошибок. Список применимых диагностик для документа
+ * подтягивается через {@link ObjectProvider} prototype-бина {@code diagnostics}
+ * — native-image не поддерживает {@code @Lookup}-инъекцию (Spring строит CGLIB-сабкласс
+ * во время выполнения, что несовместимо с AOT-компиляцией).
  */
 @Component
 @Slf4j
 @RequiredArgsConstructor
-public abstract class DiagnosticComputer {
+public class DiagnosticComputer {
 
   private final LanguageServerConfiguration configuration;
 
   @Qualifier("diagnosticComputerExecutor")
   private final ExecutorService executor;
+
+  private final ObjectProvider<List<BSLDiagnostic>> diagnosticsProvider;
 
   /**
    * Вычислить все диагностики для документа.
@@ -93,6 +98,7 @@ public abstract class DiagnosticComputer {
 
   }
 
-  @Lookup("diagnostics")
-  protected abstract List<BSLDiagnostic> diagnostics(DocumentContext documentContext);
+  private List<BSLDiagnostic> diagnostics(DocumentContext documentContext) {
+    return diagnosticsProvider.getObject(documentContext);
+  }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/reader/common/xstream/ExtendXStream.java
@@ -1,0 +1,554 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.reader.common.xstream;
+
+import com.github._1c_syntax.bsl.mdclasses.ConfigurationTree;
+import com.github._1c_syntax.bsl.mdclasses.ExternalDataProcessor;
+import com.github._1c_syntax.bsl.mdclasses.ExternalReport;
+import com.github._1c_syntax.bsl.mdo.AccountingRegister;
+import com.github._1c_syntax.bsl.mdo.AccumulationRegister;
+import com.github._1c_syntax.bsl.mdo.Bot;
+import com.github._1c_syntax.bsl.mdo.BusinessProcess;
+import com.github._1c_syntax.bsl.mdo.CalculationRegister;
+import com.github._1c_syntax.bsl.mdo.Catalog;
+import com.github._1c_syntax.bsl.mdo.ChartOfAccounts;
+import com.github._1c_syntax.bsl.mdo.ChartOfCalculationTypes;
+import com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes;
+import com.github._1c_syntax.bsl.mdo.CommandGroup;
+import com.github._1c_syntax.bsl.mdo.CommonAttribute;
+import com.github._1c_syntax.bsl.mdo.CommonCommand;
+import com.github._1c_syntax.bsl.mdo.CommonForm;
+import com.github._1c_syntax.bsl.mdo.CommonModule;
+import com.github._1c_syntax.bsl.mdo.CommonPicture;
+import com.github._1c_syntax.bsl.mdo.CommonTemplate;
+import com.github._1c_syntax.bsl.mdo.Constant;
+import com.github._1c_syntax.bsl.mdo.DataProcessor;
+import com.github._1c_syntax.bsl.mdo.DefinedType;
+import com.github._1c_syntax.bsl.mdo.Document;
+import com.github._1c_syntax.bsl.mdo.DocumentJournal;
+import com.github._1c_syntax.bsl.mdo.DocumentNumerator;
+import com.github._1c_syntax.bsl.mdo.EventSubscription;
+//noinspection AmbiguousImport — нужен наш Enum, не java.lang.Enum
+import com.github._1c_syntax.bsl.mdo.ExchangePlan;
+import com.github._1c_syntax.bsl.mdo.ExternalDataSource;
+import com.github._1c_syntax.bsl.mdo.FilterCriterion;
+import com.github._1c_syntax.bsl.mdo.FunctionalOption;
+import com.github._1c_syntax.bsl.mdo.FunctionalOptionsParameter;
+import com.github._1c_syntax.bsl.mdo.HTTPService;
+import com.github._1c_syntax.bsl.mdo.InformationRegister;
+import com.github._1c_syntax.bsl.mdo.IntegrationService;
+import com.github._1c_syntax.bsl.mdo.Interface;
+import com.github._1c_syntax.bsl.mdo.Language;
+import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.PaletteColor;
+import com.github._1c_syntax.bsl.mdo.Report;
+import com.github._1c_syntax.bsl.mdo.Role;
+import com.github._1c_syntax.bsl.mdo.ScheduledJob;
+import com.github._1c_syntax.bsl.mdo.Sequence;
+import com.github._1c_syntax.bsl.mdo.SessionParameter;
+import com.github._1c_syntax.bsl.mdo.SettingsStorage;
+import com.github._1c_syntax.bsl.mdo.Style;
+import com.github._1c_syntax.bsl.mdo.StyleItem;
+import com.github._1c_syntax.bsl.mdo.Subsystem;
+import com.github._1c_syntax.bsl.mdo.Task;
+import com.github._1c_syntax.bsl.mdo.WSReference;
+import com.github._1c_syntax.bsl.mdo.WebService;
+import com.github._1c_syntax.bsl.mdo.WebSocketClient;
+import com.github._1c_syntax.bsl.mdo.XDTOPackage;
+import com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema;
+import com.github._1c_syntax.bsl.mdo.storage.RoleData;
+import com.github._1c_syntax.bsl.mdo.storage.XdtoPackageData;
+import com.github._1c_syntax.bsl.mdo.storage.form.FormElementType;
+import com.github._1c_syntax.bsl.mdo.support.ApplicationRunMode;
+import com.github._1c_syntax.bsl.mdo.support.AutoRecordType;
+import com.github._1c_syntax.bsl.mdo.support.CodeSeries;
+import com.github._1c_syntax.bsl.mdo.support.ConfigurationExtensionPurpose;
+import com.github._1c_syntax.bsl.mdo.support.DataLockControlMode;
+import com.github._1c_syntax.bsl.mdo.support.DataSeparation;
+import com.github._1c_syntax.bsl.mdo.support.FormType;
+import com.github._1c_syntax.bsl.mdo.support.IndexingType;
+import com.github._1c_syntax.bsl.mdo.support.InterfaceCompatibilityMode;
+import com.github._1c_syntax.bsl.mdo.support.MessageDirection;
+import com.github._1c_syntax.bsl.mdo.support.ObjectBelonging;
+import com.github._1c_syntax.bsl.mdo.support.ReturnValueReuse;
+import com.github._1c_syntax.bsl.mdo.support.ReuseSessions;
+import com.github._1c_syntax.bsl.mdo.support.RoleRight;
+import com.github._1c_syntax.bsl.mdo.support.TemplateType;
+import com.github._1c_syntax.bsl.mdo.support.TransferDirection;
+import com.github._1c_syntax.bsl.mdo.support.UseMode;
+import com.github._1c_syntax.bsl.mdo.support.UsePurposes;
+import com.github._1c_syntax.bsl.reader.MDReader;
+import com.github._1c_syntax.bsl.reader.common.converter.AllStringConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.CommonAttributeUseContentConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.CommonConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.CommonModuleConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.CompatibilityModeConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.ConfigurationConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.DataCompositionSchemaConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.DataSetConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.EnumConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.ExchangePlanAutoRecordConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.MethodHandlerConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.MultiLanguageStringConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.QuerySourceConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.RoleDataConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.SubsystemConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.ValueTypeConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.ValueTypeDescriptionConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.ValueTypeQualifierConverter;
+import com.github._1c_syntax.bsl.reader.common.converter.XdtoPackageDataConverter;
+import com.github._1c_syntax.bsl.reader.designer.converter.DesignerConverter;
+import com.github._1c_syntax.bsl.reader.edt.converter.EDTConverter;
+import com.github._1c_syntax.bsl.types.DateFractions;
+import com.github._1c_syntax.bsl.types.ScriptVariant;
+import com.thoughtworks.xstream.XStream;
+import com.thoughtworks.xstream.converters.ConversionException;
+import com.thoughtworks.xstream.converters.Converter;
+import com.thoughtworks.xstream.converters.SingleValueConverter;
+import com.thoughtworks.xstream.converters.UnmarshallingContext;
+import com.thoughtworks.xstream.converters.basic.BooleanConverter;
+import com.thoughtworks.xstream.converters.basic.IntConverter;
+import com.thoughtworks.xstream.converters.basic.NullConverter;
+import com.thoughtworks.xstream.converters.basic.StringConverter;
+import com.thoughtworks.xstream.converters.collections.ArrayConverter;
+import com.thoughtworks.xstream.converters.collections.CollectionConverter;
+import com.thoughtworks.xstream.converters.collections.MapConverter;
+import com.thoughtworks.xstream.converters.collections.SingletonCollectionConverter;
+import com.thoughtworks.xstream.converters.collections.SingletonMapConverter;
+import com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider;
+import com.thoughtworks.xstream.converters.reflection.ReflectionConverter;
+import com.thoughtworks.xstream.core.ClassLoaderReference;
+import com.thoughtworks.xstream.io.HierarchicalStreamReader;
+import com.thoughtworks.xstream.io.StreamException;
+import com.thoughtworks.xstream.io.xml.QNameMap;
+import com.thoughtworks.xstream.mapper.CachingMapper;
+import com.thoughtworks.xstream.mapper.CannotResolveClassException;
+import com.thoughtworks.xstream.mapper.ClassAliasingMapper;
+import com.thoughtworks.xstream.mapper.DefaultImplementationsMapper;
+import com.thoughtworks.xstream.mapper.DefaultMapper;
+import com.thoughtworks.xstream.mapper.Mapper;
+import com.thoughtworks.xstream.mapper.SecurityMapper;
+import com.thoughtworks.xstream.security.WildcardTypePermission;
+import io.github.classgraph.ClassGraph;
+import io.github.classgraph.ClassInfo;
+import io.github.classgraph.HasName;
+import lombok.Getter;
+import lombok.SneakyThrows;
+import lombok.extern.slf4j.Slf4j;
+import org.graalvm.nativeimage.ImageInfo;
+import org.jspecify.annotations.Nullable;
+
+import java.io.File;
+import java.lang.annotation.Annotation;
+import java.lang.reflect.InvocationTargetException;
+import java.nio.file.Path;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.function.Function;
+
+/**
+ * Расширение функциональности XStream.
+ * <p>
+ * Shadow-копия из {@code io.github.1c-syntax:mdclasses} с native-friendly веткой:
+ * в native-image не используется {@link ClassGraph#scan()} (он валится на JRT FS
+ * при попытке прочитать boot-модули JDK), классы и конвертеры регистрируются
+ * по статически известному списку. На JVM поведение совпадает с оригиналом.
+ */
+@Slf4j
+@Getter
+public class ExtendXStream extends XStream {
+
+  /**
+   * Список MD-классов из {@code com.github._1c_syntax.bsl.mdo} (без подпакета
+   * {@code children}), для регистрации XStream alias-ов. Список соответствует
+   * результату {@code ClassGraph.getClassesImplementing(MD.class.getName())} в
+   * mdclasses 0.18.0 — поддерживать синхронно при апдейте библиотеки.
+   */
+  private static final List<Class<? extends MD>> NATIVE_MD_CLASSES = List.of(
+    AccountingRegister.class,
+    AccumulationRegister.class,
+    Bot.class,
+    BusinessProcess.class,
+    CalculationRegister.class,
+    Catalog.class,
+    ChartOfAccounts.class,
+    ChartOfCalculationTypes.class,
+    ChartOfCharacteristicTypes.class,
+    CommandGroup.class,
+    CommonAttribute.class,
+    CommonCommand.class,
+    CommonForm.class,
+    CommonModule.class,
+    CommonPicture.class,
+    CommonTemplate.class,
+    Constant.class,
+    DataProcessor.class,
+    DefinedType.class,
+    Document.class,
+    DocumentJournal.class,
+    DocumentNumerator.class,
+    com.github._1c_syntax.bsl.mdo.Enum.class,
+    EventSubscription.class,
+    ExchangePlan.class,
+    ExternalDataSource.class,
+    FilterCriterion.class,
+    FunctionalOption.class,
+    FunctionalOptionsParameter.class,
+    HTTPService.class,
+    InformationRegister.class,
+    IntegrationService.class,
+    Interface.class,
+    Language.class,
+    PaletteColor.class,
+    Report.class,
+    Role.class,
+    ScheduledJob.class,
+    Sequence.class,
+    SessionParameter.class,
+    SettingsStorage.class,
+    Style.class,
+    StyleItem.class,
+    Subsystem.class,
+    Task.class,
+    WSReference.class,
+    WebService.class,
+    WebSocketClient.class,
+    XDTOPackage.class
+  );
+
+  /**
+   * Реестр конвертеров для трёх известных пар (пакет → класс-маркер аннотации),
+   * с которыми {@link mdclasses 0.18.0} вызывает {@link #registerConverters} в native-режиме.
+   * <p>
+   * Содержимое соответствует результату {@code ClassGraph.getClassesWithAnnotation(...)} на JVM
+   * — поддерживать синхронно при апдейте mdclasses.
+   */
+  private static final Map<String, List<Class<?>>> NATIVE_CONVERTERS = buildNativeConverters();
+
+  private static Map<String, List<Class<?>>> buildNativeConverters() {
+    var map = new HashMap<String, List<Class<?>>>();
+    map.put(
+      key("com.github._1c_syntax.bsl.reader.common.converter", CommonConverter.class),
+      List.of(
+        AllStringConverter.class,
+        CommonAttributeUseContentConverter.class,
+        CommonModuleConverter.class,
+        CompatibilityModeConverter.class,
+        ConfigurationConverter.class,
+        DataCompositionSchemaConverter.class,
+        DataSetConverter.class,
+        ExchangePlanAutoRecordConverter.class,
+        MethodHandlerConverter.class,
+        MultiLanguageStringConverter.class,
+        QuerySourceConverter.class,
+        RoleDataConverter.class,
+        SubsystemConverter.class,
+        ValueTypeConverter.class,
+        ValueTypeDescriptionConverter.class,
+        ValueTypeQualifierConverter.class,
+        XdtoPackageDataConverter.class
+      )
+    );
+    map.put(
+      key("com.github._1c_syntax.bsl.reader.designer.converter", DesignerConverter.class),
+      List.of(
+        com.github._1c_syntax.bsl.reader.designer.converter.ExchangePlanConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.ExternalSourceConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.FormAttributeConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.FormElementConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.FormHandlerConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.ManagedFormDataConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.MDChildConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.MDConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.MdoReferenceConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.MetaDataObjectConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.RoleConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.StandardAttributeConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.TemplateConverter.class,
+        com.github._1c_syntax.bsl.reader.designer.converter.XDTOPackageConverter.class
+      )
+    );
+    map.put(
+      key("com.github._1c_syntax.bsl.reader.edt.converter", EDTConverter.class),
+      List.of(
+        com.github._1c_syntax.bsl.reader.edt.converter.CommonTemplateConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.ExternalDataSourceConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.ExternalSourceConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.FormHandlerConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.FormItemConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.ManagedFormDataConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.MDChildConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.MDConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.MdoReferenceConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.ObjectTemplateConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.RoleConverter.class,
+        com.github._1c_syntax.bsl.reader.edt.converter.XDTOPackageConverter.class
+      )
+    );
+    return Map.copyOf(map);
+  }
+
+  private static String key(String pkg, Class<? extends Annotation> annotation) {
+    return pkg + "|" + annotation.getName();
+  }
+
+  public ExtendXStream(MDReader reader, ClassLoaderReference classLoaderReference, Mapper mapper) {
+    super(new PureJavaReflectionProvider(), new ExtendStaxDriver(reader), classLoaderReference, mapper);
+    init();
+  }
+
+  public ExtendXStream(MDReader reader, QNameMap qNameMap, ClassLoaderReference classLoaderReference, Mapper mapper) {
+    super(new PureJavaReflectionProvider(), new ExtendStaxDriver(reader, qNameMap), classLoaderReference, mapper);
+    init();
+  }
+
+  @Override
+  @Nullable
+  public Object fromXML(File file) {
+    Object result = null;
+    if (file.exists()) {
+      try {
+        result = super.fromXML(file);
+      } catch (ConversionException e) {
+        LOGGER.warn("Can't read file '{}' - it's broken (skipped) \n", file, e);
+      } catch (CannotResolveClassException e) {
+        LOGGER.debug("Can't read file '{}' - unknown class (skipped) \n", file, e);
+      } catch (StreamException e) {
+        LOGGER.warn("Can't read file '{}' - it's broken (skipped)", file, e);
+      } catch (Exception e) {
+        LOGGER.warn("Can't read file '{}' - unexpected error (skipped): {}", file, e.getMessage(), e);
+      }
+    }
+    return result;
+  }
+
+  @Nullable
+  public Class<?> getRealClass(String className) {
+    return getMapper().realClass(className);
+  }
+
+  @Nullable
+  public static Class<?> getRealClass(HierarchicalStreamReader reader, String className) {
+    return getCurrentMDReader(reader).getXstream().getRealClass(className);
+  }
+
+  @Nullable
+  public static Object read(HierarchicalStreamReader reader, Path contentPath) {
+    return getCurrentMDReader(reader).read(contentPath);
+  }
+
+  @Nullable
+  public static Object read(HierarchicalStreamReader reader, Path contentPath, String fullName) {
+    return getCurrentMDReader(reader).read(contentPath, fullName);
+  }
+
+  public static Path getCurrentPath(HierarchicalStreamReader reader) {
+    return ((ExtendReaderWrapper) reader).getPath();
+  }
+
+  public static MDReader getCurrentMDReader(HierarchicalStreamReader reader) {
+    return ((ExtendReaderWrapper) reader).getMDReader();
+  }
+
+  @SuppressWarnings("unchecked")
+  public static <T> T readValue(UnmarshallingContext context, Class<T> clazz) {
+    return (T) context.convertAnother(null, clazz);
+  }
+
+  /**
+   * Регистрирует конверторы нужного типа, фильтруя по пакету и аннотации.
+   * <p>
+   * На JVM выполняет рантайм-скан classpath через ClassGraph (поведение
+   * оригинального mdclasses 0.18.0). В native-image идёт по статически
+   * известному списку из {@link #NATIVE_COMMON_CONVERTERS}, потому что
+   * ClassGraph валится на JRT-файлсистеме при попытке прочитать boot-модули JDK.
+   */
+  public static void registerConverters(ExtendXStream xStream, String convertersPackageName, Class<?> annotation) {
+    if (ImageInfo.inImageRuntimeCode()) {
+      registerConvertersStatic(xStream, convertersPackageName, annotation);
+      return;
+    }
+    try (var scanResult = new ClassGraph()
+      .enableClassInfo()
+      .enableAnnotationInfo()
+      .acceptPackages(convertersPackageName)
+      .scan()) {
+
+      var classes = scanResult.getClassesWithAnnotation(annotation.getName());
+      classes.stream()
+        .map(getObjectsFromInfoClass())
+        .forEach(xStream::registerMDCConverter);
+    }
+  }
+
+  private static void registerConvertersStatic(ExtendXStream xStream, String convertersPackageName, Class<?> annotation) {
+    var classes = NATIVE_CONVERTERS.get(convertersPackageName + "|" + annotation.getName());
+    if (classes == null) {
+      throw new IllegalStateException(
+        "Unexpected registerConverters call in native-image: package=" + convertersPackageName
+          + ", annotation=" + annotation.getName()
+          + ". Обновите NATIVE_CONVERTERS в ExtendXStream под актуальный mdclasses.");
+    }
+    classes.stream()
+      .map(ExtendXStream::instantiateNoArg)
+      .forEach(xStream::registerMDCConverter);
+  }
+
+  @Override
+  protected void setupConverters() {
+    registerConverter(new NullConverter(), PRIORITY_VERY_HIGH);
+    registerConverter(new IntConverter(), PRIORITY_NORMAL);
+    registerConverter(new BooleanConverter(), PRIORITY_NORMAL);
+    registerConverter(new StringConverter(), PRIORITY_LOW);
+
+    registerConverter(new CollectionConverter(getMapper()));
+    registerConverter(new ArrayConverter(getMapper()), PRIORITY_NORMAL);
+    registerConverter(new MapConverter(getMapper()), PRIORITY_NORMAL);
+    registerConverter(new SingletonCollectionConverter(getMapper()), PRIORITY_NORMAL);
+    registerConverter(new SingletonMapConverter(getMapper()), PRIORITY_NORMAL);
+
+    registerConverter(new ReflectionConverter(getMapper(), getReflectionProvider()), PRIORITY_VERY_LOW);
+
+    registerConverters(this,
+      "com.github._1c_syntax.bsl.reader.common.converter",
+      CommonConverter.class);
+
+    registerConverter(new EnumConverter<>(ApplicationRunMode.class));
+    registerConverter(new EnumConverter<>(AutoRecordType.class));
+    registerConverter(new EnumConverter<>(ConfigurationExtensionPurpose.class));
+    registerConverter(new EnumConverter<>(DataLockControlMode.class));
+    registerConverter(new EnumConverter<>(DataSeparation.class));
+    registerConverter(new EnumConverter<>(FormType.class));
+    registerConverter(new EnumConverter<>(IndexingType.class));
+    registerConverter(new EnumConverter<>(MessageDirection.class));
+    registerConverter(new EnumConverter<>(ObjectBelonging.class));
+    registerConverter(new EnumConverter<>(ReturnValueReuse.class));
+    registerConverter(new EnumConverter<>(ReuseSessions.class));
+    registerConverter(new EnumConverter<>(RoleRight.class));
+    registerConverter(new EnumConverter<>(ScriptVariant.class));
+    registerConverter(new EnumConverter<>(TemplateType.class));
+    registerConverter(new EnumConverter<>(TransferDirection.class));
+    registerConverter(new EnumConverter<>(UseMode.class));
+    registerConverter(new EnumConverter<>(UsePurposes.class));
+    registerConverter(new EnumConverter<>(FormElementType.class));
+    registerConverter(new EnumConverter<>(InterfaceCompatibilityMode.class));
+    registerConverter(new EnumConverter<>(DateFractions.class));
+    registerConverter(new EnumConverter<>(CodeSeries.class));
+  }
+
+  private void init() {
+    setMode(XStream.NO_REFERENCES);
+    addPermission(new WildcardTypePermission(new String[]{"com.github._1c_syntax.**"}));
+
+    registerClasses();
+  }
+
+  protected void registerMDCConverter(Object converter) {
+    if (converter instanceof Converter simpleConverter) {
+      registerConverter(simpleConverter);
+    } else if (converter instanceof SingleValueConverter singleValueConverter) {
+      registerConverter(singleValueConverter);
+    } else {
+      throw new IllegalArgumentException("Unknown converter type " + converter);
+    }
+  }
+
+  private void registerClasses() {
+    if (ImageInfo.inImageRuntimeCode()) {
+      registerClassesStatic();
+    } else {
+      registerClassesViaClassGraph();
+    }
+
+    alias("Rights", RoleData.class);
+    alias("package", XdtoPackageData.class);
+    alias("DataCompositionSchema", DataCompositionSchema.class);
+    alias("Configuration", ConfigurationTree.class);
+    alias("ExternalDataProcessor", ExternalDataProcessor.class);
+    alias("ExternalReport", ExternalReport.class);
+  }
+
+  private void registerClassesViaClassGraph() {
+    try (var scanResult = new ClassGraph()
+      .enableClassInfo()
+      .acceptPackages("com.github._1c_syntax.bsl.mdo")
+      .rejectPackages("com.github._1c_syntax.bsl.mdo.children")
+      .scan()) {
+
+      scanResult.getClassesImplementing(MD.class.getName())
+        .filter(classInfo -> !classInfo.isInterface())
+        .forEach((ClassInfo clazzInfo) -> {
+          var clazz = getClassFromClassInfo(clazzInfo);
+          var simpleName = clazzInfo.getSimpleName();
+          alias(simpleName, clazz);
+        });
+    }
+  }
+
+  private void registerClassesStatic() {
+    for (var clazz : NATIVE_MD_CLASSES) {
+      alias(clazz.getSimpleName(), clazz);
+    }
+  }
+
+  @Nullable
+  private static Class<?> getClassFromClassInfo(HasName classInfo) {
+    try {
+      return Class.forName(classInfo.getName());
+    } catch (ClassNotFoundException e) {
+      LOGGER.error("Cannot resolve class {}\n", classInfo.getName(), e);
+      return null;
+    }
+  }
+
+  private static Function<ClassInfo, Object> getObjectsFromInfoClass() {
+    return (ClassInfo classInfo) -> {
+      try {
+        var clazz = Class.forName(classInfo.getName());
+        return clazz.getDeclaredConstructors()[0].newInstance();
+      } catch (ClassNotFoundException | InvocationTargetException | IllegalAccessException
+        | InstantiationException e) {
+        LOGGER.error("Cannot resolve class {}\n", classInfo.getName(), e);
+        throw new IllegalArgumentException("Cannot resolve class");
+      }
+    };
+  }
+
+  private static Object instantiateNoArg(Class<?> clazz) {
+    try {
+      return clazz.getDeclaredConstructors()[0].newInstance();
+    } catch (InvocationTargetException | IllegalAccessException | InstantiationException e) {
+      LOGGER.error("Cannot instantiate converter {}\n", clazz.getName(), e);
+      throw new IllegalArgumentException("Cannot instantiate converter " + clazz.getName(), e);
+    }
+  }
+
+  public static Mapper buildMapper(ClassLoaderReference classLoaderReference) {
+    Mapper mapper = new DefaultMapper(classLoaderReference);
+    mapper = new ClassAliasingMapper(mapper);
+    mapper = new DefaultImplementationsMapper(mapper);
+    mapper = new SecurityMapper(mapper);
+    mapper = new CachingMapper(mapper);
+    return mapper;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/utils/Lazy.java
+++ b/src/main/java/com/github/_1c_syntax/utils/Lazy.java
@@ -1,0 +1,99 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.utils;
+
+import org.jspecify.annotations.Nullable;
+
+import java.util.concurrent.locks.ReentrantLock;
+import java.util.function.Supplier;
+
+import static java.util.Objects.requireNonNull;
+
+/**
+ * Реализация хранения данных с ленивым чтением.
+ * <p>
+ * Shadow-копия из {@code io.github.1c-syntax:utils:0.7.0} с критичным фиксом:
+ * {@code lock.unlock()} вынесен в {@code finally}-блок. В оригинальной версии
+ * unlock стоит после {@code maybeCompute(...)} вне try/finally — любое исключение
+ * в supplier'е приводит к навечно захваченному lock'у и deadlock'у всех последующих
+ * обращений. Это особенно болезненно в native-image, где prototype-бины
+ * ({@code CyclomaticComplexityComputer}, {@code CognitiveComplexityComputer})
+ * хватают NPE на необложенных Spring AOT-инъекциях (`stringInterner`) и оставляют
+ * {@code computeLock} навсегда занятым, после чего весь analyze-пул виснет на
+ * {@code AbstractQueuedSynchronizer.acquire}.
+ *
+ * <p>На JVM баг тоже есть, просто не триггерится — supplier'ы там не падают.
+ */
+public final class Lazy<T> {
+
+  private final Supplier<T> supplier;
+  private final ReentrantLock lock;
+  private volatile @Nullable T value;
+
+  public Lazy(Supplier<T> supplier) {
+    this(supplier, new ReentrantLock());
+  }
+
+  public Lazy(Supplier<T> supplier, ReentrantLock lock) {
+    this.supplier = supplier;
+    this.lock = lock;
+  }
+
+  @Nullable
+  public T get() {
+    return value;
+  }
+
+  public T getOrCompute(Supplier<T> supplier) {
+    final T result = value; // Just one volatile read
+    if (result == null) {
+      lock.lock();
+      try {
+        return maybeCompute(supplier);
+      } finally {
+        lock.unlock();
+      }
+    }
+    return result;
+  }
+
+  public T getOrCompute() {
+    return getOrCompute(supplier);
+  }
+
+  public boolean isPresent() {
+    final T result = value;
+    return result != null;
+  }
+
+  public void clear() {
+    value = null;
+  }
+
+  private T maybeCompute(Supplier<T> supplier) {
+    if (value == null) {
+      requireNonNull(supplier);
+      value = requireNonNull(supplier.get());
+    }
+    return requireNonNull(value);
+  }
+}

--- a/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
@@ -1,6 +1,488 @@
 {
   "reflection": [
     {
+      "type": "Pointcuts"
+    },
+    {
+      "type": "boolean"
+    },
+    {
+      "type": "boolean[]"
+    },
+    {
+      "type": "byte[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "ch.qos.logback.classic.BasicConfigurator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.classic.LoggerContext"
+    },
+    {
+      "type": "ch.qos.logback.classic.encoder.PatternLayoutEncoder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.classic.filter.ThresholdFilter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setLevel",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.classic.spi.ILoggingEvent"
+    },
+    {
+      "type": "ch.qos.logback.classic.spi.LogbackServiceProvider"
+    },
+    {
+      "type": "ch.qos.logback.classic.util.DefaultJoranConfigurator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.Appender"
+    },
+    {
+      "type": "ch.qos.logback.core.ConsoleAppender"
+    },
+    {
+      "type": "ch.qos.logback.core.OutputStreamAppender",
+      "methods": [
+        {
+          "name": "setEncoder",
+          "parameterTypes": [
+            "ch.qos.logback.core.encoder.Encoder"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.UnsynchronizedAppenderBase",
+      "methods": [
+        {
+          "name": "addFilter",
+          "parameterTypes": [
+            "ch.qos.logback.core.filter.Filter"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.encoder.Encoder"
+    },
+    {
+      "type": "ch.qos.logback.core.encoder.LayoutWrappingEncoder",
+      "methods": [
+        {
+          "name": "setCharset",
+          "parameterTypes": [
+            "java.nio.charset.Charset"
+          ]
+        },
+        {
+          "name": "setParent",
+          "parameterTypes": [
+            "ch.qos.logback.core.spi.ContextAware"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.filter.Filter"
+    },
+    {
+      "type": "ch.qos.logback.core.pattern.PatternLayoutEncoderBase",
+      "methods": [
+        {
+          "name": "setPattern",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "ch.qos.logback.core.spi.ContextAware"
+    },
+    {
+      "type": "ch.qos.logback.core.spi.ContextAwareBase"
+    },
+    {
+      "type": "ch.qos.logback.core.spi.FilterAttachable"
+    },
+    {
+      "type": "ch.qos.logback.core.spi.LifeCycle"
+    },
+    {
+      "type": "char[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "com.couchbase.client.java.Cluster"
+    },
+    {
+      "type": "com.ctc.wstx.stax.WstxInputFactory"
+    },
+    {
+      "type": "com.ctc.wstx.stax.WstxOutputFactory"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JacksonAnnotation"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonCreator"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonCreator$Mode"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonFormat"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonFormat$Shape"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonIgnore"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonIgnoreProperties"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonInclude"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonInclude$Include"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonProperty"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonRootName"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonSetter"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonTypeInfo"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonTypeInfo$As"
+    },
+    {
+      "type": "com.fasterxml.jackson.annotation.JsonTypeInfo$Id"
+    },
+    {
+      "type": "com.fasterxml.jackson.core.JsonGenerator"
+    },
+    {
+      "type": "com.fasterxml.jackson.databind.ObjectMapper"
+    },
+    {
+      "type": "com.fasterxml.jackson.dataformat.cbor.CBORFactory"
+    },
+    {
+      "type": "com.fasterxml.jackson.dataformat.smile.SmileFactory"
+    },
+    {
+      "type": "com.fasterxml.jackson.dataformat.xml.XmlMapper"
+    },
+    {
+      "type": "com.fasterxml.jackson.dataformat.yaml.YAMLFactory"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.AnalyzeProjectOnStart",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.providers.DiagnosticProvider",
+            "com.github._1c_syntax.bsl.languageserver.LanguageClientHolder",
+            "com.github._1c_syntax.bsl.languageserver.WorkDoneProgressHelper",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "java.util.concurrent.ExecutorService"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopulatedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.AutoServerInfo",
+      "fields": [
+        {
+          "name": "applicationName"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.BSLLSPLauncher",
+      "fields": [
+        {
+          "name": "configurationOption"
+        },
+        {
+          "name": "unmatched"
+        },
+        {
+          "name": "usageHelpRequested"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "picocli.CommandLine$IFactory"
+          ]
+        },
+        {
+          "name": "main",
+          "parameterTypes": [
+            "java.lang.String[]"
+          ]
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.BSLLanguageServer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.BSLTextDocumentService",
+            "com.github._1c_syntax.bsl.languageserver.BSLWorkspaceService",
+            "com.github._1c_syntax.bsl.languageserver.providers.CommandProvider",
+            "com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder",
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "org.eclipse.lsp4j.ServerInfo",
+            "org.eclipse.lsp4j.SemanticTokensLegend",
+            "java.util.concurrent.ExecutorService"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.BSLTextDocumentService",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.DiagnosticProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.CodeActionProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.CodeLensProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.DocumentLinkProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.DocumentSymbolProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.FoldingRangeProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.FormatProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.HoverProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.CompletionProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.ReferencesProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.DefinitionProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.CallHierarchyProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.SelectionRangeProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.ColorProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.RenameProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.InlayHintProvider",
+            "com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder",
+            "com.github._1c_syntax.bsl.languageserver.providers.SemanticTokensProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.SignatureHelpProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.DocumentHighlightProvider",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor"
+          ]
+        },
+        {
+          "name": "onDestroy",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.BSLTextDocumentService$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.BSLWorkspaceService",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.providers.CommandProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.SymbolProvider",
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor",
+            "java.util.concurrent.ExecutorService"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.BSLWorkspaceService$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.LanguageClientHolder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.ParentProcessWatcher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.eclipse.lsp4j.services.LanguageServer"
+          ]
+        },
+        {
+          "name": "watch",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.WorkDoneProgressHelper",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.LanguageClientHolder",
+            "com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.AspectJConfiguration",
+      "methods": [
+        {
+          "name": "eventPublisherAspect",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryAspect",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.AspectJConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.AspectJConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.AspectJConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
       "type": "com.github._1c_syntax.bsl.languageserver.aop.EventPublisherAspect",
       "methods": [
         {
@@ -10,13 +492,15545 @@
       ]
     },
     {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.EventPublisherAspectRegistration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.aop.EventPublisherAspect"
+          ]
+        },
+        {
+          "name": "destroy",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.Pointcuts"
+    },
+    {
       "type": "com.github._1c_syntax.bsl.languageserver.aop.SentryAspect",
       "methods": [
         {
           "name": "aspectOf",
           "parameterTypes": []
+        },
+        {
+          "name": "setConfiguration",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        },
+        {
+          "name": "setExecutor",
+          "parameterTypes": [
+            "org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor"
+          ]
+        },
+        {
+          "name": "setGlobalConfiguration",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration"
+          ]
+        },
+        {
+          "name": "setLanguageClientHolder",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.LanguageClientHolder"
+          ]
         }
       ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.measures.ConditionalOnMeasuresEnabled"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.sentry.PermissionFilterBeforeSendCallback",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.LanguageClientHolder",
+            "com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder",
+            "org.eclipse.lsp4j.ServerInfo"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.sentry.SentryScopeConfigurer",
+      "methods": [
+        {
+          "name": "onApplicationReady",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryOptionsConfiguration",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.sentry.SentryScopeConfigurer$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.eclipse.lsp4j.ServerInfo",
+            "com.github._1c_syntax.bsl.languageserver.aop.sentry.PermissionFilterBeforeSendCallback"
+          ]
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.sentry.SentryScopeConfigurer$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.sentry.SentryScopeConfigurer$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.AnalyzeCommand",
+      "fields": [
+        {
+          "name": "configurationOption"
+        },
+        {
+          "name": "outputDirOption"
+        },
+        {
+          "name": "reportersOptions"
+        },
+        {
+          "name": "silentMode"
+        },
+        {
+          "name": "srcDirOption"
+        },
+        {
+          "name": "usageHelpRequested"
+        },
+        {
+          "name": "workspaceDirOption"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.reporters.ReportersAggregator",
+            "com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "java.util.concurrent.ExecutorService"
+          ]
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.AnalyzeCommand$ReportersKeys",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.reporters.ReportersAggregator"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.FormatCommand",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.FormatProvider",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "java.util.concurrent.ExecutorService"
+          ]
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.LanguageServerStartCommand",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration",
+            "org.eclipse.lsp4j.jsonrpc.Launcher",
+            "java.util.List"
+          ]
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.VersionCommand",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.eclipse.lsp4j.ServerInfo"
+          ]
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.WebsocketCommand",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration"
+          ]
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.lsp.FileAwarePrintWriter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.events.GlobalLanguageServerConfigurationChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.lsp.LanguageServerLauncherConfiguration",
+      "methods": [
+        {
+          "name": "launcher",
+          "parameterTypes": [
+            "org.eclipse.lsp4j.services.LanguageServer",
+            "com.github._1c_syntax.bsl.languageserver.cli.lsp.FileAwarePrintWriter"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.lsp.LanguageServerLauncherConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.lsp.LanguageServerLauncherConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.cli.lsp.LanguageServerLauncherConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codeactions.AbstractQuickFixSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codeactions.CodeActionSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codeactions.DisableDiagnosticTriggeringSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codeactions.ExtractStructureConstructorSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codeactions.FixAllCodeActionSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.codeactions.QuickFixSupplier"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codeactions.GenerateStandardRegionsSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codeactions.QuickFixCodeActionSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.codeactions.QuickFixSupplier"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codeactions.QuickFixSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos",
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.AbstractMethodComplexityCodeLensSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.AbstractMethodComplexityCodeLensSupplier$ComplexityCodeLensData"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.AbstractRunTestsCodeLensSupplier",
+      "methods": [
+        {
+          "name": "handleLanguageServerConfigurationChange",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.CodeLensData"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.CodeLensSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.CognitiveComplexityCodeLensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.commands.ToggleCognitiveComplexityInlayHintsCommandSupplier"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.CyclomaticComplexityCodeLensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.commands.ToggleCyclomaticComplexityInlayHintsCommandSupplier"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.DebugTestCodeLensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.codelenses.TestSourcesProvider",
+            "com.github._1c_syntax.bsl.languageserver.codelenses.testrunner.TestRunnerAdapter",
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.DebugTestCodeLensSupplier$DebugTestCodeLensData"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.DefaultCodeLensData"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.RunAllTestsCodeLensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.codelenses.TestSourcesProvider",
+            "com.github._1c_syntax.bsl.languageserver.codelenses.testrunner.TestRunnerAdapter",
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.RunTestCodeLensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.codelenses.TestSourcesProvider",
+            "com.github._1c_syntax.bsl.languageserver.codelenses.testrunner.TestRunnerAdapter",
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.RunTestCodeLensSupplier$RunTestCodeLensData"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.TestSourcesProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        },
+        {
+          "name": "evict",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.TestSourcesProvider$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.infrastructure.CodeLensesConfiguration",
+      "methods": [
+        {
+          "name": "codeLensSuppliersById",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.infrastructure.CodeLensesConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.infrastructure.CodeLensesConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.infrastructure.CodeLensesConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.testrunner.TestRunnerAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageServerConfigurationChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.codelenses.testrunner.TestRunnerAdapter$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.color.ColorInformationSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.color.ColorPresentationSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.color.ConstructorColorInformationSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.color.ConstructorColorPresentationSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.color.WebColorInformationSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.color.WebColorPresentationSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.CommandArguments"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.CommandSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.ToggleCognitiveComplexityInlayHintsCommandSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.inlayhints.CognitiveComplexityInlayHintSupplier"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.ToggleCyclomaticComplexityInlayHintsCommandSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.inlayhints.CyclomaticComplexityInlayHintSupplier"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.complexity.AbstractToggleComplexityInlayHintsCommandSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.complexity.ToggleComplexityInlayHintsCommandArguments"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.infrastructure.CommandsConfiguration",
+      "methods": [
+        {
+          "name": "commandSuppliersById",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.infrastructure.CommandsConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.infrastructure.CommandsConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.commands.infrastructure.CommandsConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration",
+      "fields": [
+        {
+          "name": "configurationFilePath"
+        },
+        {
+          "name": "globalConfigPath"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "onApplicationReady",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+      "fields": [
+        {
+          "name": "defaultConfigFileName"
+        },
+        {
+          "name": "globalConfigPath"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getConfigurationFile",
+          "parameterTypes": []
+        },
+        {
+          "name": "getConfigurationRoot",
+          "parameterTypes": []
+        },
+        {
+          "name": "getDiagnosticsOptions",
+          "parameterTypes": []
+        },
+        {
+          "name": "getExcludePaths",
+          "parameterTypes": []
+        },
+        {
+          "name": "getLanguage",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOscriptOptions",
+          "parameterTypes": []
+        },
+        {
+          "name": "getPlatformOptions",
+          "parameterTypes": []
+        },
+        {
+          "name": "getReferencesOptions",
+          "parameterTypes": []
+        },
+        {
+          "name": "getSiteRoot",
+          "parameterTypes": []
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        },
+        {
+          "name": "isUseDevSite",
+          "parameterTypes": []
+        },
+        {
+          "name": "setConfigurationRoot",
+          "parameterTypes": [
+            "java.nio.file.Path"
+          ]
+        },
+        {
+          "name": "setExcludePaths",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "setLanguage",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.Language"
+          ]
+        },
+        {
+          "name": "setSiteRoot",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "setUseDevSite",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "update",
+          "parameterTypes": [
+            "java.io.File"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration$$SpringCGLIB$$1",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfigurationBeanInfo"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfigurationCustomizer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfigurationFactory",
+      "fields": [
+        {
+          "name": "defaultConfigFileName"
+        },
+        {
+          "name": "globalConfigPath"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.capabilities.CapabilitiesOptions",
+      "methods": [
+        {
+          "name": "getTextDocumentSync",
+          "parameterTypes": []
+        },
+        {
+          "name": "setTextDocumentSync",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.capabilities.TextDocumentSyncCapabilityOptions"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.capabilities.CapabilitiesOptionsBeanInfo"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.capabilities.CapabilitiesOptionsCustomizer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.codelens.CodeLensOptions",
+      "methods": [
+        {
+          "name": "getParameters",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTestRunnerAdapterOptions",
+          "parameterTypes": []
+        },
+        {
+          "name": "setParameters",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        },
+        {
+          "name": "setTestRunnerAdapterOptions",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.codelens.TestRunnerAdapterOptions"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.codelens.CodeLensOptionsBeanInfo"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.codelens.CodeLensOptionsCustomizer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.DiagnosticsOptions",
+      "methods": [
+        {
+          "name": "getComputeTrigger",
+          "parameterTypes": []
+        },
+        {
+          "name": "getIgnoredAuthors",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMetadata",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMinimumLSPDiagnosticLevel",
+          "parameterTypes": []
+        },
+        {
+          "name": "getMode",
+          "parameterTypes": []
+        },
+        {
+          "name": "getOverrideMinimumLSPDiagnosticLevel",
+          "parameterTypes": []
+        },
+        {
+          "name": "getParameters",
+          "parameterTypes": []
+        },
+        {
+          "name": "getSkipSupport",
+          "parameterTypes": []
+        },
+        {
+          "name": "getSubsystemsFilter",
+          "parameterTypes": []
+        },
+        {
+          "name": "isAnalyzeOnStart",
+          "parameterTypes": []
+        },
+        {
+          "name": "isOrdinaryAppSupport",
+          "parameterTypes": []
+        },
+        {
+          "name": "setAnalyzeOnStart",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setComputeTrigger",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.ComputeTrigger"
+          ]
+        },
+        {
+          "name": "setIgnoredAuthors",
+          "parameterTypes": [
+            "java.util.Set"
+          ]
+        },
+        {
+          "name": "setMetadata",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        },
+        {
+          "name": "setMinimumLSPDiagnosticLevel",
+          "parameterTypes": [
+            "org.eclipse.lsp4j.DiagnosticSeverity"
+          ]
+        },
+        {
+          "name": "setMode",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.Mode"
+          ]
+        },
+        {
+          "name": "setOrdinaryAppSupport",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setOverrideMinimumLSPDiagnosticLevel",
+          "parameterTypes": [
+            "org.eclipse.lsp4j.DiagnosticSeverity"
+          ]
+        },
+        {
+          "name": "setParameters",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        },
+        {
+          "name": "setSkipSupport",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.SkipSupport"
+          ]
+        },
+        {
+          "name": "setSubsystemsFilter",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.SubsystemFilter"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.DiagnosticsOptionsBeanInfo"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.DiagnosticsOptionsCustomizer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.documentlink.DocumentLinkOptions",
+      "methods": [
+        {
+          "name": "isShowDiagnosticDescription",
+          "parameterTypes": []
+        },
+        {
+          "name": "setShowDiagnosticDescription",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.documentlink.DocumentLinkOptionsBeanInfo"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.documentlink.DocumentLinkOptionsCustomizer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.formating.FormattingOptions",
+      "methods": [
+        {
+          "name": "isUseKeywordsFormatting",
+          "parameterTypes": []
+        },
+        {
+          "name": "isUseOnTypeFormatting",
+          "parameterTypes": []
+        },
+        {
+          "name": "isUseUpperCaseForOrNotAndKeywords",
+          "parameterTypes": []
+        },
+        {
+          "name": "setUseKeywordsFormatting",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setUseOnTypeFormatting",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setUseUpperCaseForOrNotAndKeywords",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.formating.FormattingOptionsBeanInfo"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.formating.FormattingOptionsCustomizer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.inlayhints.InlayHintOptions",
+      "methods": [
+        {
+          "name": "getParameters",
+          "parameterTypes": []
+        },
+        {
+          "name": "setParameters",
+          "parameterTypes": [
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.inlayhints.InlayHintOptionsBeanInfo"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.inlayhints.InlayHintOptionsCustomizer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.references.ReferencesOptions",
+      "methods": [
+        {
+          "name": "getCommonModuleAccessors",
+          "parameterTypes": []
+        },
+        {
+          "name": "setCommonModuleAccessors",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.references.ReferencesOptionsBeanInfo"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.references.ReferencesOptionsCustomizer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.semantictokens.SemanticTokensOptions",
+      "methods": [
+        {
+          "name": "getStrTemplateMethods",
+          "parameterTypes": []
+        },
+        {
+          "name": "setStrTemplateMethods",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.semantictokens.SemanticTokensOptionsBeanInfo"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.semantictokens.SemanticTokensOptionsCustomizer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.watcher.ConfigurationFileChangeListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.watcher.ConfigurationFileSystemWatcher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.configuration.watcher.ConfigurationFileChangeListener"
+          ]
+        },
+        {
+          "name": "handleGlobalConfigurationChanged",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.events.GlobalLanguageServerConfigurationChangedEvent"
+          ]
+        },
+        {
+          "name": "handleWorkspaceAdded",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.WorkspaceAddedEvent"
+          ]
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        },
+        {
+          "name": "onDestroy",
+          "parameterTypes": []
+        },
+        {
+          "name": "watch",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.DocumentContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.net.URI",
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContext"
+          ]
+        },
+        {
+          "name": "setCognitiveComplexityComputerProvider",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "setCyclomaticComplexityComputerProvider",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "setDiagnosticComputer",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticComputer"
+          ]
+        },
+        {
+          "name": "setOScriptModuleTypeResolver",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleTypeResolver"
+          ]
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.ServerContext",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider",
+            "com.github._1c_syntax.bsl.languageserver.WorkDoneProgressHelper",
+            "com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration",
+            "java.util.concurrent.ExecutorService",
+            "java.util.concurrent.ExecutorService"
+          ]
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope"
+          ]
+        },
+        {
+          "name": "onDocumentAdded",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentAddedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.CognitiveComplexityComputer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.Computer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.CyclomaticComplexityComputer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticComputer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "java.util.concurrent.ExecutorService",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticIgnoranceComputer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticIgnoranceComputer$Data"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.MethodSymbolComputer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.ModuleSymbolComputer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.RegionSymbolComputer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.SymbolTreeComputer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.VariableSymbolComputer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.symbol.AnnotationParamSymbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.symbol.AnnotationSymbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.symbol.KeywordSymbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.symbol.ModuleSymbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTreeVisitor"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.databind.JsonMapperConfiguration",
+      "methods": [
+        {
+          "name": "jacksonCustomizer",
+          "parameterTypes": [
+            "java.util.Collection",
+            "java.util.Collection"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.databind.JsonMapperConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.databind.JsonMapperConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.databind.JsonMapperConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractCommonModuleNameDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractExecuteExternalCodeDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractExpressionTreeDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractFindMethodDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractListenerDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractMagicValueDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractMetadataDiagnostic",
+      "fields": [
+        {
+          "name": "languageServerConfiguration"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractMultilingualStringDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractSDBLListenerDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractSDBLVisitorDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractSymbolTreeDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AbstractVisitorDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AllFunctionPathMustHaveReturnDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AssignAliasFieldsInQueryDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.AssignToReadOnlyPropertyDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry",
+            "com.github._1c_syntax.bsl.languageserver.types.TypeService"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.BSLDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.BadWordsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.BeginTransactionBeforeTryCatchDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CachedPublicDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CanonicalSpellingKeywordsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CodeAfterAsyncCallDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CodeBlockBeforeSubDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CodeOutOfRegionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CognitiveComplexityDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommandModuleExportMethodsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommentedCodeDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommitTransactionOutsideTryCatchDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleAssignDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleInvalidTypeDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleMissingAPIDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameCachedDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameClientDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameClientServerDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameFullAccessDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameGlobalClientDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameGlobalDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameServerCallDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameWordsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CompilationDirectiveLostDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CompilationDirectiveNeedLessDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ConsecutiveEmptyLinesDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CrazyMultilineStringDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CreateQueryInCycleDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.CyclomaticComplexityDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DataExchangeLoadingDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeletingCollectionItemDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DenyIncompleteValuesDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedAttributes8312Diagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedCurrentDateDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedFindDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedMessageDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedMethodCallDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedMethods8310Diagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedMethods8317Diagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedTypeManagedFormDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DisableSafeModeDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DoubleNegativesDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DuplicateRegionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DuplicateStringLiteralDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.DuplicatedInsertionIntoCollectionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.EmptyCodeBlockDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.EmptyRegionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.EmptyStatementDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExcessiveAutoTestCheckDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeInCommonModuleDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExportVariablesDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExternalAppStartingDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExtraCommasDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FieldsFromJoinsWithoutIsNullDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FileSystemAccessDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ForbiddenMetadataNameDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FormDataToValueDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FullOuterJoinQueryDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionNameStartsWithGetDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionOutParameterDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionReturnsSamePrimitiveDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionShouldHaveReturnDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.GetFormMethodDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.GlobalContextMethodCollision8312Diagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IdenticalExpressionsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfConditionComplexityDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedCodeBlockDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedConditionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseIfEndsWithElseDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectLineBreakDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectUseLikeInQueryDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectUseOfStrTemplateDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.InternetAccessDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.InvalidCharacterInFileDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IsInRoleMethodDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.JoinWithSubQueryDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.JoinWithVirtualTableDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LatinAndCyrillicSymbolInWordDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LineLengthDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LogicalOrInJoinQuerySectionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LogicalOrInTheWhereSectionOfQueryDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicDateDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicNumberDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MetadataObjectNameLengthDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MethodSizeDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissedRequiredParameterDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCodeTryCatchExDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCommonModuleMethodDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingEventSubscriptionHandlerDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingParameterDescriptionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingReturnedValueDescriptionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingSpaceDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTempStorageDeletionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTemporaryFileDeletionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingVariablesDescriptionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilineStringInQueryDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringHasAllDeclaredLanguagesDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringUsingWithTemplateDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedConstructorsInStructureDeclarationDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedFunctionInParametersDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedStatementsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedTernaryOperatorDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonExportMethodsInApiRegionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonStandardRegionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfOptionalParamsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfParamsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfValuesInStructureConstructorDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OSUsersMethodDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OneStatementPerLineDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OrderOfParamsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OrdinaryAppSupportDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.PairingBrokenTransactionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ParseErrorDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.PrivilegedModuleMethodCallDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ProcedureReturnsValueDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ProtectedModuleDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.PublicMethodsDescriptionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryNestedFieldsByDotDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryParseErrorDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryToMissingMetadataDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QuickFixProvider"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.RedundantAccessToObjectDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.RefOveruseDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ReservedParameterNamesDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.RewriteMethodParameterDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SameMetadataObjectAndChildNamesDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ScheduledJobHandlerDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelectTopWithoutOrderByDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelfAssignDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelfInsertionDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SemicolonPresenceDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ServerCallsInFormEventsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ServerSideExportFormMethodDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPermissionsForNewObjectsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPrivilegedModeDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SeveralCompilerDirectivesDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SpaceAtStartCommentDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.StyleElementConstructorsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TempFilesDirDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TernaryOperatorUsageDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ThisObjectAssignDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TimeoutsInExternalResourcesDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TooManyReturnsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TransferringParametersBetweenClientAndServerDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TryNumberDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TypoDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnaryPlusInConcatenationDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnionAllDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnknownPreprocessorSymbolDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnreachableCodeDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnsafeFindByCodeDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnsafeSafeModeMethodCallDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalMethodDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalVariableDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedParametersDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsageWriteLogEventDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UseLessForEachDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UseSystemInformationDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UselessTernaryOperatorDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingCancelParameterDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingExternalCodeToolsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingFindElementByStringDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingGotoDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeNetworkAddressDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodePathDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeSecretInformationDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingLikeInQueryDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingModalWindowsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingObjectNotAvailableUnixDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingServiceTagDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingSynchronousCallsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingThisFormDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.VirtualTableCallWithoutParametersDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongDataPathForFormElementsDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongHttpServiceHandlerDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongUseFunctionProceedWithCallDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongUseOfRollbackTransactionMethodDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongWebServiceHandlerDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.YoLetterUsageDiagnostic"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticBeanPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfoRefresher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos"
+          ]
+        },
+        {
+          "name": "handleConfigurationChanged",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageServerConfigurationChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfosFactory",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.utils.StringInterner"
+          ]
+        },
+        {
+          "name": "getByClass",
+          "parameterTypes": []
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        },
+        {
+          "name": "refresh",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos$$SpringCGLIB$$1",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfosFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.context.ApplicationContext",
+            "com.github._1c_syntax.utils.StringInterner"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticObjectProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.context.ApplicationContext"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticsConfiguration"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticsConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticObjectProvider",
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticsConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticsConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticCompatibilityMode"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticMetadata",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticParameter"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticScope"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticSeverity"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticTag"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticTag[]"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticType"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.typo.CheckedWordsHolder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.typo.CheckedWordsHolder$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.typo.WordStatus"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.AbstractASTDocumentHighlightSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.AbstractSDBLDocumentHighlightSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.BracketDocumentHighlightSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.DocumentHighlightSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.IfStatementDocumentHighlightSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.LoopStatementDocumentHighlightSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.RegionDocumentHighlightSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.SDBLBracketDocumentHighlightSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.SDBLCaseDocumentHighlightSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.SDBLJoinDocumentHighlightSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.SubroutineDocumentHighlightSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.TryStatementDocumentHighlightSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documentlink.DiagnosticDescriptionDocumentLinkSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.documentlink.DocumentLinkSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.folding.AbstractCommentFoldingRangeSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.folding.CodeBlockFoldingRangeSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.folding.CommentFoldingRangeSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.folding.FoldingRangeSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.folding.PreprocIfFoldingRangeSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.folding.QueryCommentFoldingRangeSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.folding.QueryPackageFoldingRangeSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.folding.RegionFoldingRangeSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.folding.UseFoldingRangeSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.AnnotationParamSymbolMarkupContentBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.AnnotationSymbolMarkupContentBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.CollectionHoverHints",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.ConstructorCallMarkupContentBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.hover.ConstructorHoverBuilder"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.ConstructorHoverBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.TypeService",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry",
+            "com.github._1c_syntax.bsl.languageserver.hover.CollectionHoverHints",
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.KeywordSymbolMarkupContentBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.MarkupContentBuilder"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.MarkupContentBuilderConfiguration",
+      "methods": [
+        {
+          "name": "markupContentBuilders",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.MarkupContentBuilderConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.MarkupContentBuilderConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.MarkupContentBuilderConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.MethodSymbolMarkupContentBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.ModuleSymbolMarkupContentBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources",
+            "com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.PlatformMemberHoverBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.PlatformMemberSymbolMarkupContentBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.hover.PlatformMemberHoverBuilder"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.SyntheticSymbolMarkupContentBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry",
+            "com.github._1c_syntax.bsl.languageserver.hover.CollectionHoverHints",
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.hover.VariableSymbolMarkupContentBuilder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter",
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources",
+            "com.github._1c_syntax.bsl.languageserver.types.TypeService"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.CacheConfiguration",
+      "methods": [
+        {
+          "name": "cacheManager",
+          "parameterTypes": [
+            "com.github.benmanes.caffeine.cache.Caffeine"
+          ]
+        },
+        {
+          "name": "caffeineConfig",
+          "parameterTypes": []
+        },
+        {
+          "name": "ehcacheManager",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.infrastructure.CachePathProvider",
+            "java.lang.String",
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "typoCacheManager",
+          "parameterTypes": [
+            "org.ehcache.CacheManager"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.CacheConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.CacheConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.CacheConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.CachePathProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.ContextPropagatingExecutorService",
+      "methods": [
+        {
+          "name": "shutdown",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.ExecutorConfiguration",
+      "methods": [
+        {
+          "name": "cliExecutor",
+          "parameterTypes": []
+        },
+        {
+          "name": "compositeTaskDecorator",
+          "parameterTypes": [
+            "io.sentry.spring7.SentryTaskDecorator",
+            "org.springframework.core.task.TaskDecorator"
+          ]
+        },
+        {
+          "name": "computeConfigurationExecutor",
+          "parameterTypes": []
+        },
+        {
+          "name": "contextPropagatingDecorator",
+          "parameterTypes": []
+        },
+        {
+          "name": "diagnosticComputerExecutor",
+          "parameterTypes": []
+        },
+        {
+          "name": "populateContextExecutor",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryDecorator",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryExecutor",
+          "parameterTypes": [
+            "org.springframework.core.task.TaskDecorator"
+          ]
+        },
+        {
+          "name": "textDocumentServiceExecutor",
+          "parameterTypes": [
+            "org.springframework.core.task.TaskDecorator"
+          ]
+        },
+        {
+          "name": "workspaceServiceExecutor",
+          "parameterTypes": [
+            "org.springframework.core.task.TaskDecorator"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.ExecutorConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.ExecutorConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.ExecutorConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.LanguageClientAwareAppender",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setClientHolder",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.LanguageClientHolder"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.LogbackConfiguration",
+      "methods": [
+        {
+          "name": "languageClientAwareAppender",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.LogbackConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.LogbackConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.LogbackConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.SchedulingConfiguration"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.SchedulingConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.UtilsConfiguration",
+      "methods": [
+        {
+          "name": "stringInterner",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.UtilsConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.UtilsConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.UtilsConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceNameThreadLocalAccessor"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScopeConfiguration",
+      "methods": [
+        {
+          "name": "workspaceScope",
+          "parameterTypes": []
+        },
+        {
+          "name": "workspaceScopeConfigurer",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScopeConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScopeConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScopeConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceThreadLocalAccessor"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.inlayhints.AbstractComplexityInlayHintSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.inlayhints.AbstractMethodCallInlayHintSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.inlayhints.CognitiveComplexityInlayHintSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.inlayhints.CyclomaticComplexityInlayHintSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.inlayhints.InlayHintSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.inlayhints.PlatformMethodCallInlayHintSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.types.TypeService",
+            "com.github._1c_syntax.bsl.languageserver.utils.Resources"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.inlayhints.SourceDefinedMethodCallInlayHintSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex",
+            "com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.inlayhints.infrastructure.InlayHintsConfiguration"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.inlayhints.infrastructure.InlayHintsConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.jsonrpc.DiagnosticParams"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.jsonrpc.ProtocolExtension"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.CallHierarchyProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver",
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.CodeActionProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.CodeLensProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.Map",
+            "org.springframework.beans.factory.ObjectProvider",
+            "com.github._1c_syntax.bsl.languageserver.LanguageClientHolder",
+            "com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder",
+            "tools.jackson.databind.json.JsonMapper"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageServerConfigurationChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.ColorProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.List",
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.CommandProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.Map",
+            "tools.jackson.databind.json.JsonMapper",
+            "com.github._1c_syntax.bsl.languageserver.providers.CodeLensProvider",
+            "com.github._1c_syntax.bsl.languageserver.providers.InlayHintProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.CompletionProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.TypeService",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.DefinitionProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.DiagnosticProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.LanguageClientHolder",
+            "com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder"
+          ]
+        },
+        {
+          "name": "handleConfigurationChangedEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageServerConfigurationChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.DocumentHighlightProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.DocumentLinkProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.DocumentSymbolProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.FoldingRangeProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.FormatProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageServerConfigurationChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.HoverProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver",
+            "java.util.Map"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.InlayHintProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.Collection",
+            "com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder",
+            "com.github._1c_syntax.bsl.languageserver.LanguageClientHolder",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.events.LanguageServerConfigurationChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.ReferencesProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver",
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.RenameProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver",
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.SelectionRangeProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.SemanticTokensProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.List",
+            "java.util.concurrent.ExecutorService"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.SignatureHelpProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.TypeService",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.providers.SymbolProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.AnnotationReferenceFinder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.references.model.AnnotationRepository"
+          ]
+        },
+        {
+          "name": "handleContextRefresh",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopulatedEvent"
+          ]
+        },
+        {
+          "name": "handleDocumentContextChange",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.KeywordReferenceFinder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.NewExpressionReferenceFinder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.types.TypeService"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.PlatformMemberReferenceFinder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.types.TypeService"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.ReferenceFinder"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.utils.StringInterner",
+            "com.github._1c_syntax.bsl.languageserver.references.model.LocationRepository",
+            "com.github._1c_syntax.bsl.languageserver.references.model.SymbolOccurrenceRepository"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndexFiller",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndexReferenceFinder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.SourceDefinedSymbolDeclarationReferenceFinder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.model.AnnotationRepository",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "clear",
+          "parameterTypes": []
+        },
+        {
+          "name": "removeByUri",
+          "parameterTypes": [
+            "java.net.URI"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.model.AnnotationRepository$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.model.LocationRepository",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "delete",
+          "parameterTypes": [
+            "java.net.URI"
+          ]
+        },
+        {
+          "name": "getSymbolOccurrencesByLocationUri",
+          "parameterTypes": [
+            "java.net.URI"
+          ]
+        },
+        {
+          "name": "updateLocation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.model.SymbolOccurrence"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.model.LocationRepository$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.model.SymbolOccurrenceRepository",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "deleteAll",
+          "parameterTypes": [
+            "java.util.Set"
+          ]
+        },
+        {
+          "name": "save",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.model.SymbolOccurrence"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.model.SymbolOccurrenceRepository$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.AbstractDiagnosticReporter"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.CodeQualityReporter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.ConsoleReporter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.DiagnosticReporter"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.GenericIssueReporter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.JUnitReporter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.JsonReporter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.ReportersAggregator",
+      "fields": [
+        {
+          "name": "filteredReporters"
+        },
+        {
+          "name": "reporters"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.SarifReporter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos",
+            "org.eclipse.lsp4j.ServerInfo",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.TSLintReporter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.infrastructure.ReportersConfiguration"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.infrastructure.ReportersConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.infrastructure.ReportersConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.reporters.infrastructure.ReportersConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.AnnotationSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.BslDocSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.CommentSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.GlobalScopeSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry",
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.LexicalSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.MethodCallSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex",
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.NewExpressionSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.PlatformGlobalMethodSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider",
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.PreprocessorSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.eclipse.lsp4j.SemanticTokensLegend"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensLegendConfiguration",
+      "methods": [
+        {
+          "name": "semanticTokensLegend",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensLegendConfiguration$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "$$beanFactory"
+        },
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "CGLIB$SET_STATIC_CALLBACKS",
+          "parameterTypes": [
+            "org.springframework.cglib.proxy.Callback[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensLegendConfiguration$$SpringCGLIB$$FastClass$$0",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensLegendConfiguration$$SpringCGLIB$$FastClass$$1",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensSupplier"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.StringSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContext",
+            "org.eclipse.lsp4j.SemanticTokensLegend",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.semantictokens.SymbolsSemanticTokensSupplier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex",
+            "com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensHelper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.TypeService"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.TypeService$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.index.SymbolTypeIndex",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.index.SymbolTypeIndex$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.ConventionalLibraryDiscovery",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.LibConfigDiscovery"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.LibConfigDiscovery",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.LibConfigParser",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryFileSystemWatcher",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "handleIndexed",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndexedEvent"
+          ]
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        },
+        {
+          "name": "onDestroy",
+          "parameterTypes": []
+        },
+        {
+          "name": "poll",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.LibConfigDiscovery",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.LibConfigParser",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.ConventionalLibraryDiscovery",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleTypeResolver",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleMembersProvider"
+          ]
+        },
+        {
+          "name": "findClassUri",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "findModuleUri",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "handleWorkspaceAdded",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.WorkspaceAddedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleMembersProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleMembersProvider$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleTypeResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "clear",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleTypeResolver$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BslContextHolder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.PlatformContextProviderFactory"
+          ]
+        },
+        {
+          "name": "get",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BslContextHolder$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BslContextPlatformTypesProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.BslContextHolder"
+          ]
+        },
+        {
+          "name": "getLanguageScope",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTypes",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BslContextPlatformTypesProvider$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BuiltinOScriptPlatformTypesProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "getLanguageScope",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTypes",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BuiltinOScriptPlatformTypesProvider$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BuiltinPlatformTypesProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.BslContextHolder"
+          ]
+        },
+        {
+          "name": "getLanguageScope",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTypes",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BuiltinPlatformTypesProvider$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.ConfigurationModuleMembersProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.ConfigurationModuleMembersProvider$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.ConfigurationTypesProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry",
+            "com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider",
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        },
+        {
+          "name": "handleEvent",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.ConfigurationTypesProvider$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider",
+      "fields": [
+        {
+          "name": "oScriptLibraryIndex"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.BslContextHolder",
+            "com.github._1c_syntax.bsl.languageserver.types.scope.GlobalSymbolScope"
+          ]
+        },
+        {
+          "name": "registerConfigurationQualifiedName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "registerGlobalProperty",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef",
+            "java.util.Collection",
+            "com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope",
+            "java.lang.String",
+            "com.github._1c_syntax.bsl.languageserver.types.symbol.SyntheticKind",
+            "java.util.function.Supplier"
+          ]
+        },
+        {
+          "name": "registerPlatformClass",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef",
+            "java.util.Collection",
+            "com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.PlatformContextProviderFactory",
+      "fields": [
+        {
+          "name": "platformContextEnabled"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        },
+        {
+          "name": "create",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.PlatformContextProviderFactory$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.PlatformTypesProvider"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.TypePackProvider"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.util.List",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider"
+          ]
+        },
+        {
+          "name": "bootstrap",
+          "parameterTypes": []
+        },
+        {
+          "name": "findAllGenericsByFamilyCore",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "getTypeParameters",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef"
+          ]
+        },
+        {
+          "name": "intern",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeKind",
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "registerAsGlobalProperty",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef"
+          ]
+        },
+        {
+          "name": "registerAsGlobalProperty",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef",
+            "com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope",
+            "com.github._1c_syntax.bsl.languageserver.types.symbol.SyntheticKind",
+            "java.util.function.Supplier"
+          ]
+        },
+        {
+          "name": "registerConfigurationType",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "registerConfigurationTypeAlias",
+          "parameterTypes": [
+            "java.lang.String",
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef"
+          ]
+        },
+        {
+          "name": "registerMemberSource",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef",
+            "com.github._1c_syntax.bsl.languageserver.types.model.MemberSource",
+            "com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope"
+          ]
+        },
+        {
+          "name": "registerSpecialization",
+          "parameterTypes": [
+            "java.lang.String",
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef",
+            "java.util.Map",
+            "com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope"
+          ]
+        },
+        {
+          "name": "resolve",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.scope.GlobalSymbolScope",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "findSymbol",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "register",
+          "parameterTypes": [
+            "java.lang.String",
+            "com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol",
+            "com.github._1c_syntax.bsl.languageserver.types.scope.GlobalSymbolScope$Role"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.scope.GlobalSymbolScope$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.symbol.ConstructorCallSymbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.symbol.PlatformMemberSymbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.symbol.SyntheticSymbol"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.utils.Resources"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.utils.Resources$$SpringCGLIB$$0",
+      "serializable": true,
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.utils.expressiontree.ExpressionTreeVisitor"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.websocket.LSPWebSocketEndpoint",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.eclipse.lsp4j.services.LanguageServer",
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdclasses.Configuration",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdclasses.Configuration$ConfigurationBuilder",
+      "methods": [
+        {
+          "name": "Enum",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.Enum"
+          ]
+        },
+        {
+          "name": "addUsePurposes",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.UsePurposes"
+          ]
+        },
+        {
+          "name": "briefInformation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "businessProcess",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.BusinessProcess"
+          ]
+        },
+        {
+          "name": "catalog",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.Catalog"
+          ]
+        },
+        {
+          "name": "chartOfCharacteristicTypes",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes"
+          ]
+        },
+        {
+          "name": "child",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.MD"
+          ]
+        },
+        {
+          "name": "commandGroup",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.CommandGroup"
+          ]
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "commonAttribute",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.CommonAttribute"
+          ]
+        },
+        {
+          "name": "commonCommand",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.CommonCommand"
+          ]
+        },
+        {
+          "name": "commonForm",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.CommonForm"
+          ]
+        },
+        {
+          "name": "commonModule",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.CommonModule"
+          ]
+        },
+        {
+          "name": "commonPicture",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.CommonPicture"
+          ]
+        },
+        {
+          "name": "commonTemplate",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.CommonTemplate"
+          ]
+        },
+        {
+          "name": "compatibilityMode",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.CompatibilityMode"
+          ]
+        },
+        {
+          "name": "configurationExtensionCompatibilityMode",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.CompatibilityMode"
+          ]
+        },
+        {
+          "name": "configurationSource",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ConfigurationSource"
+          ]
+        },
+        {
+          "name": "constant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.Constant"
+          ]
+        },
+        {
+          "name": "dataLockControlMode",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.DataLockControlMode"
+          ]
+        },
+        {
+          "name": "dataProcessor",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.DataProcessor"
+          ]
+        },
+        {
+          "name": "defaultLanguage",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "defaultRunMode",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.ApplicationRunMode"
+          ]
+        },
+        {
+          "name": "definedType",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.DefinedType"
+          ]
+        },
+        {
+          "name": "detailedInformation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "document",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.Document"
+          ]
+        },
+        {
+          "name": "documentJournal",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.DocumentJournal"
+          ]
+        },
+        {
+          "name": "eventSubscription",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.EventSubscription"
+          ]
+        },
+        {
+          "name": "exchangePlan",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.ExchangePlan"
+          ]
+        },
+        {
+          "name": "filterCriterion",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.FilterCriterion"
+          ]
+        },
+        {
+          "name": "functionalOption",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.FunctionalOption"
+          ]
+        },
+        {
+          "name": "functionalOptionsParameter",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.FunctionalOptionsParameter"
+          ]
+        },
+        {
+          "name": "httpService",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.HTTPService"
+          ]
+        },
+        {
+          "name": "informationRegister",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.InformationRegister"
+          ]
+        },
+        {
+          "name": "interfaceCompatibilityMode",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.InterfaceCompatibilityMode"
+          ]
+        },
+        {
+          "name": "language",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.Language"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modalityUseMode",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.UseMode"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "objectAutonumerationMode",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "report",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.Report"
+          ]
+        },
+        {
+          "name": "role",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.Role"
+          ]
+        },
+        {
+          "name": "scheduledJob",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.ScheduledJob"
+          ]
+        },
+        {
+          "name": "scriptVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ScriptVariant"
+          ]
+        },
+        {
+          "name": "sessionParameter",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.SessionParameter"
+          ]
+        },
+        {
+          "name": "settingsStorage",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.SettingsStorage"
+          ]
+        },
+        {
+          "name": "styleItem",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.StyleItem"
+          ]
+        },
+        {
+          "name": "subsystem",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.Subsystem"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synchronousPlatformExtensionAndAddInCallUseMode",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.UseMode"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "task",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.Task"
+          ]
+        },
+        {
+          "name": "useManagedFormInOrdinaryApplication",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "useOrdinaryFormInManagedApplication",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "vendor",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "version",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "webService",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.WebService"
+          ]
+        },
+        {
+          "name": "xDTOPackage",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.XDTOPackage"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdclasses.ConfigurationTree"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.AccountingRegister"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.AccumulationRegister"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Bot"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.BusinessProcess",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.BusinessProcess$BusinessProcessBuilder",
+      "methods": [
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "task",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CalculationRegister"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Catalog",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Catalog$CatalogBuilder",
+      "methods": [
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "checkUnique",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "codeSeries",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.CodeSeries"
+          ]
+        },
+        {
+          "name": "commands",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owners",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "tabularSections",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "templates",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ChartOfAccounts"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ChartOfCalculationTypes"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes$ChartOfCharacteristicTypesBuilder",
+      "methods": [
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "checkUnique",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "codeSeries",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.CodeSeries"
+          ]
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "tabularSections",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommandGroup",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommandGroup$CommandGroupBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonAttribute",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonAttribute$CommonAttributeBuilder",
+      "methods": [
+        {
+          "name": "authenticationSeparation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.DataSeparation"
+          ]
+        },
+        {
+          "name": "autoUse",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.UseMode"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "conditionalSeparation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "configurationExtensionsSeparation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.DataSeparation"
+          ]
+        },
+        {
+          "name": "content",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "dataSeparation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.DataSeparation"
+          ]
+        },
+        {
+          "name": "dataSeparationUse",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "dataSeparationValue",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "indexing",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.IndexingType"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "passwordMode",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "usersSeparation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.DataSeparation"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonCommand",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonCommand$CommonCommandBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonForm",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonForm$CommonFormBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "data",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.FormData"
+          ]
+        },
+        {
+          "name": "formType",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.FormType"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonModule",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonModule$CommonModuleBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "clientManagedApplication",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "clientOrdinaryApplication",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "externalConnection",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "global",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "isProtected",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "privileged",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "returnValuesReuse",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.ReturnValueReuse"
+          ]
+        },
+        {
+          "name": "server",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "serverCall",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uri",
+          "parameterTypes": [
+            "java.net.URI"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonPicture",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonPicture$CommonPictureBuilder",
+      "methods": [
+        {
+          "name": "availabilityForAppearance",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "availabilityForChoice",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonTemplate",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.CommonTemplate$CommonTemplateBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "data",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.TemplateData"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "templateType",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.TemplateType"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Constant",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Constant$ConstantBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "passwordMode",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.DataProcessor",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.DataProcessor$DataProcessorBuilder",
+      "methods": [
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "commands",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "tabularSections",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "templates",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.DefinedType",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.DefinedType$DefinedTypeBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Document",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Document$DocumentBuilder",
+      "methods": [
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "commands",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "registerRecords",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "tabularSections",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "templates",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.DocumentJournal",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.DocumentJournal$DocumentJournalBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "columns",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "commands",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "registeredDocuments",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "templates",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.DocumentNumerator"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Enum",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Enum$EnumBuilder",
+      "methods": [
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "enumValues",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.EventSubscription",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.EventSubscription$EventSubscriptionBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "event",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "handler",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.Handler"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "source",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ExchangePlan",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ExchangePlan$ExchangePlanBuilder",
+      "methods": [
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "content",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "distributedInfoBase",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "includeConfigurationExtensions",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ExchangePlan$RecordContent"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ExternalDataSource"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.FilterCriterion",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.FilterCriterion$FilterCriterionBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.FunctionalOption",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.FunctionalOption$FunctionalOptionBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "content",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "location",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "privilegedGetMode",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.FunctionalOptionsParameter",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.FunctionalOptionsParameter$FunctionalOptionsParameterBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "use",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.HTTPService",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.HTTPService$HTTPServiceBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "urlTemplates",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.InformationRegister",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.InformationRegister$InformationRegisterBuilder",
+      "methods": [
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "commands",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "dimensions",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "resources",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "templates",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.IntegrationService"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Interface"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Language",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Language$LanguageBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "languageCode",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.PaletteColor"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Report",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Report$ReportBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "templates",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Role",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Role$RoleBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "data",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.RoleData"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ScheduledJob",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.ScheduledJob$ScheduledJobBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "description",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "key",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "methodName",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.Handler"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "predefined",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "restartCountOnFailure",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "restartIntervalOnFailure",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "use",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Sequence"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.SessionParameter",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.SessionParameter$SessionParameterBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.SettingsStorage",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.SettingsStorage$SettingsStorageBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Style"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.StyleItem",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.StyleItem$StyleItemBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Subsystem",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Subsystem$SubsystemBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "content",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "includeHelpInContents",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "includeInCommandInterface",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "parentSubsystem",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "subsystems",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Task",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.Task$TaskBuilder",
+      "methods": [
+        {
+          "name": "addressingAttributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "commands",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "explanation",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "forms",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.WSReference"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.WebService",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.WebService$WebServiceBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "descriptorFileName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "namespace",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "operations",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "reuseSessions",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.ReuseSessions"
+          ]
+        },
+        {
+          "name": "sessionMaxAge",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.WebSocketClient"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.XDTOPackage",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.XDTOPackage$XDTOPackageBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "data",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.XdtoPackageData"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "namespace",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.Dimension",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.Dimension$DimensionBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "denyIncompleteValues",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "indexing",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.IndexingType"
+          ]
+        },
+        {
+          "name": "master",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "passwordMode",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.DocumentJournalColumn$DocumentJournalColumnBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "indexing",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.IndexingType"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "references",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.EnumValue",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.EnumValue$EnumValueBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.HTTPServiceMethod",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.HTTPServiceMethod$HTTPServiceMethodBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "handler",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.HTTPServiceURLTemplate",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.HTTPServiceURLTemplate$HTTPServiceURLTemplateBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "methods",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "template",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectAttribute",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectAttribute$ObjectAttributeBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "editFormat",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "extendedEdit",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "fillFromFillingValue",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "format",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "indexing",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.IndexingType"
+          ]
+        },
+        {
+          "name": "markNegatives",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "mask",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "multiLine",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "passwordMode",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectCommand",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectCommand$ObjectCommandBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectForm",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectForm$ObjectFormBuilder",
+      "methods": [
+        {
+          "name": "addUsePurposes",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.UsePurposes"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "data",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.FormData"
+          ]
+        },
+        {
+          "name": "formType",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.FormType"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "modules",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectTabularSection$ObjectTabularSectionBuilder",
+      "methods": [
+        {
+          "name": "attributes",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectTemplate",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.ObjectTemplate$ObjectTemplateBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "data",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.TemplateData"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "templateType",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.TemplateType"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.Resource",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.Resource$ResourceBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "indexing",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.IndexingType"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "passwordMode",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.StandardAttribute",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.StandardAttribute$StandardAttributeBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "editFormat",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "extendedEdit",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "fillFromFillingValue",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "format",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "fullName",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiName"
+          ]
+        },
+        {
+          "name": "markNegatives",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "mask",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "multiLine",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "passwordMode",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.TaskAddressingAttribute$TaskAddressingAttributeBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "editFormat",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "extendedEdit",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "fillFromFillingValue",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "format",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "indexing",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.IndexingType"
+          ]
+        },
+        {
+          "name": "markNegatives",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "mask",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "multiLine",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "passwordMode",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "toolTip",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.WebServiceOperation",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.WebServiceOperation$WebServiceOperationBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "dataLockControlMode",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.DataLockControlMode"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "nillable",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "parameters",
+          "parameterTypes": [
+            "java.util.Collection"
+          ]
+        },
+        {
+          "name": "procedureName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "transactioned",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter$WebServiceOperationParameterBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "comment",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "mdoReference",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "nillable",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "owner",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        },
+        {
+          "name": "supportVariant",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.support.SupportVariant"
+          ]
+        },
+        {
+          "name": "synonym",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "transferDirection",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.TransferDirection"
+          ]
+        },
+        {
+          "name": "uuid",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.DataCompositionSchema"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.ManagedFormData$ManagedFormDataBuilder",
+      "methods": [
+        {
+          "name": "addAttributes",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute"
+          ]
+        },
+        {
+          "name": "addHandlers",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.form.FormHandler"
+          ]
+        },
+        {
+          "name": "addItems",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.form.FormItem"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "title",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.RoleData"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.RoleData$ObjectRight$ObjectRightBuilder",
+      "methods": [
+        {
+          "name": "name",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MdoReference"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.RoleData$Right$RightBuilder",
+      "methods": [
+        {
+          "name": "name",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.support.RoleRight"
+          ]
+        },
+        {
+          "name": "value",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.RoleData$RoleDataBuilder",
+      "methods": [
+        {
+          "name": "independentRightsOfChildObjects",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setForAttributesByDefault",
+          "parameterTypes": [
+            "boolean"
+          ]
+        },
+        {
+          "name": "setForNewObjects",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.XdtoPackageData"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.form.FormAttribute$FormAttributeBuilder",
+      "methods": [
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "id",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "title",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.ValueTypeDescription"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.form.FormElementType",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem",
+      "methods": [
+        {
+          "name": "builder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.storage.form.SimpleFormItem$SimpleFormItemBuilder",
+      "methods": [
+        {
+          "name": "addItems",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.form.FormItem"
+          ]
+        },
+        {
+          "name": "build",
+          "parameterTypes": []
+        },
+        {
+          "name": "dataPath",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "id",
+          "parameterTypes": [
+            "int"
+          ]
+        },
+        {
+          "name": "name",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "title",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.types.MultiLanguageString"
+          ]
+        },
+        {
+          "name": "type",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.mdo.storage.form.FormElementType"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.ApplicationRunMode",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.AutoRecordType",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.CodeSeries",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.ConfigurationExtensionPurpose"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.DataLockControlMode",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.DataSeparation",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.FormType",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.IndexingType",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.InterfaceCompatibilityMode",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.MessageDirection"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.ObjectBelonging"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.ReturnValueReuse",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.ReuseSessions",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.RoleRight",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.TemplateType",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.TransferDirection",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.UseMode",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.mdo.support.UsePurposes",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.BSLDescriptionParser",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.antlr.v4.runtime.TokenStream"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.BSLParser",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.antlr.v4.runtime.IncrementalTokenStream"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.BSLParserBaseListener"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.BSLParserBaseVisitor"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.BSLParserListener"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.BSLParserVisitor"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.SDBLParserBaseListener"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.SDBLParserBaseVisitor"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.SDBLParserListener"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.parser.SDBLParserVisitor"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.AllStringConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.CommonAttributeUseContentConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.CommonModuleConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.CompatibilityModeConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.ConfigurationConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.DataCompositionSchemaConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.DataSetConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.ExchangePlanAutoRecordConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.MethodHandlerConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.MultiLanguageStringConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.QuerySourceConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.RoleDataConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.SubsystemConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.ValueTypeConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.ValueTypeDescriptionConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.ValueTypeQualifierConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.common.converter.XdtoPackageDataConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.DesignerRootWrapper"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.ExchangePlanConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.ExternalSourceConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.FormAttributeConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.FormElementConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.FormHandlerConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.MDChildConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.MDConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.ManagedFormDataConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.MdoReferenceConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.MetaDataObjectConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.RoleConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.StandardAttributeConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.TemplateConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.reader.designer.converter.XDTOPackageConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.types.DateFractions"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.types.ModuleType"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.types.ModuleType[]"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.types.ScriptVariant",
+      "methods": [
+        {
+          "name": "valueByName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.utils.GenericInterner"
+    },
+    {
+      "type": "com.github._1c_syntax.utils.StringInterner"
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.Cache"
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.Caffeine"
+    },
+    {
+      "type": "com.github.benmanes.caffeine.cache.UnboundedLocalCache",
+      "fields": [
+        {
+          "name": "refreshes"
+        }
+      ]
+    },
+    {
+      "type": "com.google.gson.Gson"
+    },
+    {
+      "type": "com.hazelcast.core.Hazelcast"
+    },
+    {
+      "type": "com.hazelcast.core.HazelcastInstance"
+    },
+    {
+      "type": "com.hazelcast.spring.cache.HazelcastCache"
+    },
+    {
+      "type": "com.rometools.rome.feed.WireFeed"
+    },
+    {
+      "type": "com.sun.org.apache.xerces.internal.jaxp.SAXParserFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.sun.xml.internal.stream.XMLInputFactoryImpl",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.thoughtworks.xstream.converters.reflection.FieldUtil15",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.thoughtworks.xstream.converters.reflection.PureJavaReflectionProvider"
+    },
+    {
+      "type": "com.thoughtworks.xstream.converters.reflection.SunUnsafeReflectionProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.thoughtworks.xstream.core.JVM"
+    },
+    {
+      "type": "com.thoughtworks.xstream.core.JVM$Test",
+      "unsafeAllocated": true,
+      "fields": [
+        {
+          "name": "b"
+        },
+        {
+          "name": "bool"
+        },
+        {
+          "name": "c"
+        },
+        {
+          "name": "d"
+        },
+        {
+          "name": "f"
+        },
+        {
+          "name": "i"
+        },
+        {
+          "name": "l"
+        },
+        {
+          "name": "o"
+        },
+        {
+          "name": "s"
+        }
+      ]
+    },
+    {
+      "type": "com.thoughtworks.xstream.core.util.Base64JavaUtilCodec",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.thoughtworks.xstream.core.util.CustomObjectOutputStream"
+    },
+    {
+      "type": "com.thoughtworks.xstream.core.util.SerializationMembers$NO_METHOD_MARKER"
+    },
+    {
+      "type": "com.thoughtworks.xstream.io.xml.XmlFriendlyNameCoder",
+      "methods": [
+        {
+          "name": "clone",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.AnnotationConfiguration"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.AttributeAliasingMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.AttributeMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.ClassAliasingMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.DefaultImplementationsMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.DefaultMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.ElementIgnoringMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.FieldAliasingMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.ImmutableTypesMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.ImplicitCollectionMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.LocalConversionMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.Mapper$Null"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.MapperWrapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.PackageAliasingMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.SecurityMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.mapper.SystemAttributeAliasingMapper"
+    },
+    {
+      "type": "com.thoughtworks.xstream.security.ArrayTypePermission"
+    },
+    {
+      "type": "com.thoughtworks.xstream.security.InterfaceTypePermission"
+    },
+    {
+      "type": "com.thoughtworks.xstream.security.NoTypePermission"
+    },
+    {
+      "type": "com.thoughtworks.xstream.security.PrimitiveTypePermission"
+    },
+    {
+      "type": "double[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "float[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "graphql.GraphQLError"
+    },
+    {
+      "type": "groovy.lang.Closure"
+    },
+    {
+      "type": "groovy.lang.MetaClass"
+    },
+    {
+      "type": "int[]"
+    },
+    {
+      "type": "io.micrometer.core.instrument.MeterRegistry"
+    },
+    {
+      "type": "io.micrometer.core.instrument.binder.MeterBinder"
+    },
+    {
+      "type": "io.micrometer.core.instrument.binder.tomcat.TomcatMetrics"
+    },
+    {
+      "type": "io.micrometer.observation.Observation"
+    },
+    {
+      "type": "io.micrometer.observation.contextpropagation.ObservationThreadLocalAccessor"
+    },
+    {
+      "type": "io.opentelemetry.api.OpenTelemetry"
+    },
+    {
+      "type": "io.sentry.EventProcessor"
+    },
+    {
+      "type": "io.sentry.IScopes"
+    },
+    {
+      "type": "io.sentry.ScopesAdapter",
+      "methods": [
+        {
+          "name": "close",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.Sentry$OptionsConfiguration"
+    },
+    {
+      "type": "io.sentry.SentryOptions",
+      "methods": [
+        {
+          "name": "setDsn",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.SentryOptions$BeforeSendCallback"
+    },
+    {
+      "type": "io.sentry.SentryOptions$TracesSamplerCallback"
+    },
+    {
+      "type": "io.sentry.asyncprofiler.profiling.JavaContinuousProfiler"
+    },
+    {
+      "type": "io.sentry.graphql.SentryInstrumentation"
+    },
+    {
+      "type": "io.sentry.graphql22.SentryInstrumentation"
+    },
+    {
+      "type": "io.sentry.kafka.SentryKafkaProducer"
+    },
+    {
+      "type": "io.sentry.logback.SentryAppender"
+    },
+    {
+      "type": "io.sentry.opentelemetry.OtelContextScopesStorage"
+    },
+    {
+      "type": "io.sentry.opentelemetry.OtelSpanFactory"
+    },
+    {
+      "type": "io.sentry.opentelemetry.SentryAutoConfigurationCustomizerProvider"
+    },
+    {
+      "type": "io.sentry.opentelemetry.agent.AgentMarker"
+    },
+    {
+      "type": "io.sentry.opentelemetry.agent.AgentlessMarker"
+    },
+    {
+      "type": "io.sentry.opentelemetry.agent.AgentlessSpringMarker"
+    },
+    {
+      "type": "io.sentry.quartz.SentryJobListener"
+    },
+    {
+      "type": "io.sentry.reactor.SentryReactorThreadLocalAccessor"
+    },
+    {
+      "type": "io.sentry.spotlight.SpotlightIntegration"
+    },
+    {
+      "type": "io.sentry.spring.boot4.InAppIncludesResolver"
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryAutoConfiguration$HubConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "inAppPackagesResolver",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryHub",
+          "parameterTypes": [
+            "java.util.List",
+            "io.sentry.spring.boot4.SentryProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryAutoConfiguration$HubConfiguration$ContextTagsEventProcessorConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "contextTagsEventProcessor",
+          "parameterTypes": [
+            "io.sentry.SentryOptions"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryAutoConfiguration$HubConfiguration$SentryCheckInAspectsConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryAutoConfiguration$HubConfiguration$SentryCheckInAspectsConfiguration$SentryCheckInPointcutAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryAutoConfiguration$HubConfiguration$SentryErrorAspectsConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryAutoConfiguration$HubConfiguration$SentryErrorAspectsConfiguration$SentryCaptureExceptionParameterPointcutAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryAutoConfiguration$SentryTracingCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryAutoConfiguration$SpringProfilesEventProcessorConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "springProfilesEventProcessor",
+          "parameterTypes": [
+            "org.springframework.core.env.Environment"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryLogbackAppenderAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryLogbackInitializer",
+          "parameterTypes": [
+            "io.sentry.spring.boot4.SentryProperties"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryLogbackInitializer"
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentryProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setUseGitCommitIdAsRelease",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring.boot4.SentrySpringVersionChecker",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring7.ContextTagsEventProcessor"
+    },
+    {
+      "type": "io.sentry.spring7.SentryTaskDecorator"
+    },
+    {
+      "type": "io.sentry.spring7.SpringProfilesEventProcessor"
+    },
+    {
+      "type": "io.sentry.spring7.checkin.SentryCheckInAdvice"
+    },
+    {
+      "type": "io.sentry.spring7.checkin.SentryCheckInAdviceConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryCheckInAdvice",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryCheckInAdvisor",
+          "parameterTypes": [
+            "org.springframework.aop.Pointcut",
+            "org.aopalliance.aop.Advice"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring7.checkin.SentryCheckInPointcutConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryCheckInPointcut",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring7.exception.SentryCaptureExceptionParameterAdvice"
+    },
+    {
+      "type": "io.sentry.spring7.exception.SentryCaptureExceptionParameterPointcutConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryCaptureExceptionParameterPointcut",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.spring7.exception.SentryExceptionParameterAdviceConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryCaptureExceptionParameterAdvice",
+          "parameterTypes": []
+        },
+        {
+          "name": "sentryCaptureExceptionParameterAdvisor",
+          "parameterTypes": [
+            "org.springframework.aop.Pointcut",
+            "org.aopalliance.aop.Advice"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "io.sentry.transport.apache.ApacheHttpClientTransportFactory"
+    },
+    {
+      "type": "jakarta.annotation.Nullable"
+    },
+    {
+      "type": "jakarta.annotation.PostConstruct"
+    },
+    {
+      "type": "jakarta.annotation.PreDestroy"
+    },
+    {
+      "type": "jakarta.annotation.Resource"
+    },
+    {
+      "type": "jakarta.ejb.EJB"
+    },
+    {
+      "type": "jakarta.inject.Inject"
+    },
+    {
+      "type": "jakarta.inject.Named"
+    },
+    {
+      "type": "jakarta.inject.Provider"
+    },
+    {
+      "type": "jakarta.inject.Qualifier"
+    },
+    {
+      "type": "jakarta.json.bind.Jsonb"
+    },
+    {
+      "type": "jakarta.persistence.EntityManagerFactory"
+    },
+    {
+      "type": "jakarta.servlet.MultipartConfigElement"
+    },
+    {
+      "type": "jakarta.servlet.Servlet"
+    },
+    {
+      "type": "jakarta.servlet.ServletRequest"
+    },
+    {
+      "type": "jakarta.validation.Validator"
+    },
+    {
+      "type": "jakarta.websocket.Endpoint"
+    },
+    {
+      "type": "jakarta.xml.bind.Binder"
+    },
+    {
+      "type": "java$lang$Pointcuts"
+    },
+    {
+      "type": "java.awt.Color"
+    },
+    {
+      "type": "java.awt.Font"
+    },
+    {
+      "type": "java.awt.Image"
+    },
+    {
+      "type": "java.awt.font.TextAttribute"
+    },
+    {
+      "type": "java.beans.ConstructorProperties"
+    },
+    {
+      "type": "java.beans.PropertyVetoException"
+    },
+    {
+      "type": "java.io.Closeable"
+    },
+    {
+      "type": "java.io.File"
+    },
+    {
+      "type": "java.io.File[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.io.Flushable"
+    },
+    {
+      "type": "java.io.IOException"
+    },
+    {
+      "type": "java.io.InputStream"
+    },
+    {
+      "type": "java.io.PrintWriter"
+    },
+    {
+      "type": "java.io.Serializable"
+    },
+    {
+      "type": "java.io.Serializable[]"
+    },
+    {
+      "type": "java.io.Writer"
+    },
+    {
+      "type": "java.lang$Pointcuts"
+    },
+    {
+      "type": "java.lang.Appendable"
+    },
+    {
+      "type": "java.lang.AutoCloseable"
+    },
+    {
+      "type": "java.lang.Boolean",
+      "jniAccessible": true,
+      "methods": [
+        {
+          "name": "getBoolean",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Boolean[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.lang.Byte"
+    },
+    {
+      "type": "java.lang.Byte[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.lang.CharSequence[]"
+    },
+    {
+      "type": "java.lang.Character"
+    },
+    {
+      "type": "java.lang.Character[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.lang.Class",
+      "methods": [
+        {
+          "name": "getModule",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.ClassLoader",
+      "fields": [
+        {
+          "name": "classLoaderValueMap"
+        }
+      ],
+      "methods": [
+        {
+          "name": "registerAsParallelCapable",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Class[]"
+    },
+    {
+      "type": "java.lang.CloneNotSupportedException"
+    },
+    {
+      "type": "java.lang.Cloneable"
+    },
+    {
+      "type": "java.lang.Comparable"
+    },
+    {
+      "type": "java.lang.Comparable[]"
+    },
+    {
+      "type": "java.lang.Double"
+    },
+    {
+      "type": "java.lang.Double[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.lang.Enum",
+      "methods": [
+        {
+          "name": "valueOf",
+          "parameterTypes": [
+            "java.lang.Class",
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Error"
+    },
+    {
+      "type": "java.lang.Float"
+    },
+    {
+      "type": "java.lang.Float[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.lang.FunctionalInterface"
+    },
+    {
+      "type": "java.lang.Integer"
+    },
+    {
+      "type": "java.lang.Integer[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.lang.InterruptedException"
+    },
+    {
+      "type": "java.lang.Iterable"
+    },
+    {
+      "type": "java.lang.Long"
+    },
+    {
+      "type": "java.lang.Long[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.lang.Module",
+      "methods": [
+        {
+          "name": "getLayer",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.ModuleLayer",
+      "methods": [
+        {
+          "name": "boot",
+          "parameterTypes": []
+        },
+        {
+          "name": "configuration",
+          "parameterTypes": []
+        },
+        {
+          "name": "findLoader",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "parents",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Number"
+    },
+    {
+      "type": "java.lang.Object",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.ObjectBeanInfo"
+    },
+    {
+      "type": "java.lang.ObjectCustomizer"
+    },
+    {
+      "type": "java.lang.Object[]"
+    },
+    {
+      "type": "java.lang.Pointcuts"
+    },
+    {
+      "type": "java.lang.RuntimeException"
+    },
+    {
+      "type": "java.lang.Short"
+    },
+    {
+      "type": "java.lang.Short[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.lang.StackTraceElement"
+    },
+    {
+      "type": "java.lang.StackWalker",
+      "methods": [
+        {
+          "name": "forEach",
+          "parameterTypes": [
+            "java.util.function.Consumer"
+          ]
+        },
+        {
+          "name": "getInstance",
+          "parameterTypes": [
+            "java.lang.StackWalker$Option"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.StackWalker$Option"
+    },
+    {
+      "type": "java.lang.StackWalker$StackFrame",
+      "methods": [
+        {
+          "name": "getDeclaringClass",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.String",
+      "serializable": true
+    },
+    {
+      "type": "java.lang.StringBuffer"
+    },
+    {
+      "type": "java.lang.StringBuilder"
+    },
+    {
+      "type": "java.lang.String[]"
+    },
+    {
+      "type": "java.lang.System",
+      "methods": [
+        {
+          "name": "getSecurityManager",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Thread",
+      "fields": [
+        {
+          "name": "threadLocalRandomProbe"
+        }
+      ]
+    },
+    {
+      "type": "java.lang.Throwable"
+    },
+    {
+      "type": "java.lang.Void"
+    },
+    {
+      "type": "java.lang.annotation.Documented"
+    },
+    {
+      "type": "java.lang.annotation.Inherited"
+    },
+    {
+      "type": "java.lang.annotation.Repeatable"
+    },
+    {
+      "type": "java.lang.annotation.Retention"
+    },
+    {
+      "type": "java.lang.annotation.Target"
+    },
+    {
+      "type": "java.lang.constant.Constable"
+    },
+    {
+      "type": "java.lang.constant.Constable[]"
+    },
+    {
+      "type": "java.lang.constant.ConstantDesc[]"
+    },
+    {
+      "type": "java.lang.invoke.SerializedLambda"
+    },
+    {
+      "type": "java.lang.invoke.TypeDescriptor"
+    },
+    {
+      "type": "java.lang.invoke.TypeDescriptor$OfField"
+    },
+    {
+      "type": "java.lang.module.Configuration",
+      "methods": [
+        {
+          "name": "modules",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.module.ModuleDescriptor",
+      "methods": [
+        {
+          "name": "name",
+          "parameterTypes": []
+        },
+        {
+          "name": "packages",
+          "parameterTypes": []
+        },
+        {
+          "name": "rawVersion",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.module.ModuleReader",
+      "methods": [
+        {
+          "name": "list",
+          "parameterTypes": []
+        },
+        {
+          "name": "open",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.lang.module.ModuleReference",
+      "methods": [
+        {
+          "name": "descriptor",
+          "parameterTypes": []
+        },
+        {
+          "name": "location",
+          "parameterTypes": []
+        },
+        {
+          "name": "open",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.module.ResolvedModule",
+      "methods": [
+        {
+          "name": "reference",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.reflect.AccessibleObject",
+      "methods": [
+        {
+          "name": "canAccess",
+          "parameterTypes": [
+            "java.lang.Object"
+          ]
+        },
+        {
+          "name": "trySetAccessible",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.reflect.AnnotatedElement"
+    },
+    {
+      "type": "java.lang.reflect.Constructor"
+    },
+    {
+      "type": "java.lang.reflect.Field"
+    },
+    {
+      "type": "java.lang.reflect.GenericDeclaration"
+    },
+    {
+      "type": "java.lang.reflect.Member"
+    },
+    {
+      "type": "java.lang.reflect.Method"
+    },
+    {
+      "type": "java.lang.reflect.ParameterizedType",
+      "methods": [
+        {
+          "name": "getActualTypeArguments",
+          "parameterTypes": []
+        },
+        {
+          "name": "getRawType",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.reflect.Type"
+    },
+    {
+      "type": "java.lang.reflect.TypeVariable",
+      "methods": [
+        {
+          "name": "getBounds",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.lang.reflect.UndeclaredThrowableException"
+    },
+    {
+      "type": "java.lang.reflect.WildcardType",
+      "methods": [
+        {
+          "name": "getUpperBounds",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.math.BigDecimal"
+    },
+    {
+      "type": "java.math.BigDecimal[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.math.BigInteger"
+    },
+    {
+      "type": "java.math.BigInteger[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.net.URI"
+    },
+    {
+      "type": "java.net.URL"
+    },
+    {
+      "type": "java.net.URL[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.nio.charset.Charset"
+    },
+    {
+      "type": "java.nio.file.Path"
+    },
+    {
+      "type": "java.nio.file.Paths"
+    },
+    {
+      "type": "java.security.AccessController",
+      "methods": [
+        {
+          "name": "doPrivileged",
+          "parameterTypes": [
+            "java.security.PrivilegedAction"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.security.PrivilegedAction"
+    },
+    {
+      "type": "java.security.SecureClassLoader"
+    },
+    {
+      "type": "java.sql.Connection"
+    },
+    {
+      "type": "java.sql.Date"
+    },
+    {
+      "type": "java.sql.Date[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.sql.Driver"
+    },
+    {
+      "type": "java.sql.DriverManager"
+    },
+    {
+      "type": "java.sql.Time"
+    },
+    {
+      "type": "java.sql.Time[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.sql.Timestamp"
+    },
+    {
+      "type": "java.sql.Timestamp[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.text.DecimalFormatSymbols"
+    },
+    {
+      "type": "java.time.Clock"
+    },
+    {
+      "type": "java.time.Clock$FixedClock"
+    },
+    {
+      "type": "java.time.Clock$OffsetClock"
+    },
+    {
+      "type": "java.time.Clock$SystemClock"
+    },
+    {
+      "type": "java.time.Clock$TickClock"
+    },
+    {
+      "type": "java.time.DayOfWeek"
+    },
+    {
+      "type": "java.time.Duration"
+    },
+    {
+      "type": "java.time.Instant"
+    },
+    {
+      "type": "java.time.LocalDate"
+    },
+    {
+      "type": "java.time.LocalDateTime"
+    },
+    {
+      "type": "java.time.LocalTime"
+    },
+    {
+      "type": "java.time.Month"
+    },
+    {
+      "type": "java.time.MonthDay"
+    },
+    {
+      "type": "java.time.OffsetDateTime"
+    },
+    {
+      "type": "java.time.OffsetTime"
+    },
+    {
+      "type": "java.time.Period"
+    },
+    {
+      "type": "java.time.Ser"
+    },
+    {
+      "type": "java.time.Year"
+    },
+    {
+      "type": "java.time.YearMonth"
+    },
+    {
+      "type": "java.time.ZoneId"
+    },
+    {
+      "type": "java.time.ZoneOffset"
+    },
+    {
+      "type": "java.time.ZonedDateTime"
+    },
+    {
+      "type": "java.time.chrono.Chronology"
+    },
+    {
+      "type": "java.time.chrono.HijrahDate"
+    },
+    {
+      "type": "java.time.chrono.HijrahEra"
+    },
+    {
+      "type": "java.time.chrono.JapaneseDate"
+    },
+    {
+      "type": "java.time.chrono.JapaneseEra"
+    },
+    {
+      "type": "java.time.chrono.MinguoDate"
+    },
+    {
+      "type": "java.time.chrono.MinguoEra"
+    },
+    {
+      "type": "java.time.chrono.Ser"
+    },
+    {
+      "type": "java.time.chrono.ThaiBuddhistDate"
+    },
+    {
+      "type": "java.time.chrono.ThaiBuddhistEra"
+    },
+    {
+      "type": "java.time.temporal.ChronoField"
+    },
+    {
+      "type": "java.time.temporal.ChronoUnit"
+    },
+    {
+      "type": "java.time.temporal.IsoFields$Field"
+    },
+    {
+      "type": "java.time.temporal.IsoFields$Unit"
+    },
+    {
+      "type": "java.time.temporal.JulianFields$Field"
+    },
+    {
+      "type": "java.time.temporal.ValueRange"
+    },
+    {
+      "type": "java.time.temporal.WeekFields"
+    },
+    {
+      "type": "java.util.AbstractCollection"
+    },
+    {
+      "type": "java.util.AbstractList"
+    },
+    {
+      "type": "java.util.AbstractMap"
+    },
+    {
+      "type": "java.util.ArrayList"
+    },
+    {
+      "type": "java.util.BitSet"
+    },
+    {
+      "type": "java.util.Calendar"
+    },
+    {
+      "type": "java.util.Calendar[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.util.Collection"
+    },
+    {
+      "type": "java.util.Currency"
+    },
+    {
+      "type": "java.util.Date"
+    },
+    {
+      "type": "java.util.Date[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "java.util.EnumMap"
+    },
+    {
+      "type": "java.util.EnumSet"
+    },
+    {
+      "type": "java.util.EventListener"
+    },
+    {
+      "type": "java.util.GregorianCalendar"
+    },
+    {
+      "type": "java.util.HashMap"
+    },
+    {
+      "type": "java.util.HashSet"
+    },
+    {
+      "type": "java.util.Hashtable"
+    },
+    {
+      "type": "java.util.LinkedHashMap"
+    },
+    {
+      "type": "java.util.LinkedHashSet"
+    },
+    {
+      "type": "java.util.LinkedList"
+    },
+    {
+      "type": "java.util.List"
+    },
+    {
+      "type": "java.util.Locale"
+    },
+    {
+      "type": "java.util.Map"
+    },
+    {
+      "type": "java.util.Map$Entry"
+    },
+    {
+      "type": "java.util.Optional",
+      "methods": [
+        {
+          "name": "get",
+          "parameterTypes": []
+        },
+        {
+          "name": "isPresent",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.util.OptionalDouble"
+    },
+    {
+      "type": "java.util.OptionalInt"
+    },
+    {
+      "type": "java.util.OptionalLong"
+    },
+    {
+      "type": "java.util.Properties"
+    },
+    {
+      "type": "java.util.RandomAccess"
+    },
+    {
+      "type": "java.util.SequencedCollection"
+    },
+    {
+      "type": "java.util.Set"
+    },
+    {
+      "type": "java.util.SortedSet"
+    },
+    {
+      "type": "java.util.TimeZone"
+    },
+    {
+      "type": "java.util.TreeMap"
+    },
+    {
+      "type": "java.util.TreeSet"
+    },
+    {
+      "type": "java.util.UUID"
+    },
+    {
+      "type": "java.util.Vector"
+    },
+    {
+      "type": "java.util.WeakHashMap"
+    },
+    {
+      "type": "java.util.concurrent.Callable"
+    },
+    {
+      "type": "java.util.concurrent.CompletableFuture"
+    },
+    {
+      "type": "java.util.concurrent.ConcurrentHashMap",
+      "serializable": true
+    },
+    {
+      "type": "java.util.concurrent.ConcurrentHashMap$Segment",
+      "serializable": true
+    },
+    {
+      "type": "java.util.concurrent.ConcurrentHashMap$Segment[]",
+      "serializable": true
+    },
+    {
+      "type": "java.util.concurrent.Executor",
+      "methods": [
+        {
+          "name": "execute",
+          "parameterTypes": [
+            "java.lang.Runnable"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.util.concurrent.ExecutorService",
+      "methods": [
+        {
+          "name": "submit",
+          "parameterTypes": [
+            "java.lang.Runnable"
+          ]
+        },
+        {
+          "name": "submit",
+          "parameterTypes": [
+            "java.util.concurrent.Callable"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "java.util.concurrent.ScheduledExecutorService"
+    },
+    {
+      "type": "java.util.concurrent.ThreadFactory"
+    },
+    {
+      "type": "java.util.concurrent.atomic.AtomicBoolean"
+    },
+    {
+      "type": "java.util.concurrent.atomic.AtomicInteger"
+    },
+    {
+      "type": "java.util.concurrent.atomic.AtomicLong"
+    },
+    {
+      "type": "java.util.concurrent.atomic.AtomicReference"
+    },
+    {
+      "type": "java.util.concurrent.locks.AbstractOwnableSynchronizer",
+      "serializable": true
+    },
+    {
+      "type": "java.util.concurrent.locks.AbstractQueuedSynchronizer",
+      "serializable": true
+    },
+    {
+      "type": "java.util.concurrent.locks.ReentrantLock",
+      "serializable": true
+    },
+    {
+      "type": "java.util.concurrent.locks.ReentrantLock$NonfairSync",
+      "serializable": true
+    },
+    {
+      "type": "java.util.concurrent.locks.ReentrantLock$Sync",
+      "serializable": true
+    },
+    {
+      "type": "java.util.function.Consumer"
+    },
+    {
+      "type": "java.util.logging.LogManager"
+    },
+    {
+      "type": "java.util.logging.SimpleFormatter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.util.regex.Pattern"
+    },
+    {
+      "type": "java.util.stream.AbstractPipeline"
+    },
+    {
+      "type": "java.util.stream.BaseStream"
+    },
+    {
+      "type": "java.util.stream.Collector"
+    },
+    {
+      "type": "java.util.stream.Collectors",
+      "methods": [
+        {
+          "name": "toList",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "java.util.stream.PipelineHelper"
+    },
+    {
+      "type": "java.util.stream.ReferencePipeline"
+    },
+    {
+      "type": "java.util.stream.ReferencePipeline$Head"
+    },
+    {
+      "type": "java.util.stream.Stream",
+      "methods": [
+        {
+          "name": "collect",
+          "parameterTypes": [
+            "java.util.stream.Collector"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "javax.activation.ActivationDataFlavor"
+    },
+    {
+      "type": "javax.annotation.Nonnull"
+    },
+    {
+      "type": "javax.annotation.Nullable"
+    },
+    {
+      "type": "javax.annotation.meta.TypeQualifier"
+    },
+    {
+      "type": "javax.cache.Cache"
+    },
+    {
+      "type": "javax.cache.CacheManager"
+    },
+    {
+      "type": "javax.cache.Caching"
+    },
+    {
+      "type": "javax.money.MonetaryAmount"
+    },
+    {
+      "type": "javax.naming.InitialContext"
+    },
+    {
+      "type": "javax.security.auth.Subject"
+    },
+    {
+      "type": "javax.swing.LookAndFeel"
+    },
+    {
+      "type": "javax.xml.datatype.Duration"
+    },
+    {
+      "type": "jdk.crac.management.CRaCMXBean"
+    },
+    {
+      "type": "jdk.internal.loader.BuiltinClassLoader",
+      "fields": [
+        {
+          "name": "ucp"
+        }
+      ]
+    },
+    {
+      "type": "jdk.internal.loader.ClassLoaders$AppClassLoader"
+    },
+    {
+      "type": "jdk.internal.loader.ClassLoaders$PlatformClassLoader"
+    },
+    {
+      "type": "jdk.internal.misc.Unsafe"
+    },
+    {
+      "type": "jdk.internal.module.ModuleReferenceImpl"
+    },
+    {
+      "type": "jdk.internal.module.SystemModuleFinders$SystemModuleReader"
+    },
+    {
+      "type": "kotlin.Metadata"
+    },
+    {
+      "type": "kotlin.reflect.full.KClasses"
+    },
+    {
+      "type": "kotlinx.coroutines.reactor.MonoKt"
+    },
+    {
+      "type": "kotlinx.serialization.Serializable"
+    },
+    {
+      "type": "kotlinx.serialization.cbor.Cbor"
+    },
+    {
+      "type": "kotlinx.serialization.json.Json"
+    },
+    {
+      "type": "kotlinx.serialization.protobuf.ProtoBuf"
+    },
+    {
+      "type": "long[]"
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.AntClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.ClassGraphClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.CxfContainerClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.EquinoxClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.EquinoxContextFinderClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.FallbackClassLoaderHandler"
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.FelixClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.JBossClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.JPMSClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        },
+        {
+          "name": "findClassLoaderOrder",
+          "parameterTypes": [
+            "java.lang.ClassLoader",
+            "nonapi.io.github.classgraph.classpath.ClassLoaderOrder",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        },
+        {
+          "name": "findClasspathOrder",
+          "parameterTypes": [
+            "java.lang.ClassLoader",
+            "nonapi.io.github.classgraph.classpath.ClasspathOrder",
+            "nonapi.io.github.classgraph.scanspec.ScanSpec",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.OSGiDefaultClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.ParentLastDelegationOrderTestClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.PlexusClassWorldsClassRealmClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.QuarkusClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.SpringBootRestartClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.TomcatWebappClassLoaderBaseHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.URLClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        },
+        {
+          "name": "findClassLoaderOrder",
+          "parameterTypes": [
+            "java.lang.ClassLoader",
+            "nonapi.io.github.classgraph.classpath.ClassLoaderOrder",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        },
+        {
+          "name": "findClasspathOrder",
+          "parameterTypes": [
+            "java.lang.ClassLoader",
+            "nonapi.io.github.classgraph.classpath.ClasspathOrder",
+            "nonapi.io.github.classgraph.scanspec.ScanSpec",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.UnoOneJarClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.WeblogicClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.WebsphereLibertyClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.classloaderhandler.WebsphereTraditionalClassLoaderHandler",
+      "methods": [
+        {
+          "name": "canHandle",
+          "parameterTypes": [
+            "java.lang.Class",
+            "nonapi.io.github.classgraph.utils.LogNode"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "nonapi.io.github.classgraph.scanspec.ScanSpec",
+      "fields": [
+        {
+          "name": "classAcceptReject"
+        },
+        {
+          "name": "classPackageAcceptReject"
+        },
+        {
+          "name": "classPackagePathAcceptReject"
+        },
+        {
+          "name": "classfilePathAcceptReject"
+        },
+        {
+          "name": "classpathElementResourcePathAcceptReject"
+        },
+        {
+          "name": "jarAcceptReject"
+        },
+        {
+          "name": "libOrExtJarAcceptReject"
+        },
+        {
+          "name": "moduleAcceptReject"
+        },
+        {
+          "name": "packageAcceptReject"
+        },
+        {
+          "name": "packagePrefixAcceptReject"
+        },
+        {
+          "name": "pathAcceptReject"
+        },
+        {
+          "name": "pathPrefixAcceptReject"
+        }
+      ]
+    },
+    {
+      "type": "org.antlr.v4.runtime.tree.AbstractParseTreeVisitor"
+    },
+    {
+      "type": "org.antlr.v4.runtime.tree.ParseTreeListener"
+    },
+    {
+      "type": "org.antlr.v4.runtime.tree.ParseTreeVisitor"
+    },
+    {
+      "type": "org.aopalliance.aop.Advice"
+    },
+    {
+      "type": "org.aopalliance.intercept.Interceptor"
+    },
+    {
+      "type": "org.aopalliance.intercept.MethodInterceptor"
+    },
+    {
+      "type": "org.apache.catalina.Manager"
+    },
+    {
+      "type": "org.apache.catalina.startup.Tomcat"
+    },
+    {
+      "type": "org.apache.commons.logging.LogFactory"
+    },
+    {
+      "type": "org.apache.commons.logging.impl.Slf4jLogFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.apache.commons.logging.impl.WeakHashtable",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.apache.coyote.UpgradeProtocol"
+    },
+    {
+      "type": "org.apache.logging.log4j.core.impl.Log4jContextFactory"
+    },
+    {
+      "type": "org.apache.logging.log4j.util.EnvironmentPropertySource"
+    },
+    {
+      "type": "org.apache.logging.log4j.util.SystemPropertiesPropertySource"
+    },
+    {
+      "type": "org.apache.logging.slf4j.SLF4JProvider"
+    },
+    {
+      "type": "org.aspectj.lang.ProceedingJoinPoint"
+    },
+    {
+      "type": "org.aspectj.lang.annotation.After"
+    },
+    {
+      "type": "org.aspectj.lang.annotation.AfterReturning"
+    },
+    {
+      "type": "org.aspectj.lang.annotation.AfterThrowing"
+    },
+    {
+      "type": "org.aspectj.lang.annotation.Around"
+    },
+    {
+      "type": "org.aspectj.lang.annotation.Aspect"
+    },
+    {
+      "type": "org.aspectj.lang.annotation.Before"
+    },
+    {
+      "type": "org.aspectj.lang.annotation.Pointcut"
+    },
+    {
+      "type": "org.aspectj.weaver.Advice"
+    },
+    {
+      "type": "org.aspectj.weaver.reflect.Java15AnnotationFinder",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.aspectj.weaver.reflect.Java15GenericSignatureInformationProvider",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.aspectj.weaver.World"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.aspectj.weaver.reflect.Java15ReflectionBasedReferenceTypeDelegate",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.aspectj.weaver.tools.Jdk14TraceFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.cache2k.Cache2kBuilder"
+    },
+    {
+      "type": "org.cache2k.extra.micrometer.Cache2kCacheMetrics"
+    },
+    {
+      "type": "org.cache2k.extra.spring.SpringCache2kCache"
+    },
+    {
+      "type": "org.crac.Core"
+    },
+    {
+      "type": "org.eclipse.core.runtime.FileLocator"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CallHierarchyIncomingCallsParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CallHierarchyOutgoingCallsParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CallHierarchyPrepareParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CodeAction"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CodeActionParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CodeLens"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CodeLensParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.ColorPresentationParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CompletionItem"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CompletionParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.CreateFilesParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DeclarationParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DefinitionParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DeleteFilesParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DidChangeConfigurationParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DidChangeTextDocumentParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DidChangeWatchedFilesParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DidCloseTextDocumentParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DidOpenTextDocumentParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DidSaveTextDocumentParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentColorParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentDiagnosticParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentFormattingParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentHighlightParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentLink"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentLinkParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentOnTypeFormattingParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentRangeFormattingParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentRangesFormattingParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.DocumentSymbolParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.ExecuteCommandParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.FoldingRangeRequestParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.HoverParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.ImplementationParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.InitializeParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.InlayHint"
+    },
+    {
+      "type": "org.eclipse.lsp4j.InlayHintParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.InlineCompletionParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.InlineValueParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.LinkedEditingRangeParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.MonikerParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.PrepareRenameParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.ReferenceParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.RenameFilesParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.RenameParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.SelectionRangeParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.SemanticTokensDeltaParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.SemanticTokensLegend"
+    },
+    {
+      "type": "org.eclipse.lsp4j.SemanticTokensParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.SemanticTokensRangeParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.ServerInfo"
+    },
+    {
+      "type": "org.eclipse.lsp4j.SignatureHelpParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.TextDocumentContentParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.TypeDefinitionParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.TypeHierarchyPrepareParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.TypeHierarchySubtypesParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.TypeHierarchySupertypesParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.WillSaveTextDocumentParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.WorkspaceDiagnosticParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.WorkspaceFolder"
+    },
+    {
+      "type": "org.eclipse.lsp4j.WorkspaceSymbol"
+    },
+    {
+      "type": "org.eclipse.lsp4j.WorkspaceSymbolParams"
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.CodeActionResponseAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.DocumentDiagnosticReportTypeAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.DocumentSymbolResponseAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.InlineValueResponseAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.LocationLinkListAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.PrepareRenameResponseAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.SemanticTokensFullDeltaResponseAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.WorkspaceSymbolResponseAdapter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ],
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.jsonrpc.Launcher"
+    },
+    {
+      "type": "org.eclipse.lsp4j.jsonrpc.StandardLauncher"
+    },
+    {
+      "type": "org.eclipse.lsp4j.jsonrpc.json.ResponseJsonAdapter"
+    },
+    {
+      "type": "org.eclipse.lsp4j.jsonrpc.services.JsonDelegate"
+    },
+    {
+      "type": "org.eclipse.lsp4j.jsonrpc.services.JsonNotification"
+    },
+    {
+      "type": "org.eclipse.lsp4j.jsonrpc.services.JsonRequest"
+    },
+    {
+      "type": "org.eclipse.lsp4j.jsonrpc.services.JsonSegment"
+    },
+    {
+      "type": "org.eclipse.lsp4j.jsonrpc.validation.NonNull"
+    },
+    {
+      "type": "org.eclipse.lsp4j.services.LanguageClient"
+    },
+    {
+      "type": "org.eclipse.lsp4j.services.LanguageClientAware"
+    },
+    {
+      "type": "org.eclipse.lsp4j.services.LanguageServer",
+      "methods": [
+        {
+          "name": "getNotebookDocumentService",
+          "parameterTypes": []
+        },
+        {
+          "name": "getTextDocumentService",
+          "parameterTypes": []
+        },
+        {
+          "name": "getWorkspaceService",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.eclipse.lsp4j.services.NotebookDocumentService"
+    },
+    {
+      "type": "org.eclipse.lsp4j.services.TextDocumentService"
+    },
+    {
+      "type": "org.eclipse.lsp4j.services.WorkspaceService"
+    },
+    {
+      "type": "org.eclipse.lsp4j.websocket.jakarta.WebSocketEndpoint"
+    },
+    {
+      "type": "org.ehcache.CacheManager"
+    },
+    {
+      "type": "org.ehcache.PersistentCacheManager"
+    },
+    {
+      "type": "org.ehcache.core.Ehcache"
+    },
+    {
+      "type": "org.ehcache.core.EhcacheBase"
+    },
+    {
+      "type": "org.ehcache.core.EhcacheManager"
+    },
+    {
+      "type": "org.ehcache.core.internal.statistics.DefaultStatisticsServiceFactory"
+    },
+    {
+      "type": "org.ehcache.core.internal.statistics.StatsUtils$1"
+    },
+    {
+      "type": "org.ehcache.core.internal.statistics.StatsUtils$2"
+    },
+    {
+      "type": "org.ehcache.core.internal.statistics.StatsUtils$3"
+    },
+    {
+      "type": "org.ehcache.core.spi.service.StatisticsService"
+    },
+    {
+      "type": "org.ehcache.core.spi.store.InternalCacheManager"
+    },
+    {
+      "type": "org.ehcache.core.spi.store.TransientStateHolder",
+      "serializable": true
+    },
+    {
+      "type": "org.ehcache.impl.copy.IdentityCopier",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.impl.internal.TimeSourceServiceFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.concurrent.ConcurrentHashMap",
+      "fields": [
+        {
+          "name": "baseCount"
+        },
+        {
+          "name": "cellsBusy"
+        },
+        {
+          "name": "sizeCtl"
+        },
+        {
+          "name": "transferIndex"
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.impl.internal.concurrent.ConcurrentHashMap$CounterCell",
+      "fields": [
+        {
+          "name": "value"
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.impl.internal.concurrent.ConcurrentHashMap$TreeBin",
+      "fields": [
+        {
+          "name": "lockState"
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.impl.internal.events.CacheEventNotificationListenerServiceProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.executor.DefaultExecutionServiceFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.loaderwriter.writebehind.WriteBehindProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.persistence.DefaultDiskResourceServiceFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.persistence.DefaultLocalPersistenceServiceFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.resilience.RobustResilienceStrategy",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.ehcache.spi.resilience.RecoveryStore"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.impl.internal.sizeof.DefaultSizeOfEngineProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.spi.copy.DefaultCopyProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.spi.event.DefaultCacheEventListenerProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.spi.loaderwriter.DefaultCacheLoaderWriterProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.spi.resilience.DefaultResilienceStrategyProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.spi.serialization.DefaultSerializationProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.copy.CopierStoreProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.disk.OffHeapDiskStore"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.disk.OffHeapDiskStoreProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.heap.OnHeapStore"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.heap.OnHeapStoreProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.loaderwriter.LoaderWriterStoreProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.offheap.AbstractOffHeapStore"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.offheap.OffHeapStoreProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.shared.SharedStorageProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.shared.authoritative.SharedAuthoritativeTierProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.shared.caching.SharedCachingTierProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.shared.caching.higher.SharedHigherCachingTierProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.shared.caching.lower.SharedLowerCachingTierProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.shared.store.SharedStoreProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.tiering.CompoundCachingTierProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.tiering.TieredStore"
+    },
+    {
+      "type": "org.ehcache.impl.internal.store.tiering.TieredStoreProviderFactory"
+    },
+    {
+      "type": "org.ehcache.impl.persistence.FileBasedStateRepository$Tuple",
+      "serializable": true
+    },
+    {
+      "type": "org.ehcache.impl.serialization.CompactJavaSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.ClassLoader"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.impl.serialization.StringSerializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.ClassLoader"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.impl.store.BaseStore"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$1"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$2"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$3"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$4"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$5"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$6"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$8"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.offheapstore.util.ValidationTest"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.statistics.AbstractOperationStatistic",
+      "fields": [
+        {
+          "name": "name"
+        },
+        {
+          "name": "properties"
+        },
+        {
+          "name": "tags"
+        },
+        {
+          "name": "type"
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.statistics.AbstractSourceStatistic"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.statistics.GeneralOperationStatistic"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.statistics.MappedOperationStatistic",
+      "fields": [
+        {
+          "name": "name"
+        },
+        {
+          "name": "outcomeType"
+        },
+        {
+          "name": "properties"
+        },
+        {
+          "name": "tags"
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.statistics.MappedOperationStatistic$1"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.statistics.PassThroughStatistic",
+      "fields": [
+        {
+          "name": "name"
+        },
+        {
+          "name": "properties"
+        },
+        {
+          "name": "tags"
+        },
+        {
+          "name": "type"
+        }
+      ]
+    },
+    {
+      "type": "org.infinispan.spring.embedded.provider.SpringEmbeddedCacheManager"
+    },
+    {
+      "type": "org.jboss.logging.Logger"
+    },
+    {
+      "type": "org.jspecify.annotations.NullMarked"
+    },
+    {
+      "type": "org.jspecify.annotations.NullUnmarked"
+    },
+    {
+      "type": "org.osgi.framework.FrameworkUtil"
+    },
+    {
+      "type": "org.quartz.core.QuartzScheduler"
+    },
+    {
+      "type": "org.reactivestreams.Publisher"
+    },
+    {
+      "type": "org.slf4j.MDC"
+    },
+    {
+      "type": "org.slf4j.bridge.SLF4JBridgeHandler"
+    },
+    {
+      "type": "org.slf4j.helpers.Log4jLoggerFactory"
+    },
+    {
+      "type": "org.springframework.aop.Advisor"
+    },
+    {
+      "type": "org.springframework.aop.Pointcut"
+    },
+    {
+      "type": "org.springframework.aop.PointcutAdvisor"
+    },
+    {
+      "type": "org.springframework.aop.RawTargetAccess"
+    },
+    {
+      "type": "org.springframework.aop.SpringProxy"
+    },
+    {
+      "type": "org.springframework.aop.TargetClassAware"
+    },
+    {
+      "type": "org.springframework.aop.aspectj.annotation.AnnotationAwareAspectJAutoProxyCreator",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.aop.aspectj.autoproxy.AspectJAwareAdvisorAutoProxyCreator"
+    },
+    {
+      "type": "org.springframework.aop.framework.Advised"
+    },
+    {
+      "type": "org.springframework.aop.framework.AopConfigException"
+    },
+    {
+      "type": "org.springframework.aop.framework.AopInfrastructureBean"
+    },
+    {
+      "type": "org.springframework.aop.framework.ProxyConfig",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setProxyTargetClass",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.aop.framework.ProxyProcessorSupport",
+      "methods": [
+        {
+          "name": "setOrder",
+          "parameterTypes": [
+            "int"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.aop.framework.autoproxy.AbstractAdvisorAutoProxyCreator"
+    },
+    {
+      "type": "org.springframework.aop.framework.autoproxy.AbstractAutoProxyCreator"
+    },
+    {
+      "type": "org.springframework.aop.scope.ScopedObject"
+    },
+    {
+      "type": "org.springframework.aop.scope.ScopedProxyFactoryBean",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setTargetBeanName",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.aop.support.AbstractBeanFactoryPointcutAdvisor"
+    },
+    {
+      "type": "org.springframework.aop.support.AbstractGenericPointcutAdvisor"
+    },
+    {
+      "type": "org.springframework.aop.support.AbstractPointcutAdvisor"
+    },
+    {
+      "type": "org.springframework.aop.support.ComposablePointcut"
+    },
+    {
+      "type": "org.springframework.aop.support.DefaultPointcutAdvisor"
+    },
+    {
+      "type": "org.springframework.aot.generate.Generated"
+    },
+    {
+      "type": "org.springframework.aot.hint.annotation.Reflective"
+    },
+    {
+      "type": "org.springframework.beans.factory.Aware"
+    },
+    {
+      "type": "org.springframework.beans.factory.BeanClassLoaderAware"
+    },
+    {
+      "type": "org.springframework.beans.factory.BeanFactoryAware"
+    },
+    {
+      "type": "org.springframework.beans.factory.BeanNameAware"
+    },
+    {
+      "type": "org.springframework.beans.factory.DisposableBean"
+    },
+    {
+      "type": "org.springframework.beans.factory.FactoryBean"
+    },
+    {
+      "type": "org.springframework.beans.factory.InitializingBean"
+    },
+    {
+      "type": "org.springframework.beans.factory.SmartInitializingSingleton"
+    },
+    {
+      "type": "org.springframework.beans.factory.annotation.Autowired"
+    },
+    {
+      "type": "org.springframework.beans.factory.annotation.AutowiredAnnotationBeanPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.beans.factory.annotation.Qualifier"
+    },
+    {
+      "type": "org.springframework.beans.factory.annotation.Value"
+    },
+    {
+      "type": "org.springframework.beans.factory.aot.BeanFactoryInitializationAotProcessor"
+    },
+    {
+      "type": "org.springframework.beans.factory.aot.BeanRegistrationAotProcessor"
+    },
+    {
+      "type": "org.springframework.beans.factory.config.BeanFactoryPostProcessor"
+    },
+    {
+      "type": "org.springframework.beans.factory.config.BeanPostProcessor"
+    },
+    {
+      "type": "org.springframework.beans.factory.config.CustomScopeConfigurer"
+    },
+    {
+      "type": "org.springframework.beans.factory.config.DestructionAwareBeanPostProcessor"
+    },
+    {
+      "type": "org.springframework.beans.factory.config.InstantiationAwareBeanPostProcessor"
+    },
+    {
+      "type": "org.springframework.beans.factory.config.Scope"
+    },
+    {
+      "type": "org.springframework.beans.factory.config.SmartInstantiationAwareBeanPostProcessor"
+    },
+    {
+      "type": "org.springframework.beans.factory.support.BeanDefinitionRegistryPostProcessor"
+    },
+    {
+      "type": "org.springframework.beans.factory.support.MergedBeanDefinitionPostProcessor"
+    },
+    {
+      "type": "org.springframework.boot.ApplicationProperties",
+      "methods": [
+        {
+          "name": "setBannerMode",
+          "parameterTypes": [
+            "org.springframework.boot.Banner$Mode"
+          ]
+        },
+        {
+          "name": "setLogStartupInfo",
+          "parameterTypes": [
+            "boolean"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.Banner$ModeEditor"
+    },
+    {
+      "type": "org.springframework.boot.ClearCachesApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.ExitCodeGenerator"
+    },
+    {
+      "type": "org.springframework.boot.LazyInitializationExcludeFilter"
+    },
+    {
+      "type": "org.springframework.boot.SpringBootConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.actuate.autoconfigure.endpoint.condition.ConditionalOnAvailableEndpoint"
+    },
+    {
+      "type": "org.springframework.boot.actuate.autoconfigure.endpoint.web.WebEndpointProperties"
+    },
+    {
+      "type": "org.springframework.boot.actuate.autoconfigure.web.server.ManagementContextFactory"
+    },
+    {
+      "type": "org.springframework.boot.actuate.web.exchanges.HttpExchangeRepository"
+    },
+    {
+      "type": "org.springframework.boot.ansi.AnsiOutput$Enabled"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigurationExcludeFilter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigurationImportSelector",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigurationImportSelector$AutoConfigurationGroup",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigurationPackage"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigurationPackages"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigurationPackages$BasePackages",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigurationPackages$Registrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigureAfter"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigureBefore"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.AutoConfigureOrder"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.EnableAutoConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.SharedMetadataReaderFactoryContextInitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.SpringBootApplication"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.aop.AopAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.aop.AopAutoConfiguration$AspectJAutoProxyingConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.aop.AopAutoConfiguration$AspectJAutoProxyingConfiguration$CglibAutoProxyConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.availability.ApplicationAvailabilityAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "applicationAvailability",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.cache.CacheType"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionEvaluationReportAutoConfigurationImportListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnBean"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnBooleanProperty"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnClass"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnMissingBean"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnMissingClass"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnProperty"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnResource"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnThreading"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.ConditionalOnWebApplication$Type"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnBeanCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnClassCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnPropertyCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnResourceCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnThreadingCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.OnWebApplicationCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.condition.SearchStrategy"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.context.ConfigurationPropertiesAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.context.LifecycleAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "defaultLifecycleProcessor",
+          "parameterTypes": [
+            "org.springframework.boot.autoconfigure.context.LifecycleProperties"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.context.LifecycleProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.context.MessageSourceAutoConfiguration$ResourceBundleCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.context.PropertyPlaceholderAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "propertySourcesPlaceholderConfigurer",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.boot.autoconfigure.info.ProjectInfoProperties"
+          ]
+        },
+        {
+          "name": "gitProperties",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.info.ProjectInfoAutoConfiguration$GitResourceAvailableCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.info.ProjectInfoProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.logging.ConditionEvaluationReportLoggingListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.preinitialize.BackgroundPreinitializingApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.preinitialize.CharsetsBackgroundPreinitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.preinitialize.ConversionServiceBackgroundPreinitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.ssl.FileWatcher"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.ssl.SslAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.core.io.ResourceLoader",
+            "org.springframework.boot.autoconfigure.ssl.SslProperties"
+          ]
+        },
+        {
+          "name": "fileWatcher",
+          "parameterTypes": []
+        },
+        {
+          "name": "sslBundleRegistry",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "sslPropertiesSslBundleRegistrar",
+          "parameterTypes": [
+            "org.springframework.boot.autoconfigure.ssl.FileWatcher"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.ssl.SslBundleRegistrar"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.ssl.SslProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.ssl.SslPropertiesBundleRegistrar"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.ScheduledBeanLazyInitializationExcludeFilter"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskExecutionAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskExecutionProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskExecutorConfigurations"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskExecutorConfigurations$BootstrapExecutorConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "bootstrapExecutorAliasPostProcessor",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskExecutorConfigurations$OnExecutorCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskExecutorConfigurations$SimpleAsyncTaskExecutorBuilderConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.boot.autoconfigure.task.TaskExecutionProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "simpleAsyncTaskExecutorBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskExecutorConfigurations$TaskExecutorConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskExecutorConfigurations$ThreadPoolTaskExecutorBuilderConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "threadPoolTaskExecutorBuilder",
+          "parameterTypes": [
+            "org.springframework.boot.autoconfigure.task.TaskExecutionProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskSchedulingAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "scheduledBeanLazyInitializationExcludeFilter",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskSchedulingConfigurations"
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskSchedulingConfigurations$SimpleAsyncTaskSchedulerBuilderConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.boot.autoconfigure.task.TaskSchedulingProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "simpleAsyncTaskSchedulerBuilder",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskSchedulingConfigurations$TaskSchedulerConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "taskScheduler",
+          "parameterTypes": [
+            "org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskSchedulingConfigurations$ThreadPoolTaskSchedulerBuilderConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "threadPoolTaskSchedulerBuilder",
+          "parameterTypes": [
+            "org.springframework.boot.autoconfigure.task.TaskSchedulingProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.autoconfigure.task.TaskSchedulingProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.availability.ApplicationAvailability"
+    },
+    {
+      "type": "org.springframework.boot.availability.ApplicationAvailabilityBean"
+    },
+    {
+      "type": "org.springframework.boot.availability.AvailabilityChangeEvent"
+    },
+    {
+      "type": "org.springframework.boot.availability.AvailabilityState"
+    },
+    {
+      "type": "org.springframework.boot.builder.ParentContextCloserApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.cache.autoconfigure.CacheAutoConfiguration$CacheConfigurationImportSelector",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.cache.autoconfigure.CacheCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.cache.autoconfigure.JCacheCacheConfiguration$JCacheAvailableCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.cache.autoconfigure.metrics.CacheMeterBinderProvidersConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.cache.autoconfigure.metrics.CacheMeterBinderProvidersConfiguration$CaffeineCacheMeterBinderProviderConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "caffeineCacheMeterBinderProvider",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.cache.autoconfigure.metrics.CacheMeterBinderProvidersConfiguration$JCacheCacheMeterBinderProviderConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "jCacheCacheMeterBinderProvider",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.cache.autoconfigure.metrics.CacheMetricsAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.cache.autoconfigure.metrics.CacheMetricsRegistrarConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.cache.metrics.CacheMeterBinderProvider"
+    },
+    {
+      "type": "org.springframework.boot.cache.metrics.CaffeineCacheMeterBinderProvider"
+    },
+    {
+      "type": "org.springframework.boot.cache.metrics.JCacheCacheMeterBinderProvider"
+    },
+    {
+      "type": "org.springframework.boot.cloud.CloudFoundryVcapEnvironmentPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.boot.logging.DeferredLogFactory"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.ConfigurationWarningsApplicationContextInitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.ContextIdApplicationContextInitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.FileEncodingApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.TypeExcludeFilter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.config.ConfigDataEnvironmentPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.boot.logging.DeferredLogFactory",
+            "org.springframework.boot.bootstrap.ConfigurableBootstrapContext"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.config.ConfigDataLocation[]"
+    },
+    {
+      "type": "org.springframework.boot.context.config.ConfigDataNotFoundAction"
+    },
+    {
+      "type": "org.springframework.boot.context.config.ConfigDataProperties"
+    },
+    {
+      "type": "org.springframework.boot.context.config.ConfigTreeConfigDataLoader",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.config.ConfigTreeConfigDataLocationResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.core.io.ResourceLoader"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.config.StandardConfigDataLoader",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.config.StandardConfigDataLocationResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.boot.logging.DeferredLogFactory",
+            "org.springframework.boot.context.properties.bind.Binder",
+            "org.springframework.core.io.ResourceLoader"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.config.SystemEnvironmentConfigDataLoader",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.config.SystemEnvironmentConfigDataLocationResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.event.EventPublishingRunListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.boot.SpringApplication",
+            "java.lang.String[]"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.logging.LoggingApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.BoundConfigurationProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationProperties"
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBinder$ConfigurationPropertiesBinderFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.ConfigurationPropertiesBindingPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.EnableConfigurationProperties"
+    },
+    {
+      "type": "org.springframework.boot.context.properties.EnableConfigurationPropertiesRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.context.properties.bind.Name"
+    },
+    {
+      "type": "org.springframework.boot.env.PropertiesPropertySourceLoader",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.env.YamlPropertySourceLoader",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.health.actuate.endpoint.HealthEndpoint"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.ClientHttpMessageConvertersCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.DefaultClientHttpMessageConvertersCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.DefaultServerHttpMessageConvertersCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.GsonHttpMessageConvertersConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.GsonHttpMessageConvertersConfiguration$JacksonAndJsonbUnavailableCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.GsonHttpMessageConvertersConfiguration$PreferGsonOrJacksonAndJsonbUnavailableCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "clientConvertersCustomizer",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        },
+        {
+          "name": "serverConvertersCustomizer",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration$NotReactiveWebApplicationCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration$StringHttpMessageConverterConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "stringHttpMessageConvertersCustomizer",
+          "parameterTypes": [
+            "org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersProperties"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersAutoConfiguration$StringHttpMessageConvertersCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.HttpMessageConvertersProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.Jackson2HttpMessageConvertersConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.Jackson2HttpMessageConvertersConfiguration$Jackson2JsonMessageConvertersCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.Jackson2HttpMessageConvertersConfiguration$PreferJackson2OrJacksonUnavailableCondition",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.JacksonHttpMessageConvertersConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.JacksonHttpMessageConvertersConfiguration$JacksonJsonHttpMessageConverterConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "jacksonJsonHttpMessageConvertersCustomizer",
+          "parameterTypes": [
+            "tools.jackson.databind.json.JsonMapper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.JacksonHttpMessageConvertersConfiguration$JacksonJsonHttpMessageConvertersCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.JacksonHttpMessageConvertersConfiguration$JacksonXmlHttpMessageConverterConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "jacksonXmlHttpMessageConvertersCustomizer",
+          "parameterTypes": [
+            "tools.jackson.dataformat.xml.XmlMapper"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.JacksonHttpMessageConvertersConfiguration$JacksonXmlHttpMessageConvertersCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.JsonbHttpMessageConvertersConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.KotlinSerializationHttpMessageConvertersConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.MessageConverterBackgroundPreinitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.http.converter.autoconfigure.ServerHttpMessageConvertersCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.info.GitProperties"
+    },
+    {
+      "type": "org.springframework.boot.info.InfoProperties"
+    },
+    {
+      "type": "org.springframework.boot.info.InfoProperties$Entry"
+    },
+    {
+      "type": "org.springframework.boot.io.Base64ProtocolResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.io.ClassPathResourceFilePathResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.io.ProtocolResolverApplicationContextInitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.JacksonComponentModule"
+    },
+    {
+      "type": "org.springframework.boot.jackson.JacksonMixinModule"
+    },
+    {
+      "type": "org.springframework.boot.jackson.JacksonMixinModuleEntries"
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "jacksonJsonMapper",
+          "parameterTypes": [
+            "tools.jackson.databind.json.JsonMapper$Builder"
+          ]
+        },
+        {
+          "name": "jsonComponentModule",
+          "parameterTypes": []
+        },
+        {
+          "name": "jsonMapperBuilder",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$AbstractMapperBuilderCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$JacksonJsonMapperBuilderCustomizerConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "standardJsonMapperBuilderCustomizer",
+          "parameterTypes": [
+            "org.springframework.boot.jackson.autoconfigure.JacksonProperties",
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$JacksonJsonMapperBuilderCustomizerConfiguration$StandardJsonMapperBuilderCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$JacksonMixinConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "jacksonMixinModule",
+          "parameterTypes": [
+            "org.springframework.context.ApplicationContext",
+            "org.springframework.boot.jackson.JacksonMixinModuleEntries"
+          ]
+        },
+        {
+          "name": "jacksonMixinModuleEntries",
+          "parameterTypes": [
+            "org.springframework.context.ApplicationContext"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$JsonProblemDetailsConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "problemDetailJsonMapperBuilderCustomizer",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$JsonProblemDetailsConfiguration$ProblemDetailJsonMapperBuilderCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$XmlConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "standardXmlMapperBuilderCustomizer",
+          "parameterTypes": [
+            "org.springframework.boot.jackson.autoconfigure.JacksonProperties",
+            "org.springframework.beans.factory.ObjectProvider",
+            "org.springframework.boot.jackson.autoconfigure.JacksonXmlProperties"
+          ]
+        },
+        {
+          "name": "xmlMapper",
+          "parameterTypes": [
+            "tools.jackson.dataformat.xml.XmlMapper$Builder"
+          ]
+        },
+        {
+          "name": "xmlMapperBuilder",
+          "parameterTypes": [
+            "java.util.List"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$XmlConfiguration$StandardXmlMapperBuilderCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$XmlConfiguration$XmlProblemDetailsConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "problemDetailXmlMapperBuilderCustomizer",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonAutoConfiguration$XmlConfiguration$XmlProblemDetailsConfiguration$ProblemDetailXmlMapperBuilderCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonBackgroundPreinitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JacksonXmlProperties",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.jackson.autoconfigure.XmlMapperBuilderCustomizer"
+    },
+    {
+      "type": "org.springframework.boot.jpa.autoconfigure.EntityManagerFactoryDependsOnPostProcessor"
+    },
+    {
+      "type": "org.springframework.boot.loader.launch.LaunchedClassLoader"
+    },
+    {
+      "type": "org.springframework.boot.logging.LogLevelEditor"
+    },
+    {
+      "type": "org.springframework.boot.logging.java.JavaLoggingSystem$Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.logging.log4j2.Log4J2LoggingSystem$Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.logging.log4j2.SpringBootPropertySource"
+    },
+    {
+      "type": "org.springframework.boot.logging.logback.ColorConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.logging.logback.EnclosedInSquareBracketsConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.logging.logback.ExtendedWhitespaceThrowableProxyConverter",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.logging.logback.LogbackLoggingSystem$Factory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.logging.logback.RootLogLevelConfigurator"
+    },
+    {
+      "type": "org.springframework.boot.micrometer.observation.autoconfigure.ObservationProperties"
+    },
+    {
+      "type": "org.springframework.boot.restclient.autoconfigure.RestClientAutoConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.restclient.autoconfigure.RestTemplateAutoConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.ssl.DefaultSslBundleRegistry"
+    },
+    {
+      "type": "org.springframework.boot.ssl.SslBundleRegistry"
+    },
+    {
+      "type": "org.springframework.boot.ssl.SslBundles"
+    },
+    {
+      "type": "org.springframework.boot.support.AnsiOutputApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.support.EnvironmentPostProcessorApplicationListener",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.support.RandomValuePropertySourceEnvironmentPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.springframework.boot.logging.DeferredLogFactory"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.support.SpringApplicationJsonEnvironmentPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.support.SystemEnvironmentPropertySourceEnvironmentPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.task.SimpleAsyncTaskExecutorBuilder"
+    },
+    {
+      "type": "org.springframework.boot.task.SimpleAsyncTaskSchedulerBuilder"
+    },
+    {
+      "type": "org.springframework.boot.task.ThreadPoolTaskExecutorBuilder"
+    },
+    {
+      "type": "org.springframework.boot.task.ThreadPoolTaskSchedulerBuilder"
+    },
+    {
+      "type": "org.springframework.boot.thread.Threading"
+    },
+    {
+      "type": "org.springframework.boot.tomcat.autoconfigure.TomcatBackgroundPreinitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.tomcat.reactive.TomcatReactiveWebServerFactory"
+    },
+    {
+      "type": "org.springframework.boot.tomcat.servlet.TomcatServletWebServerFactory"
+    },
+    {
+      "type": "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+      "methods": [
+        {
+          "name": "byAnnotation",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.web.context.reactive.FilteredReactiveWebContextResourceFilePathResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.web.context.servlet.ServletContextResourceFilePathResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.web.server.context.ServerPortInfoApplicationContextInitializer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.web.server.reactive.context.ReactiveWebServerApplicationContextFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.web.server.servlet.context.ServletWebServerApplicationContextFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.boot.webclient.autoconfigure.WebClientAutoConfiguration"
+    },
+    {
+      "type": "org.springframework.boot.webmvc.WebMvcWebApplicationTypeDeducer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.cache.Cache"
+    },
+    {
+      "type": "org.springframework.cache.CacheManager"
+    },
+    {
+      "type": "org.springframework.cache.annotation.AbstractCachingConfiguration",
+      "methods": [
+        {
+          "name": "setConfigurers",
+          "parameterTypes": [
+            "org.springframework.beans.factory.ObjectProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.cache.annotation.AnnotationCacheOperationSource"
+    },
+    {
+      "type": "org.springframework.cache.annotation.CacheConfig"
+    },
+    {
+      "type": "org.springframework.cache.annotation.CacheEvict"
+    },
+    {
+      "type": "org.springframework.cache.annotation.CachePut"
+    },
+    {
+      "type": "org.springframework.cache.annotation.Cacheable"
+    },
+    {
+      "type": "org.springframework.cache.annotation.CachingConfigurationSelector",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.cache.annotation.EnableCaching"
+    },
+    {
+      "type": "org.springframework.cache.annotation.ProxyCachingConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "cacheAdvisor",
+          "parameterTypes": [
+            "org.springframework.cache.interceptor.CacheOperationSource",
+            "org.springframework.cache.interceptor.CacheInterceptor"
+          ]
+        },
+        {
+          "name": "cacheInterceptor",
+          "parameterTypes": [
+            "org.springframework.cache.interceptor.CacheOperationSource"
+          ]
+        },
+        {
+          "name": "cacheOperationSource",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.cache.caffeine.CaffeineCache"
+    },
+    {
+      "type": "org.springframework.cache.caffeine.CaffeineCacheManager"
+    },
+    {
+      "type": "org.springframework.cache.interceptor.AbstractCacheInvoker"
+    },
+    {
+      "type": "org.springframework.cache.interceptor.AbstractFallbackCacheOperationSource"
+    },
+    {
+      "type": "org.springframework.cache.interceptor.BeanFactoryCacheOperationSourceAdvisor"
+    },
+    {
+      "type": "org.springframework.cache.interceptor.CacheAspectSupport"
+    },
+    {
+      "type": "org.springframework.cache.interceptor.CacheInterceptor"
+    },
+    {
+      "type": "org.springframework.cache.interceptor.CacheOperationSource"
+    },
+    {
+      "type": "org.springframework.cache.jcache.JCacheCache"
+    },
+    {
+      "type": "org.springframework.cache.jcache.JCacheCacheManager"
+    },
+    {
+      "type": "org.springframework.cache.jcache.config.AbstractJCacheConfiguration",
+      "methods": [
+        {
+          "name": "cacheOperationSource",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.cache.jcache.config.ProxyJCacheConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "cacheAdvisor",
+          "parameterTypes": [
+            "org.springframework.cache.jcache.interceptor.JCacheOperationSource",
+            "org.springframework.cache.jcache.interceptor.JCacheInterceptor"
+          ]
+        },
+        {
+          "name": "cacheInterceptor",
+          "parameterTypes": [
+            "org.springframework.cache.jcache.interceptor.JCacheOperationSource"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.cache.jcache.interceptor.AbstractFallbackJCacheOperationSource"
+    },
+    {
+      "type": "org.springframework.cache.jcache.interceptor.AnnotationJCacheOperationSource"
+    },
+    {
+      "type": "org.springframework.cache.jcache.interceptor.BeanFactoryJCacheOperationSourceAdvisor"
+    },
+    {
+      "type": "org.springframework.cache.jcache.interceptor.DefaultJCacheOperationSource"
+    },
+    {
+      "type": "org.springframework.cache.jcache.interceptor.JCacheAspectSupport"
+    },
+    {
+      "type": "org.springframework.cache.jcache.interceptor.JCacheInterceptor"
+    },
+    {
+      "type": "org.springframework.cache.jcache.interceptor.JCacheOperationSource"
+    },
+    {
+      "type": "org.springframework.cache.support.AbstractCacheManager"
+    },
+    {
+      "type": "org.springframework.cache.support.SimpleCacheManager"
+    },
+    {
+      "type": "org.springframework.cglib.proxy.Dispatcher"
+    },
+    {
+      "type": "org.springframework.cglib.proxy.Factory"
+    },
+    {
+      "type": "org.springframework.cglib.proxy.MethodInterceptor"
+    },
+    {
+      "type": "org.springframework.cglib.proxy.NoOp"
+    },
+    {
+      "type": "org.springframework.context.ApplicationContextAware"
+    },
+    {
+      "type": "org.springframework.context.ApplicationEvent"
+    },
+    {
+      "type": "org.springframework.context.ApplicationListener"
+    },
+    {
+      "type": "org.springframework.context.ApplicationStartupAware"
+    },
+    {
+      "type": "org.springframework.context.EmbeddedValueResolverAware"
+    },
+    {
+      "type": "org.springframework.context.EnvironmentAware"
+    },
+    {
+      "type": "org.springframework.context.Lifecycle"
+    },
+    {
+      "type": "org.springframework.context.LifecycleProcessor"
+    },
+    {
+      "type": "org.springframework.context.Phased"
+    },
+    {
+      "type": "org.springframework.context.ResourceLoaderAware"
+    },
+    {
+      "type": "org.springframework.context.SmartLifecycle"
+    },
+    {
+      "type": "org.springframework.context.annotation.AnnotationScopeMetadataResolver",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.context.annotation.AspectJAutoProxyRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.context.annotation.AutoProxyRegistrar",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.context.annotation.Bean"
+    },
+    {
+      "type": "org.springframework.context.annotation.CommonAnnotationBeanPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.context.annotation.ComponentScan"
+    },
+    {
+      "type": "org.springframework.context.annotation.ComponentScan$Filter"
+    },
+    {
+      "type": "org.springframework.context.annotation.Conditional"
+    },
+    {
+      "type": "org.springframework.context.annotation.Configuration"
+    },
+    {
+      "type": "org.springframework.context.annotation.ConfigurationClassEnhancer$EnhancedConfiguration"
+    },
+    {
+      "type": "org.springframework.context.annotation.ConfigurationClassPostProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "setMetadataReaderFactory",
+          "parameterTypes": [
+            "org.springframework.core.type.classreading.MetadataReaderFactory"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.context.annotation.EnableAspectJAutoProxy"
+    },
+    {
+      "type": "org.springframework.context.annotation.Import"
+    },
+    {
+      "type": "org.springframework.context.annotation.ImportAware"
+    },
+    {
+      "type": "org.springframework.context.annotation.ImportRuntimeHints"
+    },
+    {
+      "type": "org.springframework.context.annotation.Lazy"
+    },
+    {
+      "type": "org.springframework.context.annotation.Primary"
+    },
+    {
+      "type": "org.springframework.context.annotation.Role"
+    },
+    {
+      "type": "org.springframework.context.annotation.Scope"
+    },
+    {
+      "type": "org.springframework.context.annotation.ScopedProxyMode"
+    },
+    {
+      "type": "org.springframework.context.event.ContextClosedEvent"
+    },
+    {
+      "type": "org.springframework.context.event.DefaultEventListenerFactory",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.context.event.EventListener"
+    },
+    {
+      "type": "org.springframework.context.event.EventListenerMethodProcessor",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.context.event.GenericApplicationListener"
+    },
+    {
+      "type": "org.springframework.context.event.SmartApplicationListener"
+    },
+    {
+      "type": "org.springframework.context.support.DefaultLifecycleProcessor"
+    },
+    {
+      "type": "org.springframework.context.support.PropertySourcesPlaceholderConfigurer"
+    },
+    {
+      "type": "org.springframework.core.DecoratingProxy"
+    },
+    {
+      "type": "org.springframework.core.Ordered"
+    },
+    {
+      "type": "org.springframework.core.PriorityOrdered"
+    },
+    {
+      "type": "org.springframework.core.annotation.AliasFor"
+    },
+    {
+      "type": "org.springframework.core.annotation.AnnotationAttributes[]"
+    },
+    {
+      "type": "org.springframework.core.annotation.Order"
+    },
+    {
+      "type": "org.springframework.core.task.AsyncTaskExecutor"
+    },
+    {
+      "type": "org.springframework.core.task.TaskDecorator"
+    },
+    {
+      "type": "org.springframework.core.task.TaskExecutor"
+    },
+    {
+      "type": "org.springframework.core.task.support.ContextPropagatingTaskDecorator"
+    },
+    {
+      "type": "org.springframework.core.type.classreading.CachingMetadataReaderFactory"
+    },
+    {
+      "type": "org.springframework.core.type.classreading.MetadataReaderFactory"
+    },
+    {
+      "type": "org.springframework.data.redis.cache.RedisCache"
+    },
+    {
+      "type": "org.springframework.data.redis.connection.RedisConnectionFactory"
+    },
+    {
+      "type": "org.springframework.data.rest.webmvc.alps.AlpsJacksonJsonHttpMessageConverter"
+    },
+    {
+      "type": "org.springframework.graphql.execution.DataFetcherExceptionResolverAdapter"
+    },
+    {
+      "type": "org.springframework.hateoas.server.mvc.TypeConstrainedJacksonJsonHttpMessageConverter"
+    },
+    {
+      "type": "org.springframework.http.ProblemDetail"
+    },
+    {
+      "type": "org.springframework.http.ReactiveHttpInputMessage"
+    },
+    {
+      "type": "org.springframework.http.converter.HttpMessageConverter"
+    },
+    {
+      "type": "org.springframework.http.converter.StringHttpMessageConverter"
+    },
+    {
+      "type": "org.springframework.http.converter.json.JacksonJsonHttpMessageConverter"
+    },
+    {
+      "type": "org.springframework.http.converter.xml.JacksonXmlHttpMessageConverter"
+    },
+    {
+      "type": "org.springframework.jmx.export.MBeanExporter"
+    },
+    {
+      "type": "org.springframework.kafka.core.KafkaTemplate"
+    },
+    {
+      "type": "org.springframework.orm.jpa.LocalContainerEntityManagerFactoryBean"
+    },
+    {
+      "type": "org.springframework.scheduling.SchedulingTaskExecutor"
+    },
+    {
+      "type": "org.springframework.scheduling.TaskScheduler"
+    },
+    {
+      "type": "org.springframework.scheduling.annotation.Async"
+    },
+    {
+      "type": "org.springframework.scheduling.annotation.AsyncConfigurer"
+    },
+    {
+      "type": "org.springframework.scheduling.annotation.EnableScheduling"
+    },
+    {
+      "type": "org.springframework.scheduling.annotation.Scheduled"
+    },
+    {
+      "type": "org.springframework.scheduling.annotation.ScheduledAnnotationBeanPostProcessor"
+    },
+    {
+      "type": "org.springframework.scheduling.annotation.Schedules"
+    },
+    {
+      "type": "org.springframework.scheduling.annotation.SchedulingConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "scheduledAnnotationProcessor",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.scheduling.concurrent.CustomizableThreadFactory"
+    },
+    {
+      "type": "org.springframework.scheduling.concurrent.ExecutorConfigurationSupport",
+      "methods": [
+        {
+          "name": "shutdown",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor"
+    },
+    {
+      "type": "org.springframework.scheduling.concurrent.ThreadPoolTaskScheduler"
+    },
+    {
+      "type": "org.springframework.scheduling.config.ScheduledTaskHolder"
+    },
+    {
+      "type": "org.springframework.scheduling.quartz.SchedulerFactoryBean"
+    },
+    {
+      "type": "org.springframework.stereotype.Component"
+    },
+    {
+      "type": "org.springframework.stereotype.Indexed"
+    },
+    {
+      "type": "org.springframework.util.ConcurrentReferenceHashMap$Segment[]"
+    },
+    {
+      "type": "org.springframework.util.CustomizableThreadCreator"
+    },
+    {
+      "type": "org.springframework.web.client.RestClient"
+    },
+    {
+      "type": "org.springframework.web.client.RestTemplate"
+    },
+    {
+      "type": "org.springframework.web.context.ConfigurableWebApplicationContext"
+    },
+    {
+      "type": "org.springframework.web.context.support.GenericWebApplicationContext"
+    },
+    {
+      "type": "org.springframework.web.context.support.ServletContextResource"
+    },
+    {
+      "type": "org.springframework.web.filter.CharacterEncodingFilter"
+    },
+    {
+      "type": "org.springframework.web.multipart.support.StandardServletMultipartResolver"
+    },
+    {
+      "type": "org.springframework.web.reactive.HandlerResult"
+    },
+    {
+      "type": "org.springframework.web.reactive.function.client.WebClient"
+    },
+    {
+      "type": "org.springframework.web.servlet.DispatcherServlet"
+    },
+    {
+      "type": "org.springframework.web.servlet.config.annotation.WebMvcConfigurer"
+    },
+    {
+      "type": "org.springframework.web.socket.config.annotation.DelegatingWebSocketMessageBrokerConfiguration"
+    },
+    {
+      "type": "org.springframework.web.socket.config.annotation.EnableWebSocket"
+    },
+    {
+      "type": "org.springframework.web.socket.config.annotation.WebSocketMessageBrokerConfigurer"
+    },
+    {
+      "type": "picocli.CommandLine"
+    },
+    {
+      "type": "picocli.CommandLine$Command"
+    },
+    {
+      "type": "picocli.CommandLine$IFactory"
+    },
+    {
+      "type": "picocli.CommandLine$Option"
+    },
+    {
+      "type": "picocli.CommandLine$Unmatched"
+    },
+    {
+      "type": "picocli.spring.PicocliSpringFactory"
+    },
+    {
+      "type": "picocli.spring.boot.autoconfigure.PicocliAutoConfiguration",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "picocliSpringFactory",
+          "parameterTypes": [
+            "org.springframework.context.ApplicationContext"
+          ]
+        },
+        {
+          "name": "picocliSpringFactoryImpl",
+          "parameterTypes": [
+            "org.springframework.context.ApplicationContext"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "reactor.core.scheduler.Schedulers"
+    },
+    {
+      "type": "short[]",
+      "unsafeAllocated": true
+    },
+    {
+      "type": "sun.misc.Unsafe",
+      "fields": [
+        {
+          "name": "theUnsafe"
+        }
+      ],
+      "methods": [
+        {
+          "name": "allocateInstance",
+          "parameterTypes": [
+            "java.lang.Class"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "sun.reflect.ReflectionFactory",
+      "methods": [
+        {
+          "name": "getReflectionFactory",
+          "parameterTypes": []
+        },
+        {
+          "name": "newConstructorForSerialization",
+          "parameterTypes": [
+            "java.lang.Class",
+            "java.lang.reflect.Constructor"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.MD5",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.NativePRNG",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "java.security.SecureRandomParameters"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "sun.security.provider.SHA",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "sun.text.resources.cldr.FormatData"
+    },
+    {
+      "type": "sun.text.resources.cldr.FormatData_en"
+    },
+    {
+      "type": "sun.text.resources.cldr.FormatData_en_US"
+    },
+    {
+      "type": "sun.util.resources.cldr.CalendarData"
+    },
+    {
+      "type": "sun.util.resources.cldr.TimeZoneNames"
+    },
+    {
+      "type": "sun.util.resources.cldr.TimeZoneNames_en"
+    },
+    {
+      "type": "sun.util.resources.cldr.TimeZoneNames_en_US"
+    },
+    {
+      "type": "tools.jackson.core.TreeCodec"
+    },
+    {
+      "type": "tools.jackson.core.TreeNode"
+    },
+    {
+      "type": "tools.jackson.core.Versioned"
+    },
+    {
+      "type": "tools.jackson.databind.JacksonModule"
+    },
+    {
+      "type": "tools.jackson.databind.JsonNode"
+    },
+    {
+      "type": "tools.jackson.databind.ObjectMapper"
+    },
+    {
+      "type": "tools.jackson.databind.annotation.JsonDeserialize"
+    },
+    {
+      "type": "tools.jackson.databind.annotation.JsonSerialize"
+    },
+    {
+      "type": "tools.jackson.databind.cfg.MapperBuilder"
+    },
+    {
+      "type": "tools.jackson.databind.deser.Deserializers[]"
+    },
+    {
+      "type": "tools.jackson.databind.deser.KeyDeserializers[]"
+    },
+    {
+      "type": "tools.jackson.databind.deser.ValueDeserializerModifier[]"
+    },
+    {
+      "type": "tools.jackson.databind.deser.ValueInstantiators[]"
+    },
+    {
+      "type": "tools.jackson.databind.json.JsonMapper"
+    },
+    {
+      "type": "tools.jackson.databind.json.JsonMapper$Builder"
+    },
+    {
+      "type": "tools.jackson.databind.module.SimpleModule"
+    },
+    {
+      "type": "tools.jackson.databind.ser.Serializers[]"
+    },
+    {
+      "type": "tools.jackson.databind.ser.ValueSerializerModifier[]"
+    },
+    {
+      "type": "tools.jackson.dataformat.cbor.CBORMapper"
+    },
+    {
+      "type": "tools.jackson.dataformat.smile.SmileMapper"
+    },
+    {
+      "type": "tools.jackson.dataformat.xml.XmlMapper"
+    },
+    {
+      "type": "tools.jackson.dataformat.xml.XmlMapper$Builder"
+    },
+    {
+      "type": "tools.jackson.dataformat.yaml.YAMLMapper"
+    },
+    {
+      "type": {
+        "proxy": [
+          "java.lang.reflect.ParameterizedType",
+          "org.springframework.core.SerializableTypeWrapper$SerializableTypeProxy",
+          "java.io.Serializable"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "java.lang.reflect.TypeVariable",
+          "org.springframework.core.SerializableTypeWrapper$SerializableTypeProxy",
+          "java.io.Serializable"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "java.lang.reflect.WildcardType",
+          "org.springframework.core.SerializableTypeWrapper$SerializableTypeProxy",
+          "java.io.Serializable"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "java.security.PrivilegedAction"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "java.util.List",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "java.util.concurrent.ExecutorService",
+          "org.springframework.aop.scope.ScopedObject",
+          "java.io.Serializable",
+          "org.springframework.aop.framework.AopInfrastructureBean",
+          "org.springframework.aop.SpringProxy",
+          "org.springframework.aop.framework.Advised",
+          "org.springframework.core.DecoratingProxy"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "java.util.function.Consumer"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.eclipse.lsp4j.services.LanguageClient",
+          "org.eclipse.lsp4j.jsonrpc.Endpoint"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.ehcache.shadow.org.terracotta.offheapstore.storage.portability.Portability",
+          "org.ehcache.shadow.org.terracotta.offheapstore.disk.persistent.PersistentPortability"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.ehcache.shadow.org.terracotta.offheapstore.storage.portability.WriteBackPortability",
+          "org.ehcache.shadow.org.terracotta.offheapstore.disk.persistent.PersistentPortability"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.boot.context.properties.ConfigurationProperties"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.cache.annotation.CacheConfig"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.cache.annotation.CacheEvict"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.cache.annotation.CachePut"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.cache.annotation.Cacheable"
+        ]
+      }
+    },
+    {
+      "type": {
+        "proxy": [
+          "org.springframework.context.event.EventListener"
+        ]
+      }
+    },
+    {
+      "type": {
+        "lambda": {
+          "declaringClass": "com.github._1c_syntax.bsl.languageserver.aop.sentry.SentryScopeConfigurer",
+          "interfaces": [
+            "io.sentry.Sentry$OptionsConfiguration"
+          ]
+        }
+      }
+    },
+    {
+      "type": {
+        "lambda": {
+          "declaringClass": "com.github._1c_syntax.bsl.languageserver.databind.JsonMapperConfiguration",
+          "interfaces": [
+            "org.springframework.boot.jackson.autoconfigure.JsonMapperBuilderCustomizer"
+          ]
+        }
+      }
+    },
+    {
+      "type": {
+        "lambda": {
+          "declaringClass": "com.github._1c_syntax.bsl.languageserver.infrastructure.ExecutorConfiguration",
+          "interfaces": [
+            "org.springframework.core.task.TaskDecorator"
+          ]
+        }
+      }
+    },
+    {
+      "type": {
+        "lambda": {
+          "declaringClass": "org.springframework.boot.autoconfigure.task.TaskExecutorConfigurations$BootstrapExecutorConfiguration",
+          "interfaces": [
+            "org.springframework.beans.factory.config.BeanFactoryPostProcessor"
+          ]
+        }
+      }
+    },
+    {
+      "type": {
+        "lambda": {
+          "declaringClass": "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter",
+          "interfaces": [
+            "org.springframework.boot.validation.beanvalidation.MethodValidationExcludeFilter"
+          ]
+        }
+      }
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticComputer$$SpringCGLIB$$0",
+      "fields": [
+        {
+          "name": "CGLIB$CALLBACK_FILTER"
+        },
+        {
+          "name": "CGLIB$FACTORY_DATA"
+        }
+      ],
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration",
+            "java.util.concurrent.ExecutorService"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.springframework.beans.factory.annotation.Lookup"
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.aop.MeasuresAspect",
@@ -26,18 +16040,6 @@
           "parameterTypes": []
         }
       ]
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration$$SpringCGLIB$$1",
-      "allDeclaredFields": true,
-      "allDeclaredConstructors": true,
-      "allDeclaredMethods": true
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos$$SpringCGLIB$$1",
-      "allDeclaredFields": true,
-      "allDeclaredConstructors": true,
-      "allDeclaredMethods": true
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.references.model.AnnotationRepository$$SpringCGLIB$$1",
@@ -158,6 +16160,2836 @@
       "allDeclaredFields": true,
       "allDeclaredConstructors": true,
       "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.CompletionItemDefaultsEditRangeTypeAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.CompletionItemTextEditTypeAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.DocumentChangeListAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.HoverTypeAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.InitializeParamsTypeAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.ProgressNotificationAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.ResourceOperationTypeAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.SymbolInformationTypeAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.TextEditListAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.VersionedTextDocumentIdentifierTypeAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.WorkDoneProgressNotificationAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.WorkspaceDocumentDiagnosticReportListAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "org.eclipse.lsp4j.adapters.WorkspaceSymbolLocationTypeAdapter",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    }
+  ],
+  "resources": [
+    {
+      "glob": "META-INF/MANIFEST.MF"
+    },
+    {
+      "glob": "META-INF/build-info.properties"
+    },
+    {
+      "glob": "META-INF/services/ch.qos.logback.classic.spi.Configurator"
+    },
+    {
+      "glob": "META-INF/services/io.micrometer.context.ContextAccessor"
+    },
+    {
+      "glob": "META-INF/services/io.micrometer.context.ThreadLocalAccessor"
+    },
+    {
+      "glob": "META-INF/services/java.net.spi.InetAddressResolverProvider"
+    },
+    {
+      "glob": "META-INF/services/java.net.spi.URLStreamHandlerProvider"
+    },
+    {
+      "glob": "META-INF/services/java.time.zone.ZoneRulesProvider"
+    },
+    {
+      "glob": "META-INF/services/java.util.spi.ResourceBundleControlProvider"
+    },
+    {
+      "glob": "META-INF/services/javax.xml.parsers.SAXParserFactory"
+    },
+    {
+      "glob": "META-INF/services/javax.xml.stream.XMLInputFactory"
+    },
+    {
+      "glob": "META-INF/services/javax.xml.stream.XMLOutputFactory"
+    },
+    {
+      "glob": "META-INF/services/org.apache.commons.logging.LogFactory"
+    },
+    {
+      "glob": "META-INF/services/org.apache.juli.logging.Log"
+    },
+    {
+      "glob": "META-INF/services/org.apache.logging.log4j.util.PropertySource"
+    },
+    {
+      "glob": "META-INF/services/org.ehcache.core.spi.service.ServiceFactory"
+    },
+    {
+      "glob": "META-INF/services/org.slf4j.spi.SLF4JServiceProvider"
+    },
+    {
+      "glob": "META-INF/services/tools.jackson.databind.JacksonModule"
+    },
+    {
+      "glob": "META-INF/spring-autoconfigure-metadata.properties"
+    },
+    {
+      "glob": "META-INF/spring.components"
+    },
+    {
+      "glob": "META-INF/spring.factories"
+    },
+    {
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.imports"
+    },
+    {
+      "glob": "META-INF/spring/org.springframework.boot.autoconfigure.AutoConfiguration.replacements"
+    },
+    {
+      "glob": "application-default.properties"
+    },
+    {
+      "glob": "application-default.xml"
+    },
+    {
+      "glob": "application-default.yaml"
+    },
+    {
+      "glob": "application-default.yml"
+    },
+    {
+      "glob": "application.properties"
+    },
+    {
+      "glob": "application.xml"
+    },
+    {
+      "glob": "application.yaml"
+    },
+    {
+      "glob": "application.yml"
+    },
+    {
+      "glob": "ch/qos/logback/classic/logback-classic-version.properties"
+    },
+    {
+      "glob": "ch/qos/logback/core/logback-core-version.properties"
+    },
+    {
+      "glob": "com/fasterxml/jackson/annotation/JacksonAnnotation.class"
+    },
+    {
+      "glob": "com/fasterxml/jackson/annotation/JsonIgnoreProperties.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/AnalyzeProjectOnStart.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/AutoServerInfo.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/ClientCapabilitiesHolder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/LanguageClientHolder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/ParentProcessWatcher.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/WorkDoneProgressHelper$WorkDoneProgressReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/WorkDoneProgressHelper.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/aop/AspectJConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/aop/EventPublisherAspectRegistration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/aop/SentryAspect.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/aop/sentry/PermissionFilterBeforeSendCallback.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/aop/sentry/PermissionFilterBeforeSendCallback.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/aop/sentry/PermissionFilterBeforeSendCallback_en.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/aop/sentry/PermissionFilterBeforeSendCallback_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/aop/sentry/SentryScopeConfigurer.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand$ReportersKeys.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/cli/FormatCommand.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/cli/LanguageServerStartCommand.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/cli/VersionCommand.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/cli/WebsocketCommand.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/cli/lsp/FileAwarePrintWriter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/cli/lsp/LanguageServerLauncherConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codeactions/AbstractQuickFixSupplier$LightDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codeactions/AbstractQuickFixSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codeactions/CodeActionSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codeactions/DisableDiagnosticTriggeringSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codeactions/ExtractStructureConstructorSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codeactions/FixAllCodeActionSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codeactions/QuickFixCodeActionSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codeactions/QuickFixSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/AbstractMethodComplexityCodeLensSupplier$ComplexityCodeLensData.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/AbstractMethodComplexityCodeLensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/AbstractRunTestsCodeLensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/CodeLensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/CognitiveComplexityCodeLensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/CyclomaticComplexityCodeLensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/DebugTestCodeLensSupplier$DebugTestCodeLensData.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/DebugTestCodeLensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/RunAllTestsCodeLensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/RunTestCodeLensSupplier$RunTestCodeLensData.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/RunTestCodeLensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/TestSourcesProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/infrastructure/CodeLensesConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/codelenses/testrunner/TestRunnerAdapter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/color/ColorInformationSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/color/ColorPresentationSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/color/ConstructorColorInformationSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/color/ConstructorColorPresentationSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/color/WebColorInformationSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/color/WebColorPresentationSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/commands/CommandSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/commands/ToggleCognitiveComplexityInlayHintsCommandSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/commands/ToggleCyclomaticComplexityInlayHintsCommandSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/commands/complexity/AbstractToggleComplexityInlayHintsCommandSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/commands/infrastructure/CommandsConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/configuration/GlobalLanguageServerConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfigurationFactory.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/configuration/watcher/ConfigurationFileChangeListener.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/configuration/watcher/ConfigurationFileSystemWatcher.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/ServerContext$State.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/ServerContext.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/ServerContext.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/ServerContext_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/computer/CognitiveComplexityComputer.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/computer/Computer.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/computer/CyclomaticComplexityComputer.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/context/symbol/SymbolTreeVisitor.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/databind/JsonMapperConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractCommonModuleNameDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractExecuteExternalCodeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractExpressionTreeDiagnostic$ExpressionTreeBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractExpressionTreeDiagnostic$ExpressionVisitorDecision.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractExpressionTreeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractFindMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractListenerDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractMagicValueDiagnostic$CallParamInfo.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractMagicValueDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractMetadataDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractMultilingualStringDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractSDBLListenerDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractSDBLVisitorDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractSymbolTreeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractVisitorDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AllFunctionPathMustHaveReturnDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AllFunctionPathMustHaveReturnDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AllFunctionPathMustHaveReturnDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AssignAliasFieldsInQueryDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AssignToReadOnlyPropertyDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/BSLDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/BadWordsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/BadWordsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/BadWordsDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/BeginTransactionBeforeTryCatchDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CachedPublicDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CanonicalSpellingKeywordsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CodeAfterAsyncCallDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CodeBlockBeforeSubDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CodeOutOfRegionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CodeOutOfRegionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CodeOutOfRegionDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CognitiveComplexityDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CognitiveComplexityDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CognitiveComplexityDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommandModuleExportMethodsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommentedCodeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommentedCodeDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommentedCodeDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommitTransactionOutsideTryCatchDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleAssignDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleInvalidTypeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleMissingAPIDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameCachedDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameClientDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameClientServerDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameFullAccessDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameGlobalClientDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameGlobalDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameServerCallDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameWordsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameWordsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameWordsDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CompilationDirectiveLostDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CompilationDirectiveNeedLessDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ConsecutiveEmptyLinesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ConsecutiveEmptyLinesDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ConsecutiveEmptyLinesDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CrazyMultilineStringDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CreateQueryInCycleDiagnostic$CodeFlowType.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CreateQueryInCycleDiagnostic$Scope.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CreateQueryInCycleDiagnostic$VariableDefinition.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CreateQueryInCycleDiagnostic$VariableScope.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CreateQueryInCycleDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CyclomaticComplexityDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CyclomaticComplexityDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CyclomaticComplexityDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DataExchangeLoadingDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DataExchangeLoadingDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DataExchangeLoadingDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeletingCollectionItemDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DenyIncompleteValuesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedAttributes8312Diagnostic$Metaobject.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedAttributes8312Diagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedCurrentDateDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedFindDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedMessageDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedMethodCallDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedMethods8310Diagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedMethods8317Diagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedTypeManagedFormDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DisableSafeModeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DoubleNegativesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DuplicateRegionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DuplicateStringLiteralDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DuplicateStringLiteralDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DuplicateStringLiteralDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DuplicatedInsertionIntoCollectionDiagnostic$GroupingData.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DuplicatedInsertionIntoCollectionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DuplicatedInsertionIntoCollectionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DuplicatedInsertionIntoCollectionDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyCodeBlockDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyCodeBlockDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyCodeBlockDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyRegionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyStatementDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExcessiveAutoTestCheckDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExecuteExternalCodeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExecuteExternalCodeInCommonModuleDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExportVariablesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExternalAppStartingDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExternalAppStartingDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExternalAppStartingDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExtraCommasDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FileSystemAccessDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FileSystemAccessDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FileSystemAccessDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ForbiddenMetadataNameDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FormDataToValueDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FullOuterJoinQueryDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionNameStartsWithGetDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionOutParameterDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionReturnsSamePrimitiveDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionReturnsSamePrimitiveDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionReturnsSamePrimitiveDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionShouldHaveReturnDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/GetFormMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/GlobalContextMethodCollision8312Diagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IdenticalExpressionsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IdenticalExpressionsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IdenticalExpressionsDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfConditionComplexityDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfConditionComplexityDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfConditionComplexityDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseDuplicatedCodeBlockDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseDuplicatedConditionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseIfEndsWithElseDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IncorrectLineBreakDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IncorrectLineBreakDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IncorrectLineBreakDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IncorrectUseLikeInQueryDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IncorrectUseOfStrTemplateDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/InternetAccessDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/InvalidCharacterInFileDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IsInRoleMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/JoinWithSubQueryDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/JoinWithVirtualTableDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LatinAndCyrillicSymbolInWordDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LatinAndCyrillicSymbolInWordDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LatinAndCyrillicSymbolInWordDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LineLengthDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LineLengthDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LineLengthDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LogicalOrInJoinQuerySectionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LogicalOrInTheWhereSectionOfQueryDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MagicDateDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MagicDateDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MagicDateDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MagicNumberDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MagicNumberDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MagicNumberDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MetadataObjectNameLengthDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MetadataObjectNameLengthDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MetadataObjectNameLengthDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MethodSizeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MethodSizeDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MethodSizeDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissedRequiredParameterDiagnostic$MethodCall.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissedRequiredParameterDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingCodeTryCatchExDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingCodeTryCatchExDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingCodeTryCatchExDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingCommonModuleMethodDiagnostic$CallData.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingCommonModuleMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingEventSubscriptionHandlerDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingParameterDescriptionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingReturnedValueDescriptionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingReturnedValueDescriptionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingReturnedValueDescriptionDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingSpaceDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingSpaceDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingSpaceDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingTempStorageDeletionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingTemporaryFileDeletionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingTemporaryFileDeletionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingTemporaryFileDeletionDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingVariablesDescriptionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MultilineStringInQueryDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MultilingualStringHasAllDeclaredLanguagesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MultilingualStringHasAllDeclaredLanguagesDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MultilingualStringHasAllDeclaredLanguagesDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MultilingualStringUsingWithTemplateDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MultilingualStringUsingWithTemplateDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MultilingualStringUsingWithTemplateDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedConstructorsInStructureDeclarationDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedFunctionInParametersDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedFunctionInParametersDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedFunctionInParametersDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedStatementsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedStatementsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedStatementsDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedTernaryOperatorDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NonExportMethodsInApiRegionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NonExportMethodsInApiRegionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NonExportMethodsInApiRegionDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NonStandardRegionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfOptionalParamsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfOptionalParamsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfOptionalParamsDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfParamsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfParamsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfParamsDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfValuesInStructureConstructorDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfValuesInStructureConstructorDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfValuesInStructureConstructorDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OSUsersMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OneStatementPerLineDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OrderOfParamsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OrdinaryAppSupportDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PairingBrokenTransactionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ParseErrorDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PrivilegedModuleMethodCallDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PrivilegedModuleMethodCallDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PrivilegedModuleMethodCallDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ProcedureReturnsValueDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ProtectedModuleDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PublicMethodsDescriptionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PublicMethodsDescriptionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PublicMethodsDescriptionDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/QueryNestedFieldsByDotDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/QueryParseErrorDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/QueryToMissingMetadataDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/QuickFixProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RedundantAccessToObjectDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RedundantAccessToObjectDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RedundantAccessToObjectDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RefOveruseDiagnostic$TabularSectionTable.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RefOveruseDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ReservedParameterNamesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ReservedParameterNamesDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ReservedParameterNamesDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RewriteMethodParameterDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SameMetadataObjectAndChildNamesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ScheduledJobHandlerDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SelectTopWithoutOrderByDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SelectTopWithoutOrderByDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SelectTopWithoutOrderByDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SelfAssignDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SelfInsertionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SemicolonPresenceDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ServerCallsInFormEventsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ServerSideExportFormMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SetPermissionsForNewObjectsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SetPermissionsForNewObjectsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SetPermissionsForNewObjectsDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SetPrivilegedModeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SeveralCompilerDirectivesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SpaceAtStartCommentDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SpaceAtStartCommentDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SpaceAtStartCommentDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/StyleElementConstructorsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TempFilesDirDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TernaryOperatorUsageDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ThisObjectAssignDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TimeoutsInExternalResourcesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TimeoutsInExternalResourcesDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TimeoutsInExternalResourcesDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TooManyReturnsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TooManyReturnsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TooManyReturnsDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TransferringParametersBetweenClientAndServerDiagnostic$ParamReference.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TransferringParametersBetweenClientAndServerDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TransferringParametersBetweenClientAndServerDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TransferringParametersBetweenClientAndServerDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TryNumberDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnaryPlusInConcatenationDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnionAllDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnknownPreprocessorSymbolDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnreachableCodeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnsafeFindByCodeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnsafeSafeModeMethodCallDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalMethodDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalMethodDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalVariableDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedParametersDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsageWriteLogEventDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UseLessForEachDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UseSystemInformationDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UselessTernaryOperatorDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingCancelParameterDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingExternalCodeToolsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingFindElementByStringDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingGotoDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodeNetworkAddressDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodeNetworkAddressDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodeNetworkAddressDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodePathDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodePathDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodePathDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodeSecretInformationDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodeSecretInformationDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingHardcodeSecretInformationDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingLikeInQueryDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingModalWindowsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingModalWindowsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingModalWindowsDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingObjectNotAvailableUnixDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingServiceTagDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingServiceTagDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingServiceTagDiagnostic_ru.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingSynchronousCallsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingThisFormDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/VirtualTableCallWithoutParametersDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongDataPathForFormElementsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongHttpServiceHandlerDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongUseFunctionProceedWithCallDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongUseOfRollbackTransactionMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongWebServiceHandlerDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/YoLetterUsageDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/infrastructure/DiagnosticBeanPostProcessor.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/infrastructure/DiagnosticInfoRefresher.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/infrastructure/DiagnosticInfos.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/infrastructure/DiagnosticInfosFactory.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/infrastructure/DiagnosticObjectProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/infrastructure/DiagnosticsConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/metadata/DiagnosticMetadata.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/typo/CheckedWordsHolder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/AbstractASTDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/AbstractSDBLDocumentHighlightSupplier$QueryTokenInfo.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/AbstractSDBLDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/BracketDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/DocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/IfStatementDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/LoopStatementDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/RegionDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/SDBLBracketDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/SDBLCaseDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/SDBLJoinDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/SubroutineDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documenthighlight/TryStatementDocumentHighlightSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documentlink/DiagnosticDescriptionDocumentLinkSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/documentlink/DocumentLinkSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/AbstractCommentFoldingRangeSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/CodeBlockFoldingRangeSupplier$CodeBlockVisitor.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/CodeBlockFoldingRangeSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/CommentFoldingRangeSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/FoldingRangeSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/PreprocIfFoldingRangeSupplier$PreprocIfVisitor.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/PreprocIfFoldingRangeSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/QueryCommentFoldingRangeSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/QueryPackageFoldingRangeSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/RegionFoldingRangeSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/folding/UseFoldingRangeSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/AnnotationParamSymbolMarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/AnnotationSymbolMarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/CollectionHoverHints.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/ConstructorCallMarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/ConstructorHoverBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/DescriptionFormatter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/KeywordSymbolMarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/MarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/MarkupContentBuilderConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/ModuleSymbolMarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/PlatformMemberHoverBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/PlatformMemberSymbolMarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/SyntheticSymbolMarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/infrastructure/CacheConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/infrastructure/CachePathProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration$NamedForkJoinWorkerThreadFactory.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration$WorkspaceAwareFJWTFactory.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/infrastructure/LogbackConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/infrastructure/SchedulingConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/infrastructure/UtilsConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceScopeConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/inlayhints/AbstractComplexityInlayHintSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/inlayhints/AbstractMethodCallInlayHintSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/inlayhints/CognitiveComplexityInlayHintSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/inlayhints/CyclomaticComplexityInlayHintSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/inlayhints/InlayHintSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/inlayhints/infrastructure/InlayHintsConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/jsonrpc/ProtocolExtension.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/CallHierarchyProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/CodeActionProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/CodeLensProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/ColorProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/CommandProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider$DotCompletionInfo.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider$LineInfo.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/DefinitionProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/DiagnosticProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/DocumentHighlightProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/DocumentLinkProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/FoldingRangeProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider$EditWindow.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider$LineTokens.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/HoverProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/InlayHintProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/ReferencesProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/RenameProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/SelectionRangeProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider$CachedTokenData.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/AnnotationReferenceFinder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/KeywordReferenceFinder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/NewExpressionReferenceFinder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/PlatformMemberReferenceFinder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/ReferenceFinder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller$MethodSymbolReferenceIndexFinder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller$VariableSymbolReferenceIndexFinder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexReferenceFinder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/ReferenceResolver.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/SourceDefinedSymbolDeclarationReferenceFinder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/model/AnnotationRepository.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/model/LocationRepository.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/references/model/SymbolOccurrenceRepository.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/AbstractDiagnosticReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/CodeQualityReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/ConsoleReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/DiagnosticReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/GenericIssueReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/JUnitReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/JsonReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/ReportersAggregator.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/SarifReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/TSLintReporter.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/reporters/infrastructure/ReportersConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/AnnotationSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/CommentSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/GlobalScopeSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/LexicalSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/MethodCallSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/NewExpressionSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformGlobalMethodSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/PreprocessorSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensHelper.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensLegendConfiguration.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/StringSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplier.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/TypeService$TypedMember.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/TypeService.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndex.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer$InferenceContext.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/ConventionalLibraryDiscovery$ConventionalLibrary.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/ConventionalLibraryDiscovery.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigDiscovery.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser$LibConfig.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser$LibEntry.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser$RawEntry.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser$RawPackageDef.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryFileSystemWatcher.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex$EntryKind.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex$LibraryEntry.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptModuleMembersProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptModuleTypeResolver.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextHolder.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinOScriptPlatformTypesProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinPlatformTypesProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider$KeywordDescription.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider$Loaded.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider$PlatformVariable.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformContextProviderFactory.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformTypesProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/TypePackProvider.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry$ScopedConstructorSource.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry$ScopedConstructors.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry$ScopedDescription.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry$ScopedMemberSource.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-oscript-globals.json"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-oscript-platform-types.json"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/scope/GlobalSymbolScope$Entry.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/scope/GlobalSymbolScope$Role.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/scope/GlobalSymbolScope.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/utils/Resources.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/utils/expressiontree/ExpressionTreeVisitor.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/websocket/LSPWebSocketEndpoint.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/parser/BSLParserBaseListener.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/parser/BSLParserBaseVisitor.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/parser/BSLParserListener.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/parser/BSLParserVisitor.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/parser/SDBLParserBaseListener.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/parser/SDBLParserBaseVisitor.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/parser/SDBLParserListener.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/parser/SDBLParserVisitor.class"
+    },
+    {
+      "glob": "commons-logging.properties"
+    },
+    {
+      "glob": "config/application-default.properties"
+    },
+    {
+      "glob": "config/application-default.xml"
+    },
+    {
+      "glob": "config/application-default.yaml"
+    },
+    {
+      "glob": "config/application-default.yml"
+    },
+    {
+      "glob": "config/application.properties"
+    },
+    {
+      "glob": "config/application.xml"
+    },
+    {
+      "glob": "config/application.yaml"
+    },
+    {
+      "glob": "config/application.yml"
+    },
+    {
+      "glob": "git.properties"
+    },
+    {
+      "glob": "io/sentry/SentryOptions$BeforeSendCallback.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$ApacheHttpClientTransportFactoryAutoconfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$ContextTagsEventProcessorConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$Graphql22Configuration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$GraphqlConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$OpenTelemetryAgentWithoutAutoInitConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$OpenTelemetryNoAgentConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$QuartzConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryCacheConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryCheckInAspectsConfiguration$SentryCheckInPointcutAutoConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryCheckInAspectsConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryErrorAspectsConfiguration$SentryCaptureExceptionParameterPointcutAutoConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryErrorAspectsConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryKafkaQueueConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryPerformanceAspectsConfiguration$SentrySpanPointcutAutoConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryPerformanceAspectsConfiguration$SentryTransactionPointcutAutoConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryPerformanceAspectsConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryPerformanceRestTemplateConfigurationWrapper.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryPerformanceWebClientConfigurationWrapper.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentrySpanRestClientConfigurationWrapper.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration$SentryWebMvcConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$HubConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$SentryTracingCondition$SentryTracesSampleRateCondition.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$SentryTracingCondition$SentryTracesSamplerBeanCondition.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$SentryTracingCondition.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration$SpringProfilesEventProcessorConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryAutoConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring/boot4/SentryLogbackAppenderAutoConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring7/checkin/SentryCheckInAdviceConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring7/checkin/SentryCheckInPointcutConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring7/exception/SentryCaptureExceptionParameterPointcutConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring7/exception/SentryExceptionParameterAdviceConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring7/tracing/SentryAdviceConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring7/tracing/SentrySpanPointcutConfiguration.class"
+    },
+    {
+      "glob": "io/sentry/spring7/tracing/SentryTransactionPointcutConfiguration.class"
+    },
+    {
+      "glob": "jakarta/websocket/Endpoint.class"
+    },
+    {
+      "glob": "language-client-aware-appender.xml"
+    },
+    {
+      "glob": "log4j2.StatusLogger.properties"
+    },
+    {
+      "glob": "log4j2.component.properties"
+    },
+    {
+      "glob": "log4j2.system.properties"
+    },
+    {
+      "glob": "logback-spring.groovy"
+    },
+    {
+      "glob": "logback-spring.xml"
+    },
+    {
+      "glob": "logback-test-spring.groovy"
+    },
+    {
+      "glob": "logback-test-spring.xml"
+    },
+    {
+      "glob": "logback-test.groovy"
+    },
+    {
+      "glob": "logback-test.xml"
+    },
+    {
+      "glob": "logback.groovy"
+    },
+    {
+      "glob": "logback.xml"
+    },
+    {
+      "glob": "messages.properties"
+    },
+    {
+      "glob": "org/antlr/v4/runtime/tree/AbstractParseTreeVisitor.class"
+    },
+    {
+      "glob": "org/antlr/v4/runtime/tree/ParseTreeListener.class"
+    },
+    {
+      "glob": "org/antlr/v4/runtime/tree/ParseTreeVisitor.class"
+    },
+    {
+      "glob": "org/apache/catalina/authenticator/LocalStrings.properties"
+    },
+    {
+      "glob": "org/apache/catalina/util/LocalStrings.properties"
+    },
+    {
+      "glob": "org/apache/catalina/valves/LocalStrings.properties"
+    },
+    {
+      "glob": "org/apache/tomcat/util/http/LocalStrings.properties"
+    },
+    {
+      "glob": "org/eclipse/lsp4j/ServerInfo.class"
+    },
+    {
+      "glob": "org/eclipse/lsp4j/jsonrpc/services/JsonSegment.class"
+    },
+    {
+      "glob": "org/eclipse/lsp4j/services/LanguageClientAware.class"
+    },
+    {
+      "glob": "org/eclipse/lsp4j/services/LanguageServer.class"
+    },
+    {
+      "glob": "org/eclipse/lsp4j/services/TextDocumentService.class"
+    },
+    {
+      "glob": "org/eclipse/lsp4j/services/WorkspaceService.class"
+    },
+    {
+      "glob": "org/eclipse/lsp4j/websocket/jakarta/WebSocketEndpoint.class"
+    },
+    {
+      "glob": "org/jspecify/annotations/NullMarked.class"
+    },
+    {
+      "glob": "org/springframework/aop/aspectj/annotation/AnnotationAwareAspectJAutoProxyCreator.class"
+    },
+    {
+      "glob": "org/springframework/beans/factory/Aware.class"
+    },
+    {
+      "glob": "org/springframework/beans/factory/BeanClassLoaderAware.class"
+    },
+    {
+      "glob": "org/springframework/beans/factory/config/BeanPostProcessor.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/AutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/AutoConfigureAfter.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/AutoConfigureBefore.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/AutoConfigureOrder.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/admin/SpringApplicationAdminJmxAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/aop/AopAutoConfiguration$AspectJAutoProxyingConfiguration$CglibAutoProxyConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/aop/AopAutoConfiguration$AspectJAutoProxyingConfiguration$JdkDynamicAutoProxyConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/aop/AopAutoConfiguration$AspectJAutoProxyingConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/aop/AopAutoConfiguration$ClassProxyingConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/aop/AopAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/availability/ApplicationAvailabilityAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/condition/ConditionalOnBean.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/condition/ConditionalOnBooleanProperty.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/condition/ConditionalOnClass.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/condition/ConditionalOnMissingBean.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/condition/ConditionalOnProperty.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/context/ConfigurationPropertiesAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/context/LifecycleAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/context/MessageSourceAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/context/PropertyPlaceholderAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/info/ProjectInfoAutoConfiguration$GitResourceAvailableCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/info/ProjectInfoAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/jmx/JmxAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/ssl/SslAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutionAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations$AsyncConfigurerConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations$AsyncConfigurerWrapperConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations$BootstrapExecutorConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations$OnExecutorCondition$ExecutorBeanCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations$OnExecutorCondition$ModelCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations$OnExecutorCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations$SimpleAsyncTaskExecutorBuilderConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations$TaskExecutorConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskExecutorConfigurations$ThreadPoolTaskExecutorBuilderConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskSchedulingAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskSchedulingConfigurations$SimpleAsyncTaskSchedulerBuilderConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskSchedulingConfigurations$TaskSchedulerConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/autoconfigure/task/TaskSchedulingConfigurations$ThreadPoolTaskSchedulerBuilderConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/CacheAutoConfiguration$CacheConfigurationImportSelector.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/CacheAutoConfiguration$CacheManagerEntityManagerFactoryDependsOnConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/CacheAutoConfiguration$CacheManagerEntityManagerFactoryDependsOnPostProcessor.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/CacheAutoConfiguration$CacheManagerValidator.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/CacheAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/CaffeineCacheConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/GenericCacheConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/HazelcastJCacheCustomizationConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/JCacheCacheConfiguration$JCacheAvailableCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/JCacheCacheConfiguration$JCacheProviderAvailableCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/JCacheCacheConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/NoOpCacheConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/SimpleCacheConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/metrics/CacheMeterBinderProvidersConfiguration$Cache2kCacheMeterBinderProviderConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/metrics/CacheMeterBinderProvidersConfiguration$CaffeineCacheMeterBinderProviderConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/metrics/CacheMeterBinderProvidersConfiguration$HazelcastCacheMeterBinderProviderConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/metrics/CacheMeterBinderProvidersConfiguration$JCacheCacheMeterBinderProviderConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/metrics/CacheMeterBinderProvidersConfiguration$RedisCacheMeterBinderProviderConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/metrics/CacheMeterBinderProvidersConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/metrics/CacheMetricsAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/cache/autoconfigure/metrics/CacheMetricsRegistrarConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationProperties.class"
+    },
+    {
+      "glob": "org/springframework/boot/context/properties/EnableConfigurationPropertiesRegistrar.class"
+    },
+    {
+      "glob": "org/springframework/boot/data/couchbase/autoconfigure$DataCouchbaseAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/data/couchbase/autoconfigure/DataCouchbaseAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/data/redis/autoconfigure$DataRedisAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/data/redis/autoconfigure/DataRedisAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/gson/autoconfigure$GsonAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/gson/autoconfigure/GsonAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/hazelcast/autoconfigure$HazelcastAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/hazelcast/autoconfigure/HazelcastAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/hibernate/autoconfigure$HibernateJpaAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/hibernate/autoconfigure/HibernateJpaAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration$GsonHttpConvertersCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration$GsonHttpMessageConverterConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration$JacksonAndJsonbUnavailableCondition$Jackson2Available.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration$JacksonAndJsonbUnavailableCondition$JacksonAvailable.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration$JacksonAndJsonbUnavailableCondition$JsonbPreferred.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration$JacksonAndJsonbUnavailableCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration$PreferGsonOrJacksonAndJsonbUnavailableCondition$GsonPreferred.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration$PreferGsonOrJacksonAndJsonbUnavailableCondition$JacksonJsonbUnavailable.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration$PreferGsonOrJacksonAndJsonbUnavailableCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/GsonHttpMessageConvertersConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfiguration$NotReactiveWebApplicationCondition$ReactiveWebApplication.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfiguration$NotReactiveWebApplicationCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfiguration$StringHttpMessageConverterConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfiguration$StringHttpMessageConvertersCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/HttpMessageConvertersAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration$Jackson2JsonMessageConvertersCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration$Jackson2XmlMessageConvertersCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration$MappingJackson2HttpMessageConverterConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration$MappingJackson2XmlHttpMessageConverterConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration$PreferJackson2OrJacksonUnavailableCondition$Jackson2Preferred.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration$PreferJackson2OrJacksonUnavailableCondition$JacksonUnavailable.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration$PreferJackson2OrJacksonUnavailableCondition.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/Jackson2HttpMessageConvertersConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/JacksonHttpMessageConvertersConfiguration$JacksonJsonHttpMessageConverterConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/JacksonHttpMessageConvertersConfiguration$JacksonJsonHttpMessageConvertersCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/JacksonHttpMessageConvertersConfiguration$JacksonXmlHttpMessageConverterConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/JacksonHttpMessageConvertersConfiguration$JacksonXmlHttpMessageConvertersCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/JacksonHttpMessageConvertersConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/JsonbHttpMessageConvertersConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/http/converter/autoconfigure/KotlinSerializationHttpMessageConvertersConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$AbstractMapperBuilderCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$CborConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$JacksonAutoConfigurationRuntimeHints.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$JacksonJsonMapperBuilderCustomizerConfiguration$StandardJsonMapperBuilderCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$JacksonJsonMapperBuilderCustomizerConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$JacksonMixinConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$JsonProblemDetailsConfiguration$ProblemDetailJsonMapperBuilderCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$JsonProblemDetailsConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$XmlConfiguration$StandardXmlMapperBuilderCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$XmlConfiguration$XmlProblemDetailsConfiguration$ProblemDetailXmlMapperBuilderCustomizer.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$XmlConfiguration$XmlProblemDetailsConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration$XmlConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson/autoconfigure/JacksonAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson2/autoconfigure$Jackson2AutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jackson2/autoconfigure/Jackson2AutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jsonb/autoconfigure$JsonbAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/jsonb/autoconfigure/JsonbAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/kotlinx/serialization/json/autoconfigure$KotlinxSerializationJsonAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/kotlinx/serialization/json/autoconfigure/KotlinxSerializationJsonAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/logging/logback/defaults.xml"
+    },
+    {
+      "glob": "org/springframework/boot/micrometer/metrics/autoconfigure$CompositeMeterRegistryAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/micrometer/metrics/autoconfigure/CompositeMeterRegistryAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/servlet/autoconfigure/HttpEncodingAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/servlet/autoconfigure/MultipartAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/tomcat/autoconfigure/metrics/TomcatMetricsAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/tomcat/autoconfigure/servlet/TomcatServletWebServerAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/validation/autoconfigure$ValidationAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/validation/autoconfigure/ValidationAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/webmvc/autoconfigure/DispatcherServletAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/webmvc/autoconfigure/WebMvcAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/webmvc/autoconfigure/error/ErrorMvcAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/boot/websocket/autoconfigure/servlet/WebSocketMessagingAutoConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/cache/annotation/AbstractCachingConfiguration$CachingConfigurerSupplier.class"
+    },
+    {
+      "glob": "org/springframework/cache/annotation/AbstractCachingConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/cache/annotation/CacheConfig.class"
+    },
+    {
+      "glob": "org/springframework/cache/annotation/CachingConfigurationSelector.class"
+    },
+    {
+      "glob": "org/springframework/cache/annotation/EnableCaching.class"
+    },
+    {
+      "glob": "org/springframework/cache/annotation/ProxyCachingConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/cache/jcache/config/AbstractJCacheConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/cache/jcache/config/ProxyJCacheConfiguration.class"
+    },
+    {
+      "glob": "org/springframework/context/ApplicationContextAware.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/AdviceModeImportSelector.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/AspectJAutoProxyRegistrar.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/AutoProxyRegistrar.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/Conditional.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/Configuration.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/EnableAspectJAutoProxy.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/Import.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/ImportAware.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/ImportBeanDefinitionRegistrar.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/Primary.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/Role.class"
+    },
+    {
+      "glob": "org/springframework/context/annotation/Scope.class"
+    },
+    {
+      "glob": "org/springframework/core/annotation/Order.class"
+    },
+    {
+      "glob": "org/springframework/scheduling/annotation/EnableScheduling.class"
+    },
+    {
+      "glob": "org/springframework/scheduling/annotation/SchedulingConfiguration.class"
+    },
+    {
+      "glob": "picocli/CommandLine$Command.class"
+    },
+    {
+      "glob": "picocli/spring/boot/autoconfigure/PicocliAutoConfiguration.class"
+    },
+    {
+      "glob": "sentry-debug-meta.properties"
+    },
+    {
+      "glob": "sentry.properties"
+    },
+    {
+      "glob": "spring.properties"
+    },
+    {
+      "module": "java.base",
+      "glob": "java/util/currency.data"
+    },
+    {
+      "module": "java.base",
+      "glob": "jdk/internal/icu/impl/data/icudt76b/nfc.nrm"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.aop.sentry.PermissionFilterBeforeSendCallback"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.context.ServerContext"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.AllFunctionPathMustHaveReturnDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.BadWordsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CodeOutOfRegionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CognitiveComplexityDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommentedCodeDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameWordsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ConsecutiveEmptyLinesDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CyclomaticComplexityDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.DataExchangeLoadingDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.DuplicateStringLiteralDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.DuplicatedInsertionIntoCollectionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.EmptyCodeBlockDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExternalAppStartingDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.FileSystemAccessDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionReturnsSamePrimitiveDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.IdenticalExpressionsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfConditionComplexityDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectLineBreakDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.LatinAndCyrillicSymbolInWordDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.LineLengthDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicDateDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicNumberDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MetadataObjectNameLengthDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MethodSizeDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCodeTryCatchExDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingReturnedValueDescriptionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingSpaceDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTemporaryFileDeletionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringHasAllDeclaredLanguagesDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringUsingWithTemplateDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedFunctionInParametersDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedStatementsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonExportMethodsInApiRegionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfOptionalParamsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfParamsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfValuesInStructureConstructorDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.PrivilegedModuleMethodCallDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.PublicMethodsDescriptionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.RedundantAccessToObjectDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ReservedParameterNamesDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelectTopWithoutOrderByDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPermissionsForNewObjectsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.SpaceAtStartCommentDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.TimeoutsInExternalResourcesDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.TooManyReturnsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.TransferringParametersBetweenClientAndServerDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.TypoDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalMethodDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeNetworkAddressDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodePathDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeSecretInformationDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingModalWindowsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingServiceTagDiagnostic"
+    },
+    {
+      "bundle": "org.apache.catalina.authenticator.LocalStrings"
+    },
+    {
+      "bundle": "org.apache.catalina.util.LocalStrings"
+    },
+    {
+      "bundle": "org.apache.catalina.valves.LocalStrings"
+    },
+    {
+      "bundle": "org.apache.tomcat.util.http.LocalStrings"
     }
   ],
   "bundles": [

--- a/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
@@ -1,0 +1,136 @@
+{
+  "reflection": [
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticInfos$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.model.AnnotationRepository$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.model.LocationRepository$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.references.model.SymbolOccurrenceRepository$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.TypeService$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.index.SymbolTypeIndex$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleMembersProvider$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleTypeResolver$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BslContextHolder$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BslContextPlatformTypesProvider$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BuiltinOScriptPlatformTypesProvider$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.BuiltinPlatformTypesProvider$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.ConfigurationModuleMembersProvider$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.ConfigurationTypesProvider$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.PlatformContextProviderFactory$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.types.scope.GlobalSymbolScope$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.utils.Resources$$SpringCGLIB$$1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    }
+  ]
+}

--- a/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
@@ -17287,6 +17287,498 @@
       "allDeclaredFields": true,
       "allDeclaredConstructors": true,
       "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Attachment",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.WebRequest",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Fix",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.EdgeTraversal",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ConfigurationOverride",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.InitialState",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.EnvironmentVariables",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Suppression$Status",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.PropertyBag",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Location",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Result",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Result$Kind",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.CodeFlow",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ReportingDescriptorReference",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.LogicalLocation",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.GraphTraversal",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.GlobalMessageStrings",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ArtifactLocation",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.StackFrame",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.MultiformatMessageString",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.State",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Replacement",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Exception",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.WebResponse",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.SarifSchema210$Version",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.PartialFingerprints",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Headers__1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Headers",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ReportingConfiguration$Level",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Artifact",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Result$Level",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ReportingDescriptor",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ThreadFlowLocation$Importance",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ExternalPropertyFileReferences",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Node",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Parameters",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Notification$Level",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Rectangle",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ReportingConfiguration",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Invocation",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Role",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ExternalProperties$Version",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.FinalState",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ThreadFlowLocation",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ReportingDescriptorRelationship",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Suppression",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Message",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.SpecialLocations",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Run",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Stack",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Region",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Hashes",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ThreadFlow",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ImmutableState__1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Tool",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.VersionControlDetails",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.MessageStrings",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Fingerprints",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ArtifactChange",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.TranslationMetadata",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.PhysicalLocation",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Address",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Result$BaselineState",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Edge",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ToolComponent",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.LocationRelationship",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Content",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Notification",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Run$ColumnKind",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Conversion",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ResultProvenance",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.SarifSchema210",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ExternalProperties",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ImmutableState",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.OriginalUriBaseIds",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.RunAutomationDetails",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Suppression$Kind",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ToolComponentReference",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ArtifactContent",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.Graph",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.ExternalPropertyFileReference",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
+    },
+    {
+      "type": "com.contrastsecurity.sarif.InitialState__1",
+      "allDeclaredFields": true,
+      "allDeclaredConstructors": true,
+      "allDeclaredMethods": true
     }
   ],
   "resources": [
@@ -20603,6 +21095,12 @@
     },
     {
       "glob": "org/languagetool/resource/**"
+    },
+    {
+      "glob": "net/loomchild/segment/res/**"
+    },
+    {
+      "glob": "net/loomchild/segment/**"
     }
   ],
   "bundles": [

--- a/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
@@ -1,6 +1,33 @@
 {
   "reflection": [
     {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.EventPublisherAspect",
+      "methods": [
+        {
+          "name": "aspectOf",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.SentryAspect",
+      "methods": [
+        {
+          "name": "aspectOf",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.aop.MeasuresAspect",
+      "methods": [
+        {
+          "name": "aspectOf",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
       "type": "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration$$SpringCGLIB$$1",
       "allDeclaredFields": true,
       "allDeclaredConstructors": true,
@@ -131,6 +158,623 @@
       "allDeclaredFields": true,
       "allDeclaredConstructors": true,
       "allDeclaredMethods": true
+    }
+  ],
+  "bundles": [
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.AnalyzeProjectOnStart"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.aop.SentryAspect"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.aop.sentry.PermissionFilterBeforeSendCallback"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.codeactions.DisableDiagnosticTriggeringSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.codeactions.ExtractStructureConstructorSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.codeactions.GenerateStandardRegionsSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.codelenses.CognitiveComplexityCodeLensSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.codelenses.CyclomaticComplexityCodeLensSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.codelenses.DebugTestCodeLensSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.codelenses.RunAllTestsCodeLensSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.codelenses.RunTestCodeLensSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.color.ConstructorColorPresentationSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.color.WebColorPresentationSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.context.ServerContext"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.AllFunctionPathMustHaveReturnDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.AssignAliasFieldsInQueryDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.AssignToReadOnlyPropertyDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.BadWordsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.BeginTransactionBeforeTryCatchDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CachedPublicDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CanonicalSpellingKeywordsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CodeAfterAsyncCallDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CodeBlockBeforeSubDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CodeOutOfRegionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CognitiveComplexityDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommandModuleExportMethodsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommentedCodeDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommitTransactionOutsideTryCatchDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleAssignDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleInvalidTypeDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleMissingAPIDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameCachedDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameClientDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameClientServerDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameFullAccessDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameGlobalClientDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameGlobalDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameServerCallDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameWordsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CompilationDirectiveLostDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CompilationDirectiveNeedLessDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ConsecutiveEmptyLinesDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CrazyMultilineStringDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CreateQueryInCycleDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.CyclomaticComplexityDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DataExchangeLoadingDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeletingCollectionItemDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DenyIncompleteValuesDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedAttributes8312Diagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedCurrentDateDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedFindDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedMessageDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedMethodCallDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedMethods8310Diagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedMethods8317Diagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedTypeManagedFormDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DisableSafeModeDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DoubleNegativesDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DuplicateRegionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DuplicateStringLiteralDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.DuplicatedInsertionIntoCollectionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.EmptyCodeBlockDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.EmptyRegionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.EmptyStatementDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExcessiveAutoTestCheckDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeInCommonModuleDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExportVariablesDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExternalAppStartingDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExtraCommasDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.FieldsFromJoinsWithoutIsNullDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.FileSystemAccessDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ForbiddenMetadataNameDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.FormDataToValueDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.FullOuterJoinQueryDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionNameStartsWithGetDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionOutParameterDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionReturnsSamePrimitiveDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionShouldHaveReturnDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.GetFormMethodDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.GlobalContextMethodCollision8312Diagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.IdenticalExpressionsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfConditionComplexityDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedCodeBlockDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedConditionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseIfEndsWithElseDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectLineBreakDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectUseLikeInQueryDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectUseOfStrTemplateDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.InternetAccessDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.InvalidCharacterInFileDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.IsInRoleMethodDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.JoinWithSubQueryDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.JoinWithVirtualTableDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.LatinAndCyrillicSymbolInWordDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.LineLengthDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.LogicalOrInJoinQuerySectionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.LogicalOrInTheWhereSectionOfQueryDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicDateDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicNumberDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MetadataObjectNameLengthDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MethodSizeDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissedRequiredParameterDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCodeTryCatchExDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCommonModuleMethodDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingEventSubscriptionHandlerDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingParameterDescriptionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingReturnedValueDescriptionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingSpaceDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTempStorageDeletionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTemporaryFileDeletionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingVariablesDescriptionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilineStringInQueryDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringHasAllDeclaredLanguagesDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringUsingWithTemplateDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedConstructorsInStructureDeclarationDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedFunctionInParametersDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedStatementsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedTernaryOperatorDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonExportMethodsInApiRegionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonStandardRegionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfOptionalParamsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfParamsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfValuesInStructureConstructorDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.OSUsersMethodDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.OneStatementPerLineDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.OrderOfParamsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.OrdinaryAppSupportDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.PairingBrokenTransactionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ParseErrorDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.PrivilegedModuleMethodCallDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ProcedureReturnsValueDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ProtectedModuleDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.PublicMethodsDescriptionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryNestedFieldsByDotDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryParseErrorDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryToMissingMetadataDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.RedundantAccessToObjectDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.RefOveruseDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ReservedParameterNamesDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.RewriteMethodParameterDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.SameMetadataObjectAndChildNamesDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ScheduledJobHandlerDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelectTopWithoutOrderByDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelfAssignDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelfInsertionDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.SemicolonPresenceDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ServerCallsInFormEventsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ServerSideExportFormMethodDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPermissionsForNewObjectsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPrivilegedModeDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.SeveralCompilerDirectivesDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.SpaceAtStartCommentDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.StyleElementConstructorsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.TempFilesDirDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.TernaryOperatorUsageDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.ThisObjectAssignDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.TimeoutsInExternalResourcesDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.TooManyReturnsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.TransferringParametersBetweenClientAndServerDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.TryNumberDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.TypoDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnaryPlusInConcatenationDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnionAllDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnknownPreprocessorSymbolDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnreachableCodeDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnsafeFindByCodeDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnsafeSafeModeMethodCallDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalMethodDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalVariableDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedParametersDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsageWriteLogEventDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UseLessForEachDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UseSystemInformationDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UselessTernaryOperatorDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingCancelParameterDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingExternalCodeToolsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingFindElementByStringDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingGotoDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeNetworkAddressDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodePathDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeSecretInformationDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingLikeInQueryDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingModalWindowsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingObjectNotAvailableUnixDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingServiceTagDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingSynchronousCallsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingThisFormDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.VirtualTableCallWithoutParametersDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongDataPathForFormElementsDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongHttpServiceHandlerDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongUseFunctionProceedWithCallDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongUseOfRollbackTransactionMethodDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongWebServiceHandlerDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.diagnostics.YoLetterUsageDiagnostic"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.documentlink.DiagnosticDescriptionDocumentLinkSupplier"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.hover.CollectionHoverHints"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.hover.ConstructorHoverBuilder"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.hover.KeywordSymbolMarkupContentBuilder"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.hover.ModuleSymbolMarkupContentBuilder"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.hover.PlatformMemberHoverBuilder"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.hover.SyntheticSymbolMarkupContentBuilder"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.hover.VariableSymbolMarkupContentBuilder"
+    },
+    {
+      "name": "com.github._1c_syntax.bsl.languageserver.inlayhints.PlatformMethodCallInlayHintSupplier"
     }
   ]
 }

--- a/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
+++ b/src/main/resources/META-INF/native-image/io.github.1c-syntax/bsl-language-server-hints/reachability-metadata.json
@@ -624,6 +624,9 @@
       ]
     },
     {
+      "type": "com.github._1c_syntax.bsl.languageserver.cfg.CfgEdge"
+    },
+    {
       "type": "com.github._1c_syntax.bsl.languageserver.cli.AnalyzeCommand",
       "fields": [
         {
@@ -1823,13 +1826,52 @@
       ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.CognitiveComplexityComputer"
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.CognitiveComplexityComputer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.DocumentContext"
+          ]
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        },
+        {
+          "name": "setStringInterner",
+          "parameterTypes": [
+            "com.github._1c_syntax.utils.StringInterner"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.ComplexityData"
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.context.computer.Computer"
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.CyclomaticComplexityComputer"
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.CyclomaticComplexityComputer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.DocumentContext"
+          ]
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        },
+        {
+          "name": "setStringInterner",
+          "parameterTypes": [
+            "com.github._1c_syntax.utils.StringInterner"
+          ]
+        }
+      ]
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticComputer",
@@ -1855,6 +1897,9 @@
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.context.computer.ModuleSymbolComputer"
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.context.computer.QueryComputer"
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.context.computer.RegionSymbolComputer"
@@ -2485,397 +2530,1221 @@
       ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeInCommonModuleDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExportVariablesDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExternalAppStartingDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExtraCommasDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FieldsFromJoinsWithoutIsNullDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FileSystemAccessDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ForbiddenMetadataNameDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FormDataToValueDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FullOuterJoinQueryDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionNameStartsWithGetDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionOutParameterDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionReturnsSamePrimitiveDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionShouldHaveReturnDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.GetFormMethodDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.GlobalContextMethodCollision8312Diagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IdenticalExpressionsDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfConditionComplexityDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedCodeBlockDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedConditionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseIfEndsWithElseDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectLineBreakDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectUseLikeInQueryDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectUseOfStrTemplateDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.InternetAccessDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.InvalidCharacterInFileDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IsInRoleMethodDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.JoinWithSubQueryDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.JoinWithVirtualTableDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LatinAndCyrillicSymbolInWordDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LineLengthDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LogicalOrInJoinQuerySectionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LogicalOrInTheWhereSectionOfQueryDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicDateDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicNumberDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MetadataObjectNameLengthDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MethodSizeDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissedRequiredParameterDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCodeTryCatchExDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCommonModuleMethodDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingEventSubscriptionHandlerDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingParameterDescriptionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingReturnedValueDescriptionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingSpaceDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTempStorageDeletionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTemporaryFileDeletionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingVariablesDescriptionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilineStringInQueryDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringHasAllDeclaredLanguagesDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringUsingWithTemplateDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedConstructorsInStructureDeclarationDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedFunctionInParametersDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedStatementsDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedTernaryOperatorDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonExportMethodsInApiRegionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonStandardRegionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfOptionalParamsDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfParamsDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfValuesInStructureConstructorDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OSUsersMethodDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OneStatementPerLineDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OrderOfParamsDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OrdinaryAppSupportDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.PairingBrokenTransactionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ParseErrorDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.PrivilegedModuleMethodCallDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ProcedureReturnsValueDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ProtectedModuleDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.PublicMethodsDescriptionDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryNestedFieldsByDotDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryParseErrorDiagnostic"
-    },
-    {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryToMissingMetadataDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeInCommonModuleDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExportVariablesDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExternalAppStartingDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExtraCommasDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FieldsFromJoinsWithoutIsNullDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FileSystemAccessDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ForbiddenMetadataNameDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FormDataToValueDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FullOuterJoinQueryDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionNameStartsWithGetDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionOutParameterDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionReturnsSamePrimitiveDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionShouldHaveReturnDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.GetFormMethodDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.GlobalContextMethodCollision8312Diagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IdenticalExpressionsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.providers.FormatProvider"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfConditionComplexityDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedCodeBlockDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedConditionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseIfEndsWithElseDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectLineBreakDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectUseLikeInQueryDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectUseOfStrTemplateDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.InternetAccessDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.InvalidCharacterInFileDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.IsInRoleMethodDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.JoinWithSubQueryDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.JoinWithVirtualTableDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LatinAndCyrillicSymbolInWordDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LineLengthDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LogicalOrInJoinQuerySectionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.LogicalOrInTheWhereSectionOfQueryDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicDateDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicNumberDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MetadataObjectNameLengthDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MethodSizeDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissedRequiredParameterDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCodeTryCatchExDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCommonModuleMethodDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.model.LocationRepository"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingEventSubscriptionHandlerDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingParameterDescriptionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingReturnedValueDescriptionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingSpaceDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.utils.StringInterner"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTempStorageDeletionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTemporaryFileDeletionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingVariablesDescriptionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilineStringInQueryDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringHasAllDeclaredLanguagesDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringUsingWithTemplateDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedConstructorsInStructureDeclarationDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedFunctionInParametersDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedStatementsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        },
+        {
+          "name": "init",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedTernaryOperatorDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonExportMethodsInApiRegionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonStandardRegionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfOptionalParamsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfParamsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfValuesInStructureConstructorDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OSUsersMethodDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OneStatementPerLineDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OrderOfParamsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.OrdinaryAppSupportDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.PairingBrokenTransactionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ParseErrorDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.PrivilegedModuleMethodCallDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ProcedureReturnsValueDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ProtectedModuleDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.PublicMethodsDescriptionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryNestedFieldsByDotDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryParseErrorDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
+    },
+    {
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryToMissingMetadataDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.QuickFixProvider"
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.RedundantAccessToObjectDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.RedundantAccessToObjectDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.RefOveruseDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.RefOveruseDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ReservedParameterNamesDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ReservedParameterNamesDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.RewriteMethodParameterDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.RewriteMethodParameterDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SameMetadataObjectAndChildNamesDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SameMetadataObjectAndChildNamesDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.utils.StringInterner"
+          ]
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ScheduledJobHandlerDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ScheduledJobHandlerDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelectTopWithoutOrderByDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelectTopWithoutOrderByDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelfAssignDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelfAssignDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelfInsertionDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelfInsertionDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SemicolonPresenceDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SemicolonPresenceDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ServerCallsInFormEventsDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ServerCallsInFormEventsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ServerSideExportFormMethodDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ServerSideExportFormMethodDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPermissionsForNewObjectsDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPermissionsForNewObjectsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPrivilegedModeDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPrivilegedModeDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SeveralCompilerDirectivesDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SeveralCompilerDirectivesDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SpaceAtStartCommentDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.SpaceAtStartCommentDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.StyleElementConstructorsDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.StyleElementConstructorsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TempFilesDirDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TempFilesDirDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TernaryOperatorUsageDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TernaryOperatorUsageDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ThisObjectAssignDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.ThisObjectAssignDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TimeoutsInExternalResourcesDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TimeoutsInExternalResourcesDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TooManyReturnsDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TooManyReturnsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TransferringParametersBetweenClientAndServerDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TransferringParametersBetweenClientAndServerDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TryNumberDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TryNumberDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TypoDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.TypoDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.diagnostics.typo.CheckedWordsHolder"
+          ]
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnaryPlusInConcatenationDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnaryPlusInConcatenationDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnionAllDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnionAllDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnknownPreprocessorSymbolDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnknownPreprocessorSymbolDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnreachableCodeDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnreachableCodeDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnsafeFindByCodeDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnsafeFindByCodeDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnsafeSafeModeMethodCallDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnsafeSafeModeMethodCallDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalMethodDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalMethodDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalVariableDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalVariableDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex"
+          ]
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedParametersDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedParametersDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsageWriteLogEventDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsageWriteLogEventDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UseLessForEachDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UseLessForEachDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UseSystemInformationDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UseSystemInformationDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UselessTernaryOperatorDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UselessTernaryOperatorDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingCancelParameterDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingCancelParameterDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingExternalCodeToolsDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingExternalCodeToolsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingFindElementByStringDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingFindElementByStringDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingGotoDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingGotoDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeNetworkAddressDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeNetworkAddressDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodePathDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodePathDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeSecretInformationDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeSecretInformationDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingLikeInQueryDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingLikeInQueryDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingModalWindowsDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingModalWindowsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingObjectNotAvailableUnixDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingObjectNotAvailableUnixDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingServiceTagDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingServiceTagDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingSynchronousCallsDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingSynchronousCallsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingThisFormDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingThisFormDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.VirtualTableCallWithoutParametersDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.VirtualTableCallWithoutParametersDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongDataPathForFormElementsDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongDataPathForFormElementsDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongHttpServiceHandlerDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongHttpServiceHandlerDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongUseFunctionProceedWithCallDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongUseFunctionProceedWithCallDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongUseOfRollbackTransactionMethodDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongUseOfRollbackTransactionMethodDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongWebServiceHandlerDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongWebServiceHandlerDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.YoLetterUsageDiagnostic"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.YoLetterUsageDiagnostic",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": []
+        }
+      ]
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.infrastructure.DiagnosticBeanPostProcessor",
@@ -3083,7 +3952,8 @@
       ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.typo.WordStatus"
+      "type": "com.github._1c_syntax.bsl.languageserver.diagnostics.typo.WordStatus",
+      "serializable": true
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.documenthighlight.AbstractASTDocumentHighlightSupplier"
@@ -4483,6 +5353,12 @@
           ]
         },
         {
+          "name": "getAllBySymbol",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.references.model.Symbol"
+          ]
+        },
+        {
           "name": "save",
           "parameterTypes": [
             "com.github._1c_syntax.bsl.languageserver.references.model.SymbolOccurrence"
@@ -4856,7 +5732,26 @@
       ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.types.TypeService"
+      "type": "com.github._1c_syntax.bsl.languageserver.types.TypeService",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry",
+            "com.github._1c_syntax.bsl.languageserver.types.index.SymbolTypeIndex",
+            "com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer",
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider"
+          ]
+        },
+        {
+          "name": "findMemberAt",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.DocumentContext",
+            "org.eclipse.lsp4j.Position"
+          ]
+        }
+      ]
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.types.TypeService$$SpringCGLIB$$0",
@@ -4880,9 +5775,28 @@
           ]
         },
         {
+          "name": "getDeclaredParameterTypes",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.symbol.ParameterDefinition"
+          ]
+        },
+        {
+          "name": "getDeclaredReturnTypes",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol"
+          ]
+        },
+        {
           "name": "handleEvent",
           "parameterTypes": [
             "com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent"
+          ]
+        },
+        {
+          "name": "resolveHyperlink",
+          "parameterTypes": [
+            "java.lang.String",
+            "com.github._1c_syntax.bsl.languageserver.context.FileType"
           ]
         }
       ]
@@ -4900,7 +5814,27 @@
       ]
     },
     {
-      "type": "com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer"
+      "type": "com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry",
+            "com.github._1c_syntax.bsl.languageserver.types.index.SymbolTypeIndex",
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver",
+            "com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex",
+            "com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider",
+            "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex"
+          ]
+        },
+        {
+          "name": "infer",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.utils.expressiontree.BslExpression",
+            "com.github._1c_syntax.bsl.languageserver.context.DocumentContext"
+          ]
+        }
+      ]
     },
     {
       "type": "com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer$$SpringCGLIB$$0",
@@ -4983,6 +5917,12 @@
             "com.github._1c_syntax.bsl.languageserver.types.oscript.ConventionalLibraryDiscovery",
             "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleTypeResolver",
             "com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleMembersProvider"
+          ]
+        },
+        {
+          "name": "findByName",
+          "parameterTypes": [
+            "java.lang.String"
           ]
         },
         {
@@ -5268,6 +6208,20 @@
           ]
         },
         {
+          "name": "findFunction",
+          "parameterTypes": [
+            "java.lang.String",
+            "com.github._1c_syntax.bsl.languageserver.context.FileType"
+          ]
+        },
+        {
+          "name": "findGlobalEntry",
+          "parameterTypes": [
+            "java.lang.String",
+            "com.github._1c_syntax.bsl.languageserver.context.FileType"
+          ]
+        },
+        {
           "name": "registerConfigurationQualifiedName",
           "parameterTypes": [
             "java.lang.String"
@@ -5366,15 +6320,50 @@
           ]
         },
         {
+          "name": "getDefaultElementTypes",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef"
+          ]
+        },
+        {
+          "name": "getDescription",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef"
+          ]
+        },
+        {
+          "name": "getMembers",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef"
+          ]
+        },
+        {
+          "name": "getMembers",
+          "parameterTypes": [
+            "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef",
+            "com.github._1c_syntax.bsl.languageserver.context.FileType"
+          ]
+        },
+        {
           "name": "getTypeParameters",
           "parameterTypes": [
             "com.github._1c_syntax.bsl.languageserver.types.model.TypeRef"
           ]
         },
         {
+          "name": "hasAnyReadOnlyMember",
+          "parameterTypes": []
+        },
+        {
           "name": "intern",
           "parameterTypes": [
             "com.github._1c_syntax.bsl.languageserver.types.model.TypeKind",
+            "java.lang.String"
+          ]
+        },
+        {
+          "name": "isReadOnlyMemberName",
+          "parameterTypes": [
             "java.lang.String"
           ]
         },
@@ -5428,6 +6417,19 @@
           "parameterTypes": [
             "java.lang.String"
           ]
+        },
+        {
+          "name": "resolve",
+          "parameterTypes": [
+            "java.lang.String",
+            "com.github._1c_syntax.bsl.languageserver.context.FileType"
+          ]
+        },
+        {
+          "name": "resolveGenericByPrefix",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
         }
       ]
     },
@@ -5449,6 +6451,12 @@
         {
           "name": "<init>",
           "parameterTypes": []
+        },
+        {
+          "name": "findEntry",
+          "parameterTypes": [
+            "java.lang.String"
+          ]
         },
         {
           "name": "findSymbol",
@@ -10312,6 +11320,17 @@
       "type": "com.github._1c_syntax.bsl.parser.BSLParserVisitor"
     },
     {
+      "type": "com.github._1c_syntax.bsl.parser.SDBLParser",
+      "methods": [
+        {
+          "name": "<init>",
+          "parameterTypes": [
+            "org.antlr.v4.runtime.TokenStream"
+          ]
+        }
+      ]
+    },
+    {
       "type": "com.github._1c_syntax.bsl.parser.SDBLParserBaseListener"
     },
     {
@@ -11361,6 +12380,7 @@
     },
     {
       "type": "java.lang.Enum",
+      "serializable": true,
       "methods": [
         {
           "name": "valueOf",
@@ -11385,7 +12405,8 @@
       "type": "java.lang.FunctionalInterface"
     },
     {
-      "type": "java.lang.Integer"
+      "type": "java.lang.Integer",
+      "serializable": true
     },
     {
       "type": "java.lang.Integer[]",
@@ -11437,7 +12458,8 @@
       ]
     },
     {
-      "type": "java.lang.Number"
+      "type": "java.lang.Number",
+      "serializable": true
     },
     {
       "type": "java.lang.Object",
@@ -13087,6 +14109,9 @@
       "type": "org.ehcache.core.spi.service.StatisticsService"
     },
     {
+      "type": "org.ehcache.core.spi.store.AbstractValueHolder"
+    },
+    {
       "type": "org.ehcache.core.spi.store.InternalCacheManager"
     },
     {
@@ -13282,6 +14307,30 @@
     },
     {
       "type": "org.ehcache.shadow.org.terracotta.context.query.Matchers$8"
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.offheapstore.storage.portability.Portability",
+      "methods": [
+        {
+          "name": "equals",
+          "parameterTypes": [
+            "java.lang.Object",
+            "java.nio.ByteBuffer"
+          ]
+        }
+      ]
+    },
+    {
+      "type": "org.ehcache.shadow.org.terracotta.offheapstore.storage.portability.WriteBackPortability",
+      "methods": [
+        {
+          "name": "decode",
+          "parameterTypes": [
+            "java.nio.ByteBuffer",
+            "org.ehcache.shadow.org.terracotta.offheapstore.storage.portability.WriteContext"
+          ]
+        }
+      ]
     },
     {
       "type": "org.ehcache.shadow.org.terracotta.offheapstore.util.ValidationTest"
@@ -16641,7 +17690,19 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AssignAliasFieldsInQueryDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AssignAliasFieldsInQueryDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AssignAliasFieldsInQueryDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AssignToReadOnlyPropertyDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AssignToReadOnlyPropertyDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/AssignToReadOnlyPropertyDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/BSLDiagnostic.class"
@@ -16665,7 +17726,19 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CanonicalSpellingKeywordsDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CanonicalSpellingKeywordsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CanonicalSpellingKeywordsDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CodeAfterAsyncCallDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CodeAfterAsyncCallDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CodeAfterAsyncCallDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CodeBlockBeforeSubDiagnostic.class"
@@ -16692,6 +17765,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommandModuleExportMethodsDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommandModuleExportMethodsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommandModuleExportMethodsDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommentedCodeDiagnostic.class"
     },
     {
@@ -16704,13 +17783,31 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommitTransactionOutsideTryCatchDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommitTransactionOutsideTryCatchDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommitTransactionOutsideTryCatchDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleAssignDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleAssignDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleAssignDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleInvalidTypeDiagnostic.class"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleMissingAPIDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleMissingAPIDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleMissingAPIDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleNameCachedDiagnostic.class"
@@ -16746,7 +17843,19 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CompilationDirectiveLostDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CompilationDirectiveLostDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CompilationDirectiveLostDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CompilationDirectiveNeedLessDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CompilationDirectiveNeedLessDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CompilationDirectiveNeedLessDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ConsecutiveEmptyLinesDiagnostic.class"
@@ -16776,6 +17885,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CreateQueryInCycleDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CreateQueryInCycleDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CreateQueryInCycleDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/CyclomaticComplexityDiagnostic.class"
     },
     {
@@ -16800,6 +17915,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DenyIncompleteValuesDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DenyIncompleteValuesDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DenyIncompleteValuesDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedAttributes8312Diagnostic$Metaobject.class"
     },
     {
@@ -16818,6 +17939,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedMethodCallDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedMethodCallDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedMethodCallDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DeprecatedMethods8310Diagnostic.class"
     },
     {
@@ -16828,6 +17955,12 @@
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DisableSafeModeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DisableSafeModeDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DisableSafeModeDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/DoubleNegativesDiagnostic.class"
@@ -16872,16 +18005,40 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyStatementDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyStatementDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyStatementDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExcessiveAutoTestCheckDiagnostic.class"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExecuteExternalCodeDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExecuteExternalCodeDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExecuteExternalCodeDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExecuteExternalCodeInCommonModuleDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExecuteExternalCodeInCommonModuleDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExecuteExternalCodeInCommonModuleDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExportVariablesDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExportVariablesDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExportVariablesDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExternalAppStartingDiagnostic.class"
@@ -16896,7 +18053,19 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExtraCommasDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExtraCommasDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ExtraCommasDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FieldsFromJoinsWithoutIsNullDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FileSystemAccessDiagnostic.class"
@@ -16920,7 +18089,19 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionNameStartsWithGetDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionNameStartsWithGetDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionNameStartsWithGetDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionOutParameterDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionOutParameterDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionOutParameterDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionReturnsSamePrimitiveDiagnostic.class"
@@ -16935,7 +18116,19 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionShouldHaveReturnDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionShouldHaveReturnDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/FunctionShouldHaveReturnDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/GetFormMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/GetFormMethodDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/GetFormMethodDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/GlobalContextMethodCollision8312Diagnostic.class"
@@ -16962,10 +18155,28 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseDuplicatedCodeBlockDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseDuplicatedCodeBlockDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseDuplicatedCodeBlockDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseDuplicatedConditionDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseDuplicatedConditionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseDuplicatedConditionDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseIfEndsWithElseDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseIfEndsWithElseDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IfElseIfEndsWithElseDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IncorrectLineBreakDiagnostic.class"
@@ -16986,7 +18197,19 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/InternetAccessDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/InternetAccessDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/InternetAccessDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/InvalidCharacterInFileDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/InvalidCharacterInFileDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/InvalidCharacterInFileDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/IsInRoleMethodDiagnostic.class"
@@ -17020,6 +18243,12 @@
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LogicalOrInTheWhereSectionOfQueryDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LogicalOrInTheWhereSectionOfQueryDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/LogicalOrInTheWhereSectionOfQueryDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MagicDateDiagnostic.class"
@@ -17079,10 +18308,22 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingCommonModuleMethodDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingCommonModuleMethodDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingCommonModuleMethodDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingEventSubscriptionHandlerDiagnostic.class"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingParameterDescriptionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingParameterDescriptionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingParameterDescriptionDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingReturnedValueDescriptionDiagnostic.class"
@@ -17106,6 +18347,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingTempStorageDeletionDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingTempStorageDeletionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingTempStorageDeletionDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingTemporaryFileDeletionDiagnostic.class"
     },
     {
@@ -17116,6 +18363,12 @@
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingVariablesDescriptionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingVariablesDescriptionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MissingVariablesDescriptionDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/MultilineStringInQueryDiagnostic.class"
@@ -17142,6 +18395,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedConstructorsInStructureDeclarationDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedConstructorsInStructureDeclarationDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedConstructorsInStructureDeclarationDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedFunctionInParametersDiagnostic.class"
     },
     {
@@ -17163,6 +18422,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedTernaryOperatorDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedTernaryOperatorDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NestedTernaryOperatorDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NonExportMethodsInApiRegionDiagnostic.class"
     },
     {
@@ -17173,6 +18438,12 @@
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NonStandardRegionDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NonStandardRegionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NonStandardRegionDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/NumberOfOptionalParamsDiagnostic.class"
@@ -17208,16 +18479,40 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OneStatementPerLineDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OneStatementPerLineDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OneStatementPerLineDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OrderOfParamsDiagnostic.class"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OrdinaryAppSupportDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OrdinaryAppSupportDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/OrdinaryAppSupportDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PairingBrokenTransactionDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PairingBrokenTransactionDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PairingBrokenTransactionDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ParseErrorDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ParseErrorDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ParseErrorDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/PrivilegedModuleMethodCallDiagnostic.class"
@@ -17247,6 +18542,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/QueryNestedFieldsByDotDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/QueryNestedFieldsByDotDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/QueryNestedFieldsByDotDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/QueryParseErrorDiagnostic.class"
     },
     {
@@ -17271,6 +18572,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RefOveruseDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RefOveruseDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RefOveruseDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ReservedParameterNamesDiagnostic.class"
     },
     {
@@ -17283,10 +18590,22 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RewriteMethodParameterDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RewriteMethodParameterDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/RewriteMethodParameterDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SameMetadataObjectAndChildNamesDiagnostic.class"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ScheduledJobHandlerDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ScheduledJobHandlerDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ScheduledJobHandlerDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SelectTopWithoutOrderByDiagnostic.class"
@@ -17307,6 +18626,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SemicolonPresenceDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SemicolonPresenceDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SemicolonPresenceDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ServerCallsInFormEventsDiagnostic.class"
     },
     {
@@ -17325,6 +18650,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SetPrivilegedModeDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SetPrivilegedModeDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SetPrivilegedModeDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/SeveralCompilerDirectivesDiagnostic.class"
     },
     {
@@ -17340,10 +18671,22 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/StyleElementConstructorsDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/StyleElementConstructorsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/StyleElementConstructorsDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TempFilesDirDiagnostic.class"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TernaryOperatorUsageDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TernaryOperatorUsageDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/TernaryOperatorUsageDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/ThisObjectAssignDiagnostic.class"
@@ -17403,7 +18746,19 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnreachableCodeDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnreachableCodeDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnreachableCodeDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnsafeFindByCodeDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnsafeFindByCodeDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnsafeFindByCodeDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnsafeSafeModeMethodCallDiagnostic.class"
@@ -17421,10 +18776,28 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalVariableDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalVariableDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalVariableDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedParametersDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedParametersDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedParametersDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsageWriteLogEventDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsageWriteLogEventDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsageWriteLogEventDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UseLessForEachDiagnostic.class"
@@ -17433,13 +18806,31 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UseSystemInformationDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UseSystemInformationDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UseSystemInformationDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UselessTernaryOperatorDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UselessTernaryOperatorDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UselessTernaryOperatorDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingCancelParameterDiagnostic.class"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingExternalCodeToolsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingExternalCodeToolsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingExternalCodeToolsDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingFindElementByStringDiagnostic.class"
@@ -17478,6 +18869,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingLikeInQueryDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingLikeInQueryDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingLikeInQueryDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingModalWindowsDiagnostic.class"
     },
     {
@@ -17490,6 +18887,12 @@
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingObjectNotAvailableUnixDiagnostic.class"
     },
     {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingObjectNotAvailableUnixDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingObjectNotAvailableUnixDiagnostic_ru.properties"
+    },
+    {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingServiceTagDiagnostic.class"
     },
     {
@@ -17500,6 +18903,12 @@
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingSynchronousCallsDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingSynchronousCallsDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingSynchronousCallsDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingThisFormDiagnostic.class"
@@ -17518,6 +18927,12 @@
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongUseOfRollbackTransactionMethodDiagnostic.class"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongUseOfRollbackTransactionMethodDiagnostic.properties"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongUseOfRollbackTransactionMethodDiagnostic_ru.properties"
     },
     {
       "glob": "com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongWebServiceHandlerDiagnostic.class"
@@ -18824,7 +20239,19 @@
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.AllFunctionPathMustHaveReturnDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.AssignAliasFieldsInQueryDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.AssignToReadOnlyPropertyDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.BadWordsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CanonicalSpellingKeywordsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CodeAfterAsyncCallDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CodeOutOfRegionDiagnostic"
@@ -18833,19 +20260,49 @@
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CognitiveComplexityDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommandModuleExportMethodsDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommentedCodeDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommitTransactionOutsideTryCatchDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleAssignDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleMissingAPIDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CommonModuleNameWordsDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CompilationDirectiveLostDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CompilationDirectiveNeedLessDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ConsecutiveEmptyLinesDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CreateQueryInCycleDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.CyclomaticComplexityDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.DataExchangeLoadingDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.DenyIncompleteValuesDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.DeprecatedMethodCallDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.DisableSafeModeDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.DuplicateStringLiteralDiagnostic"
@@ -18857,13 +20314,43 @@
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.EmptyCodeBlockDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.EmptyStatementDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExecuteExternalCodeInCommonModuleDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExportVariablesDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExternalAppStartingDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ExtraCommasDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.FieldsFromJoinsWithoutIsNullDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.FileSystemAccessDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionNameStartsWithGetDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionOutParameterDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionReturnsSamePrimitiveDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.FunctionShouldHaveReturnDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.GetFormMethodDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.IdenticalExpressionsDiagnostic"
@@ -18872,13 +20359,31 @@
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfConditionComplexityDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedCodeBlockDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseDuplicatedConditionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.IfElseIfEndsWithElseDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.IncorrectLineBreakDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.InternetAccessDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.InvalidCharacterInFileDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.LatinAndCyrillicSymbolInWordDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.LineLengthDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.LogicalOrInTheWhereSectionOfQueryDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MagicDateDiagnostic"
@@ -18896,13 +20401,25 @@
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCodeTryCatchExDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingCommonModuleMethodDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingParameterDescriptionDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingReturnedValueDescriptionDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingSpaceDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTempStorageDeletionDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingTemporaryFileDeletionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MissingVariablesDescriptionDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringHasAllDeclaredLanguagesDiagnostic"
@@ -18911,13 +20428,22 @@
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.MultilingualStringUsingWithTemplateDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedConstructorsInStructureDeclarationDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedFunctionInParametersDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedStatementsDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NestedTernaryOperatorDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonExportMethodsInApiRegionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NonStandardRegionDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfOptionalParamsDiagnostic"
@@ -18929,25 +20455,61 @@
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.NumberOfValuesInStructureConstructorDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.OneStatementPerLineDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.OrdinaryAppSupportDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.PairingBrokenTransactionDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ParseErrorDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.PrivilegedModuleMethodCallDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.PublicMethodsDescriptionDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.QueryNestedFieldsByDotDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.RedundantAccessToObjectDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.RefOveruseDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ReservedParameterNamesDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.RewriteMethodParameterDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.ScheduledJobHandlerDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.SelectTopWithoutOrderByDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.SemicolonPresenceDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPermissionsForNewObjectsDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.SetPrivilegedModeDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.SpaceAtStartCommentDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.StyleElementConstructorsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.TernaryOperatorUsageDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.TimeoutsInExternalResourcesDiagnostic"
@@ -18962,7 +20524,31 @@
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.TypoDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnreachableCodeDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnsafeFindByCodeDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalMethodDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedLocalVariableDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UnusedParametersDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsageWriteLogEventDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UseSystemInformationDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UselessTernaryOperatorDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingExternalCodeToolsDiagnostic"
     },
     {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeNetworkAddressDiagnostic"
@@ -18974,10 +20560,22 @@
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingHardcodeSecretInformationDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingLikeInQueryDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingModalWindowsDiagnostic"
     },
     {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingObjectNotAvailableUnixDiagnostic"
+    },
+    {
       "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingServiceTagDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.UsingSynchronousCallsDiagnostic"
+    },
+    {
+      "bundle": "com.github._1c_syntax.bsl.languageserver.diagnostics.WrongUseOfRollbackTransactionMethodDiagnostic"
     },
     {
       "bundle": "org.apache.catalina.authenticator.LocalStrings"
@@ -18990,6 +20588,21 @@
     },
     {
       "bundle": "org.apache.tomcat.util.http.LocalStrings"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-globals.json"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/configuration/parameters-schema.json"
+    },
+    {
+      "glob": "com/github/_1c_syntax/bsl/languageserver/configuration/schema.json"
+    },
+    {
+      "glob": "org/languagetool/**"
+    },
+    {
+      "glob": "org/languagetool/resource/**"
     }
   ],
   "bundles": [

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/codelenses/AbstractRunTestsCodeLensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/codelenses/AbstractRunTestsCodeLensSupplierTest.java
@@ -92,8 +92,11 @@ class AbstractRunTestsCodeLensSupplierTest extends AbstractServerContextAwareTes
   @TestConfiguration
   static class TestConfig {
     @Bean
-    public AbstractRunTestsCodeLensSupplier<DefaultCodeLensData> supplier(LanguageServerConfiguration configuration) {
-      return new AbstractRunTestsCodeLensSupplier<>(configuration) {
+    public AbstractRunTestsCodeLensSupplier<DefaultCodeLensData> supplier(
+      LanguageServerConfiguration configuration,
+      TestSourcesProvider testSourcesProvider
+    ) {
+      return new AbstractRunTestsCodeLensSupplier<>(configuration, testSourcesProvider) {
 
         @Override
         public List<CodeLens> getCodeLenses(DocumentContext documentContext) {
@@ -103,11 +106,6 @@ class AbstractRunTestsCodeLensSupplierTest extends AbstractServerContextAwareTes
         @Override
         public Class<DefaultCodeLensData> getCodeLensDataClass() {
           return DefaultCodeLensData.class;
-        }
-
-        @Override
-        protected AbstractRunTestsCodeLensSupplier<DefaultCodeLensData> getSelf() {
-          return this;
         }
 
         @Override


### PR DESCRIPTION
## Summary

Подключаю `org.graalvm.buildtools.native` и довожу `./gradlew nativeCompile` до успешной сборки бинаря размером ~125 MB. По пути правится несколько проблем, мешавших Spring AOT и native-image:

- **AOT-процессор + AspectJ.** `AspectJBeanFactoryInitializationAotProcessor` парсит pointcut-выражения `@Aspect`-бинов через `ReflectiveAspectJAdvisorFactory`, которому нужен `org.aspectj.weaver.tools.PointcutParser`. Раньше при запуске `processAot` получали `ClassNotFoundException: org.aspectj.weaver.reflect.ReflectionWorld$ReflectionWorldException`. Лечится подкидыванием `aspectjweaver` только в classpath `ProcessAot`/`ProcessTestAot` — рантайм/`bootJar` остаются «чистыми», CTW (`io.freefair.aspectj.post-compile-weaving`) продолжает работать как раньше.
- **gRPC из LanguageTool → image heap.** `org.languagetool:languagetool-core` (и языковые модули) транзитивно тянут `io.grpc.netty-shaded`. Его статические инициализаторы захватывают `ch.qos.logback.classic.Logger` в image heap, native-image валится. Используется он только для удалённых правил (n-gram сервис), у нас не задействован — выкидывается `exclude`-ами в трёх dependency-блоках LanguageTool.
- **GraalVM build tools.** Регистрируется блок `graalvmNative { binaries { named("main") { ... } } }`: явно ставлю `sharedLibrary.set(false)`, mainClass = `BSLLSPLauncher`, `--no-fallback`, отчёт стектрейсов и `UnlockExperimentalVMOptions`.
- **Reachability-metadata для workspace-scoped прокси.** Spring AOT для каждого `@Component @Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)` бина генерирует `<FQN>$$SpringCGLIB$$1`, но регистрирует ему только `allDeclaredConstructors`. Native-image затем падает на доступе к статическому полю `CGLIB$FACTORY_DATA`. Кладём дополнительный `META-INF/native-image/.../reachability-metadata.json` с полной рефлексией на эти 22 класса (генерируется по `@Scope(... TARGET_CLASS)` в `src/main/java`).
- **AutoServerInfo NPE.** `Thread.currentThread().getContextClassLoader().getResourceAsStream("META-INF/MANIFEST.MF")` в native-image возвращает `null`, `Manifest.read(null)` падает с NPE. Добавлен null-check с fallback на `Package.getImplementationVersion()`.

После этого `./gradlew nativeCompile` собирает executable (`build/native/nativeCompile/bsl-language-server`, ~125 MB, время сборки ~3.5 мин на 12-ядерной машине). Сборка проходит и под GraalVM CE 25.0.2.

## Что НЕ работает

⚠️ **Полноценный запуск бинаря пока ломается на инициализации Spring-контекста.** Корень — конфликт между pre-generated CGLIB-стабами Spring AOT и runtime-AOP проксированием. Конкретно:

1. С `aspectjweaver` в runtime — Spring AOP активно создаёт CGLIB-прокси через `Enhancer.create()` для бинов с `@Cacheable`/`@Lazy self`. На pre-generated `$$SpringCGLIB$$0` пытается выставить callbacks несовместимого типа → `ClassCastException: CglibAopProxy$SerializableNoOp cannot be cast to Dispatcher` при `DebugTestCodeLensSupplier.setCallbacks`.
2. Без `aspectjweaver` в runtime — Spring AOT-зарегистрированные `sentryCheckInAdvisor`/`cacheAdvisor` падают с `NoClassDefFoundError: AspectJExpressionPointcut`.

Чтобы бинарь нормально стартовал, нужно:
- либо отказаться от `@Lazy self`-injection в `DebugTestCodeLensSupplier`/`RunTestCodeLensSupplier`/`RunAllTestsCodeLensSupplier` (заменить, например, на `ApplicationContextAware` + ленивый lookup),
- либо отключить Spring AOP-инфраструктуру (с потерей `@Cacheable` через прокси — кэширование нужно будет перевести на CTW-аспект или Caffeine напрямую),
- параллельно расширить RuntimeHints для Sentry-AOP бинов и Spring-cache advisor'ов.

Это пока выносится за рамки PR — задача отдельной итерации.

## Performance comparison (native vs `java -jar`)

Запланированное сравнение времени `analyze` на `ssl_3_2` с SARIF-репортером **не получилось провести**: native-бинарь падает на старте контекста (см. выше), поэтому до самой логики анализа дело не доходит. Сравнение будет иметь смысл после фикса runtime-блокеров.

## Test plan

- [x] `./gradlew bootJar` собирает `*-exec.jar` как раньше; `java -jar ... --version` → `version: feature-update-deps-...`
- [x] `./gradlew compileTestJava` — без ошибок
- [x] `./gradlew :test --tests "*AutoServerInfo*"` — проходит (`testDataIsFilled() PASSED`)
- [x] `./gradlew processAot` — больше не падает на `ReflectionWorld$ReflectionWorldException`
- [x] `./gradlew nativeCompile` под `GRAALVM_HOME=GraalVM CE 25.0.2` — `BUILD SUCCESSFUL`, executable создан
- [ ] Запуск собранного `bsl-language-server` — пока fail на инициализации Spring-контекста (см. «Что НЕ работает»)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added GraalVM native-image support, runtime reachability hints, and an optional thread-dump watchdog (env-controlled).

* **New Component**
  * Added a cached provider for locating test source directories.
  * Introduced an enhanced XStream-based reader with native-image compatibility.

* **Bug Fixes**
  * Improved version detection when manifest data is unavailable.

* **Refactor**
  * Rewired test-run code lens plumbing to use the new provider and removed legacy self-injection.
  * Converted diagnostics and document/server initialization for AOT/native compatibility.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3938?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->