### PR TITLE
Подсветка accessProperty платформенных типов (Property+DefaultLibrary)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
@@ -44,6 +44,7 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -465,6 +466,61 @@ public class SemanticTokensProvider {
         executor
       )
       .join();
+  }
+
+  /**
+   * Пересечение двух токенов, выданных сапплаерами на одном участке кода.
+   *
+   * @param first  токен с меньшей (или равной) начальной позицией
+   * @param second пересекающийся с ним токен
+   */
+  public record TokenOverlap(SemanticTokenEntry first, SemanticTokenEntry second) {
+  }
+
+  /**
+   * Находит пересечения токенов на одной строке (отладочный guard).
+   * <p>
+   * По спецификации LSP токены семантической подсветки не должны пересекаться:
+   * если два сапплаера покрасили один и тот же (или перекрывающийся) участок
+   * разными {@code type}/{@code modifiers} — это конфликт подсветки, который
+   * клиент отрисует недетерминированно. Точные дубли (полностью совпадающие
+   * по позиции и оформлению токены от разных сапплаеров) конфликтом не
+   * считаются — их убирает де-дупликация в {@link #toDeltaEncodedArray}.
+   *
+   * @param entries собранные со всех сапплаеров токены
+   * @return список пар пересекающихся токенов; пустой, если конфликтов нет
+   */
+  static List<TokenOverlap> findOverlaps(List<SemanticTokenEntry> entries) {
+    var byLine = new HashMap<Integer, List<SemanticTokenEntry>>();
+    for (var entry : entries) {
+      byLine.computeIfAbsent(entry.line(), k -> new ArrayList<>()).add(entry);
+    }
+
+    var overlaps = new ArrayList<TokenOverlap>();
+    for (var lineTokens : byLine.values()) {
+      lineTokens.sort(Comparator.comparingInt(SemanticTokenEntry::start));
+      for (int i = 0; i < lineTokens.size(); i++) {
+        var a = lineTokens.get(i);
+        int aEnd = a.start() + a.length();
+        for (int j = i + 1; j < lineTokens.size(); j++) {
+          var b = lineTokens.get(j);
+          if (b.start() >= aEnd) {
+            break; // токены отсортированы по start — дальше пересечений с a нет
+          }
+          if (!isExactDuplicate(a, b)) {
+            overlaps.add(new TokenOverlap(a, b));
+          }
+        }
+      }
+    }
+    return overlaps;
+  }
+
+  private static boolean isExactDuplicate(SemanticTokenEntry a, SemanticTokenEntry b) {
+    return a.start() == b.start()
+      && a.length() == b.length()
+      && a.type() == b.type()
+      && a.modifiers() == b.modifiers();
   }
 
   private static int[] toDeltaEncodedArray(List<SemanticTokenEntry> entries) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
@@ -53,6 +53,7 @@ import java.util.UUID;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ExecutorService;
+import java.util.function.Function;
 
 /**
  * Провайдер для предоставления семантических токенов.
@@ -172,8 +173,8 @@ public class SemanticTokensProvider {
   ) {
     Range range = params.getRange();
 
-    // Collect tokens from all suppliers in parallel
-    var entries = collectTokens(documentContext);
+    // Collect tokens from all suppliers in parallel, scoping expensive suppliers to the range
+    var entries = collectTokens(documentContext, range);
 
     // Filter tokens that fall within the specified range
     var filteredEntries = filterTokensByRange(entries, range);
@@ -457,10 +458,25 @@ public class SemanticTokensProvider {
    * Collect tokens from all suppliers in parallel using ForkJoinPool.
    */
   private List<SemanticTokenEntry> collectTokens(DocumentContext documentContext) {
+    return collectTokens(supplier -> supplier.getSemanticTokens(documentContext));
+  }
+
+  /**
+   * Собрать токены всех сапплаеров для запрошенного диапазона. Дорогие сапплаеры
+   * ограничивают тяжёлую работу диапазоном, дешёвые отдают полный набор (его
+   * затем триммит {@link #filterTokensByRange}).
+   */
+  private List<SemanticTokenEntry> collectTokens(DocumentContext documentContext, Range range) {
+    return collectTokens(supplier -> supplier.getSemanticTokens(documentContext, range));
+  }
+
+  private List<SemanticTokenEntry> collectTokens(
+    Function<SemanticTokensSupplier, List<SemanticTokenEntry>> invoker
+  ) {
     return CompletableFuture
       .supplyAsync(
         () -> suppliers.parallelStream()
-          .map(supplier -> supplier.getSemanticTokens(documentContext))
+          .map(invoker)
           .flatMap(Collection::stream)
           .toList(),
         executor

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
@@ -523,20 +523,15 @@ public class SemanticTokensProvider {
           if (b.start() >= aEnd) {
             break; // токены отсортированы по start — дальше пересечений с a нет
           }
-          if (!isExactDuplicate(a, b)) {
+          // a и b уже на одной строке, поэтому equals рекорда (все 5 полей)
+          // эквивалентен проверке «точный дубль»: одинаковые позиция и оформление.
+          if (!a.equals(b)) {
             overlaps.add(new TokenOverlap(a, b));
           }
         }
       }
     }
     return overlaps;
-  }
-
-  private static boolean isExactDuplicate(SemanticTokenEntry a, SemanticTokenEntry b) {
-    return a.start() == b.start()
-      && a.length() == b.length()
-      && a.type() == b.type()
-      && a.modifiers() == b.modifiers();
   }
 
   private static int[] toDeltaEncodedArray(List<SemanticTokenEntry> entries) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
@@ -455,9 +455,10 @@ public class SemanticTokensProvider {
   }
 
   /**
-   * Collect tokens from all suppliers in parallel using ForkJoinPool.
+   * Собрать токены всех сапплаеров по всему документу (как для full-запроса).
+   * Package-private — используется регрессионным guard-тестом на пересечения.
    */
-  private List<SemanticTokenEntry> collectTokens(DocumentContext documentContext) {
+  List<SemanticTokenEntry> collectTokens(DocumentContext documentContext) {
     return collectTokens(supplier -> supplier.getSemanticTokens(documentContext));
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
@@ -44,7 +44,6 @@ import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
-import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
@@ -483,56 +482,6 @@ public class SemanticTokensProvider {
         executor
       )
       .join();
-  }
-
-  /**
-   * Пересечение двух токенов, выданных сапплаерами на одном участке кода.
-   *
-   * @param first  токен с меньшей (или равной) начальной позицией
-   * @param second пересекающийся с ним токен
-   */
-  public record TokenOverlap(SemanticTokenEntry first, SemanticTokenEntry second) {
-  }
-
-  /**
-   * Находит пересечения токенов на одной строке (отладочный guard).
-   * <p>
-   * По спецификации LSP токены семантической подсветки не должны пересекаться:
-   * если два сапплаера покрасили один и тот же (или перекрывающийся) участок
-   * разными {@code type}/{@code modifiers} — это конфликт подсветки, который
-   * клиент отрисует недетерминированно. Точные дубли (полностью совпадающие
-   * по позиции и оформлению токены от разных сапплаеров) конфликтом не
-   * считаются — их убирает де-дупликация в {@link #toDeltaEncodedArray}.
-   *
-   * @param entries собранные со всех сапплаеров токены
-   * @return список пар пересекающихся токенов; пустой, если конфликтов нет
-   */
-  static List<TokenOverlap> findOverlaps(List<SemanticTokenEntry> entries) {
-    var byLine = new HashMap<Integer, List<SemanticTokenEntry>>();
-    for (var entry : entries) {
-      byLine.computeIfAbsent(entry.line(), k -> new ArrayList<>()).add(entry);
-    }
-
-    var overlaps = new ArrayList<TokenOverlap>();
-    for (var lineTokens : byLine.values()) {
-      lineTokens.sort(Comparator.comparingInt(SemanticTokenEntry::start));
-      for (int i = 0; i < lineTokens.size(); i++) {
-        var a = lineTokens.get(i);
-        int aEnd = a.start() + a.length();
-        for (int j = i + 1; j < lineTokens.size(); j++) {
-          var b = lineTokens.get(j);
-          if (b.start() >= aEnd) {
-            break; // токены отсортированы по start — дальше пересечений с a нет
-          }
-          // a и b уже на одной строке, поэтому equals рекорда (все 5 полей)
-          // эквивалентен проверке «точный дубль»: одинаковые позиция и оформление.
-          if (!a.equals(b)) {
-            overlaps.add(new TokenOverlap(a, b));
-          }
-        }
-      }
-    }
-    return overlaps;
   }
 
   private static int[] toDeltaEncodedArray(List<SemanticTokenEntry> entries) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/AbstractPlatformMemberSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/AbstractPlatformMemberSemanticTokensSupplier.java
@@ -23,12 +23,12 @@ package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
-import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
+import org.eclipse.lsp4j.util.Positions;
 
 import java.util.ArrayList;
 import java.util.List;
@@ -39,9 +39,9 @@ import java.util.function.Predicate;
 /**
  * Общая основа сапплаеров, подсвечивающих обращения к членам платформенных типов
  * (свойство через accessProperty, вызов метода через accessCall). Тип члена
- * резолвится через {@link TypeService#memberAt(DocumentContext, Position)} —
- * дорогой инференс, поэтому в range-запросе он вызывается только для узлов в
- * пределах запрошенного диапазона.
+ * резолвится через {@link TypeService#memberAt} — дорогой инференс, поэтому в
+ * range-запросе он вызывается только для узлов, пересекающихся с запрошенным
+ * диапазоном.
  * <p>
  * Подклассы определяют четыре точки расширения:
  * <ul>
@@ -87,7 +87,17 @@ public abstract class AbstractPlatformMemberSemanticTokensSupplier<T extends Par
 
   @Override
   public final List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext, Range range) {
-    return collect(documentContext, nameRange -> Ranges.containsPosition(range, nameRange.getStart()));
+    return collect(documentContext, nameRange -> overlaps(range, nameRange));
+  }
+
+  /**
+   * Диапазон имени пересекается с запрошенным (частичное пересечение, как в
+   * {@code SemanticTokensProvider.filterTokensByRange}): имя, начинающееся до
+   * границы диапазона, но заходящее внутрь, не отбрасывается.
+   */
+  private static boolean overlaps(Range range, Range nameRange) {
+    return Positions.isBefore(nameRange.getStart(), range.getEnd())
+      && Positions.isBefore(range.getStart(), nameRange.getEnd());
   }
 
   private List<SemanticTokenEntry> collect(DocumentContext documentContext, Predicate<Range> inScope) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/AbstractPlatformMemberSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/AbstractPlatformMemberSemanticTokensSupplier.java
@@ -1,0 +1,107 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.semantictokens;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.languageserver.utils.Trees;
+import lombok.RequiredArgsConstructor;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SemanticTokenModifiers;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.function.BiPredicate;
+import java.util.function.Predicate;
+
+/**
+ * Общая основа сапплаеров, подсвечивающих обращения к членам платформенных типов
+ * (свойство через accessProperty, вызов метода через accessCall). Тип члена
+ * резолвится через {@link TypeService#memberAt(DocumentContext, Position)} —
+ * дорогой инференс, поэтому в range-запросе он вызывается только для узлов в
+ * пределах запрошенного диапазона.
+ * <p>
+ * Подклассы определяют четыре точки расширения:
+ * <ul>
+ *   <li>{@link #ruleIndex()} — какой rule-узел AST обходить;</li>
+ *   <li>{@link #nameRange(ParserRuleContext)} — диапазон имени члена в узле;</li>
+ *   <li>{@link #skipFilter(DocumentContext)} — узлы, которые красит другой
+ *       сапплаер (домен GlobalScope, source-defined вызовы) и которые нужно
+ *       пропустить, чтобы не дублировать токен;</li>
+ *   <li>{@link #emit(List, DocumentContext, Range)} — резолв члена и выдача токена
+ *       нужного типа/модификаторов.</li>
+ * </ul>
+ *
+ * @param <T> тип AST-узла обращения к члену
+ */
+@RequiredArgsConstructor
+public abstract class AbstractPlatformMemberSemanticTokensSupplier<T extends ParserRuleContext>
+  implements SemanticTokensSupplier {
+
+  protected static final String[] DEFAULT_LIBRARY_MODIFIERS = {SemanticTokenModifiers.DefaultLibrary};
+
+  protected final TypeService typeService;
+  protected final SemanticTokensHelper helper;
+
+  /** Индекс rule-узла AST для обхода (например {@code BSLParser.RULE_accessProperty}). */
+  protected abstract int ruleIndex();
+
+  /** Диапазон имени члена в узле; empty, если имени нет. */
+  protected abstract Optional<Range> nameRange(T node);
+
+  /**
+   * Предикат «пропустить узел» — позиции, которые уже красит другой сапплаер.
+   * Считается один раз на документ (можно предвычислить тяжёлое состояние).
+   */
+  protected abstract BiPredicate<T, Range> skipFilter(DocumentContext documentContext);
+
+  /** Резолвит член в позиции и при успехе добавляет токен в {@code entries}. */
+  protected abstract void emit(List<SemanticTokenEntry> entries, DocumentContext documentContext, Range range);
+
+  @Override
+  public final List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext) {
+    return collect(documentContext, range -> true);
+  }
+
+  @Override
+  public final List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext, Range range) {
+    return collect(documentContext, nameRange -> Ranges.containsPosition(range, nameRange.getStart()));
+  }
+
+  private List<SemanticTokenEntry> collect(DocumentContext documentContext, Predicate<Range> inScope) {
+    var entries = new ArrayList<SemanticTokenEntry>();
+    var ast = documentContext.getAst();
+    var skip = skipFilter(documentContext);
+
+    for (T node : Trees.<T>findAllRuleNodes(ast, ruleIndex())) {
+      nameRange(node)
+        .filter(inScope)
+        .filter(range -> !skip.test(node, range))
+        .ifPresent(range -> emit(entries, documentContext, range));
+    }
+
+    return entries;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
@@ -42,6 +42,7 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Сапплаер семантических токенов для вызовов методов платформенных типов через
@@ -75,6 +76,16 @@ public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticT
 
   @Override
   public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext) {
+    return collect(documentContext, range -> true);
+  }
+
+  @Override
+  public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext, Range range) {
+    // Дорогой memberAt вызывается только для вызовов в пределах запрошенного диапазона.
+    return collect(documentContext, nameRange -> Ranges.containsPosition(range, nameRange.getStart()));
+  }
+
+  private List<SemanticTokenEntry> collect(DocumentContext documentContext, Predicate<Range> inScope) {
     var entries = new ArrayList<SemanticTokenEntry>();
     var ast = documentContext.getAst();
 
@@ -84,6 +95,7 @@ public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticT
 
     for (var accessCall : Trees.<BSLParser.AccessCallContext>findAllRuleNodes(ast, BSLParser.RULE_accessCall)) {
       methodNameRange(accessCall)
+        .filter(inScope)
         .filter(range -> !sourceDefinedCallSites.contains(range.getStart()))
         .flatMap(range -> platformMethodAt(documentContext, range.getStart())
           .map(descriptor -> new Resolved(range, descriptor)))

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
@@ -27,9 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.types.TypeService;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
-import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
-import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
@@ -37,12 +35,11 @@ import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.eclipse.lsp4j.SymbolKind;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 
 /**
  * Сапплаер семантических токенов для вызовов методов платформенных типов через
@@ -56,61 +53,58 @@ import java.util.function.Predicate;
  * а для async-методов платформы (флаг {@link MemberDescriptor#async()}) добавляется
  * ещё и {@link SemanticTokenModifiers#Async}.
  * <p>
+ * Симметричен {@link PlatformMemberPropertyAccessSemanticTokensSupplier} (обращения к
+ * свойствам через accessProperty) — общий каркас в
+ * {@link AbstractPlatformMemberSemanticTokensSupplier}.
+ * <p>
  * Source-defined вызовы (методы общих модулей, локальные методы, OScript-library)
  * подсвечиваются через {@link MethodCallSemanticTokensSupplier} по ReferenceIndex —
  * этот сапплаер их пропускает, чтобы не дублировать токены.
  */
 @Component
-@RequiredArgsConstructor
-public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticTokensSupplier {
+public class PlatformMemberMethodCallSemanticTokensSupplier
+  extends AbstractPlatformMemberSemanticTokensSupplier<BSLParser.AccessCallContext> {
 
-  private static final String[] DEFAULT_LIBRARY_MODIFIERS = {SemanticTokenModifiers.DefaultLibrary};
   private static final String[] DEFAULT_LIBRARY_ASYNC_MODIFIERS = {
     SemanticTokenModifiers.DefaultLibrary,
     SemanticTokenModifiers.Async
   };
 
-  private final TypeService typeService;
   private final ReferenceIndex referenceIndex;
-  private final SemanticTokensHelper helper;
 
-  @Override
-  public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext) {
-    return collect(documentContext, range -> true);
+  public PlatformMemberMethodCallSemanticTokensSupplier(TypeService typeService,
+                                                        ReferenceIndex referenceIndex,
+                                                        SemanticTokensHelper helper) {
+    super(typeService, helper);
+    this.referenceIndex = referenceIndex;
   }
 
   @Override
-  public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext, Range range) {
-    // Дорогой memberAt вызывается только для вызовов в пределах запрошенного диапазона.
-    return collect(documentContext, nameRange -> Ranges.containsPosition(range, nameRange.getStart()));
+  protected int ruleIndex() {
+    return BSLParser.RULE_accessCall;
   }
 
-  private List<SemanticTokenEntry> collect(DocumentContext documentContext, Predicate<Range> inScope) {
-    var entries = new ArrayList<SemanticTokenEntry>();
-    var ast = documentContext.getAst();
-
-    // Позиции, уже обработанные MethodCallSemanticTokensSupplier: пропускаем,
-    // чтобы не дублировать токен на одной и той же позиции.
-    var sourceDefinedCallSites = collectSourceDefinedCallSites(documentContext);
-
-    for (var accessCall : Trees.<BSLParser.AccessCallContext>findAllRuleNodes(ast, BSLParser.RULE_accessCall)) {
-      methodNameRange(accessCall)
-        .filter(inScope)
-        .filter(range -> !sourceDefinedCallSites.contains(range.getStart()))
-        .flatMap(range -> platformMethodAt(documentContext, range.getStart())
-          .map(descriptor -> new Resolved(range, descriptor)))
-        .ifPresent(resolved -> helper.addRange(
-          entries, resolved.range(), SemanticTokenTypes.Method, modifiers(resolved.descriptor())));
-    }
-
-    return entries;
-  }
-
-  private static Optional<Range> methodNameRange(BSLParser.AccessCallContext accessCall) {
-    return Optional.ofNullable(accessCall.methodCall())
+  @Override
+  protected Optional<Range> nameRange(BSLParser.AccessCallContext node) {
+    return Optional.ofNullable(node.methodCall())
       .map(BSLParser.MethodCallContext::methodName)
       .map(BSLParser.MethodNameContext::IDENTIFIER)
       .map(Ranges::create);
+  }
+
+  @Override
+  protected BiPredicate<BSLParser.AccessCallContext, Range> skipFilter(DocumentContext documentContext) {
+    // Позиции, уже обработанные MethodCallSemanticTokensSupplier по ReferenceIndex:
+    // предвычисляем один раз на документ.
+    var sourceDefinedCallSites = collectSourceDefinedCallSites(documentContext);
+    return (node, range) -> sourceDefinedCallSites.contains(range.getStart());
+  }
+
+  @Override
+  protected void emit(List<SemanticTokenEntry> entries, DocumentContext documentContext, Range range) {
+    platformMethodAt(documentContext, range.getStart())
+      .ifPresent(descriptor -> helper.addRange(
+        entries, range, SemanticTokenTypes.Method, modifiers(descriptor)));
   }
 
   private Optional<MemberDescriptor> platformMethodAt(DocumentContext documentContext, Position position) {
@@ -121,9 +115,6 @@ public class PlatformMemberMethodCallSemanticTokensSupplier implements SemanticT
 
   static String[] modifiers(MemberDescriptor descriptor) {
     return descriptor.async() ? DEFAULT_LIBRARY_ASYNC_MODIFIERS : DEFAULT_LIBRARY_MODIFIERS;
-  }
-
-  private record Resolved(Range range, MemberDescriptor descriptor) {
   }
 
   private Set<Position> collectSourceDefinedCallSites(DocumentContext documentContext) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
@@ -1,0 +1,113 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.semantictokens;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
+import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.languageserver.utils.Trees;
+import com.github._1c_syntax.bsl.parser.BSLParser;
+import lombok.RequiredArgsConstructor;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SemanticTokenModifiers;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.eclipse.lsp4j.SymbolKind;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+
+/**
+ * Сапплаер семантических токенов для обращения к свойствам платформенных типов
+ * через accessProperty (т.е. обращений вида {@code receiver.property} без скобок,
+ * где {@code receiver} — типизированное выражение, чей тип резолвится через
+ * {@link com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer}).
+ * <p>
+ * Свойство резолвится через {@link TypeService#findMemberAt(DocumentContext, Position)}.
+ * Если найден member с {@link MemberKind#PROPERTY} — имя свойства получает
+ * {@link SemanticTokenTypes#Property} + {@link SemanticTokenModifiers#DefaultLibrary}.
+ * <p>
+ * Симметричен {@link PlatformMemberMethodCallSemanticTokensSupplier}, который
+ * подсвечивает вызовы методов платформенных типов через accessCall.
+ * <p>
+ * Source-defined переменные (в т.ч. экспортные переменные модуля объекта,
+ * доступные как {@code Объект.Перем}) подсвечиваются через
+ * {@link SymbolsSemanticTokensSupplier} по ReferenceIndex — этот сапплаер
+ * пропускает такие позиции, чтобы не дублировать токены.
+ */
+@Component
+@RequiredArgsConstructor
+public class PlatformMemberPropertyAccessSemanticTokensSupplier implements SemanticTokensSupplier {
+
+  private static final String[] DEFAULT_LIBRARY_MODIFIERS = {SemanticTokenModifiers.DefaultLibrary};
+
+  private final TypeService typeService;
+  private final ReferenceIndex referenceIndex;
+  private final SemanticTokensHelper helper;
+
+  @Override
+  public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext) {
+    var entries = new ArrayList<SemanticTokenEntry>();
+    var ast = documentContext.getAst();
+
+    // Позиции, уже обработанные SymbolsSemanticTokensSupplier (source-defined
+    // переменные): пропускаем, чтобы не дублировать токен на одной позиции.
+    var sourceDefinedVarSites = collectSourceDefinedVarSites(documentContext);
+
+    for (var accessProperty
+      : Trees.<BSLParser.AccessPropertyContext>findAllRuleNodes(ast, BSLParser.RULE_accessProperty)) {
+      propertyNameRange(accessProperty)
+        .filter(range -> !sourceDefinedVarSites.contains(range.getStart()))
+        .filter(range -> isPlatformProperty(documentContext, range.getStart()))
+        .ifPresent(range -> helper.addRange(
+          entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS));
+    }
+
+    return entries;
+  }
+
+  private static Optional<Range> propertyNameRange(BSLParser.AccessPropertyContext accessProperty) {
+    return Optional.ofNullable(accessProperty.IDENTIFIER())
+      .map(Ranges::create);
+  }
+
+  private boolean isPlatformProperty(DocumentContext documentContext, Position position) {
+    return typeService.findMemberAt(documentContext, position)
+      .map(TypeService.TypedMember::descriptor)
+      .filter(descriptor -> descriptor.kind() == MemberKind.PROPERTY)
+      .isPresent();
+  }
+
+  private Set<Position> collectSourceDefinedVarSites(DocumentContext documentContext) {
+    var positions = new HashSet<Position>();
+    for (var reference : referenceIndex.getReferencesFrom(documentContext.getUri(), SymbolKind.Variable)) {
+      positions.add(reference.selectionRange().getStart());
+    }
+    return positions;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
@@ -41,6 +41,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Сапплаер семантических токенов для обращения к свойствам платформенных типов
@@ -82,6 +83,16 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier implements Seman
 
   @Override
   public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext) {
+    return collect(documentContext, range -> true);
+  }
+
+  @Override
+  public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext, Range range) {
+    // Дорогой memberAt вызывается только для свойств в пределах запрошенного диапазона.
+    return collect(documentContext, nameRange -> Ranges.containsPosition(range, nameRange.getStart()));
+  }
+
+  private List<SemanticTokenEntry> collect(DocumentContext documentContext, Predicate<Range> inScope) {
     var entries = new ArrayList<SemanticTokenEntry>();
     var ast = documentContext.getAst();
     var fileType = documentContext.getFileType();
@@ -92,6 +103,7 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier implements Seman
         continue;
       }
       propertyNameRange(accessProperty)
+        .filter(inScope)
         .filter(range -> resolvesToMember(documentContext, range.getStart()))
         .ifPresent(range -> helper.addRange(
           entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS));

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
@@ -29,19 +29,16 @@ import com.github._1c_syntax.bsl.languageserver.types.scope.GlobalSymbolScope;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
-import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
-import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.springframework.stereotype.Component;
 
-import java.util.ArrayList;
 import java.util.List;
 import java.util.Optional;
 import java.util.Set;
-import java.util.function.Predicate;
+import java.util.function.BiPredicate;
 
 /**
  * Сапплаер семантических токенов для обращения к свойствам платформенных типов
@@ -50,15 +47,11 @@ import java.util.function.Predicate;
  * {@link com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer}).
  * <p>
  * Свойство резолвится через {@link TypeService#memberAt(DocumentContext, Position)}.
- * Если найден member с {@link MemberKind#PROPERTY} — имя свойства получает
- * {@link SemanticTokenTypes#Property} + {@link SemanticTokenModifiers#DefaultLibrary}.
+ * Имя свойства получает {@link SemanticTokenTypes#Property} +
+ * {@link org.eclipse.lsp4j.SemanticTokenModifiers#DefaultLibrary}.
  * <p>
- * Симметричен {@link PlatformMemberMethodCallSemanticTokensSupplier}, который
- * подсвечивает вызовы методов платформенных типов через accessCall. В отличие от
- * методного сапплаера здесь не нужен skip source-defined call-site'ов: source-defined
- * переменные (в т.ч. экспортные переменные модуля объекта) не выставляются как
- * члены типа, поэтому {@link TypeService#memberAt} их не находит и пересечения
- * по позиции с {@link SymbolsSemanticTokensSupplier} не возникает.
+ * Симметричен {@link PlatformMemberMethodCallSemanticTokensSupplier} (вызовы методов
+ * через accessCall) — общий каркас в {@link AbstractPlatformMemberSemanticTokensSupplier}.
  * <p>
  * Цепочки, начинающиеся с глобального synthetic-имени ({@code Справочники.Контрагенты},
  * {@code Перечисления.Пол.Мужской}, {@code КодировкаТекста.UTF8}), целиком красит
@@ -70,51 +63,44 @@ import java.util.function.Predicate;
  * GlobalScope не трогает — их подсвечиваем мы.
  */
 @Component
-@RequiredArgsConstructor
-public class PlatformMemberPropertyAccessSemanticTokensSupplier implements SemanticTokensSupplier {
+public class PlatformMemberPropertyAccessSemanticTokensSupplier
+  extends AbstractPlatformMemberSemanticTokensSupplier<BSLParser.AccessPropertyContext> {
 
-  private static final String[] DEFAULT_LIBRARY_MODIFIERS = {SemanticTokenModifiers.DefaultLibrary};
   private static final Set<Integer> CHAIN_ROOTS =
     Set.of(BSLParser.RULE_complexIdentifier, BSLParser.RULE_callStatement);
 
-  private final TypeService typeService;
   private final GlobalScopeProvider globalScopeProvider;
-  private final SemanticTokensHelper helper;
 
-  @Override
-  public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext) {
-    return collect(documentContext, range -> true);
+  public PlatformMemberPropertyAccessSemanticTokensSupplier(TypeService typeService,
+                                                            GlobalScopeProvider globalScopeProvider,
+                                                            SemanticTokensHelper helper) {
+    super(typeService, helper);
+    this.globalScopeProvider = globalScopeProvider;
   }
 
   @Override
-  public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext, Range range) {
-    // Дорогой memberAt вызывается только для свойств в пределах запрошенного диапазона.
-    return collect(documentContext, nameRange -> Ranges.containsPosition(range, nameRange.getStart()));
+  protected int ruleIndex() {
+    return BSLParser.RULE_accessProperty;
   }
 
-  private List<SemanticTokenEntry> collect(DocumentContext documentContext, Predicate<Range> inScope) {
-    var entries = new ArrayList<SemanticTokenEntry>();
-    var ast = documentContext.getAst();
+  @Override
+  protected Optional<Range> nameRange(BSLParser.AccessPropertyContext node) {
+    return Optional.ofNullable(node.IDENTIFIER()).map(Ranges::create);
+  }
+
+  @Override
+  protected BiPredicate<BSLParser.AccessPropertyContext, Range> skipFilter(DocumentContext documentContext) {
     var fileType = documentContext.getFileType();
-
-    for (var accessProperty
-      : Trees.<BSLParser.AccessPropertyContext>findAllRuleNodes(ast, BSLParser.RULE_accessProperty)) {
-      if (isGlobalScopeChain(accessProperty, fileType)) {
-        continue;
-      }
-      propertyNameRange(accessProperty)
-        .filter(inScope)
-        .filter(range -> resolvesToMember(documentContext, range.getStart()))
-        .ifPresent(range -> helper.addRange(
-          entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS));
-    }
-
-    return entries;
+    return (node, range) -> isGlobalScopeChain(node, fileType);
   }
 
-  private static Optional<Range> propertyNameRange(BSLParser.AccessPropertyContext accessProperty) {
-    return Optional.ofNullable(accessProperty.IDENTIFIER())
-      .map(Ranges::create);
+  @Override
+  protected void emit(List<SemanticTokenEntry> entries, DocumentContext documentContext, Range range) {
+    // Для accessProperty memberAt возвращает только свойство (метод — только для
+    // accessCall), поэтому достаточно проверки наличия члена.
+    if (typeService.memberAt(documentContext, range.getStart()).isPresent()) {
+      helper.addRange(entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS);
+    }
   }
 
   /**
@@ -143,14 +129,5 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier implements Seman
       base = callStatement.IDENTIFIER();
     }
     return Optional.ofNullable(base).map(TerminalNode::getText);
-  }
-
-  /**
-   * В позиции резолвится член типа. Для accessProperty это всегда свойство
-   * (метод резолвится только для accessCall), поэтому отдельная проверка
-   * {@link com.github._1c_syntax.bsl.languageserver.types.model.MemberKind} не нужна.
-   */
-  private boolean resolvesToMember(DocumentContext documentContext, Position position) {
-    return typeService.memberAt(documentContext, position).isPresent();
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
@@ -22,8 +22,8 @@
 package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
@@ -33,14 +33,11 @@ import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
-import org.eclipse.lsp4j.SymbolKind;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.HashSet;
 import java.util.List;
 import java.util.Optional;
-import java.util.Set;
 
 /**
  * Сапплаер семантических токенов для обращения к свойствам платформенных типов
@@ -53,12 +50,11 @@ import java.util.Set;
  * {@link SemanticTokenTypes#Property} + {@link SemanticTokenModifiers#DefaultLibrary}.
  * <p>
  * Симметричен {@link PlatformMemberMethodCallSemanticTokensSupplier}, который
- * подсвечивает вызовы методов платформенных типов через accessCall.
- * <p>
- * Source-defined переменные (в т.ч. экспортные переменные модуля объекта,
- * доступные как {@code Объект.Перем}) подсвечиваются через
- * {@link SymbolsSemanticTokensSupplier} по ReferenceIndex — этот сапплаер
- * пропускает такие позиции, чтобы не дублировать токены.
+ * подсвечивает вызовы методов платформенных типов через accessCall. В отличие от
+ * методного сапплаера здесь не нужен skip source-defined call-site'ов: source-defined
+ * переменные (в т.ч. экспортные переменные модуля объекта) не выставляются как
+ * члены типа, поэтому {@link TypeService#findMemberAt} их не находит и пересечения
+ * по позиции с {@link SymbolsSemanticTokensSupplier} не возникает.
  */
 @Component
 @RequiredArgsConstructor
@@ -67,7 +63,6 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier implements Seman
   private static final String[] DEFAULT_LIBRARY_MODIFIERS = {SemanticTokenModifiers.DefaultLibrary};
 
   private final TypeService typeService;
-  private final ReferenceIndex referenceIndex;
   private final SemanticTokensHelper helper;
 
   @Override
@@ -75,14 +70,9 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier implements Seman
     var entries = new ArrayList<SemanticTokenEntry>();
     var ast = documentContext.getAst();
 
-    // Позиции, уже обработанные SymbolsSemanticTokensSupplier (source-defined
-    // переменные): пропускаем, чтобы не дублировать токен на одной позиции.
-    var sourceDefinedVarSites = collectSourceDefinedVarSites(documentContext);
-
     for (var accessProperty
       : Trees.<BSLParser.AccessPropertyContext>findAllRuleNodes(ast, BSLParser.RULE_accessProperty)) {
       propertyNameRange(accessProperty)
-        .filter(range -> !sourceDefinedVarSites.contains(range.getStart()))
         .filter(range -> isPlatformProperty(documentContext, range.getStart()))
         .ifPresent(range -> helper.addRange(
           entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS));
@@ -99,15 +89,11 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier implements Seman
   private boolean isPlatformProperty(DocumentContext documentContext, Position position) {
     return typeService.findMemberAt(documentContext, position)
       .map(TypeService.TypedMember::descriptor)
-      .filter(descriptor -> descriptor.kind() == MemberKind.PROPERTY)
+      .filter(PlatformMemberPropertyAccessSemanticTokensSupplier::isProperty)
       .isPresent();
   }
 
-  private Set<Position> collectSourceDefinedVarSites(DocumentContext documentContext) {
-    var positions = new HashSet<Position>();
-    for (var reference : referenceIndex.getReferencesFrom(documentContext.getUri(), SymbolKind.Variable)) {
-      positions.add(reference.selectionRange().getStart());
-    }
-    return positions;
+  static boolean isProperty(MemberDescriptor descriptor) {
+    return descriptor.kind() == MemberKind.PROPERTY;
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
@@ -22,14 +22,15 @@
 package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
-import com.github._1c_syntax.bsl.languageserver.types.TypeService.TypedMember;
-import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
-import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
+import com.github._1c_syntax.bsl.languageserver.types.scope.GlobalSymbolScope;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
 import lombok.RequiredArgsConstructor;
+import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
@@ -38,8 +39,8 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Objects;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Сапплаер семантических токенов для обращения к свойствам платформенных типов
@@ -58,33 +59,40 @@ import java.util.Optional;
  * члены типа, поэтому {@link TypeService#memberAt} их не находит и пересечения
  * по позиции с {@link SymbolsSemanticTokensSupplier} не возникает.
  * <p>
- * Члены, которые уже красит {@link GlobalScopeSemanticTokensSupplier}, пропускаются,
- * чтобы не накладывать второй токен на тот же идентификатор:
- * <ul>
- *   <li>ссылка на метаобъект конфигурации ({@code Справочники.Контрагенты}) —
- *       returnType с {@link TypeKind#CONFIGURATION} → красится как {@code Class};</li>
- *   <li>self-typed значение перечисления ({@code КодировкаТекста.UTF8}) —
- *       owner совпадает с returnType → красится как {@code EnumMember}.</li>
- * </ul>
+ * Цепочки, начинающиеся с глобального synthetic-имени ({@code Справочники.Контрагенты},
+ * {@code Перечисления.Пол.Мужской}, {@code КодировкаТекста.UTF8}), целиком красит
+ * {@link GlobalScopeSemanticTokensSupplier} (метаобъекты → {@code Class}, значения
+ * перечислений → {@code EnumMember}). Такие цепочки пропускаются по базовому
+ * идентификатору — это ровно домен GlobalScope, и только там возникал конфликт
+ * {@code Property} vs {@code Class}/{@code EnumMember}. Обращения к свойствам
+ * локально-типизированных переменных ({@code Объект.Ссылка}, {@code Строка.Родитель})
+ * GlobalScope не трогает — их подсвечиваем мы.
  */
 @Component
 @RequiredArgsConstructor
 public class PlatformMemberPropertyAccessSemanticTokensSupplier implements SemanticTokensSupplier {
 
   private static final String[] DEFAULT_LIBRARY_MODIFIERS = {SemanticTokenModifiers.DefaultLibrary};
+  private static final Set<Integer> CHAIN_ROOTS =
+    Set.of(BSLParser.RULE_complexIdentifier, BSLParser.RULE_callStatement);
 
   private final TypeService typeService;
+  private final GlobalScopeProvider globalScopeProvider;
   private final SemanticTokensHelper helper;
 
   @Override
   public List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext) {
     var entries = new ArrayList<SemanticTokenEntry>();
     var ast = documentContext.getAst();
+    var fileType = documentContext.getFileType();
 
     for (var accessProperty
       : Trees.<BSLParser.AccessPropertyContext>findAllRuleNodes(ast, BSLParser.RULE_accessProperty)) {
+      if (isGlobalScopeChain(accessProperty, fileType)) {
+        continue;
+      }
       propertyNameRange(accessProperty)
-        .filter(range -> isPlatformProperty(documentContext, range.getStart()))
+        .filter(range -> resolvesToMember(documentContext, range.getStart()))
         .ifPresent(range -> helper.addRange(
           entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS));
     }
@@ -97,28 +105,40 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier implements Seman
       .map(Ranges::create);
   }
 
-  private boolean isPlatformProperty(DocumentContext documentContext, Position position) {
-    return typeService.memberAt(documentContext, position)
-      .filter(PlatformMemberPropertyAccessSemanticTokensSupplier::isHighlightableProperty)
-      .isPresent();
+  /**
+   * Цепочка обращения для {@code accessProperty} начинается с глобального
+   * synthetic-имени (менеджер метаданных, глобальное перечисление, library-модуль),
+   * т.е. целиком относится к домену {@link GlobalScopeSemanticTokensSupplier}.
+   */
+  private boolean isGlobalScopeChain(BSLParser.AccessPropertyContext accessProperty, FileType fileType) {
+    return chainBaseName(accessProperty)
+      .flatMap(name -> globalScopeProvider.findGlobalEntry(name, fileType))
+      .map(entry -> entry.role() == GlobalSymbolScope.Role.VALUE)
+      .orElse(false);
   }
 
   /**
-   * Член — это свойство, которое не относится к домену
-   * {@link GlobalScopeSemanticTokensSupplier} (метаобъект конфигурации или
-   * значение перечисления), а потому может быть покрашено как {@code Property}.
+   * Имя базового идентификатора цепочки, в которой находится {@code accessProperty}
+   * (например, {@code Справочники} для {@code Справочники.Контрагенты.Ссылка}).
+   * Пусто, если цепочка начинается не с идентификатора (конструктор {@code Новый ...} и т.п.).
    */
-  static boolean isHighlightableProperty(TypedMember member) {
-    var descriptor = member.descriptor();
-    if (descriptor.kind() != MemberKind.PROPERTY) {
-      return false;
+  private static Optional<String> chainBaseName(BSLParser.AccessPropertyContext accessProperty) {
+    var root = Trees.getRootParent(accessProperty, CHAIN_ROOTS);
+    TerminalNode base = null;
+    if (root instanceof BSLParser.ComplexIdentifierContext complexId) {
+      base = complexId.IDENTIFIER();
+    } else if (root instanceof BSLParser.CallStatementContext callStatement) {
+      base = callStatement.IDENTIFIER();
     }
-    var returnType = descriptor.returnType();
-    // Ссылка на метаобъект конфигурации (Справочники.Контрагенты) → Class в GlobalScope.
-    if (returnType.kind() == TypeKind.CONFIGURATION) {
-      return false;
-    }
-    // Self-typed значение перечисления (КодировкаТекста.UTF8) → EnumMember в GlobalScope.
-    return !Objects.equals(member.owner(), returnType);
+    return Optional.ofNullable(base).map(TerminalNode::getText);
+  }
+
+  /**
+   * В позиции резолвится член типа. Для accessProperty это всегда свойство
+   * (метод резолвится только для accessCall), поэтому отдельная проверка
+   * {@link com.github._1c_syntax.bsl.languageserver.types.model.MemberKind} не нужна.
+   */
+  private boolean resolvesToMember(DocumentContext documentContext, Position position) {
+    return typeService.memberAt(documentContext, position).isPresent();
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
@@ -23,8 +23,9 @@ package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
-import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.TypeService.TypedMember;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
@@ -37,6 +38,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Objects;
 import java.util.Optional;
 
 /**
@@ -45,7 +47,7 @@ import java.util.Optional;
  * где {@code receiver} — типизированное выражение, чей тип резолвится через
  * {@link com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer}).
  * <p>
- * Свойство резолвится через {@link TypeService#findMemberAt(DocumentContext, Position)}.
+ * Свойство резолвится через {@link TypeService#memberAt(DocumentContext, Position)}.
  * Если найден member с {@link MemberKind#PROPERTY} — имя свойства получает
  * {@link SemanticTokenTypes#Property} + {@link SemanticTokenModifiers#DefaultLibrary}.
  * <p>
@@ -53,8 +55,17 @@ import java.util.Optional;
  * подсвечивает вызовы методов платформенных типов через accessCall. В отличие от
  * методного сапплаера здесь не нужен skip source-defined call-site'ов: source-defined
  * переменные (в т.ч. экспортные переменные модуля объекта) не выставляются как
- * члены типа, поэтому {@link TypeService#findMemberAt} их не находит и пересечения
+ * члены типа, поэтому {@link TypeService#memberAt} их не находит и пересечения
  * по позиции с {@link SymbolsSemanticTokensSupplier} не возникает.
+ * <p>
+ * Члены, которые уже красит {@link GlobalScopeSemanticTokensSupplier}, пропускаются,
+ * чтобы не накладывать второй токен на тот же идентификатор:
+ * <ul>
+ *   <li>ссылка на метаобъект конфигурации ({@code Справочники.Контрагенты}) —
+ *       returnType с {@link TypeKind#CONFIGURATION} → красится как {@code Class};</li>
+ *   <li>self-typed значение перечисления ({@code КодировкаТекста.UTF8}) —
+ *       owner совпадает с returnType → красится как {@code EnumMember}.</li>
+ * </ul>
  */
 @Component
 @RequiredArgsConstructor
@@ -87,13 +98,27 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier implements Seman
   }
 
   private boolean isPlatformProperty(DocumentContext documentContext, Position position) {
-    return typeService.findMemberAt(documentContext, position)
-      .map(TypeService.TypedMember::descriptor)
-      .filter(PlatformMemberPropertyAccessSemanticTokensSupplier::isProperty)
+    return typeService.memberAt(documentContext, position)
+      .filter(PlatformMemberPropertyAccessSemanticTokensSupplier::isHighlightableProperty)
       .isPresent();
   }
 
-  static boolean isProperty(MemberDescriptor descriptor) {
-    return descriptor.kind() == MemberKind.PROPERTY;
+  /**
+   * Член — это свойство, которое не относится к домену
+   * {@link GlobalScopeSemanticTokensSupplier} (метаобъект конфигурации или
+   * значение перечисления), а потому может быть покрашено как {@code Property}.
+   */
+  static boolean isHighlightableProperty(TypedMember member) {
+    var descriptor = member.descriptor();
+    if (descriptor.kind() != MemberKind.PROPERTY) {
+      return false;
+    }
+    var returnType = descriptor.returnType();
+    // Ссылка на метаобъект конфигурации (Справочники.Контрагенты) → Class в GlobalScope.
+    if (returnType.kind() == TypeKind.CONFIGURATION) {
+      return false;
+    }
+    // Self-typed значение перечисления (КодировкаТекста.UTF8) → EnumMember в GlobalScope.
+    return !Objects.equals(member.owner(), returnType);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensSupplier.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import org.eclipse.lsp4j.Range;
 
 import java.util.List;
 
@@ -37,5 +38,22 @@ public interface SemanticTokensSupplier {
    * @return Список семантических токенов
    */
   List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext);
+
+  /**
+   * Получить семантические токены только для указанного диапазона документа
+   * (запрос {@code textDocument/semanticTokens/range}).
+   * <p>
+   * Реализация по умолчанию игнорирует диапазон и возвращает токены всего
+   * документа — провайдер всё равно отфильтрует их по диапазону. Дорогие
+   * сапплаеры (с инференсом типов на каждый узел) переопределяют этот метод,
+   * чтобы не выполнять тяжёлую работу за пределами видимой области.
+   *
+   * @param documentContext Контекст документа
+   * @param range           Запрошенный диапазон (всегда задан вызывающим)
+   * @return Список семантических токенов в пределах диапазона
+   */
+  default List<SemanticTokenEntry> getSemanticTokens(DocumentContext documentContext, Range range) {
+    return getSemanticTokens(documentContext);
+  }
 }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensOverlapGuardTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensOverlapGuardTest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.providers;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokenEntry;
+import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensSupplier;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.SemanticTokensLegend;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.ArrayList;
+import java.util.List;
+
+import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Guard: сапплаеры не должны выдавать пересекающиеся токены на одном участке кода.
+ * <p>
+ * Прогоняет все {@link SemanticTokensSupplier} на модуле из реальной конфигурации
+ * (с populateContext, чтобы работал инференс типов) и проверяет отсутствие
+ * конфликтов через {@link SemanticTokensProvider#findOverlaps}. Регрессионная
+ * защита: например, доступ {@code РегистрыСведений.РегистрСведений1} красится
+ * GlobalScope как {@code Class}, и сапплаер свойств не должен накладывать на тот
+ * же токен {@code Property}.
+ */
+@CleanupContextBeforeClassAndAfterClass
+class SemanticTokensOverlapGuardTest extends AbstractServerContextAwareTest {
+
+  private static final String MODULE =
+    PATH_TO_METADATA + "/CommonModules/ПервыйОбщийМодуль/Ext/Module.bsl";
+
+  @Autowired
+  private List<SemanticTokensSupplier> suppliers;
+
+  @Autowired
+  private SemanticTokensLegend legend;
+
+  @Test
+  void suppliersDoNotProduceOverlappingTokens() {
+    // given — поднимаем конфигурацию с инференсом типов.
+    initServerContext(PATH_TO_METADATA);
+    var documentContext = TestUtils.getDocumentContextFromFile(MODULE, context);
+
+    // when — собираем токены со всех сапплаеров, как это делает провайдер.
+    var allTokens = new ArrayList<SemanticTokenEntry>();
+    for (var supplier : suppliers) {
+      allTokens.addAll(supplier.getSemanticTokens(documentContext));
+    }
+    var overlaps = SemanticTokensProvider.findOverlaps(allTokens);
+
+    // then — пересечений быть не должно.
+    assertThat(overlaps)
+      .as("Конфликты подсветки: %s", describe(overlaps, documentContext))
+      .isEmpty();
+  }
+
+  private String describe(List<SemanticTokensProvider.TokenOverlap> overlaps, DocumentContext documentContext) {
+    var lines = documentContext.getContentList();
+    var sb = new StringBuilder();
+    for (var overlap : overlaps) {
+      var a = overlap.first();
+      var b = overlap.second();
+      var src = a.line() < lines.length ? lines[a.line()].strip() : "";
+      sb.append(String.format("%nL%d c%d: %s/%d vs %s/%d | %s",
+        a.line() + 1, a.start(), typeName(a.type()), a.modifiers(),
+        typeName(b.type()), b.modifiers(), src));
+    }
+    return sb.toString();
+  }
+
+  private String typeName(int idx) {
+    var types = legend.getTokenTypes();
+    return idx >= 0 && idx < types.size() ? types.get(idx) : ("?" + idx);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensOverlapGuardTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensOverlapGuardTest.java
@@ -39,7 +39,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * <p>
  * Собирает токены тем же путём, что и провайдер ({@link SemanticTokensProvider#collectTokens}),
  * на модуле из реальной конфигурации (с populateContext, чтобы работал инференс
- * типов) и проверяет отсутствие конфликтов через {@link SemanticTokensProvider#findOverlaps}.
+ * типов) и проверяет отсутствие конфликтов через {@link TokenOverlaps#findOverlaps}.
  * Регрессионная защита: например, доступ {@code РегистрыСведений.РегистрСведений1}
  * красится GlobalScope как {@code Class}, и сапплаер свойств не должен накладывать
  * на тот же токен {@code Property}.
@@ -64,7 +64,7 @@ class SemanticTokensOverlapGuardTest extends AbstractServerContextAwareTest {
 
     // when — собираем токены тем же путём, что и провайдер для full-запроса.
     var allTokens = provider.collectTokens(documentContext);
-    var overlaps = SemanticTokensProvider.findOverlaps(allTokens);
+    var overlaps = TokenOverlaps.findOverlaps(allTokens);
 
     // then — пересечений быть не должно.
     assertThat(overlaps)
@@ -72,7 +72,7 @@ class SemanticTokensOverlapGuardTest extends AbstractServerContextAwareTest {
       .isEmpty();
   }
 
-  private String describe(List<SemanticTokensProvider.TokenOverlap> overlaps, DocumentContext documentContext) {
+  private String describe(List<TokenOverlaps.TokenOverlap> overlaps, DocumentContext documentContext) {
     var lines = documentContext.getContentList();
     var sb = new StringBuilder();
     for (var overlap : overlaps) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensOverlapGuardTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensOverlapGuardTest.java
@@ -64,7 +64,9 @@ class SemanticTokensOverlapGuardTest extends AbstractServerContextAwareTest {
 
     // when — собираем токены тем же путём, что и провайдер для full-запроса.
     var allTokens = provider.collectTokens(documentContext);
-    var overlaps = TokenOverlaps.findOverlaps(allTokens);
+    var lines = documentContext.getContentList();
+    var overlaps = TokenOverlaps.findOverlaps(allTokens,
+      line -> line >= 0 && line < lines.length ? lines[line].length() : 0);
 
     // then — пересечений быть не должно.
     assertThat(overlaps)

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensOverlapGuardTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensOverlapGuardTest.java
@@ -23,15 +23,12 @@ package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokenEntry;
-import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensSupplier;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.SemanticTokensLegend;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
-import java.util.ArrayList;
 import java.util.List;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
@@ -40,12 +37,12 @@ import static org.assertj.core.api.Assertions.assertThat;
 /**
  * Guard: сапплаеры не должны выдавать пересекающиеся токены на одном участке кода.
  * <p>
- * Прогоняет все {@link SemanticTokensSupplier} на модуле из реальной конфигурации
- * (с populateContext, чтобы работал инференс типов) и проверяет отсутствие
- * конфликтов через {@link SemanticTokensProvider#findOverlaps}. Регрессионная
- * защита: например, доступ {@code РегистрыСведений.РегистрСведений1} красится
- * GlobalScope как {@code Class}, и сапплаер свойств не должен накладывать на тот
- * же токен {@code Property}.
+ * Собирает токены тем же путём, что и провайдер ({@link SemanticTokensProvider#collectTokens}),
+ * на модуле из реальной конфигурации (с populateContext, чтобы работал инференс
+ * типов) и проверяет отсутствие конфликтов через {@link SemanticTokensProvider#findOverlaps}.
+ * Регрессионная защита: например, доступ {@code РегистрыСведений.РегистрСведений1}
+ * красится GlobalScope как {@code Class}, и сапплаер свойств не должен накладывать
+ * на тот же токен {@code Property}.
  */
 @CleanupContextBeforeClassAndAfterClass
 class SemanticTokensOverlapGuardTest extends AbstractServerContextAwareTest {
@@ -54,7 +51,7 @@ class SemanticTokensOverlapGuardTest extends AbstractServerContextAwareTest {
     PATH_TO_METADATA + "/CommonModules/ПервыйОбщийМодуль/Ext/Module.bsl";
 
   @Autowired
-  private List<SemanticTokensSupplier> suppliers;
+  private SemanticTokensProvider provider;
 
   @Autowired
   private SemanticTokensLegend legend;
@@ -65,11 +62,8 @@ class SemanticTokensOverlapGuardTest extends AbstractServerContextAwareTest {
     initServerContext(PATH_TO_METADATA);
     var documentContext = TestUtils.getDocumentContextFromFile(MODULE, context);
 
-    // when — собираем токены со всех сапплаеров, как это делает провайдер.
-    var allTokens = new ArrayList<SemanticTokenEntry>();
-    for (var supplier : suppliers) {
-      allTokens.addAll(supplier.getSemanticTokens(documentContext));
-    }
+    // when — собираем токены тем же путём, что и провайдер для full-запроса.
+    var allTokens = provider.collectTokens(documentContext);
     var overlaps = SemanticTokensProvider.findOverlaps(allTokens);
 
     // then — пересечений быть не должно.

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
@@ -1893,6 +1893,20 @@ class SemanticTokensProviderTest {
     assertThat(overlaps).hasSize(1);
   }
 
+  @Test
+  void findOverlaps_detectsMultilineTokenOverlapOnContinuationLine() {
+    // given — многострочный токен со строки 0 (длина уходит на строку 1) и токен
+    // на строке 1, попадающий в его продолжение. Строки длиной 5 символов.
+    var multiline = new SemanticTokenEntry(0, 0, 12, 0, 0);
+    var onNextLine = new SemanticTokenEntry(1, 2, 3, 1, 0);
+
+    // when — с учётом длин строк токен раскладывается на строки 0 и 1.
+    var overlaps = TokenOverlaps.findOverlaps(List.of(multiline, onNextLine), line -> 5);
+
+    // then — пересечение на строке-продолжении найдено (без multiline-учёта было бы 0).
+    assertThat(overlaps).hasSize(1);
+  }
+
   // endregion
 }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
@@ -1821,7 +1821,7 @@ class SemanticTokensProviderTest {
     var propertyToken = new SemanticTokenEntry(0, 5, 10, 1, 0);
 
     // when
-    var overlaps = SemanticTokensProvider.findOverlaps(List.of(classToken, propertyToken));
+    var overlaps = TokenOverlaps.findOverlaps(List.of(classToken, propertyToken));
 
     // then — конфликт зафиксирован.
     assertThat(overlaps).hasSize(1);
@@ -1834,7 +1834,7 @@ class SemanticTokensProviderTest {
     var duplicate = new SemanticTokenEntry(0, 5, 10, 0, 0);
 
     // when
-    var overlaps = SemanticTokensProvider.findOverlaps(List.of(token, duplicate));
+    var overlaps = TokenOverlaps.findOverlaps(List.of(token, duplicate));
 
     // then — точный дубль конфликтом не считается.
     assertThat(overlaps).isEmpty();
@@ -1848,7 +1848,7 @@ class SemanticTokensProviderTest {
     var distantOtherLine = new SemanticTokenEntry(1, 2, 5, 2, 0);
 
     // when
-    var overlaps = SemanticTokensProvider.findOverlaps(List.of(first, adjacent, distantOtherLine));
+    var overlaps = TokenOverlaps.findOverlaps(List.of(first, adjacent, distantOtherLine));
 
     // then — пересечений нет.
     assertThat(overlaps).isEmpty();
@@ -1861,7 +1861,7 @@ class SemanticTokensProviderTest {
     var b = new SemanticTokenEntry(0, 5, 8, 1, 0);
 
     // when
-    var overlaps = SemanticTokensProvider.findOverlaps(List.of(a, b));
+    var overlaps = TokenOverlaps.findOverlaps(List.of(a, b));
 
     // then — частичное наложение — это конфликт.
     assertThat(overlaps).hasSize(1);
@@ -1874,7 +1874,7 @@ class SemanticTokensProviderTest {
     var b = new SemanticTokenEntry(0, 5, 8, 0, 0);
 
     // when
-    var overlaps = SemanticTokensProvider.findOverlaps(List.of(a, b));
+    var overlaps = TokenOverlaps.findOverlaps(List.of(a, b));
 
     // then — разная длина при общем начале — конфликт.
     assertThat(overlaps).hasSize(1);
@@ -1887,7 +1887,7 @@ class SemanticTokensProviderTest {
     var b = new SemanticTokenEntry(0, 5, 10, 0, 1);
 
     // when
-    var overlaps = SemanticTokensProvider.findOverlaps(List.of(a, b));
+    var overlaps = TokenOverlaps.findOverlaps(List.of(a, b));
 
     // then — разные модификаторы на одном спане — конфликт.
     assertThat(overlaps).hasSize(1);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.providers;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndexFiller;
+import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokenEntry;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.utils.Absolute;
@@ -1807,6 +1808,89 @@ class SemanticTokensProviderTest {
           .isNotEqualTo(4);
       }
     }
+  }
+
+  // endregion
+
+  // region findOverlaps
+
+  @Test
+  void findOverlaps_detectsConflictingTokensAtSamePosition() {
+    // given — два токена на одной позиции с разным типом (class vs property).
+    var classToken = new SemanticTokenEntry(0, 5, 10, 0, 0);
+    var propertyToken = new SemanticTokenEntry(0, 5, 10, 1, 0);
+
+    // when
+    var overlaps = SemanticTokensProvider.findOverlaps(List.of(classToken, propertyToken));
+
+    // then — конфликт зафиксирован.
+    assertThat(overlaps).hasSize(1);
+  }
+
+  @Test
+  void findOverlaps_ignoresExactDuplicates() {
+    // given — полностью идентичные токены от разных сапплаеров (де-дуп их уберёт).
+    var token = new SemanticTokenEntry(0, 5, 10, 0, 0);
+    var duplicate = new SemanticTokenEntry(0, 5, 10, 0, 0);
+
+    // when
+    var overlaps = SemanticTokensProvider.findOverlaps(List.of(token, duplicate));
+
+    // then — точный дубль конфликтом не считается.
+    assertThat(overlaps).isEmpty();
+  }
+
+  @Test
+  void findOverlaps_ignoresAdjacentAndDistinctTokens() {
+    // given — смежные (стык в стык) и непересекающиеся токены на одной строке.
+    var first = new SemanticTokenEntry(0, 0, 5, 0, 0);
+    var adjacent = new SemanticTokenEntry(0, 5, 5, 1, 0);
+    var distantOtherLine = new SemanticTokenEntry(1, 2, 5, 2, 0);
+
+    // when
+    var overlaps = SemanticTokensProvider.findOverlaps(List.of(first, adjacent, distantOtherLine));
+
+    // then — пересечений нет.
+    assertThat(overlaps).isEmpty();
+  }
+
+  @Test
+  void findOverlaps_detectsPartialOverlap() {
+    // given — частичное наложение спанов на одной строке.
+    var a = new SemanticTokenEntry(0, 0, 8, 0, 0);
+    var b = new SemanticTokenEntry(0, 5, 8, 1, 0);
+
+    // when
+    var overlaps = SemanticTokensProvider.findOverlaps(List.of(a, b));
+
+    // then — частичное наложение — это конфликт.
+    assertThat(overlaps).hasSize(1);
+  }
+
+  @Test
+  void findOverlaps_detectsSameStartDifferentLength() {
+    // given — общий start, но разная длина (один сапплаер покрасил шире другого).
+    var a = new SemanticTokenEntry(0, 5, 10, 0, 0);
+    var b = new SemanticTokenEntry(0, 5, 8, 0, 0);
+
+    // when
+    var overlaps = SemanticTokensProvider.findOverlaps(List.of(a, b));
+
+    // then — разная длина при общем начале — конфликт.
+    assertThat(overlaps).hasSize(1);
+  }
+
+  @Test
+  void findOverlaps_detectsSameSpanDifferentModifiers() {
+    // given — совпадают позиция и тип, но различаются модификаторы.
+    var a = new SemanticTokenEntry(0, 5, 10, 0, 0);
+    var b = new SemanticTokenEntry(0, 5, 10, 0, 1);
+
+    // when
+    var overlaps = SemanticTokensProvider.findOverlaps(List.of(a, b));
+
+    // then — разные модификаторы на одном спане — конфликт.
+    assertThat(overlaps).hasSize(1);
   }
 
   // endregion

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/TokenOverlaps.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/TokenOverlaps.java
@@ -26,7 +26,11 @@ import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokenEntr
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.function.IntUnaryOperator;
 
 /**
  * Тестовая утилита: детект пересечений семантических токенов, выданных
@@ -57,36 +61,82 @@ final class TokenOverlaps {
   }
 
   /**
-   * Находит пересечения токенов на одной строке.
+   * Часть токена в пределах одной строки: токен может быть многострочным
+   * (склеенные комментарии и т.п.), тогда он раскладывается на несколько спанов.
+   */
+  private record Span(int line, int start, int end, SemanticTokenEntry origin) {
+  }
+
+  /**
+   * Находит пересечения токенов, считая каждый токен однострочным.
+   * Подходит для синтетических токенов в юнит-тестах.
    *
    * @param entries собранные со всех сапплаеров токены
    * @return список пар пересекающихся токенов; пустой, если конфликтов нет
    */
   static List<TokenOverlap> findOverlaps(List<SemanticTokenEntry> entries) {
-    var byLine = new HashMap<Integer, List<SemanticTokenEntry>>();
+    return findOverlaps(entries, line -> Integer.MAX_VALUE);
+  }
+
+  /**
+   * Находит пересечения токенов с учётом многострочных токенов: длина токена,
+   * выходящая за конец строки, переносится на следующие строки (по длинам строк
+   * из {@code lineLength}). Без этого многострочный токен сравнивался бы только
+   * на своей стартовой строке, и пересечение на строке-продолжении терялось бы.
+   *
+   * @param entries    собранные со всех сапплаеров токены
+   * @param lineLength длина строки по её 0-индексу (число символов без перевода строки)
+   * @return список пар пересекающихся токенов; пустой, если конфликтов нет
+   */
+  static List<TokenOverlap> findOverlaps(List<SemanticTokenEntry> entries, IntUnaryOperator lineLength) {
+    var spansByLine = new HashMap<Integer, List<Span>>();
     for (var entry : entries) {
-      byLine.computeIfAbsent(entry.line(), k -> new ArrayList<>()).add(entry);
+      expand(entry, lineLength, spansByLine);
     }
 
     var overlaps = new ArrayList<TokenOverlap>();
-    for (var lineTokens : byLine.values()) {
-      lineTokens.sort(Comparator.comparingInt(SemanticTokenEntry::start));
-      for (int i = 0; i < lineTokens.size(); i++) {
-        var a = lineTokens.get(i);
-        int aEnd = a.start() + a.length();
-        for (int j = i + 1; j < lineTokens.size(); j++) {
-          var b = lineTokens.get(j);
-          if (b.start() >= aEnd) {
-            break; // токены отсортированы по start — дальше пересечений с a нет
+    var reported = new HashSet<Set<SemanticTokenEntry>>();
+    for (var spans : spansByLine.values()) {
+      spans.sort(Comparator.comparingInt(Span::start));
+      for (int i = 0; i < spans.size(); i++) {
+        var a = spans.get(i);
+        for (int j = i + 1; j < spans.size(); j++) {
+          var b = spans.get(j);
+          if (b.start() >= a.end()) {
+            break; // спаны отсортированы по start — дальше пересечений с a нет
           }
-          // a и b уже на одной строке, поэтому equals рекорда (все 5 полей)
-          // эквивалентен проверке «точный дубль»: одинаковые позиция и оформление.
-          if (!a.equals(b)) {
-            overlaps.add(new TokenOverlap(a, b));
+          if (a.origin().equals(b.origin())) {
+            continue; // точный дубль токена — не конфликт
+          }
+          // пара токенов может пересекаться на нескольких строках — рапортуем один раз.
+          if (reported.add(Set.of(a.origin(), b.origin()))) {
+            overlaps.add(new TokenOverlap(a.origin(), b.origin()));
           }
         }
       }
     }
     return overlaps;
+  }
+
+  /** Разложить токен на пер-строчные спаны, перенося длину за концом строки. */
+  private static void expand(SemanticTokenEntry entry, IntUnaryOperator lineLength,
+                             Map<Integer, List<Span>> spansByLine) {
+    int line = entry.line();
+    int col = entry.start();
+    int remaining = entry.length();
+    while (remaining > 0) {
+      int available = Math.max(0, lineLength.applyAsInt(line) - col);
+      int take = Math.min(remaining, available);
+      if (take > 0) {
+        spansByLine.computeIfAbsent(line, k -> new ArrayList<>())
+          .add(new Span(line, col, col + take, entry));
+      }
+      if (remaining <= available) {
+        break;
+      }
+      remaining -= available + 1; // +1 — символ перевода строки
+      line++;
+      col = 0;
+    }
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/TokenOverlaps.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/TokenOverlaps.java
@@ -1,0 +1,92 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.providers;
+
+import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokenEntry;
+
+import java.util.ArrayList;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+
+/**
+ * Тестовая утилита: детект пересечений семантических токенов, выданных
+ * сапплаерами на одном участке кода.
+ * <p>
+ * По спецификации LSP токены семантической подсветки не должны пересекаться:
+ * если два сапплаера покрасили один и тот же (или перекрывающийся) участок
+ * разными {@code type}/{@code modifiers} — это конфликт подсветки, который
+ * клиент отрисует недетерминированно. Точные дубли (полностью совпадающие
+ * токены от разных сапплаеров) конфликтом не считаются — их убирает
+ * де-дупликация в {@code SemanticTokensProvider}.
+ * <p>
+ * Чисто отладочный/регрессионный инструмент, поэтому живёт в тестовом
+ * source-set, а не в продакшен-провайдере.
+ */
+final class TokenOverlaps {
+
+  private TokenOverlaps() {
+  }
+
+  /**
+   * Пересечение двух токенов на одном участке кода.
+   *
+   * @param first  токен с меньшей (или равной) начальной позицией
+   * @param second пересекающийся с ним токен
+   */
+  record TokenOverlap(SemanticTokenEntry first, SemanticTokenEntry second) {
+  }
+
+  /**
+   * Находит пересечения токенов на одной строке.
+   *
+   * @param entries собранные со всех сапплаеров токены
+   * @return список пар пересекающихся токенов; пустой, если конфликтов нет
+   */
+  static List<TokenOverlap> findOverlaps(List<SemanticTokenEntry> entries) {
+    var byLine = new HashMap<Integer, List<SemanticTokenEntry>>();
+    for (var entry : entries) {
+      byLine.computeIfAbsent(entry.line(), k -> new ArrayList<>()).add(entry);
+    }
+
+    var overlaps = new ArrayList<TokenOverlap>();
+    for (var lineTokens : byLine.values()) {
+      lineTokens.sort(Comparator.comparingInt(SemanticTokenEntry::start));
+      for (int i = 0; i < lineTokens.size(); i++) {
+        var a = lineTokens.get(i);
+        int aEnd = a.start() + a.length();
+        for (int j = i + 1; j < lineTokens.size(); j++) {
+          var b = lineTokens.get(j);
+          if (b.start() >= aEnd) {
+            break; // токены отсортированы по start — дальше пересечений с a нет
+          }
+          // a и b уже на одной строке, поэтому equals рекорда (все 5 полей)
+          // эквивалентен проверке «точный дубль»: одинаковые позиция и оформление.
+          if (!a.equals(b)) {
+            overlaps.add(new TokenOverlap(a, b));
+          }
+        }
+      }
+    }
+    return overlaps;
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
@@ -25,6 +25,9 @@ import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwa
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.junit.jupiter.api.Test;
@@ -63,6 +66,28 @@ class PlatformMemberMethodCallSemanticTokensSupplierTest extends AbstractServerC
       new ExpectedToken(2, 6, 8, SemanticTokenTypes.Method,
         Set.of(SemanticTokenModifiers.DefaultLibrary), "Добавить")
     ));
+  }
+
+  @Test
+  void testRangeScopingReturnsOnlyTokensInRange() {
+    // given — два вызова метода на разных строках (2 и 3).
+    String bsl = """
+      Процедура Тест()
+          М = Новый Массив;
+          М.Добавить(1);
+          М.Добавить(2);
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(bsl);
+    // диапазон покрывает только строку 2 (первый вызов).
+    var range = new Range(new Position(2, 0), new Position(2, 100));
+
+    // when — range-перегрузка ограничивает дорогой memberAt диапазоном.
+    var decoded = helper.decodeFromEntries(supplier.getSemanticTokens(documentContext, range));
+
+    // then — токен только на строке 2, вызов на строке 3 не обработан.
+    assertThat(decoded).hasSize(1);
+    assertThat(decoded).allSatisfy(token -> assertThat(token.line()).isEqualTo(2));
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplierTest.java
@@ -25,9 +25,6 @@ import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwa
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
-import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
-import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.junit.jupiter.api.Test;
@@ -68,27 +65,9 @@ class PlatformMemberMethodCallSemanticTokensSupplierTest extends AbstractServerC
     ));
   }
 
-  @Test
-  void testRangeScopingReturnsOnlyTokensInRange() {
-    // given — два вызова метода на разных строках (2 и 3).
-    String bsl = """
-      Процедура Тест()
-          М = Новый Массив;
-          М.Добавить(1);
-          М.Добавить(2);
-      КонецПроцедуры
-      """;
-    var documentContext = TestUtils.getDocumentContext(bsl);
-    // диапазон покрывает только строку 2 (первый вызов).
-    var range = new Range(new Position(2, 0), new Position(2, 100));
-
-    // when — range-перегрузка ограничивает дорогой memberAt диапазоном.
-    var decoded = helper.decodeFromEntries(supplier.getSemanticTokens(documentContext, range));
-
-    // then — токен только на строке 2, вызов на строке 3 не обработан.
-    assertThat(decoded).hasSize(1);
-    assertThat(decoded).allSatisfy(token -> assertThat(token.line()).isEqualTo(2));
-  }
+  // Range-scoping — общее поведение базы AbstractPlatformMemberSemanticTokensSupplier,
+  // покрыто в PlatformMemberPropertyAccessSemanticTokensSupplierTest (один сапплаер
+  // на общий путь, чтобы не дублировать тест).
 
   @Test
   void testPlatformMethodAfterAwait() {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
@@ -1,0 +1,142 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.semantictokens;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
+import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
+import org.eclipse.lsp4j.SemanticTokenModifiers;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@Import(SemanticTokensTestHelper.class)
+class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private PlatformMemberPropertyAccessSemanticTokensSupplier supplier;
+
+  @Autowired
+  private SemanticTokensTestHelper helper;
+
+  @Test
+  void testPlatformPropertyOnTypedVariable() {
+    // given — таблица значений с известным свойством Колонки из платформы.
+    String bsl = """
+      Процедура Тест()
+          ТЗ = Новый ТаблицаЗначений;
+          К = ТЗ.Колонки;
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — Колонки подсвечивается как Property+DefaultLibrary.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(2, 11, 7, SemanticTokenTypes.Property,
+        Set.of(SemanticTokenModifiers.DefaultLibrary), "Колонки")
+    ));
+  }
+
+  @Test
+  void testPropertyChain() {
+    // given — обращение к свойству в середине цепочки accessProperty.
+    String bsl = """
+      Процедура Тест()
+          ТЗ = Новый ТаблицаЗначений;
+          Колво = ТЗ.Колонки.Количество();
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — Колонки (accessProperty) подсвечен; Количество (accessCall) — нет.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(2, 15, 7, SemanticTokenTypes.Property,
+        Set.of(SemanticTokenModifiers.DefaultLibrary), "Колонки")
+    ));
+    assertThat(decoded)
+      .as("Количество — это accessCall, не accessProperty; данный сапплаер его не выдаёт")
+      .noneMatch(token -> token.length() == "Количество".length());
+  }
+
+  @Test
+  void testStructureDynamicFieldHighlighted() {
+    // given — кейс из issue: поле Структуры, накопленное из конструктора.
+    String bsl = """
+      Процедура Тест()
+          Стр = Новый Структура("Имя", "Иван");
+          А = Стр.Имя;
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — Имя подсвечивается как Property+DefaultLibrary.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(2, 12, 3, SemanticTokenTypes.Property,
+        Set.of(SemanticTokenModifiers.DefaultLibrary), "Имя")
+    ));
+  }
+
+  @Test
+  void testMethodCallNotHighlightedAsProperty() {
+    // given — вызов метода платформенного типа (accessCall, со скобками).
+    String bsl = """
+      Процедура Тест()
+          М = Новый Массив;
+          М.Добавить(1);
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — accessCall этим сапплаером не подсвечивается.
+    assertThat(decoded).isEmpty();
+  }
+
+  @Test
+  void testUnknownTypeReceiverProducesNoToken() {
+    // given — переменная без type inference: тип не резолвится → свойство не подсвечивается.
+    String bsl = """
+      Процедура Тест(НеТипизированный)
+          А = НеТипизированный.НеизвестноеСвойство;
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — пусто (свойство неизвестно).
+    assertThat(decoded).isEmpty();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
@@ -22,14 +22,8 @@
 package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
-import com.github._1c_syntax.bsl.languageserver.types.TypeService.TypedMember;
-import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
-import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
-import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
-import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.junit.jupiter.api.Test;
@@ -39,12 +33,11 @@ import org.springframework.context.annotation.Import;
 import java.util.List;
 import java.util.Set;
 
+import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @Import(SemanticTokensTestHelper.class)
 class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
-
-  private static final Range DUMMY_RANGE = Ranges.create();
 
   @Autowired
   private PlatformMemberPropertyAccessSemanticTokensSupplier supplier;
@@ -150,58 +143,38 @@ class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractSer
   }
 
   @Test
-  void testHighlightablePlatformProperty() {
-    // given — обычное платформенное свойство (Колонки), returnType не из конфигурации.
-    var owner = new TypeRef(TypeKind.PLATFORM, "ТаблицаЗначений");
-    var returnType = new TypeRef(TypeKind.PLATFORM, "КоллекцияКолонокТаблицыЗначений");
-    var member = new TypedMember(owner, MemberDescriptor.property("Колонки", returnType), DUMMY_RANGE);
+  void testGlobalManagerChainSkipped() {
+    // given — конфигурация поднята: Справочники.Справочник1 резолвится и как
+    // глобальный менеджер (база цепочки), и как член (метаобъект). Без скипа член
+    // покрасился бы как Property, но всю цепочку красит GlobalScope (→ Class).
+    initServerContext(PATH_TO_METADATA);
+    String bsl = """
+      Процедура Тест()
+          А = Справочники.Справочник1;
+      КонецПроцедуры
+      """;
 
     // when
-    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isHighlightableProperty(member);
+    var decoded = helper.getDecodedTokens(bsl, supplier);
 
-    // then — красим как Property.
-    assertThat(result).isTrue();
+    // then — на члене глобальной цепочки наш сапплаер ничего не выдаёт.
+    assertThat(decoded).isEmpty();
   }
 
   @Test
-  void testMethodNotHighlightable() {
-    // given
-    var owner = new TypeRef(TypeKind.PLATFORM, "Массив");
-    var member = new TypedMember(owner, MemberDescriptor.method("Добавить"), DUMMY_RANGE);
+  void testGlobalChainInCallStatementSkipped() {
+    // given — глобальная цепочка в statement-позиции (callStatement): база — Справочники.
+    initServerContext(PATH_TO_METADATA);
+    String bsl = """
+      Процедура Тест()
+          Справочники.Справочник1.СоздатьЭлемент();
+      КонецПроцедуры
+      """;
 
     // when
-    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isHighlightableProperty(member);
+    var decoded = helper.getDecodedTokens(bsl, supplier);
 
-    // then — метод не является property.
-    assertThat(result).isFalse();
-  }
-
-  @Test
-  void testConfigurationReferenceMemberSkipped() {
-    // given — Справочники.ПрофилиГруппДоступа: returnType — ссылка на метаобъект.
-    // Такой член красит GlobalScope как Class; мы его пропускаем.
-    var owner = new TypeRef(TypeKind.PLATFORM, "СправочникиМенеджер");
-    var returnType = new TypeRef(TypeKind.CONFIGURATION, "СправочникСсылка.ПрофилиГруппДоступа");
-    var member = new TypedMember(owner, MemberDescriptor.property("ПрофилиГруппДоступа", returnType), DUMMY_RANGE);
-
-    // when
-    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isHighlightableProperty(member);
-
-    // then — не красим (домен GlobalScope, иначе конфликт Class vs Property).
-    assertThat(result).isFalse();
-  }
-
-  @Test
-  void testSelfTypedEnumMemberSkipped() {
-    // given — КодировкаТекста.UTF8: owner совпадает с returnType (значение перечисления).
-    // Такой член красит GlobalScope как EnumMember; мы его пропускаем.
-    var enumType = new TypeRef(TypeKind.PLATFORM, "КодировкаТекста");
-    var member = new TypedMember(enumType, MemberDescriptor.property("UTF8", enumType), DUMMY_RANGE);
-
-    // when
-    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isHighlightableProperty(member);
-
-    // then — не красим (домен GlobalScope, иначе конфликт EnumMember vs Property).
-    assertThat(result).isFalse();
+    // then — пусто (член глобальной цепочки в callStatement тоже пропущен).
+    assertThat(decoded).isEmpty();
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
@@ -22,9 +22,14 @@
 package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.types.TypeService.TypedMember;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.junit.jupiter.api.Test;
@@ -38,6 +43,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 @Import(SemanticTokensTestHelper.class)
 class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
+
+  private static final Range DUMMY_RANGE = Ranges.create();
 
   @Autowired
   private PlatformMemberPropertyAccessSemanticTokensSupplier supplier;
@@ -143,26 +150,58 @@ class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractSer
   }
 
   @Test
-  void testIsPropertyForPropertyDescriptor() {
-    // given
-    var property = MemberDescriptor.property("Колонки");
+  void testHighlightablePlatformProperty() {
+    // given — обычное платформенное свойство (Колонки), returnType не из конфигурации.
+    var owner = new TypeRef(TypeKind.PLATFORM, "ТаблицаЗначений");
+    var returnType = new TypeRef(TypeKind.PLATFORM, "КоллекцияКолонокТаблицыЗначений");
+    var member = new TypedMember(owner, MemberDescriptor.property("Колонки", returnType), DUMMY_RANGE);
 
     // when
-    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isProperty(property);
+    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isHighlightableProperty(member);
 
-    // then — свойство распознаётся как property.
+    // then — красим как Property.
     assertThat(result).isTrue();
   }
 
   @Test
-  void testIsPropertyForMethodDescriptor() {
+  void testMethodNotHighlightable() {
     // given
-    var method = MemberDescriptor.method("Добавить");
+    var owner = new TypeRef(TypeKind.PLATFORM, "Массив");
+    var member = new TypedMember(owner, MemberDescriptor.method("Добавить"), DUMMY_RANGE);
 
     // when
-    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isProperty(method);
+    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isHighlightableProperty(member);
 
     // then — метод не является property.
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testConfigurationReferenceMemberSkipped() {
+    // given — Справочники.ПрофилиГруппДоступа: returnType — ссылка на метаобъект.
+    // Такой член красит GlobalScope как Class; мы его пропускаем.
+    var owner = new TypeRef(TypeKind.PLATFORM, "СправочникиМенеджер");
+    var returnType = new TypeRef(TypeKind.CONFIGURATION, "СправочникСсылка.ПрофилиГруппДоступа");
+    var member = new TypedMember(owner, MemberDescriptor.property("ПрофилиГруппДоступа", returnType), DUMMY_RANGE);
+
+    // when
+    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isHighlightableProperty(member);
+
+    // then — не красим (домен GlobalScope, иначе конфликт Class vs Property).
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void testSelfTypedEnumMemberSkipped() {
+    // given — КодировкаТекста.UTF8: owner совпадает с returnType (значение перечисления).
+    // Такой член красит GlobalScope как EnumMember; мы его пропускаем.
+    var enumType = new TypeRef(TypeKind.PLATFORM, "КодировкаТекста");
+    var member = new TypedMember(enumType, MemberDescriptor.property("UTF8", enumType), DUMMY_RANGE);
+
+    // when
+    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isHighlightableProperty(member);
+
+    // then — не красим (домен GlobalScope, иначе конфликт EnumMember vs Property).
     assertThat(result).isFalse();
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
@@ -24,6 +24,9 @@ package com.github._1c_syntax.bsl.languageserver.semantictokens;
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.junit.jupiter.api.Test;
@@ -159,6 +162,28 @@ class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractSer
 
     // then — на члене глобальной цепочки наш сапплаер ничего не выдаёт.
     assertThat(decoded).isEmpty();
+  }
+
+  @Test
+  void testRangeScopingReturnsOnlyTokensInRange() {
+    // given — два обращения к свойству на разных строках (2 и 3).
+    String bsl = """
+      Процедура Тест()
+          ТЗ = Новый ТаблицаЗначений;
+          А = ТЗ.Колонки;
+          Б = ТЗ.Колонки;
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(bsl);
+    // диапазон покрывает только строку 2 (первое обращение).
+    var range = new Range(new Position(2, 0), new Position(2, 100));
+
+    // when — range-перегрузка ограничивает дорогой memberAt диапазоном.
+    var decoded = helper.decodeFromEntries(supplier.getSemanticTokens(documentContext, range));
+
+    // then — токен только на строке 2, обращение на строке 3 не обработано.
+    assertThat(decoded).hasSize(1);
+    assertThat(decoded).allSatisfy(token -> assertThat(token.line()).isEqualTo(2));
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
@@ -82,9 +83,10 @@ class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractSer
       new ExpectedToken(2, 15, 7, SemanticTokenTypes.Property,
         Set.of(SemanticTokenModifiers.DefaultLibrary), "Колонки")
     ));
+    // Количество начинается на line 2, char 23 (после "ТЗ.Колонки.").
     assertThat(decoded)
       .as("Количество — это accessCall, не accessProperty; данный сапплаер его не выдаёт")
-      .noneMatch(token -> token.length() == "Количество".length());
+      .noneMatch(token -> token.line() == 2 && token.start() == 23);
   }
 
   @Test
@@ -138,5 +140,29 @@ class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractSer
 
     // then — пусто (свойство неизвестно).
     assertThat(decoded).isEmpty();
+  }
+
+  @Test
+  void testIsPropertyForPropertyDescriptor() {
+    // given
+    var property = MemberDescriptor.property("Колонки");
+
+    // when
+    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isProperty(property);
+
+    // then — свойство распознаётся как property.
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void testIsPropertyForMethodDescriptor() {
+    // given
+    var method = MemberDescriptor.method("Добавить");
+
+    // when
+    var result = PlatformMemberPropertyAccessSemanticTokensSupplier.isProperty(method);
+
+    // then — метод не является property.
+    assertThat(result).isFalse();
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
@@ -165,8 +165,9 @@ class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractSer
   }
 
   @Test
-  void testRangeScopingReturnsOnlyTokensInRange() {
-    // given — два обращения к свойству на разных строках (2 и 3).
+  void testRangeScopingByOverlap() {
+    // given — два обращения к свойству Колонки на разных строках (2 и 3).
+    // На строке 2 «Колонки» занимает столбцы [11, 18).
     String bsl = """
       Процедура Тест()
           ТЗ = Новый ТаблицаЗначений;
@@ -175,15 +176,18 @@ class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractSer
       КонецПроцедуры
       """;
     var documentContext = TestUtils.getDocumentContext(bsl);
-    // диапазон покрывает только строку 2 (первое обращение).
-    var range = new Range(new Position(2, 0), new Position(2, 100));
 
-    // when — range-перегрузка ограничивает дорогой memberAt диапазоном.
-    var decoded = helper.decodeFromEntries(supplier.getSemanticTokens(documentContext, range));
+    // when/then — диапазон строки 2 не захватывает обращение на строке 3.
+    var line2 = helper.decodeFromEntries(supplier.getSemanticTokens(
+      documentContext, new Range(new Position(2, 0), new Position(2, 100))));
+    assertThat(line2).hasSize(1);
+    assertThat(line2).allSatisfy(token -> assertThat(token.line()).isEqualTo(2));
 
-    // then — токен только на строке 2, обращение на строке 3 не обработано.
-    assertThat(decoded).hasSize(1);
-    assertThat(decoded).allSatisfy(token -> assertThat(token.line()).isEqualTo(2));
+    // when/then — имя начинается до границы диапазона (start=14 внутри «Колонки»),
+    // но заходит внутрь → по overlap-семантике не отбрасывается.
+    var straddling = helper.decodeFromEntries(supplier.getSemanticTokens(
+      documentContext, new Range(new Position(2, 14), new Position(2, 100))));
+    assertThat(straddling).hasSize(1);
   }
 
   @Test


### PR DESCRIPTION
## Что

Добавлен `PlatformMemberPropertyAccessSemanticTokensSupplier` — симметричный свежему методному `PlatformMemberMethodCallSemanticTokensSupplier`, но для **обращения к свойствам** платформенных типов (`получатель.свойство` без скобок).

До этого `Стр.Имя`, `ТЗ.Колонки`, `Сертификат.Владелец` визуально не отличались от обычного текста.

## Как

1. Обходит все `accessProperty` в AST (`BSLParser.RULE_accessProperty`).
2. Берёт `IDENTIFIER` после точки и его позицию.
3. Резолвит член через `TypeService.findMemberAt(documentContext, position)`.
4. При `MemberKind.PROPERTY` выдаёт `SemanticTokenTypes.Property` + `SemanticTokenModifiers.DefaultLibrary`.
5. Позиции source-defined переменных (`ReferenceIndex`, `SymbolKind.Variable`) пропускаются, чтобы не дублировать токены `SymbolsSemanticTokensSupplier` (актуально для экспортных переменных модуля объекта).

Изменения легенды не требуются: `Property` и `DefaultLibrary` уже зарегистрированы. Регистрация бина не нужна — `@Component` авто-собирается в `SemanticTokensProvider`.

## Тесты

`PlatformMemberPropertyAccessSemanticTokensSupplierTest` (given/when/then):
- `testPlatformPropertyOnTypedVariable` — `ТЗ.Колонки` → Property+DefaultLibrary
- `testPropertyChain` — `ТЗ.Колонки.Количество()` → подсвечен только `Колонки`, не метод
- `testStructureDynamicFieldHighlighted` — динамическое поле `Стр.Имя` из конструктора `Новый Структура("Имя", ...)`
- `testMethodCallNotHighlightedAsProperty` — `М.Добавить(1)` → пусто (accessCall не трогается)
- `testUnknownTypeReceiverProducesNoToken` — без type inference пусто

Регрессий нет: пакет `semantictokens` и `SemanticTokensProviderTest` зелёные.

Closes #3949

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Editor highlights platform member property accesses as property tokens (marked as library symbols) and respects requested ranges for range requests.
* **Bug Fixes**
  * Skips global-manager chains to avoid incorrect highlights and adds overlap-detection to prevent conflicting/duplicate semantic tokens.
* **Refactor**
  * Consolidated platform-member token logic into a shared abstraction and improved range-scoped token collection for providers.
* **Tests**
  * Added comprehensive tests and utilities covering property highlighting, chains, structure fields, methods vs properties, unknown types, range scoping, global-chain skipping, and overlap detection.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->