### PR TITLE
fix(symbols): описание и параметры асинхронных методов

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
@@ -89,11 +89,11 @@ public final class MethodSymbolComputer
   public ParseTree visitFunction(BSLParser.FunctionContext ctx) {
     BSLParser.FuncDeclarationContext declaration = ctx.funcDeclaration();
 
-    TerminalNode startNode = declaration.FUNCTION_KEYWORD();
+    TerminalNode functionKeyword = declaration.FUNCTION_KEYWORD();
     TerminalNode stopNode = ctx.ENDFUNCTION_KEYWORD();
 
-    if (startNode == null
-      || startNode instanceof ErrorNode
+    if (functionKeyword == null
+      || functionKeyword instanceof ErrorNode
       || stopNode == null
       || stopNode instanceof ErrorNode
     ) {
@@ -101,15 +101,8 @@ public final class MethodSymbolComputer
     }
 
     TerminalNode asyncKeyword = declaration.ASYNC_KEYWORD();
-    Token startOfMethod = asyncKeyword != null
-      ? asyncKeyword.getSymbol()
-      : declaration.FUNCTION_KEYWORD().getSymbol();
-
-    if (!declaration.annotation().isEmpty()) {
-      startNode = declaration.annotation().getFirst().AMPERSAND();
-    } else if (asyncKeyword != null) {
-      startNode = asyncKeyword;
-    }
+    TerminalNode startNode = selectStartNode(declaration.annotation(), asyncKeyword, functionKeyword);
+    Token startOfMethod = asyncKeyword != null ? asyncKeyword.getSymbol() : functionKeyword.getSymbol();
 
     MethodSymbol methodSymbol = createMethodSymbol(
       startNode,
@@ -131,11 +124,11 @@ public final class MethodSymbolComputer
   public ParseTree visitProcedure(BSLParser.ProcedureContext ctx) {
     BSLParser.ProcDeclarationContext declaration = ctx.procDeclaration();
 
-    TerminalNode startNode = declaration.PROCEDURE_KEYWORD();
+    TerminalNode procedureKeyword = declaration.PROCEDURE_KEYWORD();
     TerminalNode stopNode = ctx.ENDPROCEDURE_KEYWORD();
 
-    if (startNode == null
-      || startNode instanceof ErrorNode
+    if (procedureKeyword == null
+      || procedureKeyword instanceof ErrorNode
       || stopNode == null
       || stopNode instanceof ErrorNode
     ) {
@@ -143,15 +136,8 @@ public final class MethodSymbolComputer
     }
 
     TerminalNode asyncKeyword = declaration.ASYNC_KEYWORD();
-    Token startOfMethod = asyncKeyword != null
-      ? asyncKeyword.getSymbol()
-      : declaration.PROCEDURE_KEYWORD().getSymbol();
-
-    if (!declaration.annotation().isEmpty()) {
-      startNode = declaration.annotation().getFirst().AMPERSAND();
-    } else if (asyncKeyword != null) {
-      startNode = asyncKeyword;
-    }
+    TerminalNode startNode = selectStartNode(declaration.annotation(), asyncKeyword, procedureKeyword);
+    Token startOfMethod = asyncKeyword != null ? asyncKeyword.getSymbol() : procedureKeyword.getSymbol();
 
     MethodSymbol methodSymbol = createMethodSymbol(
       startNode,
@@ -168,6 +154,27 @@ public final class MethodSymbolComputer
     methods.add(methodSymbol);
 
     return ctx;
+  }
+
+  /**
+   * Выбирает токен начала символа метода в соответствии с грамматикой
+   * {@code (preprocessor | compilerDirective | annotation)* ASYNC_KEYWORD? PROCEDURE_KEYWORD|FUNCTION_KEYWORD}.
+   * Приоритет (от самой ранней позиции к самой поздней):
+   * первая аннотация → {@code Асинх} → ключевое слово {@code Процедура}/{@code Функция}.
+   * Препроцессоры и compiler-directive исторически не входят в range символа.
+   */
+  private static TerminalNode selectStartNode(
+    List<? extends BSLParser.AnnotationContext> annotations,
+    @Nullable TerminalNode asyncKeyword,
+    TerminalNode keywordNode
+  ) {
+    if (!annotations.isEmpty()) {
+      return annotations.getFirst().AMPERSAND();
+    }
+    if (asyncKeyword != null) {
+      return asyncKeyword;
+    }
+    return keywordNode;
   }
 
   // есть определенные предпочтения при использовании &НаКлиентеНаСервереБезКонтекста в модуле упр.формы

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
@@ -100,14 +100,21 @@ public final class MethodSymbolComputer
       return ctx;
     }
 
+    TerminalNode asyncKeyword = declaration.ASYNC_KEYWORD();
+    Token startOfMethod = asyncKeyword != null
+      ? asyncKeyword.getSymbol()
+      : declaration.FUNCTION_KEYWORD().getSymbol();
+
     if (!declaration.annotation().isEmpty()) {
       startNode = declaration.annotation().getFirst().AMPERSAND();
+    } else if (asyncKeyword != null) {
+      startNode = asyncKeyword;
     }
 
     MethodSymbol methodSymbol = createMethodSymbol(
       startNode,
       stopNode,
-      declaration.FUNCTION_KEYWORD().getSymbol(),
+      startOfMethod,
       declaration.subName().getStart(),
       declaration.paramList(),
       true,
@@ -135,14 +142,21 @@ public final class MethodSymbolComputer
       return ctx;
     }
 
+    TerminalNode asyncKeyword = declaration.ASYNC_KEYWORD();
+    Token startOfMethod = asyncKeyword != null
+      ? asyncKeyword.getSymbol()
+      : declaration.PROCEDURE_KEYWORD().getSymbol();
+
     if (!declaration.annotation().isEmpty()) {
       startNode = declaration.annotation().getFirst().AMPERSAND();
+    } else if (asyncKeyword != null) {
+      startNode = asyncKeyword;
     }
 
     MethodSymbol methodSymbol = createMethodSymbol(
       startNode,
       stopNode,
-      declaration.PROCEDURE_KEYWORD().getSymbol(),
+      startOfMethod,
       declaration.subName().getStart(),
       declaration.paramList(),
       false,

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerTest.java
@@ -359,6 +359,63 @@ class MethodSymbolComputerTest {
     assertThat(method.getParameters().getFirst().getDescription()).isPresent();
   }
 
+  @Test
+  void testAsyncMethodWithAnnotation() {
+    // given
+    var source = """
+      // Описание async + аннотация.
+      //
+      // Параметры:
+      //   Парам1 - Произвольный - описание
+      &После
+      Асинх Процедура ОбработатьСобытие(Парам1) Экспорт
+      КонецПроцедуры
+      """;
+
+    // when
+    var documentContext = TestUtils.getDocumentContext(source);
+    var methods = documentContext.getSymbolTree().getMethods();
+
+    // then
+    assertThat(methods).hasSize(1);
+    var method = methods.getFirst();
+    assertThat(method.getName()).isEqualTo("ОбработатьСобытие");
+    assertThat(method.getDescription()).isPresent();
+    assertThat(method.getParameters().getFirst().getDescription()).isPresent();
+    assertThat(method.getAnnotations()).hasSize(1);
+    assertThat(method.getAnnotations().getFirst().getKind()).isEqualTo(AnnotationKind.AFTER);
+    // у аннотации приоритет над Асинх: range начинается с AMPERSAND аннотации, а не с Асинх
+    assertThat(method.getRange()).isEqualTo(Ranges.create(4, 0, 6, 14));
+  }
+
+  @Test
+  void testAsyncMethodWithCompilerDirective() {
+    // given
+    var source = """
+      // Описание async + директива компиляции.
+      //
+      // Параметры:
+      //   Парам1 - Произвольный - описание
+      &НаКлиенте
+      Асинх Процедура ВыполнитьНаКлиенте(Парам1) Экспорт
+      КонецПроцедуры
+      """;
+
+    // when
+    var documentContext = TestUtils.getDocumentContext(source);
+    var methods = documentContext.getSymbolTree().getMethods();
+
+    // then
+    assertThat(methods).hasSize(1);
+    var method = methods.getFirst();
+    assertThat(method.getName()).isEqualTo("ВыполнитьНаКлиенте");
+    assertThat(method.getDescription()).isPresent();
+    assertThat(method.getParameters().getFirst().getDescription()).isPresent();
+    assertThat(method.getCompilerDirectiveKind().orElse(null)).isEqualTo(CompilerDirectiveKind.AT_CLIENT);
+    // директивы компиляции исторически не входят в range; ASYNC задаёт начало range
+    assertThat(method.getRange()).isEqualTo(Ranges.create(5, 0, 6, 14));
+  }
+
   private static void checkCompilerDirective_for_AtClient_AndAnnotation_After(MethodSymbol methodSymbol) {
     assertThat(methodSymbol.getCompilerDirectiveKind().orElse(null)).isEqualTo(CompilerDirectiveKind.AT_CLIENT);
     var annotations = methodSymbol.getAnnotations();

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerTest.java
@@ -297,6 +297,68 @@ class MethodSymbolComputerTest {
 
   }
 
+  @Test
+  void testAsyncFunctionDescription() {
+    // given
+    var source = """
+      // Описание асинхронной функции.
+      //
+      // Параметры:
+      //   Желудь - Произвольный - первый параметр
+      //   ОпределениеЖелудя - Произвольный - второй параметр
+      //
+      // Возвращаемое значение:
+      //   Произвольный
+      Асинх Функция ОбработатьЖелудь(Желудь, ОпределениеЖелудя) Экспорт
+          Возврат Желудь;
+      КонецФункции
+      """;
+
+    // when
+    var documentContext = TestUtils.getDocumentContext(source);
+    var methods = documentContext.getSymbolTree().getMethods();
+
+    // then
+    assertThat(methods).hasSize(1);
+    var method = methods.getFirst();
+    assertThat(method.getName()).isEqualTo("ОбработатьЖелудь");
+    assertThat(method.getDescription()).isPresent();
+    assertThat(method.getDescription().orElseThrow().getDescription())
+      .contains("Описание асинхронной функции");
+
+    var parameters = method.getParameters();
+    assertThat(parameters).hasSize(2);
+    assertThat(parameters.get(0).getName()).isEqualTo("Желудь");
+    assertThat(parameters.get(0).getDescription()).isPresent();
+    assertThat(parameters.get(1).getName()).isEqualTo("ОпределениеЖелудя");
+    assertThat(parameters.get(1).getDescription()).isPresent();
+  }
+
+  @Test
+  void testAsyncProcedureDescription() {
+    // given
+    var source = """
+      // Описание асинхронной процедуры.
+      //
+      // Параметры:
+      //   Парам1 - Произвольный - описание
+      Асинх Процедура ВыполнитьЧтоТо(Парам1) Экспорт
+      КонецПроцедуры
+      """;
+
+    // when
+    var documentContext = TestUtils.getDocumentContext(source);
+    var methods = documentContext.getSymbolTree().getMethods();
+
+    // then
+    assertThat(methods).hasSize(1);
+    var method = methods.getFirst();
+    assertThat(method.getName()).isEqualTo("ВыполнитьЧтоТо");
+    assertThat(method.getDescription()).isPresent();
+    assertThat(method.getParameters()).hasSize(1);
+    assertThat(method.getParameters().getFirst().getDescription()).isPresent();
+  }
+
   private static void checkCompilerDirective_for_AtClient_AndAnnotation_After(MethodSymbol methodSymbol) {
     assertThat(methodSymbol.getCompilerDirectiveKind().orElse(null)).isEqualTo(CompilerDirectiveKind.AT_CLIENT);
     var annotations = methodSymbol.getAnnotations();


### PR DESCRIPTION
## Summary

- Для методов с `Асинх` (например, `Асинх Функция Foo()`) не парсился `MethodDescription`: поиск комментариев в `Trees.getComments` шёл назад от `FUNCTION_KEYWORD`/`PROCEDURE_KEYWORD` и обрывался на пробеле между `Асинх` и ключевым словом (`Trees.isBlankLine` трактует `WHITE_SPACE` на той же строке как пустую). Из-за этого пропадало описание метода, описания параметров в hover и блок описания в semantic tokens.
- В `MethodSymbolComputer.visitFunction` / `visitProcedure` стартовый токен для поиска комментариев теперь `ASYNC_KEYWORD`, если он есть; начало `range` символа метода также сдвигается на `Асинх`, когда нет аннотаций.

## Test plan

- [x] Новые тесты `MethodSymbolComputerTest#testAsyncFunctionDescription` и `#testAsyncProcedureDescription` (сначала падали, после фикса — зелёные)
- [x] `./gradlew test --tests "...MethodSymbolComputerTest"` — зелёно
- [x] Прогон смежных тестов (`context.computer.*`, `hover.*`, `semantictokens.*`, `SemanticTokensProviderTest`, `HoverProviderTest`) — зелёно

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection and symbol computation for async functions and procedures, ensuring method range starts account for async keyword, annotations, and compiler directives.

* **Tests**
  * Added tests verifying symbol metadata, method/parameter descriptions, annotation recognition, compiler-directive handling, and correct method range computation for async declarations.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3946?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->