### PR TITLE
Убрать ложные методы у примитива Строка

### DIFF
--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json
@@ -162,23 +162,7 @@
     "aliases": [
       "String"
     ],
-    "members": [
-      {
-        "name": "Длина",
-        "kind": "METHOD",
-        "returnType": "Число"
-      },
-      {
-        "name": "ВРег",
-        "kind": "METHOD",
-        "returnType": "Строка"
-      },
-      {
-        "name": "НРег",
-        "kind": "METHOD",
-        "returnType": "Строка"
-      }
-    ]
+    "members": []
   },
   {
     "kind": "PRIMITIVE_TYPE",

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinPlatformTypesProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinPlatformTypesProviderTest.java
@@ -135,6 +135,25 @@ class BuiltinPlatformTypesProviderTest {
   }
 
   @Test
+  void primitiveStringHasNoMembers() {
+    // given — у примитива Строка нет методов ни в BSL, ни в OneScript:
+    // Длина/ВРег/НРег — это глобальные функции (СтрДлина/ВРег/НРег), а не члены типа.
+    when(holder.get()).thenReturn(Optional.empty());
+    var provider = new BuiltinPlatformTypesProvider(holder);
+
+    // when
+    var stringDecl = provider.getTypes().stream()
+      .filter(td -> "Строка".equals(td.name().primary()))
+      .findFirst()
+      .orElseThrow();
+
+    // then
+    assertThat(stringDecl.members())
+      .as("у примитива Строка не должно быть методов")
+      .isEmpty();
+  }
+
+  @Test
   void oscriptBilingualMemberPairsAreMergedIntoSingleBilingualMember() {
     // В дампе OneScript Массив.Добавить и Массив.Add — два отдельных
     // моноязычных члена подряд. После склейки при загрузке это один


### PR DESCRIPTION
## Проблема

Примитив `Строка` в `builtin-platform-types.json` был объявлен с членами `Длина`, `ВРег`, `НРег` (как `kind: PRIMITIVE_TYPE` — единственный примитив с непустым `members`). Из-за этого при выводе типа из строкового литерала автодополнение по точке (`Стр.`) предлагало эти «методы».

Ни в 1С:Предприятии, ни в OneScript у строк нет методов — `СтрДлина`/`ВРег`/`НРег` являются глобальными функциями, а не членами типа `Строка`.

## Решение

- У типа `Строка` очищен список `members` (`[]`).
- Ресурс `builtin-platform-types.json` общий для BSL и OneScript; отдельного определения `Строка` с методами в `builtin-oscript-platform-types.json` нет, поэтому правка устраняет проблему для обоих языков.
- Добавлен регресс-тест `BuiltinPlatformTypesProviderTest#primitiveStringHasNoMembers`.

## Проверка

`BuiltinPlatformTypesProviderTest` и `CompletionProviderTest` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Changes**
  * Removed method definitions from the string type in the platform type registry.

* **Tests**
  * Added test verifying string type has no methods in fallback mode.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->