### PR TITLE
fix: skip variable declarations with missing names in document symbols

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
@@ -241,7 +241,8 @@ public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> impl
    * <p>
    * {@link Trees#nodeContainsErrors} здесь не подходит: он проверяет только
    * {@link org.antlr.v4.runtime.ParserRuleContext#exception}, но не подставленные
-   * при восстановлении узлы-ошибки.
+   * при восстановлении узлы-ошибки (см.
+   * <a href="https://github.com/1c-syntax/bsl-language-server/issues/3968">#3968</a>).
    *
    * @param varName Контекст имени переменной
    * @return {@code true}, если идентификатор имени отсутствует или является узлом-ошибкой

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
@@ -36,10 +36,12 @@ import com.github._1c_syntax.bsl.parser.BSLParserBaseVisitor;
 import com.github._1c_syntax.bsl.parser.description.VariableDescription;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.ErrorNode;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -87,7 +89,7 @@ public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> impl
 
   @Override
   public ParseTree visitModuleVarDeclaration(BSLParser.ModuleVarDeclarationContext ctx) {
-    if (moduleVariables.containsKey(ctx.var_name().getText())) {
+    if (hasInvalidName(ctx.var_name()) || moduleVariables.containsKey(ctx.var_name().getText())) {
       return ctx;
     }
 
@@ -118,6 +120,10 @@ public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> impl
 
   @Override
   public ParseTree visitSubVarDeclaration(BSLParser.SubVarDeclarationContext ctx) {
+    if (hasInvalidName(ctx.var_name())) {
+      return ctx;
+    }
+
     var symbol = VariableSymbol.builder()
       .name(ctx.var_name().getText())
       .owner(documentContext)
@@ -221,6 +227,25 @@ public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> impl
       return Collections.emptyList();
     }
     return Annotations.from(moduleVar.annotation());
+  }
+
+  /**
+   * Проверяет, что имя переменной не было разобрано корректно.
+   * <p>
+   * При незавершённом объявлении (например, {@code Перем} без имени) парсер
+   * выполняет восстановление и подставляет фиктивный токен-ошибку. Такой токен
+   * получает позицию следующей значимой лексемы, из-за чего диапазон объявления
+   * становится «вывернутым» (начало после конца), а {@code selectionRange}
+   * перестаёт содержаться в {@code range}. Подобный символ ломает весь ответ
+   * на запрос {@code textDocument/documentSymbol}, поэтому его нужно пропустить.
+   *
+   * @param varName Контекст имени переменной
+   * @return {@code true}, если имя отсутствует или содержит узел-ошибку
+   */
+  private static boolean hasInvalidName(BSLParser.@Nullable Var_nameContext varName) {
+    return varName == null
+      || varName.getChildCount() == 0
+      || varName.getChildren().stream().anyMatch(ErrorNode.class::isInstance);
   }
 
   private SourceDefinedSymbol getVariableScope(BSLParser.SubVarDeclarationContext ctx) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/VariableSymbolComputer.java
@@ -41,7 +41,6 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
-import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -89,7 +88,7 @@ public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> impl
 
   @Override
   public ParseTree visitModuleVarDeclaration(BSLParser.ModuleVarDeclarationContext ctx) {
-    if (hasInvalidName(ctx.var_name()) || moduleVariables.containsKey(ctx.var_name().getText())) {
+    if (hasMissingName(ctx.var_name()) || moduleVariables.containsKey(ctx.var_name().getText())) {
       return ctx;
     }
 
@@ -120,7 +119,7 @@ public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> impl
 
   @Override
   public ParseTree visitSubVarDeclaration(BSLParser.SubVarDeclarationContext ctx) {
-    if (hasInvalidName(ctx.var_name())) {
+    if (hasMissingName(ctx.var_name())) {
       return ctx;
     }
 
@@ -230,22 +229,26 @@ public class VariableSymbolComputer extends BSLParserBaseVisitor<ParseTree> impl
   }
 
   /**
-   * Проверяет, что имя переменной не было разобрано корректно.
+   * Проверяет, что имя переменной отсутствует в исходном коде.
    * <p>
    * При незавершённом объявлении (например, {@code Перем} без имени) парсер
-   * выполняет восстановление и подставляет фиктивный токен-ошибку. Такой токен
-   * получает позицию следующей значимой лексемы, из-за чего диапазон объявления
-   * становится «вывернутым» (начало после конца), а {@code selectionRange}
-   * перестаёт содержаться в {@code range}. Подобный символ ломает весь ответ
-   * на запрос {@code textDocument/documentSymbol}, поэтому его нужно пропустить.
+   * выполняет восстановление и подставляет на место идентификатора фиктивный
+   * токен ({@link ErrorNode}). Такой токен получает позицию следующей значимой
+   * лексемы, из-за чего диапазон объявления становится «вывернутым» (начало
+   * после конца), а {@code selectionRange} перестаёт содержаться в {@code range}.
+   * Подобный символ ломает весь ответ на запрос {@code textDocument/documentSymbol},
+   * поэтому его нужно пропустить.
+   * <p>
+   * {@link Trees#nodeContainsErrors} здесь не подходит: он проверяет только
+   * {@link org.antlr.v4.runtime.ParserRuleContext#exception}, но не подставленные
+   * при восстановлении узлы-ошибки.
    *
    * @param varName Контекст имени переменной
-   * @return {@code true}, если имя отсутствует или содержит узел-ошибку
+   * @return {@code true}, если идентификатор имени отсутствует или является узлом-ошибкой
    */
-  private static boolean hasInvalidName(BSLParser.@Nullable Var_nameContext varName) {
-    return varName == null
-      || varName.getChildCount() == 0
-      || varName.getChildren().stream().anyMatch(ErrorNode.class::isInstance);
+  private static boolean hasMissingName(BSLParser.Var_nameContext varName) {
+    var identifier = varName.IDENTIFIER();
+    return identifier == null || identifier instanceof ErrorNode;
   }
 
   private SourceDefinedSymbol getVariableScope(BSLParser.SubVarDeclarationContext ctx) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
@@ -41,6 +41,11 @@ class DocumentSymbolProviderTest {
   @Autowired
   private DocumentSymbolProvider documentSymbolProvider;
 
+  /**
+   * Регрессионный тест: незавершённое объявление переменной ({@code Перем} без имени)
+   * не должно порождать символ с «вывернутым» диапазоном и ломать весь ответ на
+   * запрос {@code textDocument/documentSymbol}.
+   */
   @Test
   void testIncompleteVariableDeclarationDoesNotBreakSelectionRange() {
     // given - незавершённое объявление переменной без имени (Перем без идентификатора).
@@ -74,11 +79,21 @@ class DocumentSymbolProviderTest {
       .isEmpty();
   }
 
+  /**
+   * Рекурсивно разворачивает иерархию символов документа в плоский список,
+   * включая всех вложенных потомков.
+   *
+   * @param documentSymbols Символы (как правило, верхнего уровня документа)
+   * @return Плоский список символов вместе со всеми вложенными
+   */
   private static List<DocumentSymbol> flatten(List<DocumentSymbol> documentSymbols) {
     List<DocumentSymbol> result = new ArrayList<>();
     documentSymbols.forEach(documentSymbol -> {
       result.add(documentSymbol);
-      result.addAll(flatten(documentSymbol.getChildren()));
+      var children = documentSymbol.getChildren();
+      if (children != null) {
+        result.addAll(flatten(children));
+      }
     });
     return result;
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
@@ -52,31 +52,26 @@ class DocumentSymbolProviderTest {
     // Парсер восстанавливается, подставляя токен-ошибку, из-за чего диапазон объявления
     // становится «вывернутым» и selectionRange перестаёт содержаться в range, что ломало
     // весь ответ на запрос textDocument/documentSymbol.
-    var documentContext = TestUtils.getDocumentContext(
-      "Функция ЗначениеПеременной(ИмяПеременной) Экспорт\n"
-        + "\tПерем\n"
-        + "КонецФункции"
-    );
+    var documentContext = TestUtils.getDocumentContext("""
+      Функция ЗначениеПеременной(ИмяПеременной) Экспорт
+      	Перем
+      КонецФункции""");
 
     // when
     List<DocumentSymbol> documentSymbols = documentSymbolProvider.getDocumentSymbols(documentContext);
 
     var allSymbols = flatten(documentSymbols);
 
-    // then - метод по-прежнему отдаётся в структуре документа
+    // then
     assertThat(allSymbols)
-      .anyMatch(documentSymbol -> documentSymbol.getKind() == SymbolKind.Method);
-
-    // каждый symbol (включая вложенные) имеет selectionRange внутри range
-    assertThat(allSymbols)
+      // метод по-прежнему отдаётся в структуре документа
+      .anyMatch(documentSymbol -> documentSymbol.getKind() == SymbolKind.Method)
+      // каждый symbol (включая вложенные) имеет selectionRange внутри range
       .allMatch(documentSymbol ->
         Ranges.containsRange(documentSymbol.getRange(), documentSymbol.getSelectionRange())
-      );
-
-    // сломанный символ переменной без имени не попадает в структуру документа
-    assertThat(allSymbols)
-      .filteredOn(documentSymbol -> documentSymbol.getKind() == SymbolKind.Variable)
-      .isEmpty();
+      )
+      // сломанный символ переменной без имени не попадает в структуру документа
+      .noneMatch(documentSymbol -> documentSymbol.getKind() == SymbolKind.Variable);
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
@@ -30,6 +30,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -39,6 +40,48 @@ class DocumentSymbolProviderTest {
 
   @Autowired
   private DocumentSymbolProvider documentSymbolProvider;
+
+  @Test
+  void testIncompleteVariableDeclarationDoesNotBreakSelectionRange() {
+    // given - незавершённое объявление переменной без имени (Перем без идентификатора).
+    // Парсер восстанавливается, подставляя токен-ошибку, из-за чего диапазон объявления
+    // становится «вывернутым» и selectionRange перестаёт содержаться в range, что ломало
+    // весь ответ на запрос textDocument/documentSymbol.
+    var documentContext = TestUtils.getDocumentContext(
+      "Функция ЗначениеПеременной(ИмяПеременной) Экспорт\n"
+        + "\tПерем\n"
+        + "КонецФункции"
+    );
+
+    // when
+    List<DocumentSymbol> documentSymbols = documentSymbolProvider.getDocumentSymbols(documentContext);
+
+    var allSymbols = flatten(documentSymbols);
+
+    // then - метод по-прежнему отдаётся в структуре документа
+    assertThat(allSymbols)
+      .anyMatch(documentSymbol -> documentSymbol.getKind() == SymbolKind.Method);
+
+    // каждый symbol (включая вложенные) имеет selectionRange внутри range
+    assertThat(allSymbols)
+      .allMatch(documentSymbol ->
+        Ranges.containsRange(documentSymbol.getRange(), documentSymbol.getSelectionRange())
+      );
+
+    // сломанный символ переменной без имени не попадает в структуру документа
+    assertThat(allSymbols)
+      .filteredOn(documentSymbol -> documentSymbol.getKind() == SymbolKind.Variable)
+      .isEmpty();
+  }
+
+  private static List<DocumentSymbol> flatten(List<DocumentSymbol> documentSymbols) {
+    List<DocumentSymbol> result = new ArrayList<>();
+    documentSymbols.forEach(documentSymbol -> {
+      result.add(documentSymbol);
+      result.addAll(flatten(documentSymbol.getChildren()));
+    });
+    return result;
+  }
 
   @Test
   void testDocumentSymbol() {


### PR DESCRIPTION
An incomplete variable declaration (e.g. `Перем` without an identifier)
makes the parser recover by inserting a synthesized error token. That
token takes the position of the next significant token, so the declaration
range becomes inverted (start after end) and its selectionRange is no longer
contained in range. The vscode-languageclient validates this invariant and
rejects the whole textDocument/documentSymbol response with
"selectionRange must be contained in fullRange", breaking the outline.

Skip such malformed declarations in VariableSymbolComputer, mirroring the
existing ErrorNode handling in MethodSymbolComputer.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Incomplete or malformed variable declarations no longer produce invalid symbols; code navigation and document outline maintain correct ranges and selection behavior.
* **Tests**
  * Added a test to ensure malformed unnamed variables are excluded and that document symbols (including nested ones) keep valid selection ranges.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3967?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->