### PR TITLE
feat(semantictokens): подсветка платформенных member-методов через accessCall

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
@@ -1,0 +1,123 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.semantictokens;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
+import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.languageserver.utils.Trees;
+import com.github._1c_syntax.bsl.parser.BSLParser;
+import lombok.RequiredArgsConstructor;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SemanticTokenModifiers;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.eclipse.lsp4j.SymbolKind;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+
+/**
+ * Сапплаер семантических токенов для вызовов методов платформенных типов через
+ * accessCall (т.е. вызовов вида {@code receiver.method(...)}, где {@code receiver}
+ * — типизированное выражение, чей тип резолвится через
+ * {@link com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer}).
+ * <p>
+ * Метод резолвится через {@link TypeService#findMemberAt(DocumentContext, Position)}.
+ * Если найден member с {@link MemberKind#METHOD} — имя метода получает
+ * {@link SemanticTokenTypes#Method} + {@link SemanticTokenModifiers#DefaultLibrary}.
+ * <p>
+ * Source-defined вызовы (методы общих модулей, локальные методы, OScript-library)
+ * подсвечиваются через {@link MethodCallSemanticTokensSupplier} по ReferenceIndex —
+ * этот сапплаер их пропускает, чтобы не дублировать токены.
+ */
+@Component
+@RequiredArgsConstructor
+public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticTokensSupplier {
+
+  private static final String[] DEFAULT_LIBRARY_MODIFIERS = {SemanticTokenModifiers.DefaultLibrary};
+
+  private final TypeService typeService;
+  private final ReferenceIndex referenceIndex;
+  private final SemanticTokensHelper helper;
+
+  @Override
+  public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext) {
+    var entries = new ArrayList<SemanticTokenEntry>();
+    var ast = documentContext.getAst();
+    if (ast == null) {
+      return entries;
+    }
+
+    // Позиции, уже обработанные MethodCallSemanticTokensSupplier: пропускаем,
+    // чтобы не дублировать токен на одной и той же позиции.
+    Set<Position> sourceDefinedCallSites = collectSourceDefinedCallSites(documentContext);
+
+    for (var node : Trees.findAllRuleNodes(ast, BSLParser.RULE_accessCall)) {
+      if (!(node instanceof BSLParser.AccessCallContext accessCall)) {
+        continue;
+      }
+      var methodCall = accessCall.methodCall();
+      if (methodCall == null) {
+        continue;
+      }
+      var methodNameCtx = methodCall.methodName();
+      if (methodNameCtx == null) {
+        continue;
+      }
+      var methodIdentifier = methodNameCtx.IDENTIFIER();
+      if (methodIdentifier == null) {
+        continue;
+      }
+
+      Range range = Ranges.create(methodIdentifier);
+      if (sourceDefinedCallSites.contains(range.getStart())) {
+        continue;
+      }
+
+      var member = typeService.findMemberAt(documentContext, range.getStart());
+      if (member.isEmpty()) {
+        continue;
+      }
+      if (member.get().descriptor().kind() != MemberKind.METHOD) {
+        continue;
+      }
+
+      helper.addRange(entries, range, SemanticTokenTypes.Method, DEFAULT_LIBRARY_MODIFIERS);
+    }
+
+    return entries;
+  }
+
+  private Set<Position> collectSourceDefinedCallSites(DocumentContext documentContext) {
+    var positions = new HashSet<Position>();
+    for (var reference : referenceIndex.getReferencesFrom(documentContext.getUri(), SymbolKind.Method)) {
+      positions.add(reference.selectionRange().getStart());
+    }
+    return positions;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
@@ -39,6 +39,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
+import java.util.Optional;
 import java.util.Set;
 
 /**
@@ -69,45 +70,33 @@ public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticT
   public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext) {
     var entries = new ArrayList<SemanticTokenEntry>();
     var ast = documentContext.getAst();
-    if (ast == null) {
-      return entries;
-    }
 
     // Позиции, уже обработанные MethodCallSemanticTokensSupplier: пропускаем,
     // чтобы не дублировать токен на одной и той же позиции.
-    Set<Position> sourceDefinedCallSites = collectSourceDefinedCallSites(documentContext);
+    var sourceDefinedCallSites = collectSourceDefinedCallSites(documentContext);
 
     for (var accessCall : Trees.<BSLParser.AccessCallContext>findAllRuleNodes(ast, BSLParser.RULE_accessCall)) {
-      var methodCall = accessCall.methodCall();
-      if (methodCall == null) {
-        continue;
-      }
-      var methodNameCtx = methodCall.methodName();
-      if (methodNameCtx == null) {
-        continue;
-      }
-      var methodIdentifier = methodNameCtx.IDENTIFIER();
-      if (methodIdentifier == null) {
-        continue;
-      }
-
-      Range range = Ranges.create(methodIdentifier);
-      if (sourceDefinedCallSites.contains(range.getStart())) {
-        continue;
-      }
-
-      var member = typeService.findMemberAt(documentContext, range.getStart());
-      if (member.isEmpty()) {
-        continue;
-      }
-      if (member.get().descriptor().kind() != MemberKind.METHOD) {
-        continue;
-      }
-
-      helper.addRange(entries, range, SemanticTokenTypes.Method, DEFAULT_LIBRARY_MODIFIERS);
+      methodNameRange(accessCall)
+        .filter(range -> !sourceDefinedCallSites.contains(range.getStart()))
+        .filter(range -> isPlatformMethodAt(documentContext, range.getStart()))
+        .ifPresent(range -> helper.addRange(entries, range, SemanticTokenTypes.Method, DEFAULT_LIBRARY_MODIFIERS));
     }
 
     return entries;
+  }
+
+  private static Optional<Range> methodNameRange(BSLParser.AccessCallContext accessCall) {
+    return Optional.ofNullable(accessCall.methodCall())
+      .map(BSLParser.MethodCallContext::methodName)
+      .map(BSLParser.MethodNameContext::IDENTIFIER)
+      .map(Ranges::create);
+  }
+
+  private boolean isPlatformMethodAt(DocumentContext documentContext, Position position) {
+    return typeService.findMemberAt(documentContext, position)
+      .map(TypeService.TypedMember::descriptor)
+      .map(descriptor -> descriptor.kind() == MemberKind.METHOD)
+      .orElse(false);
   }
 
   private Set<Position> collectSourceDefinedCallSites(DocumentContext documentContext) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
@@ -77,10 +77,7 @@ public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticT
     // чтобы не дублировать токен на одной и той же позиции.
     Set<Position> sourceDefinedCallSites = collectSourceDefinedCallSites(documentContext);
 
-    for (var node : Trees.findAllRuleNodes(ast, BSLParser.RULE_accessCall)) {
-      if (!(node instanceof BSLParser.AccessCallContext accessCall)) {
-        continue;
-      }
+    for (var accessCall : Trees.<BSLParser.AccessCallContext>findAllRuleNodes(ast, BSLParser.RULE_accessCall)) {
       var methodCall = accessCall.methodCall();
       if (methodCall == null) {
         continue;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
@@ -1,0 +1,123 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.semantictokens;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
+import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
+import org.eclipse.lsp4j.SemanticTokenModifiers;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@CleanupContextBeforeClassAndAfterClass
+@Import(SemanticTokensTestHelper.class)
+class PlatformMemberMethodCallSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private PlatformMemberMethodCallSemanticTokensSupplier supplier;
+
+  @Autowired
+  private SemanticTokensTestHelper helper;
+
+  @Test
+  void testPlatformMethodOnTypedVariable() {
+    // given — массив с известным методом Добавить из платформы.
+    String bsl = """
+      Процедура Тест()
+          М = Новый Массив;
+          М.Добавить(1);
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — Добавить подсвечивается как Method+DefaultLibrary.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(2, 6, 8, SemanticTokenTypes.Method,
+        Set.of(SemanticTokenModifiers.DefaultLibrary), "Добавить")
+    ));
+  }
+
+  @Test
+  void testPlatformMethodAfterAwait() {
+    // given — реальный кейс: вызов метода платформенного типа после Ждать.
+    // Воспроизводит юзер-репорт «не красится метод после Ждать».
+    String bsl = """
+      Асинх Процедура Тест()
+          М = Новый Массив;
+          Ждать М.Добавить(1);
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — Добавить подсвечен даже внутри Ждать-выражения.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(2, 12, 8, SemanticTokenTypes.Method,
+        Set.of(SemanticTokenModifiers.DefaultLibrary), "Добавить")
+    ));
+  }
+
+  @Test
+  void testAccessPropertyIgnored() {
+    // given — property access (без скобок) этим сапплаером не подсвечивается:
+    // мы обходим только accessCall (с doCall), а accessProperty — нет.
+    String bsl = """
+      Процедура Тест()
+          Стр = Новый Структура("Имя, Возраст", "Иван", 30);
+          А = Стр.Имя;
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — никаких токенов для accessProperty.
+    assertThat(decoded).isEmpty();
+  }
+
+  @Test
+  void testUnknownTypeReceiverProducesNoToken() {
+    // given — переменная без type inference: тип не резолвится → метод не подсвечивается.
+    String bsl = """
+      Процедура Тест(НеТипизированный)
+          НеТипизированный.НеизвестныйМетод(1);
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — пусто (метод неизвестен).
+    assertThat(decoded).isEmpty();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
@@ -22,7 +22,6 @@
 package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
-import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
@@ -36,7 +35,6 @@ import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
-@CleanupContextBeforeClassAndAfterClass
 @Import(SemanticTokensTestHelper.class)
 class PlatformMemberMethodCallSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
 


### PR DESCRIPTION
## Summary

- Новый `PlatformMemberMethodCallSemanticTokensSupplier` подсвечивает вызовы методов на типизированных переменных вида `receiver.method(...)` для платформенных типов как `Method+defaultLibrary`.
- Источник истины — `TypeService.findMemberAt(...)` (тот же путь, что hover/go-to-definition): вывод типа ресивера через `ExpressionTypeInferencer`, поиск member через `TypeRegistry.getMembers`.
- Source-defined вызовы (общие модули, OScript-library, локальные методы) остаются за `MethodCallSemanticTokensSupplier` — этот сапплаер пропускает позиции, уже зарегистрированные в `ReferenceIndex`, чтобы не дублировать токен.
- Async-модификатор для платформенных member-методов пока не выставляется: у `MemberDescriptor` нет поля `async`. Отдельная задача — расширение `PlatformMetadata` + парсера платформенных контекстов.
- Follow-up issue #3949 — симметричный сапплаер для accessProperty (`Стр.Имя` сейчас тоже не подсвечивается).

Закрывает баг из юзер-репорта «не красится метод после `Ждать`»: корень был в том, что `СертификатКриптографии.ИнициализироватьАсинх(...)` — это вызов метода платформенного типа, который ни один существующий сапплаер не покрывал.

## Test plan

- [x] `PlatformMemberMethodCallSemanticTokensSupplierTest`:
  - `testPlatformMethodOnTypedVariable` — `М.Добавить(...)` (Массив) → Method+DefaultLibrary
  - `testPlatformMethodAfterAwait` — `Ждать М.Добавить(...)` (юзер-репорт)
  - `testAccessPropertyIgnored` — `Стр.Имя` не подсвечивается (это для follow-up)
  - `testUnknownTypeReceiverProducesNoToken` — без типа пусто
- [x] `./gradlew test --tests "...semantictokens.*" --tests "...SemanticTokensProviderTest"` — зелёно, регрессий нет
- [x] `./gradlew bootJar` — собирается

## Draft

PR оформлен как draft: жду подтверждения подхода (через `TypeService.findMemberAt` против самостоятельного построения BslExpression) и решения по сопутствующему issue #3949 — публиковать оба супплаера вместе одним PR или отдельно.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced semantic token recognition for method calls on typed variables, providing improved syntax highlighting with proper token classification.
  * Better support for semantic highlighting of platform method calls even when expressions follow await operations.

* **Tests**
  * Added comprehensive test coverage for semantic token behavior across multiple scenarios including typed variable method calls, post-await expressions, and edge cases with property access and untyped receivers.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3950?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->