### PR TITLE
feat(configuration): rename platform→v8platform и чтение секций v8platform/oscript из конфига

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfiguration.java
@@ -324,6 +324,7 @@ public class LanguageServerConfiguration {
     PropertyUtils.copyProperties(this.formattingOptions, configuration.formattingOptions);
     PropertyUtils.copyProperties(this.referencesOptions, configuration.referencesOptions);
     PropertyUtils.copyProperties(this.semanticTokensOptions, configuration.semanticTokensOptions);
+    PropertyUtils.copyProperties(this.oscriptOptions, configuration.oscriptOptions);
     PropertyUtils.copyProperties(this.v8PlatformOptions, configuration.v8PlatformOptions);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfiguration.java
@@ -123,9 +123,9 @@ public class LanguageServerConfiguration {
   @Setter(value = AccessLevel.NONE)
   private OScriptOptions oscriptOptions = new OScriptOptions();
 
-  @JsonProperty("platform")
+  @JsonProperty("v8platform")
   @Setter(value = AccessLevel.NONE)
-  private V8PlatformOptions platformOptions = new V8PlatformOptions();
+  private V8PlatformOptions v8PlatformOptions = new V8PlatformOptions();
 
   private String siteRoot = "https://1c-syntax.github.io/bsl-language-server";
   private boolean useDevSite;
@@ -324,5 +324,6 @@ public class LanguageServerConfiguration {
     PropertyUtils.copyProperties(this.formattingOptions, configuration.formattingOptions);
     PropertyUtils.copyProperties(this.referencesOptions, configuration.referencesOptions);
     PropertyUtils.copyProperties(this.semanticTokensOptions, configuration.semanticTokensOptions);
+    PropertyUtils.copyProperties(this.v8PlatformOptions, configuration.v8PlatformOptions);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/oscript/OScriptOptions.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/oscript/OScriptOptions.java
@@ -21,7 +21,6 @@
  */
 package com.github._1c_syntax.bsl.languageserver.configuration.oscript;
 
-import lombok.AccessLevel;
 import lombok.Getter;
 import lombok.Setter;
 import com.fasterxml.jackson.annotation.JsonProperty;
@@ -44,7 +43,6 @@ public class OScriptOptions {
    * в подпапках которого ищется {@code lib.config}.
    */
   @JsonProperty("libRoots")
-  @Setter(AccessLevel.NONE)
   private List<String> libRoots = new ArrayList<>();
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformContextProviderFactory.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformContextProviderFactory.java
@@ -74,7 +74,7 @@ public class PlatformContextProviderFactory {
       LOGGER.debug("Platform context loader is disabled via app.platform-context.enabled=false");
       return Optional.empty();
     }
-    var platformOptions = configuration.getPlatformOptions();
+    var platformOptions = configuration.getV8PlatformOptions();
     if (!platformOptions.isEnabled()) {
       LOGGER.debug("Platform context loader is disabled via configuration");
       return Optional.empty();

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/schema.json
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/schema.json
@@ -1220,6 +1220,34 @@
                 }
             }
         },
+        "oscript": {
+            "$id": "#/properties/oscript",
+            "type": "object",
+            "title": "OneScript libraries configuration.",
+            "properties": {
+                "libRoots": {
+                    "$id": "#/properties/oscript/libRoots",
+                    "type": "array",
+                    "title": "Additional root directories to search for OneScript libraries (each subdirectory is scanned for lib.config).",
+                    "items": {
+                        "type": "string"
+                    },
+                    "default": []
+                },
+                "useEnvLibLocation": {
+                    "$id": "#/properties/oscript/useEnvLibLocation",
+                    "type": "boolean",
+                    "title": "Also use paths from the OSCRIPT_LIB_LOCATION environment variable in addition to libRoots.",
+                    "default": false
+                },
+                "showImplicitLibraryEntriesInCompletion": {
+                    "$id": "#/properties/oscript/showImplicitLibraryEntriesInCompletion",
+                    "type": "boolean",
+                    "title": "Suggest implicit library entries (.os files not declared in lib.config) in no-dot completion.",
+                    "default": false
+                }
+            }
+        },
         "v8platform": {
             "$id": "#/properties/v8platform",
             "type": "object",

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/schema.json
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/schema.json
@@ -1219,6 +1219,24 @@
                     ]
                 }
             }
+        },
+        "v8platform": {
+            "$id": "#/properties/v8platform",
+            "type": "object",
+            "title": "1C:Enterprise platform types configuration.",
+            "properties": {
+                "binPath": {
+                    "$id": "#/properties/v8platform/binPath",
+                    "type": "string",
+                    "title": "Path to the 'bin' directory of an installed 1C:Enterprise platform (where syntax-helper files shcntx_*.hbk, shlang_*.hbk are located). If not set, the most recent installation on the machine is autodetected."
+                },
+                "enabled": {
+                    "$id": "#/properties/v8platform/enabled",
+                    "type": "boolean",
+                    "title": "Allow loading platform context from the syntax-helper of an installed 1C:Enterprise.",
+                    "default": true
+                }
+            }
         }
     }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfigurationTest.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.Diagno
 import com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.Mode;
 import com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.SkipSupport;
 import com.github._1c_syntax.bsl.languageserver.configuration.inlayhints.InlayHintOptions;
+import com.github._1c_syntax.bsl.languageserver.configuration.oscript.OScriptOptions;
 import com.github._1c_syntax.bsl.languageserver.configuration.platform.V8PlatformOptions;
 import com.github._1c_syntax.bsl.languageserver.configuration.semantictokens.SemanticTokensOptions;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
@@ -58,6 +59,8 @@ class LanguageServerConfigurationTest {
     = "./src/test/resources/.partial-bsl-language-server.json";
   private static final String PATH_TO_V8PLATFORM_CONFIGURATION_FILE
     = "./src/test/resources/.v8platform-bsl-language-server.json";
+  private static final String PATH_TO_OSCRIPT_CONFIGURATION_FILE
+    = "./src/test/resources/.oscript-bsl-language-server.json";
 
   @Autowired
   private LanguageServerConfiguration configuration;
@@ -202,6 +205,22 @@ class LanguageServerConfigurationTest {
     V8PlatformOptions v8PlatformOptions = configuration.getV8PlatformOptions();
     assertThat(v8PlatformOptions.isEnabled()).isFalse();
     assertThat(v8PlatformOptions.getBinPath()).isEqualTo(Path.of("/opt/1cv8/8.3.27.1786/bin"));
+  }
+
+  @Test
+  void testOScriptOptions() {
+    // given
+    File configurationFile = new File(PATH_TO_OSCRIPT_CONFIGURATION_FILE);
+
+    // when
+    configuration.update(configurationFile);
+
+    // then
+    OScriptOptions oscriptOptions = configuration.getOscriptOptions();
+    assertThat(oscriptOptions.getLibRoots())
+      .containsExactly("./libs", "/opt/oscript-lib");
+    assertThat(oscriptOptions.isUseEnvLibLocation()).isTrue();
+    assertThat(oscriptOptions.isShowImplicitLibraryEntriesInCompletion()).isTrue();
   }
 
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/configuration/LanguageServerConfigurationTest.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.Diagno
 import com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.Mode;
 import com.github._1c_syntax.bsl.languageserver.configuration.diagnostics.SkipSupport;
 import com.github._1c_syntax.bsl.languageserver.configuration.inlayhints.InlayHintOptions;
+import com.github._1c_syntax.bsl.languageserver.configuration.platform.V8PlatformOptions;
 import com.github._1c_syntax.bsl.languageserver.configuration.semantictokens.SemanticTokensOptions;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.utils.Absolute;
@@ -55,6 +56,8 @@ class LanguageServerConfigurationTest {
   private static final String PATH_TO_METADATA = "src/test/resources/metadata/designer";
   private static final String PATH_TO_PARTIAL_CONFIGURATION_FILE
     = "./src/test/resources/.partial-bsl-language-server.json";
+  private static final String PATH_TO_V8PLATFORM_CONFIGURATION_FILE
+    = "./src/test/resources/.v8platform-bsl-language-server.json";
 
   @Autowired
   private LanguageServerConfiguration configuration;
@@ -185,6 +188,20 @@ class LanguageServerConfigurationTest {
     assertThat(semanticTokensOptions.getParsedStrTemplateMethods().moduleMethodPairs())
       .containsKey("custommodule");
 
+  }
+
+  @Test
+  void testV8PlatformOptions() {
+    // given
+    File configurationFile = new File(PATH_TO_V8PLATFORM_CONFIGURATION_FILE);
+
+    // when
+    configuration.update(configurationFile);
+
+    // then
+    V8PlatformOptions v8PlatformOptions = configuration.getV8PlatformOptions();
+    assertThat(v8PlatformOptions.isEnabled()).isFalse();
+    assertThat(v8PlatformOptions.getBinPath()).isEqualTo(Path.of("/opt/1cv8/8.3.27.1786/bin"));
   }
 
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformContextProviderFactoryTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformContextProviderFactoryTest.java
@@ -68,14 +68,14 @@ class PlatformContextProviderFactoryTest {
     Optional<ContextProvider> result = factory.create();
 
     assertThat(result).isEmpty();
-    verify(configuration, never()).getPlatformOptions();
+    verify(configuration, never()).getV8PlatformOptions();
   }
 
   @Test
   void create_returnsEmpty_whenPropertyEnabledButPlatformOptionsDisabled() throws IOException {
     var configuration = mock(LanguageServerConfiguration.class);
     var options = mock(V8PlatformOptions.class);
-    when(configuration.getPlatformOptions()).thenReturn(options);
+    when(configuration.getV8PlatformOptions()).thenReturn(options);
     when(options.isEnabled()).thenReturn(false);
 
     try (MockedStatic<PlatformContextGrabber> grabbers = mockStatic(PlatformContextGrabber.class)) {
@@ -96,7 +96,7 @@ class PlatformContextProviderFactoryTest {
   void create_runsAutoDetect_whenBinPathNotConfigured() throws IOException {
     var configuration = mock(LanguageServerConfiguration.class);
     var options = mock(V8PlatformOptions.class);
-    when(configuration.getPlatformOptions()).thenReturn(options);
+    when(configuration.getV8PlatformOptions()).thenReturn(options);
     when(options.isEnabled()).thenReturn(true);
     when(options.getBinPath()).thenReturn(null);
 
@@ -126,7 +126,7 @@ class PlatformContextProviderFactoryTest {
     var configuration = mock(LanguageServerConfiguration.class);
     var options = mock(V8PlatformOptions.class);
     Path binPath = Paths.get("/opt/1cv8/bin");
-    when(configuration.getPlatformOptions()).thenReturn(options);
+    when(configuration.getV8PlatformOptions()).thenReturn(options);
     when(options.isEnabled()).thenReturn(true);
     when(options.getBinPath()).thenReturn(binPath);
 
@@ -154,7 +154,7 @@ class PlatformContextProviderFactoryTest {
   void create_returnsEmpty_whenGrabberProviderIsNull() throws IOException {
     var configuration = mock(LanguageServerConfiguration.class);
     var options = mock(V8PlatformOptions.class);
-    when(configuration.getPlatformOptions()).thenReturn(options);
+    when(configuration.getV8PlatformOptions()).thenReturn(options);
     when(options.isEnabled()).thenReturn(true);
     when(options.getBinPath()).thenReturn(null);
 

--- a/src/test/resources/.oscript-bsl-language-server.json
+++ b/src/test/resources/.oscript-bsl-language-server.json
@@ -1,0 +1,11 @@
+{
+  "$schema": "../../main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/schema.json",
+  "oscript": {
+    "libRoots": [
+      "./libs",
+      "/opt/oscript-lib"
+    ],
+    "useEnvLibLocation": true,
+    "showImplicitLibraryEntriesInCompletion": true
+  }
+}

--- a/src/test/resources/.v8platform-bsl-language-server.json
+++ b/src/test/resources/.v8platform-bsl-language-server.json
@@ -1,0 +1,7 @@
+{
+  "$schema": "../../main/resources/com/github/_1c_syntax/bsl/languageserver/configuration/schema.json",
+  "v8platform": {
+    "binPath": "/opt/1cv8/8.3.27.1786/bin",
+    "enabled": false
+  }
+}


### PR DESCRIPTION
## Что сделано

Две связанные задачи (отдельные коммиты):

### 1. `platform` → `v8platform`
- `@JsonProperty("platform")` → `@JsonProperty("v8platform")`; поле `platformOptions` → `v8PlatformOptions`, геттер теперь `getV8PlatformOptions()` (обновлены вызовы в `PlatformContextProviderFactory` и тесте).
- `copyPropertiesFrom()` теперь пробрасывает `v8PlatformOptions` из конфиг-файла — раньше значения секции не применялись (у поля нет сеттера, верхнеуровневый `PropertyUtils.copyProperties` его пропускал).
- В `schema.json` добавлена секция `v8platform` (`binPath`, `enabled`).

### 2. Чтение секции `oscript` (тот же латентный баг)
- `libRoots` получил сеттер (убран `@Setter(NONE)`) — как у `references.commonModuleAccessors`, иначе `PropertyUtils` не копирует список.
- `copyPropertiesFrom()` пробрасывает `oscriptOptions` (`libRoots`, `useEnvLibLocation`, `showImplicitLibraryEntriesInCompletion`); раньше секция полностью игнорировалась.
- В `schema.json` добавлена секция `oscript`.

## Тесты
- Новые `LanguageServerConfigurationTest.testV8PlatformOptions` / `testOScriptOptions` + ресурсы `.v8platform-bsl-language-server.json` / `.oscript-bsl-language-server.json`.
- Прогнаны `LanguageServerConfigurationTest`, `PlatformContextProviderFactoryTest`, `OScriptOptionsTest`, `types.oscript.*` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added OneScript configuration support with customizable library paths and environment variable integration
  * Added V8 Platform configuration support with binary path auto-detection and context loading controls

* **Improvements**
  * Enhanced configuration structure for clearer organization of platform-specific settings

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3962?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->