### PR TITLE
fix: устранение ложных reliability-замечаний Sonar (S2583/S2637)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/diagnostics/DiagnosticsOptions.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/configuration/diagnostics/DiagnosticsOptions.java
@@ -76,7 +76,7 @@ public class DiagnosticsOptions {
   private Set<String> ignoredAuthors = new HashSet<>();
 
   @JsonSetter("ignoredAuthors")
-  public void setIgnoredAuthors(Set<String> authors) {
+  public void setIgnoredAuthors(@Nullable Set<String> authors) {
     this.ignoredAuthors = authors == null
       ? new HashSet<>()
       : authors.stream()

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/BracketDocumentHighlightSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/BracketDocumentHighlightSupplier.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.parser.BSLParser;
 import org.antlr.v4.runtime.Token;
 import org.eclipse.lsp4j.DocumentHighlight;
 import org.eclipse.lsp4j.DocumentHighlightParams;
+import org.jspecify.annotations.Nullable;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
 
@@ -111,7 +112,7 @@ public class BracketDocumentHighlightSupplier implements DocumentHighlightSuppli
     return highlights;
   }
 
-  private Token findMatchingBracket(Token token, List<Token> allTokens, int openType, int closeType, boolean isOpening) {
+  private @Nullable Token findMatchingBracket(Token token, List<Token> allTokens, int openType, int closeType, boolean isOpening) {
     int tokenIndex = token.getTokenIndex();
     int depth = 1;
 


### PR DESCRIPTION
## Что и зачем

Quality gate на `develop` падал по единственному условию — `new_reliability_rating` = C (порог A). Причина — 38 reliability-замечаний в новом коде, почти все из которых ложные срабатывания или намеренные паттерны (Spring DI прототип-бинов, ANTLR-nullability при `@NullMarked`).

Этот PR устраняет **две** позиции, где в коде действительно стоит уточнить контракт nullability (а не править логику):

1. **`DiagnosticsOptions.setIgnoredAuthors`** (java:S2583) — `@JsonSetter`, вызывается Jackson и реально может получить `null` (`"ignoredAuthors": null`). Проверка `authors == null` корректна; из-за `@NullMarked` Sonar считал её недостижимой. Параметр помечен `@Nullable`.
2. **`BracketDocumentHighlightSupplier.findMatchingBracket`** (java:S2637) — приватный хелпер возвращает `null`, когда пара не найдена; вызывающий код уже проверяет результат. Возврат помечен `@Nullable`.

Обе правки — только аннотации, без изменения поведения (NullAway в сборке не используется).

## Остальные замечания

Прочие reliability-замечания в новом коде разобраны индивидуально и являются ложными срабатываниями либо намеренными паттернами, которые **нельзя** чинить правкой кода без вреда дизайну:

- **java:S6832 ×23** — инъекция workspace/prototype-бинов (`DocumentContext`, `LanguageServerConfiguration`) в одноаргументный конструктор. Потребители — либо классы, создаваемые через `new` вручную (`*Computer`), либо сами prototype-бины (диагностики). Не синглтоны → реальной проблемы нет.
- **java:S6813 ×4** — намеренный field-injection (self-injection с `@Lazy` для кэша; разрыв цикла через `@Qualifier`/`@Lazy`; документированный обход циклической зависимости).
- **java:S2637/S2583 в `cfg`/expression tree и ParseTree-коде** — ANTLR может вернуть `null` даже там, где сигнатура этого не заявляет; защитные проверки оставлены.

Они закрываются в SonarCloud как False Positive / Won't Fix (вне этого PR).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code quality improvements for enhanced null-safety handling

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3963?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->