### PR TITLE
feat(oscript): автокомплит видит соседей по своему пакету без #Использовать

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -37,6 +37,7 @@ import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryInde
 import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
 import com.github._1c_syntax.bsl.languageserver.types.scope.UseDirectiveScanner;
 import com.github._1c_syntax.bsl.languageserver.types.symbol.SyntheticKind;
+import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.Command;
@@ -58,6 +59,9 @@ import java.util.Collection;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
+import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Провайдер для запросов {@code textDocument/completion}.
@@ -164,13 +168,53 @@ public final class CompletionProvider {
     return Character.isLetter(ch) && Character.UnicodeBlock.of(ch) == Character.UnicodeBlock.BASIC_LATIN;
   }
 
-  private List<String> libraryEntryNames(OScriptLibraryIndex.EntryKind kind) {
-    var showImplicit = configuration.getOscriptOptions().isShowImplicitLibraryEntriesInCompletion();
-    return oScriptLibraryIndex.findEntries(kind).stream()
-      .filter(entry -> showImplicit || !entry.implicit())
-      .map(OScriptLibraryIndex.LibraryEntry::qualifiedName)
-      .distinct()
-      .toList();
+  /**
+   * Видна ли library-запись в no-dot completion текущего документа.
+   * <p>
+   * Запись видна, если:
+   * <ul>
+   *   <li>файл — не BSL (в BSL OneScript-library-сущности скрыты целиком);</li>
+   *   <li>её библиотека объявлена в {@code #Использовать} ИЛИ это та же
+   *       библиотека-«пакет» (тот же корень), что и редактируемый файл
+   *       ({@code ownLibOrigin});</li>
+   *   <li>implicit-запись из чужой библиотеки скрывается при выключенном
+   *       {@code oscript.showImplicitLibraryEntriesInCompletion}; из своего
+   *       пакета implicit-запись видна всегда.</li>
+   * </ul>
+   */
+  private boolean libraryEntryVisible(OScriptLibraryIndex.LibraryEntry entry,
+                                      FileType fileType,
+                                      Set<String> usedLibsLower,
+                                      Optional<String> ownLibOrigin) {
+    if (fileType == FileType.BSL) {
+      return false;
+    }
+    var origin = entry.libOrigin();
+    if (origin == null || origin.isBlank()) {
+      return true;
+    }
+    var originLower = origin.toLowerCase(Locale.ROOT);
+    var samePackage = ownLibOrigin.map(originLower::equals).orElse(false);
+    if (entry.implicit()
+      && !configuration.getOscriptOptions().isShowImplicitLibraryEntriesInCompletion()
+      && !samePackage) {
+      return false;
+    }
+    return samePackage || usedLibsLower.contains(originLower);
+  }
+
+  /**
+   * Видно ли имя из global scope с точки зрения library-gating. Если имя не
+   * относится к зарегистрированной library-записи — видно (платформенные и
+   * конфигурационные имена не ограничиваем).
+   */
+  private boolean libraryNameVisible(String name,
+                                     FileType fileType,
+                                     Set<String> usedLibsLower,
+                                     Optional<String> ownLibOrigin) {
+    return oScriptLibraryIndex.findByName(name)
+      .map(entry -> libraryEntryVisible(entry, fileType, usedLibsLower, ownLibOrigin))
+      .orElse(true);
   }
 
   /**
@@ -286,23 +330,20 @@ public final class CompletionProvider {
     var items = new ArrayList<CompletionItem>();
 
     // Per-document #Использовать gating. Строгая семантика OneScript:
-    // library-сущность видна только если она объявлена в директиве
-    // #Использовать <libName>. Без директив — ничего из библиотек не видно.
-    // В BSL-файлах library-сущности скрыты целиком.
+    // сторонняя library-сущность видна только если её библиотека объявлена в
+    // директиве #Использовать <libName>. Без директив сторонние библиотеки не
+    // видны. В BSL-файлах library-сущности скрыты целиком.
     var usedLibs = UseDirectiveScanner.usedLibraries(documentContext);
     var usedLibsLower = usedLibs.isEmpty()
-      ? java.util.Set.<String>of()
-      : usedLibs.stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(java.util.stream.Collectors.toUnmodifiableSet());
-    java.util.function.Predicate<String> libVisible = name -> {
-      var origin = oScriptLibraryIndex.findByName(name).map(OScriptLibraryIndex.LibraryEntry::libOrigin);
-      if (origin.isEmpty()) {
-        return true;
-      }
-      if (fileType == FileType.BSL) {
-        return false;
-      }
-      return usedLibsLower.contains(origin.get().toLowerCase(Locale.ROOT));
-    };
+      ? Set.<String>of()
+      : usedLibs.stream().map(s -> s.toLowerCase(Locale.ROOT)).collect(Collectors.toUnmodifiableSet());
+    // Библиотека-«пакет» редактируемого файла: если сам документ является
+    // зарегистрированной library-записью, его соседи по тому же корню видны
+    // в completion без #Использовать (как implicit, так и explicit).
+    var ownLibOrigin = oScriptLibraryIndex.findByUri(Absolute.uri(documentContext.getUri()))
+      .map(OScriptLibraryIndex.LibraryEntry::libOrigin)
+      .filter(o -> o != null && !o.isBlank())
+      .map(o -> o.toLowerCase(Locale.ROOT));
 
     var scriptVariant = documentContext.getScriptVariantLanguage();
     if (afterNew) {
@@ -314,10 +355,11 @@ public final class CompletionProvider {
           items.add(buildPlatformClassCompletionItem(className, fileType, scriptVariant));
         }
       }
-      for (var libClassName : libraryEntryNames(OScriptLibraryIndex.EntryKind.CLASS)) {
-        if (!libVisible.test(libClassName)) {
+      for (var classEntry : oScriptLibraryIndex.findEntries(OScriptLibraryIndex.EntryKind.CLASS)) {
+        if (!libraryEntryVisible(classEntry, fileType, usedLibsLower, ownLibOrigin)) {
           continue;
         }
+        var libClassName = classEntry.qualifiedName();
         if (matches(libClassName, prefix)) {
           var item = new CompletionItem(libClassName);
           item.setKind(CompletionItemKind.Class);
@@ -341,17 +383,15 @@ public final class CompletionProvider {
     }
 
     // Global contexts — все VALUE-имена в global scope (property, enum, library-module).
-    // CompletionItemKind выбирается по фактическому SyntheticKind. Для library-модулей
-    // (SyntheticKind.LIBRARY_MODULE) применяется #Использовать-gating.
+    // CompletionItemKind выбирается по фактическому SyntheticKind. К library-сущностям
+    // применяется library-gating (#Использовать / свой пакет / implicit) через
+    // libraryNameVisible; платформенные и конфигурационные имена не ограничиваются.
     for (var ctx : globalScopeProvider.getGlobalContexts(fileType)) {
       var name = ctx.getName();
       if (!matches(name, prefix)) {
         continue;
       }
-      if (ctx.getSyntheticKind() == SyntheticKind.LIBRARY_MODULE && !libVisible.test(name)) {
-        continue;
-      }
-      if (isImplicitlyHiddenInCompletion(name)) {
+      if (!libraryNameVisible(name, fileType, usedLibsLower, ownLibOrigin)) {
         continue;
       }
       var item = new CompletionItem(name);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderOScriptLibraryTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderOScriptLibraryTest.java
@@ -261,6 +261,83 @@ class CompletionProviderOScriptLibraryTest extends AbstractServerContextAwareTes
       .contains("ПолучитьСтроку", "СтатусМодуля");
   }
 
+  @Test
+  void noDotCompletionAfterNovyiSurfacesSamePackageClassWithoutUseDirective() {
+    // given
+    initLib();
+    // редактируется файл, который сам принадлежит библиотеке mylib; #Использовать нет
+    var moduleUri = Path.of("src/test/resources/oscript-libraries/mylib/src/MyModule.os")
+      .toAbsolutePath().toUri();
+    var content = "А = Новый MyCl";
+    var dc = TestUtils.getDocumentContext(moduleUri, content, context);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(dc.getUri().toString()));
+    params.setPosition(new Position(0, content.length()));
+
+    // when
+    var items = completionProvider.getCompletion(dc, params).getItems();
+
+    // then
+    assertThat(items)
+      .as("класс-сосед по тому же корню библиотеки виден после `Новый` без #Использовать")
+      .filteredOn(it -> "MyClass".equals(it.getLabel()))
+      .singleElement()
+      .extracting(CompletionItem::getKind)
+      .isEqualTo(CompletionItemKind.Class);
+  }
+
+  @Test
+  void noDotCompletionSurfacesSamePackageModuleWithoutUseDirective() {
+    // given
+    initLib();
+    var classUri = Path.of("src/test/resources/oscript-libraries/mylib/src/MyClass.os")
+      .toAbsolutePath().toUri();
+    var content = "MyMod";
+    var dc = TestUtils.getDocumentContext(classUri, content, context);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(dc.getUri().toString()));
+    params.setPosition(new Position(0, content.length()));
+
+    // when
+    var items = completionProvider.getCompletion(dc, params).getItems();
+
+    // then
+    assertThat(items)
+      .as("модуль-сосед по тому же корню библиотеки виден без #Использовать")
+      .filteredOn(it -> "MyModule".equals(it.getLabel()))
+      .singleElement()
+      .extracting(CompletionItem::getKind)
+      .isEqualTo(CompletionItemKind.Module);
+  }
+
+  @Test
+  void noDotCompletionAfterNovyiSurfacesImplicitSamePackageClassWithoutUseDirective() {
+    // given
+    var fixtureRoot = Path.of("src/test/resources/oscript-libraries/implicit-test").toAbsolutePath();
+    initServerContext(fixtureRoot, false);
+    index.reindex(context);
+    // редактируется публичный класс библиотеки; AutoFound — implicit-сосед,
+    // флаг показа implicit выключен (default) — но из своего пакета он виден
+    var publicUri = fixtureRoot.resolve("src/PublicHello.os").toUri();
+    var content = "А = Новый AutoF";
+    var dc = TestUtils.getDocumentContext(publicUri, content, context);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(dc.getUri().toString()));
+    params.setPosition(new Position(0, content.length()));
+
+    // when
+    var items = completionProvider.getCompletion(dc, params).getItems();
+
+    // then
+    assertThat(items)
+      .as("implicit-класс-сосед виден после `Новый` из своего пакета даже при выключенном флаге")
+      .extracting(CompletionItem::getLabel)
+      .contains("AutoFound");
+  }
+
   private void initLib() {
     var fixtureRoot = Path.of("src/test/resources/oscript-libraries/mylib").toAbsolutePath();
     initServerContext(fixtureRoot, false);


### PR DESCRIPTION
## Что и зачем

В автокомплите OneScript после `Новый` (и в no-dot completion для модулей) сейчас не показываются классы/модули, не импортированные через `#Использовать`. Это неудобно, когда редактируешь файл, который сам лежит внутри библиотеки: соседние классы/модули того же «пакета» (корня библиотеки) в OneScript доступны напрямую, без `#Использовать`, но в подсказки не попадали.

Теперь: если редактируемый `.os`-файл сам является зарегистрированной library-записью, его соседи по тому же корню библиотеки видны в completion **без** `#Использовать` — как `explicit` (из `lib.config`), так и `implicit` (необъявленные `.os` в convention-каталогах).

## Как сделано

- Вычисляется «своя» библиотека документа: по URI редактируемого файла в `OScriptLibraryIndex` берётся `libOrigin` → `ownLibOrigin`.
- Логика видимости вынесена в `libraryEntryVisible(...)` / `libraryNameVisible(...)`:
  - сторонняя сущность видна только при `#Использовать`;
  - сущность своего пакета видна всегда;
  - `implicit` своего пакета виден независимо от `oscript.showImplicitLibraryEntriesInCompletion`; `implicit` чужого пакета — только при включённом флаге.
- Цикл классов после `Новый` итерируется по `findEntries(CLASS)` напрямую, поэтому implicit-соседи своего пакета тоже попадают в подсказки.

## Сохранённая семантика

- BSL-файлы по-прежнему не видят OneScript-library-сущности.
- Платформенные/конфигурационные имена не ограничиваются.
- Без `#Использовать` сторонние библиотеки не видны.

## Тесты

`CompletionProviderOScriptLibraryTest`:
- класс-сосед после `Новый` без `#Использовать`;
- модуль-сосед в no-dot без `#Использовать`;
- implicit-класс-сосед после `Новый` при выключенном флаге.

Зелёные также существующие тесты completion и пакета `types.oscript`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved code completion for library classes and modules. Completion now correctly surfaces classes and modules from the same library package context.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3977?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->