### PR TITLE
feat(semantictokens): async-модификатор для платформенных member-методов

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.semantictokens;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
@@ -50,7 +51,9 @@ import java.util.Set;
  * <p>
  * Метод резолвится через {@link TypeService#findMemberAt(DocumentContext, Position)}.
  * Если найден member с {@link MemberKind#METHOD} — имя метода получает
- * {@link SemanticTokenTypes#Method} + {@link SemanticTokenModifiers#DefaultLibrary}.
+ * {@link SemanticTokenTypes#Method} + {@link SemanticTokenModifiers#DefaultLibrary},
+ * а для async-методов платформы (флаг {@link MemberDescriptor#async()}) добавляется
+ * ещё и {@link SemanticTokenModifiers#Async}.
  * <p>
  * Source-defined вызовы (методы общих модулей, локальные методы, OScript-library)
  * подсвечиваются через {@link MethodCallSemanticTokensSupplier} по ReferenceIndex —
@@ -61,6 +64,10 @@ import java.util.Set;
 public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticTokensSupplier {
 
   private static final String[] DEFAULT_LIBRARY_MODIFIERS = {SemanticTokenModifiers.DefaultLibrary};
+  private static final String[] DEFAULT_LIBRARY_ASYNC_MODIFIERS = {
+    SemanticTokenModifiers.DefaultLibrary,
+    SemanticTokenModifiers.Async
+  };
 
   private final TypeService typeService;
   private final ReferenceIndex referenceIndex;
@@ -78,8 +85,10 @@ public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticT
     for (var accessCall : Trees.<BSLParser.AccessCallContext>findAllRuleNodes(ast, BSLParser.RULE_accessCall)) {
       methodNameRange(accessCall)
         .filter(range -> !sourceDefinedCallSites.contains(range.getStart()))
-        .filter(range -> isPlatformMethodAt(documentContext, range.getStart()))
-        .ifPresent(range -> helper.addRange(entries, range, SemanticTokenTypes.Method, DEFAULT_LIBRARY_MODIFIERS));
+        .flatMap(range -> platformMethodAt(documentContext, range.getStart())
+          .map(descriptor -> new Resolved(range, descriptor)))
+        .ifPresent(resolved -> helper.addRange(
+          entries, resolved.range(), SemanticTokenTypes.Method, modifiers(resolved.descriptor())));
     }
 
     return entries;
@@ -92,11 +101,17 @@ public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticT
       .map(Ranges::create);
   }
 
-  private boolean isPlatformMethodAt(DocumentContext documentContext, Position position) {
+  private Optional<MemberDescriptor> platformMethodAt(DocumentContext documentContext, Position position) {
     return typeService.findMemberAt(documentContext, position)
       .map(TypeService.TypedMember::descriptor)
-      .map(descriptor -> descriptor.kind() == MemberKind.METHOD)
-      .orElse(false);
+      .filter(descriptor -> descriptor.kind() == MemberKind.METHOD);
+  }
+
+  static String[] modifiers(MemberDescriptor descriptor) {
+    return descriptor.async() ? DEFAULT_LIBRARY_ASYNC_MODIFIERS : DEFAULT_LIBRARY_MODIFIERS;
+  }
+
+  private record Resolved(Range range, MemberDescriptor descriptor) {
   }
 
   private Set<Position> collectSourceDefinedCallSites(DocumentContext documentContext) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
@@ -101,6 +102,30 @@ class PlatformMemberMethodCallSemanticTokensSupplierTest extends AbstractServerC
 
     // then — никаких токенов для accessProperty.
     assertThat(decoded).isEmpty();
+  }
+
+  @Test
+  void testModifiersForAsyncDescriptor() {
+    // given
+    var asyncMethod = MemberDescriptor.method("ИнициализироватьАсинх").withAsync(true);
+
+    // when
+    var mods = PlatformMemberMethodCallSemanticTokensSupplier.modifiers(asyncMethod);
+
+    // then — async-метод платформы получает DefaultLibrary + Async.
+    assertThat(mods).containsExactly(SemanticTokenModifiers.DefaultLibrary, SemanticTokenModifiers.Async);
+  }
+
+  @Test
+  void testModifiersForRegularDescriptor() {
+    // given
+    var regularMethod = MemberDescriptor.method("Добавить");
+
+    // when
+    var mods = PlatformMemberMethodCallSemanticTokensSupplier.modifiers(regularMethod);
+
+    // then — обычный метод платформы получает только DefaultLibrary.
+    assertThat(mods).containsExactly(SemanticTokenModifiers.DefaultLibrary);
   }
 
   @Test


### PR DESCRIPTION
## Summary

После того как в develop появился `MemberDescriptor.async`, расширяю `PlatformMemberMethodCallSemanticTokensSupplier` чтобы сайт вызова async-метода платформенного типа получал не только `Method + defaultLibrary`, но ещё и стандартный модификатор `async`. Обычные методы остаются без `async` (как раньше).

Реализовано через `flatMap`-пару `(range, descriptor)` в виде `Resolved`-record и кэшированных статических массивов модификаторов (`DEFAULT_LIBRARY_MODIFIERS` / `DEFAULT_LIBRARY_ASYNC_MODIFIERS`).

## Test plan

- [x] `testModifiersForAsyncDescriptor` — `MemberDescriptor.method("X").withAsync(true)` → `[defaultLibrary, async]`
- [x] `testModifiersForRegularDescriptor` — обычный `MemberDescriptor.method("Y")` → `[defaultLibrary]`
- [x] Existing 4 интеграционных теста (`Массив.Добавить` и т.п.) — без регрессий
- [x] `./gradlew test --tests "*.semantictokens.*" --tests "*.SemanticTokensProviderTest"` — зелёно

Production-фикстуры платформенных типов пока не содержат member-методов с `async: true` (флаг есть только у глобальных функций типа `ВопросАсинх`, которые обрабатывает `PlatformGlobalMethodSemanticTokensSupplier`). Поэтому путь Async-метод проверяется на уровне статического хелпера `modifiers(...)`; как только в платформенной модели появятся async member-методы — подсветка заработает автоматически.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Improved semantic token handling for platform method calls: the language server now detects and applies appropriate semantic modifiers for asynchronous platform methods.

* **Tests**
  * Added test coverage validating semantic token modifier selection for both regular and asynchronous platform method calls.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3953?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->