### PR TITLE
feat: модификатор async для объявлений и вызовов методов

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
@@ -112,6 +112,7 @@ public final class MethodSymbolComputer
       declaration.paramList(),
       true,
       declaration.EXPORT_KEYWORD() != null,
+      asyncKeyword != null,
       getCompilerDirective(declaration.compilerDirective()),
       createAnnotations(declaration.annotation()));
 
@@ -147,6 +148,7 @@ public final class MethodSymbolComputer
       declaration.paramList(),
       false,
       declaration.EXPORT_KEYWORD() != null,
+      asyncKeyword != null,
       getCompilerDirective(declaration.compilerDirective()),
       createAnnotations(declaration.annotation())
     );
@@ -229,6 +231,7 @@ public final class MethodSymbolComputer
     BSLParser.ParamListContext paramList,
     boolean function,
     boolean export,
+    boolean async,
     Optional<CompilerDirectiveKind> compilerDirective,
     List<Annotation> annotations
   ) {
@@ -251,6 +254,7 @@ public final class MethodSymbolComputer
         .subNameRange(subNameRange)
         .function(function)
         .export(export)
+        .async(async)
         .description(description)
         .deprecated(deprecated)
         .parameters(parameters)
@@ -266,6 +270,7 @@ public final class MethodSymbolComputer
       .subNameRange(subNameRange)
       .function(function)
       .export(export)
+      .async(async)
       .description(description)
       .deprecated(deprecated)
       .parameters(parameters)

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/AbstractMethodSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/AbstractMethodSymbol.java
@@ -146,6 +146,11 @@ public abstract class AbstractMethodSymbol implements MethodSymbol {
   private final boolean deprecated;
 
   /**
+   * Объявлен ли метод с ключевым словом {@code Асинх} ({@code Async}).
+   */
+  private final boolean async;
+
+  /**
    * Объявленные параметры метода в порядке объявления.
    */
   @Builder.Default

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
@@ -47,8 +47,6 @@ public interface MethodSymbol extends SourceDefinedSymbol, Exportable, Describab
 
   /**
    * Объявлен ли метод с ключевым словом {@code Асинх} ({@code Async}).
-   * Влияет на семантическую подсветку (модификатор {@code async}) у объявления
-   * и у вызовов такого метода.
    */
   boolean isAsync();
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/MethodSymbol.java
@@ -45,6 +45,13 @@ public interface MethodSymbol extends SourceDefinedSymbol, Exportable, Describab
 
   boolean isDeprecated();
 
+  /**
+   * Объявлен ли метод с ключевым словом {@code Асинх} ({@code Async}).
+   * Влияет на семантическую подсветку (модификатор {@code async}) у объявления
+   * и у вызовов такого метода.
+   */
+  boolean isAsync();
+
   List<ParameterDefinition> getParameters();
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MethodCallSemanticTokensSupplier.java
@@ -41,6 +41,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class MethodCallSemanticTokensSupplier implements SemanticTokensSupplier {
 
+  private static final String[] NO_MODIFIERS = new String[0];
+  private static final String[] ASYNC_MODIFIERS = {SemanticTokenModifiers.Async};
+  private static final String[] STATIC_MODIFIERS = {SemanticTokenModifiers.Static};
+  private static final String[] STATIC_ASYNC_MODIFIERS = {
+    SemanticTokenModifiers.Static,
+    SemanticTokenModifiers.Async
+  };
+
   private final ReferenceIndex referenceIndex;
   private final SemanticTokensHelper helper;
 
@@ -74,13 +82,10 @@ public class MethodCallSemanticTokensSupplier implements SemanticTokensSupplier 
   }
 
   private static String[] methodCallModifiers(boolean isStatic, boolean isAsync) {
-    if (!isStatic && !isAsync) {
-      return new String[0];
+    if (isStatic) {
+      return isAsync ? STATIC_ASYNC_MODIFIERS : STATIC_MODIFIERS;
     }
-    if (isStatic && isAsync) {
-      return new String[]{SemanticTokenModifiers.Static, SemanticTokenModifiers.Async};
-    }
-    return new String[]{isStatic ? SemanticTokenModifiers.Static : SemanticTokenModifiers.Async};
+    return isAsync ? ASYNC_MODIFIERS : NO_MODIFIERS;
   }
 }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MethodCallSemanticTokensSupplier.java
@@ -55,21 +55,32 @@ public class MethodCallSemanticTokensSupplier implements SemanticTokensSupplier 
       }
 
       reference.getSourceDefinedSymbol().ifPresent(symbol -> {
+        if (!(symbol instanceof MethodSymbol method)) {
+          helper.addRange(entries, reference.selectionRange(), SemanticTokenTypes.Method);
+          return;
+        }
         // Метод объявлен в «статическом» модуле (CommonModule/ManagerModule/OScript-модуль)?
         // Тогда подсвечиваем вызов как Method + Static. instance-методы
-        // (ObjectModule, формы, OScript-классы) остаются без модификатора.
-        boolean isStatic = symbol instanceof MethodSymbol method
-          && Modules.isStaticModule(method.getOwner());
-        if (isStatic) {
-          helper.addRange(entries, reference.selectionRange(), SemanticTokenTypes.Method,
-            SemanticTokenModifiers.Static);
-        } else {
-          helper.addRange(entries, reference.selectionRange(), SemanticTokenTypes.Method);
-        }
+        // (ObjectModule, формы, OScript-классы) остаются без Static.
+        // Вызовы async-методов получают модификатор Async — это касается и
+        // statics, и instance-методов, поэтому Async может комбинироваться со Static.
+        boolean isStatic = Modules.isStaticModule(method.getOwner());
+        var modifiers = methodCallModifiers(isStatic, method.isAsync());
+        helper.addRange(entries, reference.selectionRange(), SemanticTokenTypes.Method, modifiers);
       });
     }
 
     return entries;
+  }
+
+  private static String[] methodCallModifiers(boolean isStatic, boolean isAsync) {
+    if (!isStatic && !isAsync) {
+      return new String[0];
+    }
+    if (isStatic && isAsync) {
+      return new String[]{SemanticTokenModifiers.Static, SemanticTokenModifiers.Async};
+    }
+    return new String[]{isStatic ? SemanticTokenModifiers.Static : SemanticTokenModifiers.Async};
   }
 }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensLegendConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensLegendConfiguration.java
@@ -73,7 +73,8 @@ public class SemanticTokensLegendConfiguration {
       SemanticTokenModifiers.DefaultLibrary,  // Added for SDBL built-in functions and types
       SemanticTokenModifiers.Declaration,  // Added for SDBL alias declarations
       SemanticTokenModifiers.Readonly,  // Added for SDBL parameters
-      SemanticTokenModifiers.Static  // Methods of CommonModule / ManagerModule / OScript-module
+      SemanticTokenModifiers.Static,  // Methods of CommonModule / ManagerModule / OScript-module
+      SemanticTokenModifiers.Async  // Methods declared as Асинх/Async (both declarations and call sites)
     );
 
     return new SemanticTokensLegend(tokenTypes, tokenModifiers);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplier.java
@@ -46,6 +46,14 @@ import java.util.List;
 @RequiredArgsConstructor
 public class SymbolsSemanticTokensSupplier implements SemanticTokensSupplier {
 
+  private static final String[] NO_MODIFIERS = new String[0];
+  private static final String[] ASYNC_MODIFIERS = {SemanticTokenModifiers.Async};
+  private static final String[] STATIC_MODIFIERS = {SemanticTokenModifiers.Static};
+  private static final String[] STATIC_ASYNC_MODIFIERS = {
+    SemanticTokenModifiers.Static,
+    SemanticTokenModifiers.Async
+  };
+
   private final ReferenceIndex referenceIndex;
   private final SemanticTokensHelper helper;
 
@@ -100,13 +108,10 @@ public class SymbolsSemanticTokensSupplier implements SemanticTokensSupplier {
   }
 
   private static String[] methodModifiers(boolean isStatic, boolean isAsync) {
-    if (!isStatic && !isAsync) {
-      return new String[0];
+    if (isStatic) {
+      return isAsync ? STATIC_ASYNC_MODIFIERS : STATIC_MODIFIERS;
     }
-    if (isStatic && isAsync) {
-      return new String[]{SemanticTokenModifiers.Static, SemanticTokenModifiers.Async};
-    }
-    return new String[]{isStatic ? SemanticTokenModifiers.Static : SemanticTokenModifiers.Async};
+    return isAsync ? ASYNC_MODIFIERS : NO_MODIFIERS;
   }
 }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplier.java
@@ -59,11 +59,8 @@ public class SymbolsSemanticTokensSupplier implements SemanticTokensSupplier {
     var isStatic = Modules.isStaticModule(documentContext);
     for (var method : symbolTree.getMethods()) {
       var semanticTokenType = method.isFunction() ? SemanticTokenTypes.Function : SemanticTokenTypes.Method;
-      if (isStatic) {
-        helper.addRange(entries, method.getSubNameRange(), semanticTokenType, SemanticTokenModifiers.Static);
-      } else {
-        helper.addRange(entries, method.getSubNameRange(), semanticTokenType);
-      }
+      var modifiers = methodModifiers(isStatic, method.isAsync());
+      helper.addRange(entries, method.getSubNameRange(), semanticTokenType, modifiers);
       for (ParameterDefinition parameter : method.getParameters()) {
         helper.addRange(entries, parameter.getRange(), SemanticTokenTypes.Parameter, SemanticTokenModifiers.Definition);
       }
@@ -100,6 +97,16 @@ public class SymbolsSemanticTokensSupplier implements SemanticTokensSupplier {
         }));
 
     return entries;
+  }
+
+  private static String[] methodModifiers(boolean isStatic, boolean isAsync) {
+    if (!isStatic && !isAsync) {
+      return new String[0];
+    }
+    if (isStatic && isAsync) {
+      return new String[]{SemanticTokenModifiers.Static, SemanticTokenModifiers.Async};
+    }
+    return new String[]{isStatic ? SemanticTokenModifiers.Static : SemanticTokenModifiers.Async};
   }
 }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerTest.java
@@ -322,6 +322,7 @@ class MethodSymbolComputerTest {
     assertThat(methods).hasSize(1);
     var method = methods.getFirst();
     assertThat(method.getName()).isEqualTo("ОбработатьЖелудь");
+    assertThat(method.isAsync()).isTrue();
     assertThat(method.getDescription()).isPresent();
     assertThat(method.getDescription().orElseThrow().getDescription())
       .contains("Описание асинхронной функции");
@@ -354,6 +355,7 @@ class MethodSymbolComputerTest {
     assertThat(methods).hasSize(1);
     var method = methods.getFirst();
     assertThat(method.getName()).isEqualTo("ВыполнитьЧтоТо");
+    assertThat(method.isAsync()).isTrue();
     assertThat(method.getDescription()).isPresent();
     assertThat(method.getParameters()).hasSize(1);
     assertThat(method.getParameters().getFirst().getDescription()).isPresent();
@@ -380,6 +382,7 @@ class MethodSymbolComputerTest {
     assertThat(methods).hasSize(1);
     var method = methods.getFirst();
     assertThat(method.getName()).isEqualTo("ОбработатьСобытие");
+    assertThat(method.isAsync()).isTrue();
     assertThat(method.getDescription()).isPresent();
     assertThat(method.getParameters().getFirst().getDescription()).isPresent();
     assertThat(method.getAnnotations()).hasSize(1);
@@ -409,11 +412,34 @@ class MethodSymbolComputerTest {
     assertThat(methods).hasSize(1);
     var method = methods.getFirst();
     assertThat(method.getName()).isEqualTo("ВыполнитьНаКлиенте");
+    assertThat(method.isAsync()).isTrue();
     assertThat(method.getDescription()).isPresent();
     assertThat(method.getParameters().getFirst().getDescription()).isPresent();
     assertThat(method.getCompilerDirectiveKind().orElse(null)).isEqualTo(CompilerDirectiveKind.AT_CLIENT);
     // директивы компиляции исторически не входят в range; ASYNC задаёт начало range
     assertThat(method.getRange()).isEqualTo(Ranges.create(5, 0, 6, 14));
+  }
+
+  @Test
+  void testNonAsyncMethodHasNoAsyncFlag() {
+    // given
+    var source = """
+      Процедура Обычная()
+      КонецПроцедуры
+
+      Функция ОбычнаяФункция()
+          Возврат 1;
+      КонецФункции
+      """;
+
+    // when
+    var documentContext = TestUtils.getDocumentContext(source);
+    var methods = documentContext.getSymbolTree().getMethods();
+
+    // then
+    assertThat(methods).hasSize(2);
+    assertThat(methods.get(0).isAsync()).isFalse();
+    assertThat(methods.get(1).isAsync()).isFalse();
   }
 
   private static void checkCompilerDirective_for_AtClient_AndAnnotation_After(MethodSymbol methodSymbol) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MethodCallSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MethodCallSemanticTokensSupplierTest.java
@@ -140,6 +140,51 @@ class MethodCallSemanticTokensSupplierTest extends AbstractServerContextAwareTes
   }
 
   @Test
+  void testAsyncModifierOnCallToAsyncMethod() {
+    // given — async-метод объявлен в том же модуле и вызывается из обычного метода.
+    String bsl = """
+      Асинх Процедура ЖдатьАсинх()
+      КонецПроцедуры
+
+      Процедура Тест()
+        ЖдатьАсинх();
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — сайт вызова async-метода получает модификатор Async.
+    var expected = List.of(
+      new ExpectedToken(4, 2, 10, SemanticTokenTypes.Method,
+        Set.of(SemanticTokenModifiers.Async), "ЖдатьАсинх")
+    );
+    helper.assertTokensMatch(decoded, expected);
+  }
+
+  @Test
+  void testAsyncModifierAbsentOnCallToRegularMethod() {
+    // given
+    String bsl = """
+      Процедура Обычная()
+      КонецПроцедуры
+
+      Процедура Тест()
+        Обычная();
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — нет модификатора Async у вызова обычного метода.
+    var expected = List.of(
+      new ExpectedToken(4, 2, 7, SemanticTokenTypes.Method, "Обычная")
+    );
+    helper.assertTokensMatch(decoded, expected);
+  }
+
+  @Test
   void testStaticModifierOnCallToCommonModuleMethod() {
     // given - конфигурация загружена; вызывающий файл содержит
     // `ПервыйОбщийМодуль.УстаревшаяПроцедура();` на строке 2 (0-idx).

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplierTest.java
@@ -146,6 +146,60 @@ class SymbolsSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void testAsyncModifierOnAsyncFunctionDeclaration() {
+    // given
+    String bsl = """
+      Асинх Функция ОбработатьАсинхронно()
+        Возврат 1;
+      КонецФункции
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(0, 14, 20, SemanticTokenTypes.Function,
+        Set.of(SemanticTokenModifiers.Async), "ОбработатьАсинхронно")
+    ));
+  }
+
+  @Test
+  void testAsyncModifierOnAsyncProcedureDeclaration() {
+    // given
+    String bsl = """
+      Асинх Процедура ВыполнитьАсинхронно()
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(0, 16, 19, SemanticTokenTypes.Method,
+        Set.of(SemanticTokenModifiers.Async), "ВыполнитьАсинхронно")
+    ));
+  }
+
+  @Test
+  void testAsyncModifierAbsentOnRegularMethod() {
+    // given
+    String bsl = """
+      Процедура Обычная()
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — нет модификатора Async у обычного метода
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(0, 10, 7, SemanticTokenTypes.Method, "Обычная")
+    ));
+  }
+
+  @Test
   void testVariableDeclaration() {
     // given
     String bsl = """


### PR DESCRIPTION
## Summary

- `MethodSymbol.isAsync()` — флаг `Асинх` теперь часть модели метода (`AbstractMethodSymbol`), заполняется в `MethodSymbolComputer` из `declaration.ASYNC_KEYWORD()`. По object layout добавление бесплатно: новое `boolean` поле садится в существующий 1-байтовый padding-gap (HotSpot 25, compressed oops + compressed klass, 8-byte align — проверено JOL), размер объекта 80 → 80 байт.
- В легенду семантических токенов добавлен `SemanticTokenModifiers.Async`.
- `SymbolsSemanticTokensSupplier` помечает имя `Асинх`-метода в декларации модификатором `async` (комбинируется со `static` для CommonModule / ManagerModule / OScript-module).
- `MethodCallSemanticTokensSupplier` помечает имя в сайте вызова `Асинх`-метода модификатором `async` — через `methodSymbol.isAsync()` у разрешённой ссылки, без повторного спуска в parse tree. `static` и `async` могут комбинироваться.

## Test plan

- [x] `MethodSymbolComputerTest`: новый `testNonAsyncMethodHasNoAsyncFlag` + расширены существующие async-тесты проверками `isAsync()`
- [x] `SymbolsSemanticTokensSupplierTest`: `testAsyncModifierOnAsyncFunctionDeclaration`, `testAsyncModifierOnAsyncProcedureDeclaration`, `testAsyncModifierAbsentOnRegularMethod`
- [x] `MethodCallSemanticTokensSupplierTest`: `testAsyncModifierOnCallToAsyncMethod`, `testAsyncModifierAbsentOnCallToRegularMethod`
- [x] `./gradlew test --tests "*.semantictokens.*" --tests "*.SemanticTokensProviderTest"` — зелёно

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Async methods/functions are now tracked and expose an async attribute used by the language server.
  * Semantic tokens now include an Async modifier for declarations and calls, combined with existing Static modifier where applicable.

* **Tests**
  * Added tests verifying Async modifier presence on async declarations and call sites, and absence on regular methods.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3947?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->