### PR TITLE
Исправлено автодополнение членов общего модуля после точки (#3988)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionAtPosition.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionAtPosition.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.utils.expressiontree.BslExpressi
 import com.github._1c_syntax.bsl.languageserver.utils.expressiontree.ExpressionTreeBuildingVisitor;
 import com.github._1c_syntax.bsl.parser.BSLParser;
 import lombok.experimental.UtilityClass;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.eclipse.lsp4j.Position;
 import org.jspecify.annotations.Nullable;
 
@@ -54,15 +55,7 @@ public class ExpressionAtPosition {
     DocumentContext documentContext,
     Position position
   ) {
-    var ast = safeGetAst(documentContext);
-    if (ast == null) {
-      return Optional.empty();
-    }
-    return Trees.findTerminalNodeContainsPosition(ast, position)
-      .map(terminal -> terminal.getParent() instanceof org.antlr.v4.runtime.ParserRuleContext prc ? prc : null)
-      .map(rule -> Trees.getRootParent(rule, BSLParser.RULE_expression))
-      .filter(BSLParser.ExpressionContext.class::isInstance)
-      .map(BSLParser.ExpressionContext.class::cast);
+    return findEnclosingRule(documentContext, position, BSLParser.RULE_expression);
   }
 
   /**
@@ -74,15 +67,7 @@ public class ExpressionAtPosition {
     DocumentContext documentContext,
     Position position
   ) {
-    var ast = safeGetAst(documentContext);
-    if (ast == null) {
-      return Optional.empty();
-    }
-    return Trees.findTerminalNodeContainsPosition(ast, position)
-      .map(terminal -> terminal.getParent() instanceof org.antlr.v4.runtime.ParserRuleContext prc ? prc : null)
-      .map(rule -> Trees.getRootParent(rule, BSLParser.RULE_complexIdentifier))
-      .filter(BSLParser.ComplexIdentifierContext.class::isInstance)
-      .map(BSLParser.ComplexIdentifierContext.class::cast);
+    return findEnclosingRule(documentContext, position, BSLParser.RULE_complexIdentifier);
   }
 
   /**
@@ -94,15 +79,7 @@ public class ExpressionAtPosition {
     DocumentContext documentContext,
     Position position
   ) {
-    var ast = safeGetAst(documentContext);
-    if (ast == null) {
-      return Optional.empty();
-    }
-    return Trees.findTerminalNodeContainsPosition(ast, position)
-      .map(terminal -> terminal.getParent() instanceof org.antlr.v4.runtime.ParserRuleContext prc ? prc : null)
-      .map(rule -> Trees.getRootParent(rule, BSLParser.RULE_callStatement))
-      .filter(BSLParser.CallStatementContext.class::isInstance)
-      .map(BSLParser.CallStatementContext.class::cast);
+    return findEnclosingRule(documentContext, position, BSLParser.RULE_callStatement);
   }
 
   /**
@@ -115,15 +92,7 @@ public class ExpressionAtPosition {
     DocumentContext documentContext,
     Position position
   ) {
-    var ast = safeGetAst(documentContext);
-    if (ast == null) {
-      return Optional.empty();
-    }
-    return Trees.findTerminalNodeContainsPosition(ast, position)
-      .map(terminal -> terminal.getParent() instanceof org.antlr.v4.runtime.ParserRuleContext prc ? prc : null)
-      .map(rule -> Trees.getRootParent(rule, BSLParser.RULE_lValue))
-      .filter(BSLParser.LValueContext.class::isInstance)
-      .map(BSLParser.LValueContext.class::cast);
+    return findEnclosingRule(documentContext, position, BSLParser.RULE_lValue);
   }
 
   /**
@@ -150,7 +119,7 @@ public class ExpressionAtPosition {
       return Optional.empty();
     }
     return Trees.findTerminalNodeContainsPosition(ast, position)
-      .map(terminal -> terminal.getParent() instanceof org.antlr.v4.runtime.ParserRuleContext prc ? prc : null)
+      .map(terminal -> terminal.getParent() instanceof ParserRuleContext prc ? prc : null)
       .map(rule -> Trees.getRootParent(rule, BSLParser.RULE_assignment))
       .filter(BSLParser.AssignmentContext.class::isInstance)
       .map(BSLParser.AssignmentContext.class::cast);
@@ -179,6 +148,43 @@ public class ExpressionAtPosition {
       return Optional.empty();
     }
     return forEach.IDENTIFIER() == hit ? Optional.of(forEach) : Optional.empty();
+  }
+
+  /**
+   * Найти узел правила {@code ruleIndex}, накрывающий терминал под курсором:
+   * берём терминал в позиции, поднимаемся к его непосредственному родителю и
+   * ищем целевое правило, считая сам родитель кандидатом (см.
+   * {@link #ancestorOrSelf}). Тип результата выводится из ожидаемого
+   * {@code Optional<T>} вызывающего метода.
+   */
+  private static <T extends ParserRuleContext> Optional<T> findEnclosingRule(
+    DocumentContext documentContext, Position position, int ruleIndex
+  ) {
+    var ast = safeGetAst(documentContext);
+    if (ast == null) {
+      return Optional.empty();
+    }
+    return Trees.findTerminalNodeContainsPosition(ast, position)
+      .map(terminal -> terminal.getParent() instanceof ParserRuleContext prc ? prc : null)
+      .map(rule -> ExpressionAtPosition.<T>ancestorOrSelf(rule, ruleIndex));
+  }
+
+  /**
+   * Найти ближайший узел правила {@code ruleIndex}, считая сам {@code node}
+   * кандидатом (inclusive). {@link Trees#getAncestorByRuleIndex} ищет строго
+   * среди предков и пропускает сам узел — но в текущей грамматике
+   * ресивер-идентификатор стоит прямым ребёнком целевого правила (например,
+   * {@code (callStatement Идентификатор (incompleteAccess .))} для висячей точки
+   * {@code Идентификатор.}), поэтому без проверки самого узла lookup даёт null.
+   */
+  @Nullable
+  private static <T extends ParserRuleContext> T ancestorOrSelf(ParserRuleContext node, int ruleIndex) {
+    if (node.getRuleIndex() == ruleIndex) {
+      @SuppressWarnings("unchecked")
+      var self = (T) node;
+      return self;
+    }
+    return Trees.getAncestorByRuleIndex(node, ruleIndex);
   }
 
   private static BSLParser.@Nullable FileContext safeGetAst(DocumentContext documentContext) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionAtPosition.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionAtPosition.java
@@ -151,11 +151,10 @@ public class ExpressionAtPosition {
   }
 
   /**
-   * Найти узел правила {@code ruleIndex}, накрывающий терминал под курсором:
-   * берём терминал в позиции, поднимаемся к его непосредственному родителю и
-   * ищем целевое правило, считая сам родитель кандидатом (см.
-   * {@link #ancestorOrSelf}). Тип результата выводится из ожидаемого
-   * {@code Optional<T>} вызывающего метода.
+   * Найти узел правила {@code ruleIndex}, накрывающий терминал под курсором. Берём
+   * терминал в позиции, поднимаемся к его непосредственному родителю и ищем целевое
+   * правило, считая сам родитель кандидатом (см. {@link #ancestorOrSelf}). Тип
+   * результата выводится из ожидаемого {@code Optional<T>} вызывающего метода.
    */
   private static <T extends ParserRuleContext> Optional<T> findEnclosingRule(
     DocumentContext documentContext, Position position, int ruleIndex
@@ -171,9 +170,9 @@ public class ExpressionAtPosition {
 
   /**
    * Найти ближайший узел правила {@code ruleIndex}, считая сам {@code node}
-   * кандидатом (inclusive). {@link Trees#getAncestorByRuleIndex} ищет строго
-   * среди предков и пропускает сам узел — но в текущей грамматике
-   * ресивер-идентификатор стоит прямым ребёнком целевого правила (например,
+   * кандидатом (inclusive). {@link Trees#getAncestorByRuleIndex} ищет строго среди
+   * предков и пропускает сам узел — но в текущей грамматике ресивер-идентификатор
+   * стоит прямым ребёнком целевого правила (например,
    * {@code (callStatement Идентификатор (incompleteAccess .))} для висячей точки
    * {@code Идентификатор.}), поэтому без проверки самого узла lookup даёт null.
    */

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionAtPositionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionAtPositionTest.java
@@ -21,12 +21,21 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.inferencer;
 
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.Position;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.Arguments;
+import org.junit.jupiter.params.provider.MethodSource;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.util.stream.Stream;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.junit.jupiter.params.provider.Arguments.arguments;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 /**
  * Тесты для {@link ExpressionAtPosition} — поиска assignment/forEach/expression
@@ -184,19 +193,6 @@ class ExpressionAtPositionTest {
   }
 
   @Test
-  void findExpressionTreeReturnsBslExpressionForAssignmentRhs() {
-    // given
-    var content = "Х = 1 + 2;\n";
-    var dc = TestUtils.getDocumentContext(content);
-
-    // when — позиция внутри «1».
-    var tree = ExpressionAtPosition.findExpressionTree(dc, new Position(0, 4));
-
-    // then — построено выражение поверх ExpressionContext.
-    assertThat(tree).isPresent();
-  }
-
-  @Test
   void findCallStatementContextReturnsCallStatementForTrailingDotReceiver() {
     // given — висячая точка: `ИмяМодуля.` без продолжения. В текущей грамматике
     // ресивер — прямой ребёнок callStatement: (callStatement Идентификатор
@@ -208,34 +204,73 @@ class ExpressionAtPositionTest {
     // when — позиция внутри идентификатора-ресивера ОбщегоНазначения.
     var callStmt = ExpressionAtPosition.findCallStatementContext(dc, new Position(1, 7));
 
-    // then
-    assertThat(callStmt).isPresent();
+    // then — найден именно callStatement висячей точки (текст = ресивер + точка),
+    // а не какой-либо другой непустой узел.
+    assertThat(callStmt)
+      .get()
+      .extracting(org.antlr.v4.runtime.ParserRuleContext::getText)
+      .isEqualTo("ОбщегоНазначения.");
   }
 
-  @Test
-  void findExpressionTreeReturnsBslExpressionForTrailingDotReceiver() {
-    // given — висячая точка `ИмяМодуля.`: именно этот сценарий dot-completion'а
-    // ресивера, который ранее давал пустое дерево (treePresent=false).
-    var content = "Процедура Т() Экспорт\n    ОбщегоНазначения.\nКонецПроцедуры\n";
-    var dc = TestUtils.getDocumentContext(content);
-
-    // when — позиция внутри идентификатора-ресивера.
-    var tree = ExpressionAtPosition.findExpressionTree(dc, new Position(1, 7));
-
-    // then — дерево построено, вывод типа ресивера возможен.
-    assertThat(tree).isPresent();
+  static Stream<Arguments> findExpressionTreeBuildsTreeOverExpectedNode() {
+    return Stream.of(
+      // assignment RHS: корень — бинарная операция «+» (ExpressionContext)
+      arguments("Х = 1 + 2;\n", new Position(0, 4), "+"),
+      // lValue dot-chain: fallback на findLValueContext, корень — доступ «.Свойство»
+      arguments("Объект.Свойство = 1;\n", new Position(0, 10), ".Свойство"),
+      // висячая точка `ИмяМодуля.` — раньше давала пустое дерево (treePresent=false);
+      // корень — сам ресивер, что и доказывает корректный резолв висячей точки
+      arguments("Процедура Т() Экспорт\n    ОбщегоНазначения.\nКонецПроцедуры\n",
+        new Position(1, 7), "ОбщегоНазначения")
+    );
   }
 
-  @Test
-  void findExpressionTreeReturnsBslExpressionForLValue() {
+  @ParameterizedTest
+  @MethodSource
+  void findExpressionTreeBuildsTreeOverExpectedNode(String content, Position position, String expectedText) {
     // given
-    var content = "Объект.Свойство = 1;\n";
     var dc = TestUtils.getDocumentContext(content);
 
-    // when — позиция внутри `Свойство` (lValue, не expression).
-    var tree = ExpressionAtPosition.findExpressionTree(dc, new Position(0, 10));
+    // when
+    var tree = ExpressionAtPosition.findExpressionTree(dc, position);
 
-    // then — fallback на findLValueContext сработал.
-    assertThat(tree).isPresent();
+    // then — дерево построено именно поверх ожидаемого узла (а не любого непустого).
+    assertThat(tree)
+      .get()
+      .extracting(t -> t.getRepresentingAst().getText())
+      .isEqualTo(expectedText);
+  }
+
+  @Test
+  void allLookupsReturnEmptyWhenAstUnavailable() {
+    // given — документ без инициализированного токенизатора: getAst() кидает NPE
+    // (например, документ ещё не открыт/не прочитан).
+    var dc = mock(DocumentContext.class);
+    when(dc.getAst()).thenThrow(new NullPointerException());
+
+    // when / then — все точки входа безопасно возвращают пусто (safeGetAst → null).
+    var position = new Position(0, 0);
+    assertThat(ExpressionAtPosition.findExpressionContext(dc, position)).isEmpty();
+    assertThat(ExpressionAtPosition.findComplexIdentifierContext(dc, position)).isEmpty();
+    assertThat(ExpressionAtPosition.findCallStatementContext(dc, position)).isEmpty();
+    assertThat(ExpressionAtPosition.findLValueContext(dc, position)).isEmpty();
+    assertThat(ExpressionAtPosition.findAssignment(dc, position)).isEmpty();
+    assertThat(ExpressionAtPosition.findAssignmentRhs(dc, position)).isEmpty();
+    assertThat(ExpressionAtPosition.findForEachBindingAt(dc, position)).isEmpty();
+    assertThat(ExpressionAtPosition.findExpressionTree(dc, position)).isEmpty();
+  }
+
+  @Test
+  void findForEachBindingAtEmptyWhenTerminalParentIsNotForEach() {
+    // given — обычное присваивание, терминал есть, но его родитель — не
+    // ForEachStatement.
+    var content = "А = 100;\n";
+    var dc = TestUtils.getDocumentContext(content);
+
+    // when — позиция на идентификаторе «А».
+    var forEach = ExpressionAtPosition.findForEachBindingAt(dc, new Position(0, 0));
+
+    // then
+    assertThat(forEach).isEmpty();
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionAtPositionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionAtPositionTest.java
@@ -197,6 +197,36 @@ class ExpressionAtPositionTest {
   }
 
   @Test
+  void findCallStatementContextReturnsCallStatementForTrailingDotReceiver() {
+    // given — висячая точка: `ИмяМодуля.` без продолжения. В текущей грамматике
+    // ресивер — прямой ребёнок callStatement: (callStatement Идентификатор
+    // (incompleteAccess .)). Поиск целевого правила должен считать сам узел
+    // кандидатом (inclusive), иначе callStatement не находится.
+    var content = "Процедура Т() Экспорт\n    ОбщегоНазначения.\nКонецПроцедуры\n";
+    var dc = TestUtils.getDocumentContext(content);
+
+    // when — позиция внутри идентификатора-ресивера ОбщегоНазначения.
+    var callStmt = ExpressionAtPosition.findCallStatementContext(dc, new Position(1, 7));
+
+    // then
+    assertThat(callStmt).isPresent();
+  }
+
+  @Test
+  void findExpressionTreeReturnsBslExpressionForTrailingDotReceiver() {
+    // given — висячая точка `ИмяМодуля.`: именно этот сценарий dot-completion'а
+    // ресивера, который ранее давал пустое дерево (treePresent=false).
+    var content = "Процедура Т() Экспорт\n    ОбщегоНазначения.\nКонецПроцедуры\n";
+    var dc = TestUtils.getDocumentContext(content);
+
+    // when — позиция внутри идентификатора-ресивера.
+    var tree = ExpressionAtPosition.findExpressionTree(dc, new Position(1, 7));
+
+    // then — дерево построено, вывод типа ресивера возможен.
+    assertThat(tree).isPresent();
+  }
+
+  @Test
   void findExpressionTreeReturnsBslExpressionForLValue() {
     // given
     var content = "Объект.Свойство = 1;\n";


### PR DESCRIPTION
## Проблема

Closes #3988. Автодополнение не предлагает экспортные методы общего модуля при обращении через точку (`ОбщегоНазначения.`), хотя go-to-definition/hover и автодополнение менеджеров (`Справочники.`), платформенных энумов (`КодировкаТекста.`) работают.

## Root cause

Воспроизводится только в реальном LSP-рантайме (юнит-тесты были зелёными, т.к. резолвили ресивер через reference index, маскируя баг).

AST для висячей точки `ОбщегоНазначения.`:
```
(callStatement ОбщегоНазначения (incompleteAccess .))
```
В текущей грамматике bsl-parser ресивер-идентификатор стоит **прямым ребёнком** `callStatement`. `ExpressionAtPosition.find*Context` искали целевое правило через `Trees.getAncestorByRuleIndex` (exclusive — только среди предков, пропуская сам узел). Раз родитель терминала уже и есть `callStatement`, поиск возвращал `null` → `findExpressionTree` → `Optional.empty` → `inferAtPosition` пуст → тип ресивера не резолвился → `getMembers` не вызывался → пустой попап.

Для `Справочники`/`КодировкаТекста` это маскировалось reference-индексом (`findTypes` их резолвит независимо).

## Решение

В `ExpressionAtPosition`:
- `ancestorOrSelf(node, ruleIndex)` — **inclusive**-поиск (сначала проверяет сам узел, иначе `Trees.getAncestorByRuleIndex`), generic-возврат в стиле `Trees.getAncestorByRuleIndex`;
- `findEnclosingRule(dc, pos, ruleIndex)` — общий generic-хелпер (find-terminal + inclusive-ancestor + типизированный `Optional<T>`);
- четыре `find*Context` схлопнуты в делегации (убран дублирующийся filter/cast-бойлерплейт).

Чинит общие модули и латентно — любой ресивер в сценарии висячей точки / standalone-`callStatement`.

## Проверки

- Реальный jar протестирован LSP-клиентом по stdio: `ОбщегоНазначения.` → `ОбщийМодуль, ЗначениеВМассиве`; префикс `.Общ` → `ОбщийМодуль`; `Справочники`/`КодировкаТекста` без регрессий.
- Регрессионные юнит-тесты `find{CallStatement,ExpressionTree}…ForTrailingDotReceiver` — падают без фикса, проходят с ним.
- Потребители (`CompletionProviderTest`, `HoverProviderTest`, `DefinitionProviderTest`, инференсер) — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Centralized and simplified expression lookup logic for more consistent cursor-based expression detection.

* **Tests**
  * Added coverage for incomplete/trailing-dot receivers and consolidated expression parsing tests to ensure reliable behavior when the cursor is on partial expressions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->