### PR TITLE
perf(types): кэш инференса + memo getMembers + индекс callStatement

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/EventPublisherAspect.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/EventPublisherAspect.java
@@ -31,6 +31,7 @@ import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.context.events.BeforeWorkspaceRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentAddedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopulatedEvent;
@@ -157,6 +158,18 @@ public class EventPublisherAspect {
   @AfterReturning("Pointcuts.isServerContext() && Pointcuts.isCloseDocumentCall() && args(documentContext)")
   public void serverContextCloseDocument(JoinPoint joinPoint, DocumentContext documentContext) {
     publishEvent(new ServerContextDocumentClosedEvent((ServerContext) joinPoint.getThis(), documentContext));
+  }
+
+  @AfterReturning(
+    pointcut = "Pointcuts.isServerContext() && Pointcuts.isTryClearDocumentCall() && args(documentContext)",
+    returning = "cleared"
+  )
+  public void serverContextTryClearDocument(JoinPoint joinPoint, DocumentContext documentContext, boolean cleared) {
+    // Публикуем только при реальной очистке: на открытом документе tryClearDocument
+    // делает no-op (cleared == false) и сбрасывать кэши не нужно.
+    if (cleared) {
+      publishEvent(new ServerContextDocumentClearedEvent((ServerContext) joinPoint.getThis(), documentContext));
+    }
   }
 
   @AfterReturning("Pointcuts.isLanguageServer() && Pointcuts.isInitializeCall() && args(initializeParams)")

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/Pointcuts.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/Pointcuts.java
@@ -134,6 +134,14 @@ public class Pointcuts {
   }
 
   /**
+   * Это вызов метода tryClearDocument.
+   */
+  @Pointcut("isBSLLanguageServerScope() && execution(* tryClearDocument(..))")
+  public void isTryClearDocumentCall() {
+    // no-op
+  }
+
+  /**
    * Это вызов метода populateContext.
    */
   @Pointcut("isBSLLanguageServerScope() && execution(* populateContext(..))")

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -403,14 +403,17 @@ public class ServerContext {
    * Попытаться очистить документ, если он не открыт.
    *
    * @param documentContext документ, который необходимо попытаться закрыть.
+   * @return {@code true}, если вторичные данные документа были реально освобождены;
+   *         {@code false}, если документ открыт в редакторе и очистка пропущена.
    */
-  public void tryClearDocument(DocumentContext documentContext) {
+  public boolean tryClearDocument(DocumentContext documentContext) {
     if (openedDocuments.contains(documentContext)) {
-      return;
+      return false;
     }
 
     states.put(documentContext, State.WITHOUT_CONTENT);
     documentContext.clearSecondaryData();
+    return true;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/events/ServerContextDocumentClearedEvent.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/events/ServerContextDocumentClearedEvent.java
@@ -1,0 +1,75 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.context.events;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
+import lombok.Getter;
+import org.springframework.context.ApplicationEvent;
+
+import java.io.Serial;
+
+/**
+ * Событие, публикуемое при освобождении вторичных данных документа в контексте сервера.
+ * <p>
+ * Событие генерируется контекстом сервера {@link ServerContext} при вызове метода
+ * {@link ServerContext#tryClearDocument(DocumentContext)}, и только когда тот реально
+ * освободил данные (документ не был открыт в редакторе). Так batch-анализ
+ * ({@code AnalyzeCommand}) и {@code populateContext} выбрасывают тяжёлый AST/токенайзер
+ * после обработки каждого файла.
+ * <p>
+ * В отличие от {@link DocumentContextContentChangedEvent} событие не подразумевает
+ * пересчёт — оно сигнализирует, что производные данные документа выброшены, и привязанные
+ * к URI кэши (хранящие AST-узлы или выведенные типы) должны быть сброшены, иначе они
+ * удерживали бы освобождённые данные и росли бы на весь прогон. Это отдельная от
+ * {@link ServerContextDocumentClosedEvent} семантика: документ не закрывается, лишь
+ * освобождает резидентные данные.
+ *
+ * @see ServerContext#tryClearDocument(DocumentContext)
+ */
+public class ServerContextDocumentClearedEvent extends ApplicationEvent {
+
+  @Serial
+  private static final long serialVersionUID = 8516815391686789513L;
+
+  /**
+   * Документ, чьи вторичные данные были освобождены.
+   */
+  @Getter
+  private final DocumentContext documentContext;
+
+  /**
+   * Создаёт новое событие освобождения вторичных данных документа.
+   *
+   * @param source          контекст сервера, в котором были освобождены данные документа
+   * @param documentContext документ, чьи вторичные данные были освобождены
+   */
+  public ServerContextDocumentClearedEvent(ServerContext source, DocumentContext documentContext) {
+    super(source);
+    this.documentContext = documentContext;
+  }
+
+  @Override
+  public ServerContext getSource() {
+    return (ServerContext) super.getSource();
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/IntBasedVariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/IntBasedVariableSymbol.java
@@ -104,4 +104,24 @@ public class IntBasedVariableSymbol extends AbstractVariableSymbol {
     );
   }
 
+  @Override
+  public int getVariableNameLine() {
+    return variableNameLine;
+  }
+
+  @Override
+  public int getVariableNameStartCharacter() {
+    return variableNameStartCharacter;
+  }
+
+  @Override
+  public int getVariableNameEndCharacter() {
+    return variableNameEndCharacter;
+  }
+
+  @Override
+  public int compareTo(VariableSymbol other) {
+    return NATURAL_ORDER.compare(this, other);
+  }
+
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/IntBasedVariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/IntBasedVariableSymbol.java
@@ -52,14 +52,11 @@ public class IntBasedVariableSymbol extends AbstractVariableSymbol {
   @Getter(AccessLevel.NONE)
   int endCharacter;
 
-  @Getter(AccessLevel.NONE)
   @EqualsAndHashCode.Include
   int variableNameLine;
-  @Getter(AccessLevel.NONE)
   @EqualsAndHashCode.Include
   int variableNameStartCharacter;
   @EqualsAndHashCode.Include
-  @Getter(AccessLevel.NONE)
   int variableNameEndCharacter;
 
   public IntBasedVariableSymbol(
@@ -102,26 +99,6 @@ public class IntBasedVariableSymbol extends AbstractVariableSymbol {
       variableNameLine,
       variableNameEndCharacter
     );
-  }
-
-  @Override
-  public int getVariableNameLine() {
-    return variableNameLine;
-  }
-
-  @Override
-  public int getVariableNameStartCharacter() {
-    return variableNameStartCharacter;
-  }
-
-  @Override
-  public int getVariableNameEndCharacter() {
-    return variableNameEndCharacter;
-  }
-
-  @Override
-  public int compareTo(VariableSymbol other) {
-    return NATURAL_ORDER.compare(this, other);
   }
 
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/ShortBasedVariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/ShortBasedVariableSymbol.java
@@ -104,4 +104,24 @@ public class ShortBasedVariableSymbol extends AbstractVariableSymbol {
     );
   }
 
+  @Override
+  public int getVariableNameLine() {
+    return variableNameLine;
+  }
+
+  @Override
+  public int getVariableNameStartCharacter() {
+    return variableNameStartCharacter;
+  }
+
+  @Override
+  public int getVariableNameEndCharacter() {
+    return variableNameEndCharacter;
+  }
+
+  @Override
+  public int compareTo(VariableSymbol other) {
+    return NATURAL_ORDER.compare(this, other);
+  }
+
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/ShortBasedVariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/ShortBasedVariableSymbol.java
@@ -119,9 +119,4 @@ public class ShortBasedVariableSymbol extends AbstractVariableSymbol {
     return variableNameEndCharacter;
   }
 
-  @Override
-  public int compareTo(VariableSymbol other) {
-    return NATURAL_ORDER.compare(this, other);
-  }
-
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
@@ -39,8 +39,6 @@ public interface VariableSymbol extends SourceDefinedSymbol, Exportable, Describ
   /**
    * Естественный порядок переменных, согласованный с {@code equals}: имя →
    * URI владельца → позиция имени (строка, начальный и конечный символы).
-   * Использует дешёвые {@code int}-аксессоры позиции, а не
-   * {@link #getVariableNameRange()}, который аллоцирует {@code Range}/{@code Position}.
    * Реализации {@link #compareTo(VariableSymbol)} обязаны делегировать сюда.
    */
   Comparator<VariableSymbol> NATURAL_ORDER = Comparator
@@ -72,22 +70,21 @@ public interface VariableSymbol extends SourceDefinedSymbol, Exportable, Describ
   Range getVariableNameRange();
 
   /**
-   * Дешёвый (без аллокации) аксессор строки имени переменной — в отличие от
-   * {@link #getVariableNameRange()}, который создаёт {@code Range}/{@code Position}.
+   * Строка, в которой определено имя переменной.
    *
-   * @return номер строки, в которой определено имя переменной.
+   * @return номер строки имени переменной.
    */
   int getVariableNameLine();
 
   /**
-   * Дешёвый (без аллокации) аксессор начального символа имени переменной.
+   * Начальный символ имени переменной в строке объявления.
    *
    * @return номер начального символа имени переменной.
    */
   int getVariableNameStartCharacter();
 
   /**
-   * Дешёвый (без аллокации) аксессор конечного символа имени переменной.
+   * Конечный символ имени переменной в строке объявления.
    *
    * @return номер конечного символа имени переменной.
    */

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
@@ -27,13 +27,29 @@ import com.github._1c_syntax.bsl.parser.description.VariableDescription;
 import org.eclipse.lsp4j.Range;
 
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 
 /**
  * Информация о символе, представляющем собой переменную.
  */
-public interface VariableSymbol extends SourceDefinedSymbol, Exportable, Describable {
+public interface VariableSymbol extends SourceDefinedSymbol, Exportable, Describable, Comparable<VariableSymbol> {
+
+  /**
+   * Естественный порядок переменных, согласованный с {@code equals}: имя →
+   * URI владельца → позиция имени (строка, начальный и конечный символы).
+   * Использует дешёвые {@code int}-аксессоры позиции, а не
+   * {@link #getVariableNameRange()}, который аллоцирует {@code Range}/{@code Position}.
+   * Реализации {@link #compareTo(VariableSymbol)} обязаны делегировать сюда.
+   */
+  Comparator<VariableSymbol> NATURAL_ORDER = Comparator
+    .comparing(VariableSymbol::getName)
+    .thenComparing(variable -> variable.getOwner().getUri())
+    .thenComparingInt(VariableSymbol::getVariableNameLine)
+    .thenComparingInt(VariableSymbol::getVariableNameStartCharacter)
+    .thenComparingInt(VariableSymbol::getVariableNameEndCharacter);
+
   /**
    * @return Вид переменной
    */
@@ -54,6 +70,28 @@ public interface VariableSymbol extends SourceDefinedSymbol, Exportable, Describ
    * @return Диапазон, в котором определено имя переменной.
    */
   Range getVariableNameRange();
+
+  /**
+   * Дешёвый (без аллокации) аксессор строки имени переменной — в отличие от
+   * {@link #getVariableNameRange()}, который создаёт {@code Range}/{@code Position}.
+   *
+   * @return номер строки, в которой определено имя переменной.
+   */
+  int getVariableNameLine();
+
+  /**
+   * Дешёвый (без аллокации) аксессор начального символа имени переменной.
+   *
+   * @return номер начального символа имени переменной.
+   */
+  int getVariableNameStartCharacter();
+
+  /**
+   * Дешёвый (без аллокации) аксессор конечного символа имени переменной.
+   *
+   * @return номер конечного символа имени переменной.
+   */
+  int getVariableNameEndCharacter();
 
   @Override
   Optional<VariableDescription> getDescription();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/VariableSymbol.java
@@ -37,16 +37,15 @@ import java.util.Optional;
 public interface VariableSymbol extends SourceDefinedSymbol, Exportable, Describable, Comparable<VariableSymbol> {
 
   /**
-   * Естественный порядок переменных, согласованный с {@code equals}: имя →
-   * URI владельца → позиция имени (строка, начальный и конечный символы).
-   * Реализации {@link #compareTo(VariableSymbol)} обязаны делегировать сюда.
+   * Естественный порядок переменных: имя → URI владельца → позиция начала имени
+   * (строка, символ). Старт имени уникален в пределах документа, поэтому этого
+   * достаточно для строгого порядка.
    */
   Comparator<VariableSymbol> NATURAL_ORDER = Comparator
     .comparing(VariableSymbol::getName)
     .thenComparing(variable -> variable.getOwner().getUri())
     .thenComparingInt(VariableSymbol::getVariableNameLine)
-    .thenComparingInt(VariableSymbol::getVariableNameStartCharacter)
-    .thenComparingInt(VariableSymbol::getVariableNameEndCharacter);
+    .thenComparingInt(VariableSymbol::getVariableNameStartCharacter);
 
   /**
    * @return Вид переменной
@@ -100,5 +99,10 @@ public interface VariableSymbol extends SourceDefinedSymbol, Exportable, Describ
 
   static AbstractVariableSymbol.Builder builder() {
     return AbstractVariableSymbol.builder();
+  }
+
+  @Override
+  default int compareTo(VariableSymbol other) {
+    return NATURAL_ORDER.compare(this, other);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/AbstractDocumentLifecycleClearableIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/AbstractDocumentLifecycleClearableIndex.java
@@ -1,0 +1,76 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.index;
+
+import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import org.springframework.context.event.EventListener;
+
+import java.net.URI;
+
+/**
+ * База для per-URI индексов, чьи записи привязаны к одному документу и должны
+ * сбрасываться на событиях его жизненного цикла.
+ * <p>
+ * Содержит общие {@code @EventListener}-обработчики, сбрасывающие индекс по URI на:
+ * <ul>
+ *   <li>изменение содержимого — {@link DocumentContextContentChangedEvent};</li>
+ *   <li>освобождение вторичных данных (batch-анализ выбрасывает AST после каждого
+ *       файла) — {@link ServerContextDocumentClearedEvent};</li>
+ *   <li>закрытие документа — {@link ServerContextDocumentClosedEvent};</li>
+ *   <li>удаление документа/файла — {@link ServerContextDocumentRemovedEvent}.</li>
+ * </ul>
+ * Spring наследует {@code @EventListener} в конкретных подклассах-бинах, поэтому
+ * наследникам достаточно реализовать {@link #clear(URI)}. Сама база бином не
+ * является.
+ */
+abstract class AbstractDocumentLifecycleClearableIndex {
+
+  /**
+   * Удалить записи индекса, относящиеся к данному URI документа.
+   *
+   * @param uri URI документа.
+   */
+  public abstract void clear(URI uri);
+
+  @EventListener
+  public void handleContentChanged(DocumentContextContentChangedEvent event) {
+    clear(event.getSource().getUri());
+  }
+
+  @EventListener
+  public void handleDataCleared(ServerContextDocumentClearedEvent event) {
+    clear(event.getDocumentContext().getUri());
+  }
+
+  @EventListener
+  public void handleDocumentClosed(ServerContextDocumentClosedEvent event) {
+    clear(event.getDocumentContext().getUri());
+  }
+
+  @EventListener
+  public void handleDocumentRemoved(ServerContextDocumentRemovedEvent event) {
+    clear(event.getUri());
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndex.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.types.index;
 
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
@@ -52,8 +53,10 @@ import java.util.concurrent.ConcurrentHashMap;
  * и поиск становится hash-lookup'ом по имени переменной.
  * <p>
  * Индекс держит AST-узлы, поэтому инвалидируется per-URI при изменении содержимого
- * ({@link DocumentContextContentChangedEvent}), закрытии
- * ({@link ServerContextDocumentClosedEvent}) и удалении
+ * ({@link DocumentContextContentChangedEvent}), освобождении вторичных данных
+ * ({@link ServerContextDocumentClearedEvent} — так batch-анализ выбрасывает AST после
+ * каждого файла, иначе индекс удерживал бы разобранные деревья всех файлов на весь
+ * прогон), закрытии ({@link ServerContextDocumentClosedEvent}) и удалении
  * ({@link ServerContextDocumentRemovedEvent}) документа. Строится лениво.
  */
 @Component
@@ -72,6 +75,11 @@ public class CallStatementByReceiverIndex {
    * @return callStatement'ы с таким ресивером.
    */
   public List<BSLParser.CallStatementContext> byReceiver(URI uri, BSLParser.FileContext ast, String receiverName) {
+    // Гонка clear<->computeIfAbsent осознанно не закрывается: если документ
+    // инвалидируется ровно между clear и завершением build, в карте может осесть
+    // индекс по предыдущему AST. Следующая инвалидация его уберёт, а инференс читает
+    // свежий AST явно — устаревший индекс лишь продлевает жизнь старым узлам до
+    // следующего события (та же модель «без кросс-документной инвалидации»).
     var index = byUri.computeIfAbsent(uri, k -> build(ast));
     return index.getOrDefault(receiverName.toLowerCase(Locale.ROOT), List.of());
   }
@@ -99,6 +107,11 @@ public class CallStatementByReceiverIndex {
   @EventListener
   public void handleContentChanged(DocumentContextContentChangedEvent event) {
     clear(event.getSource().getUri());
+  }
+
+  @EventListener
+  public void handleDataCleared(ServerContextDocumentClearedEvent event) {
+    clear(event.getDocumentContext().getUri());
   }
 
   @EventListener

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndex.java
@@ -1,0 +1,113 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.index;
+
+import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
+import com.github._1c_syntax.bsl.languageserver.utils.Trees;
+import com.github._1c_syntax.bsl.parser.BSLParser;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Locale;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Индекс callStatement'ов документа по базовому идентификатору-ресиверу, разрезанный
+ * по URI.
+ * <p>
+ * Накопление полей структур ({@code X.Вставить(...)}) и колонок таблиц значений
+ * ({@code X.Колонки.Добавить(...)}) в {@code ExpressionTypeInferencer} ищет mutation-
+ * вызовы для конкретной переменной. Раньше это был полный скан AST модуля
+ * ({@code findAllRuleNodes(RULE_callStatement)}) на каждую такую переменную. Индекс
+ * строит карту {@code базовый идентификатор → callStatement'ы} один раз на документ,
+ * и поиск становится hash-lookup'ом по имени переменной.
+ * <p>
+ * Индекс держит AST-узлы, поэтому инвалидируется per-URI при изменении содержимого
+ * ({@link DocumentContextContentChangedEvent}), закрытии
+ * ({@link ServerContextDocumentClosedEvent}) и удалении
+ * ({@link ServerContextDocumentRemovedEvent}) документа. Строится лениво.
+ */
+@Component
+@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class CallStatementByReceiverIndex {
+
+  private final Map<URI, Map<String, List<BSLParser.CallStatementContext>>> byUri = new ConcurrentHashMap<>();
+
+  /**
+   * callStatement'ы документа, базовый идентификатор которых равен {@code receiverName}
+   * (без учёта регистра). Пустой список, если таких нет.
+   *
+   * @param uri          URI документа.
+   * @param ast          корень AST документа (для ленивого построения индекса).
+   * @param receiverName имя ресивера (базового идентификатора цепочки).
+   * @return callStatement'ы с таким ресивером.
+   */
+  public List<BSLParser.CallStatementContext> byReceiver(URI uri, BSLParser.FileContext ast, String receiverName) {
+    var index = byUri.computeIfAbsent(uri, k -> build(ast));
+    return index.getOrDefault(receiverName.toLowerCase(Locale.ROOT), List.of());
+  }
+
+  private static Map<String, List<BSLParser.CallStatementContext>> build(BSLParser.FileContext ast) {
+    var index = new HashMap<String, List<BSLParser.CallStatementContext>>();
+    for (var call : Trees.<BSLParser.CallStatementContext>findAllRuleNodes(ast, BSLParser.RULE_callStatement)) {
+      var identifier = call.IDENTIFIER();
+      if (identifier != null) {
+        index.computeIfAbsent(identifier.getText().toLowerCase(Locale.ROOT), k -> new ArrayList<>()).add(call);
+      }
+    }
+    return index;
+  }
+
+  /**
+   * Удалить индекс по URI документа.
+   *
+   * @param uri URI документа.
+   */
+  public void clear(URI uri) {
+    byUri.remove(uri);
+  }
+
+  @EventListener
+  public void handleContentChanged(DocumentContextContentChangedEvent event) {
+    clear(event.getSource().getUri());
+  }
+
+  @EventListener
+  public void handleDocumentClosed(ServerContextDocumentClosedEvent event) {
+    clear(event.getDocumentContext().getUri());
+  }
+
+  @EventListener
+  public void handleDocumentRemoved(ServerContextDocumentRemovedEvent event) {
+    clear(event.getUri());
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndex.java
@@ -21,16 +21,11 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.index;
 
-import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
-import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
-import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
-import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -52,16 +47,16 @@ import java.util.concurrent.ConcurrentHashMap;
  * строит карту {@code базовый идентификатор → callStatement'ы} один раз на документ,
  * и поиск становится hash-lookup'ом по имени переменной.
  * <p>
- * Индекс держит AST-узлы, поэтому инвалидируется per-URI при изменении содержимого
- * ({@link DocumentContextContentChangedEvent}), освобождении вторичных данных
- * ({@link ServerContextDocumentClearedEvent} — так batch-анализ выбрасывает AST после
- * каждого файла, иначе индекс удерживал бы разобранные деревья всех файлов на весь
- * прогон), закрытии ({@link ServerContextDocumentClosedEvent}) и удалении
- * ({@link ServerContextDocumentRemovedEvent}) документа. Строится лениво.
+ * Индекс держит AST-узлы, поэтому инвалидируется per-URI на событиях жизненного
+ * цикла документа через {@link AbstractDocumentLifecycleClearableIndex} (изменение
+ * содержимого / освобождение вторичных данных / закрытие / удаление). Освобождение
+ * вторичных данных особенно важно: так batch-анализ выбрасывает AST после каждого
+ * файла, иначе индекс удерживал бы разобранные деревья всех файлов на весь прогон.
+ * Строится лениво.
  */
 @Component
 @Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
-public class CallStatementByReceiverIndex {
+public class CallStatementByReceiverIndex extends AbstractDocumentLifecycleClearableIndex {
 
   private final Map<URI, Map<String, List<BSLParser.CallStatementContext>>> byUri = new ConcurrentHashMap<>();
 
@@ -100,27 +95,8 @@ public class CallStatementByReceiverIndex {
    *
    * @param uri URI документа.
    */
+  @Override
   public void clear(URI uri) {
     byUri.remove(uri);
-  }
-
-  @EventListener
-  public void handleContentChanged(DocumentContextContentChangedEvent event) {
-    clear(event.getSource().getUri());
-  }
-
-  @EventListener
-  public void handleDataCleared(ServerContextDocumentClearedEvent event) {
-    clear(event.getDocumentContext().getUri());
-  }
-
-  @EventListener
-  public void handleDocumentClosed(ServerContextDocumentClosedEvent event) {
-    clear(event.getDocumentContext().getUri());
-  }
-
-  @EventListener
-  public void handleDocumentRemoved(ServerContextDocumentRemovedEvent event) {
-    clear(event.getUri());
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndex.java
@@ -1,0 +1,120 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.index;
+
+import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import org.jspecify.annotations.Nullable;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.context.event.EventListener;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.Map;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Кэш выведенных типов переменных, разрезанный по URI документа.
+ * <p>
+ * Заполняется <b>лениво</b> из {@code ExpressionTypeInferencer.inferVariable}:
+ * выведенный тип переменной мемоизируется, чтобы повторные обращения к ней
+ * (на каждый член-доступ {@code Переменная.X} в документе) не переинферивались
+ * с нуля. Без него полный проход семантических токенов по большому модулю
+ * пересчитывает тип одного и того же ресивера сотни раз.
+ * <p>
+ * <b>Только инвалидация, никакого жадного наполнения:</b> на старте
+ * {@code populateContext} пересобирает все документы, и AOP шлёт
+ * {@link DocumentContextContentChangedEvent} на каждый из них — обработчик лишь
+ * чистит соответствующий URI (дешёвый no-op по пустому бакету), но не наполняет
+ * кэш. Реальное наполнение происходит только при настоящих запросах инференса
+ * (семантические токены / hover / диагностики по активным документам).
+ * <p>
+ * Ключ — сам {@link VariableSymbol}: его equals включает имя + документ +
+ * позицию имени, поэтому одноимённые переменные из разных областей видимости —
+ * разные ключи (коллизий по scope нет).
+ * <p>
+ * Инвалидация — per-URI: на изменение, закрытие или удаление документа удаляется
+ * весь бакет этого URI. Кросс-документные зависимости типа (тип переменной зависит
+ * от метода чужого модуля) при правке чужого модуля не сбрасываются — это та же
+ * модель, что у {@link SymbolTypeIndex}.
+ */
+@Component
+@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+public class InferredVariableTypeIndex {
+
+  private final Map<URI, Map<VariableSymbol, TypeSet>> typesByUri = new ConcurrentHashMap<>();
+
+  /**
+   * Кэшированный тип переменной либо {@code null}, если ещё не вычислялся.
+   *
+   * @param variable переменная.
+   * @return выведенный тип или {@code null} при промахе кэша.
+   */
+  @Nullable
+  public TypeSet get(VariableSymbol variable) {
+    var byVariable = typesByUri.get(uriOf(variable));
+    return byVariable == null ? null : byVariable.get(variable);
+  }
+
+  /**
+   * Запомнить выведенный тип переменной.
+   *
+   * @param variable переменная.
+   * @param types    выведенный тип.
+   */
+  public void put(VariableSymbol variable, TypeSet types) {
+    typesByUri.computeIfAbsent(uriOf(variable), k -> new ConcurrentHashMap<>()).put(variable, types);
+  }
+
+  /**
+   * Удалить кэш по URI документа.
+   *
+   * @param uri URI документа.
+   */
+  public void clear(URI uri) {
+    typesByUri.remove(uri);
+  }
+
+  @EventListener
+  public void handleContentChanged(DocumentContextContentChangedEvent event) {
+    clear(event.getSource().getUri());
+  }
+
+  @EventListener
+  public void handleDocumentClosed(ServerContextDocumentClosedEvent event) {
+    clear(event.getDocumentContext().getUri());
+  }
+
+  @EventListener
+  public void handleDocumentRemoved(ServerContextDocumentRemovedEvent event) {
+    clear(event.getUri());
+  }
+
+  private static URI uriOf(VariableSymbol variable) {
+    return variable.getOwner().getUri();
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndex.java
@@ -21,17 +21,12 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.index;
 
-import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
-import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
-import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
-import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
-import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -48,26 +43,25 @@ import java.util.concurrent.ConcurrentHashMap;
  * пересчитывает тип одного и того же ресивера сотни раз.
  * <p>
  * <b>Только инвалидация, никакого жадного наполнения:</b> на старте
- * {@code populateContext} пересобирает все документы, и AOP шлёт
- * {@link DocumentContextContentChangedEvent} на каждый из них — обработчик лишь
- * чистит соответствующий URI (дешёвый no-op по пустому бакету), но не наполняет
- * кэш. Реальное наполнение происходит только при настоящих запросах инференса
- * (семантические токены / hover / диагностики по активным документам).
+ * {@code populateContext} пересобирает все документы, и AOP шлёт событие изменения
+ * содержимого на каждый из них — обработчик лишь чистит соответствующий URI
+ * (дешёвый no-op по пустому бакету), но не наполняет кэш. Реальное наполнение
+ * происходит только при настоящих запросах инференса (семантические токены / hover
+ * / диагностики по активным документам).
  * <p>
  * Ключ — сам {@link VariableSymbol}: его equals включает имя + документ +
  * позицию имени, поэтому одноимённые переменные из разных областей видимости —
  * разные ключи (коллизий по scope нет).
  * <p>
- * Инвалидация — per-URI: на изменение, освобождение вторичных данных
- * ({@link ServerContextDocumentClearedEvent} — batch-анализ так выбрасывает документ
- * после каждого файла), закрытие или удаление документа удаляется весь бакет этого
- * URI. Кросс-документные зависимости типа (тип переменной зависит от метода чужого
- * модуля) при правке чужого модуля не сбрасываются — это та же модель, что у
- * {@link SymbolTypeIndex}.
+ * Инвалидация — per-URI через {@link AbstractDocumentLifecycleClearableIndex}
+ * (изменение / очистка вторичных данных / закрытие / удаление документа удаляют
+ * весь бакет этого URI). Кросс-документные зависимости типа (тип переменной зависит
+ * от метода чужого модуля) при правке чужого модуля не сбрасываются — это та же
+ * модель, что у {@link SymbolTypeIndex}.
  */
 @Component
 @Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
-public class InferredVariableTypeIndex {
+public class InferredVariableTypeIndex extends AbstractDocumentLifecycleClearableIndex {
 
   private final Map<URI, Map<VariableSymbol, TypeSet>> typesByUri = new ConcurrentHashMap<>();
 
@@ -98,28 +92,9 @@ public class InferredVariableTypeIndex {
    *
    * @param uri URI документа.
    */
+  @Override
   public void clear(URI uri) {
     typesByUri.remove(uri);
-  }
-
-  @EventListener
-  public void handleContentChanged(DocumentContextContentChangedEvent event) {
-    clear(event.getSource().getUri());
-  }
-
-  @EventListener
-  public void handleDataCleared(ServerContextDocumentClearedEvent event) {
-    clear(event.getDocumentContext().getUri());
-  }
-
-  @EventListener
-  public void handleDocumentClosed(ServerContextDocumentClosedEvent event) {
-    clear(event.getDocumentContext().getUri());
-  }
-
-  @EventListener
-  public void handleDocumentRemoved(ServerContextDocumentRemovedEvent event) {
-    clear(event.getUri());
   }
 
   private static URI uriOf(VariableSymbol variable) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndex.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.types.index;
 
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
@@ -57,10 +58,12 @@ import java.util.concurrent.ConcurrentHashMap;
  * позицию имени, поэтому одноимённые переменные из разных областей видимости —
  * разные ключи (коллизий по scope нет).
  * <p>
- * Инвалидация — per-URI: на изменение, закрытие или удаление документа удаляется
- * весь бакет этого URI. Кросс-документные зависимости типа (тип переменной зависит
- * от метода чужого модуля) при правке чужого модуля не сбрасываются — это та же
- * модель, что у {@link SymbolTypeIndex}.
+ * Инвалидация — per-URI: на изменение, освобождение вторичных данных
+ * ({@link ServerContextDocumentClearedEvent} — batch-анализ так выбрасывает документ
+ * после каждого файла), закрытие или удаление документа удаляется весь бакет этого
+ * URI. Кросс-документные зависимости типа (тип переменной зависит от метода чужого
+ * модуля) при правке чужого модуля не сбрасываются — это та же модель, что у
+ * {@link SymbolTypeIndex}.
  */
 @Component
 @Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
@@ -102,6 +105,11 @@ public class InferredVariableTypeIndex {
   @EventListener
   public void handleContentChanged(DocumentContextContentChangedEvent event) {
     clear(event.getSource().getUri());
+  }
+
+  @EventListener
+  public void handleDataCleared(ServerContextDocumentClearedEvent event) {
+    clear(event.getDocumentContext().getUri());
   }
 
   @EventListener

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -33,6 +33,7 @@ import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver;
 import com.github._1c_syntax.bsl.languageserver.references.model.OccurrenceType;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
+import com.github._1c_syntax.bsl.languageserver.types.index.CallStatementByReceiverIndex;
 import com.github._1c_syntax.bsl.languageserver.types.index.InferredVariableTypeIndex;
 import com.github._1c_syntax.bsl.languageserver.types.index.SymbolTypeIndex;
 import com.github._1c_syntax.bsl.languageserver.types.inferencer.autumn.AutumnComponentInferencer;
@@ -102,6 +103,7 @@ public class ExpressionTypeInferencer {
   private final TypeRegistry typeRegistry;
   private final SymbolTypeIndex symbolTypeIndex;
   private final InferredVariableTypeIndex inferredVariableTypeIndex;
+  private final CallStatementByReceiverIndex callStatementByReceiverIndex;
   private final ReferenceResolver referenceResolver;
   private final ReferenceIndex referenceIndex;
   private final GlobalScopeProvider globalScopeProvider;
@@ -835,10 +837,7 @@ public class ExpressionTypeInferencer {
     var variableName = variable.getName();
 
     var result = base;
-    for (var ruleNode : Trees.findAllRuleNodes(ast, BSLParser.RULE_callStatement)) {
-      if (!(ruleNode instanceof BSLParser.CallStatementContext call)) {
-        continue;
-      }
+    for (var call : callStatementByReceiverIndex.byReceiver(owner.getUri(), ast, variableName)) {
       var name = extractInsertReceiverName(call);
       if (name == null || !name.equalsIgnoreCase(variableName)) {
         continue;
@@ -918,10 +917,7 @@ public class ExpressionTypeInferencer {
     TypeSet rowSet = TypeSet.of(rowRef);
     boolean hasColumns = false;
 
-    for (var ruleNode : Trees.findAllRuleNodes(ast, BSLParser.RULE_callStatement)) {
-      if (!(ruleNode instanceof BSLParser.CallStatementContext call)) {
-        continue;
-      }
+    for (var call : callStatementByReceiverIndex.byReceiver(owner.getUri(), ast, variableName)) {
       var name = extractColumnsAddReceiverName(call);
       if (name == null || !name.equalsIgnoreCase(variableName)) {
         continue;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -33,6 +33,7 @@ import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver;
 import com.github._1c_syntax.bsl.languageserver.references.model.OccurrenceType;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
+import com.github._1c_syntax.bsl.languageserver.types.index.InferredVariableTypeIndex;
 import com.github._1c_syntax.bsl.languageserver.types.index.SymbolTypeIndex;
 import com.github._1c_syntax.bsl.languageserver.types.inferencer.autumn.AutumnComponentInferencer;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
@@ -100,6 +101,7 @@ public class ExpressionTypeInferencer {
 
   private final TypeRegistry typeRegistry;
   private final SymbolTypeIndex symbolTypeIndex;
+  private final InferredVariableTypeIndex inferredVariableTypeIndex;
   private final ReferenceResolver referenceResolver;
   private final ReferenceIndex referenceIndex;
   private final GlobalScopeProvider globalScopeProvider;
@@ -738,6 +740,11 @@ public class ExpressionTypeInferencer {
    * (секция {@code // Параметры:}).
    */
   private TypeSet inferVariable(VariableSymbol variable, InferenceContext ctx) {
+    var cached = inferredVariableTypeIndex.get(variable);
+    if (cached != null) {
+      return cached;
+    }
+
     var owner = variable.getOwner();
     TypeSet acc = TypeSet.EMPTY;
     Set<Position> visitedPositions = new HashSet<>();
@@ -765,6 +772,16 @@ public class ExpressionTypeInferencer {
     acc = attachDefaultElementTypes(acc);
     acc = accumulateStructureInsertFields(variable, acc, ctx);
     acc = accumulateValueTableColumnFields(variable, acc, ctx);
+
+    // Кэшируем только «чистый корень» инференса (visited содержит максимум саму
+    // переменную). Вложенный вызов (внутри инференса другой переменной, visited
+    // ≥ 2) мог быть усечён цикл-гардом и зависит от порядка обхода — его результат
+    // некорректно переиспользовать как самостоятельный. Перф от этого не страдает:
+    // горячий путь (ресивер member-доступа) — всегда корень, а вложенные выводы
+    // и так покрыты кэшем своего корня.
+    if (ctx.visited.size() <= 1) {
+      inferredVariableTypeIndex.put(variable, acc);
+    }
     return acc;
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -62,6 +62,7 @@ import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
@@ -71,9 +72,11 @@ import java.util.ArrayList;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.Predicate;
 
 /**
  * Ленивый инференсер типов выражений.
@@ -842,42 +845,48 @@ public class ExpressionTypeInferencer {
 
     var result = base;
     for (var call : callStatementByReceiverIndex.byReceiver(owner.getUri(), ast, variableName)) {
-      var name = extractInsertReceiverName(call);
-      if (name == null || !name.equalsIgnoreCase(variableName)) {
-        continue;
-      }
-      if (scopeRange != null && !Ranges.containsRange(scopeRange, Ranges.create(call))) {
-        continue;
-      }
-      var methodCall = call.accessCall() == null ? null : call.accessCall().methodCall();
-      if (methodCall == null || !isInsertMethodName(methodCall)) {
-        continue;
-      }
-      var paramList = methodCall.doCall() == null ? null : methodCall.doCall().callParamList();
-      if (paramList == null) {
-        continue;
-      }
-      var params = paramList.callParam();
-      if (params.size() < 1) {
-        continue;
-      }
-      var keyExpr = params.get(0).expression();
-      var keyName = extractStringLiteralText(keyExpr);
-      if (keyName == null || keyName.isBlank()) {
-        continue;
-      }
-      TypeSet valueTypes;
-      if (params.size() >= 2 && params.get(1).expression() != null) {
-        var valueExpr = ExpressionTreeBuildingVisitor.buildExpressionTree(params.get(1).expression());
-        valueTypes = valueExpr == null ? TypeSet.EMPTY : inferInternal(valueExpr, ctx);
-      } else {
-        valueTypes = TypeSet.of(UNDEFINED);
-      }
-      if (!valueTypes.isEmpty()) {
-        result = result.withField(headRef, keyName.trim(), valueTypes);
+      var field = insertedStructureField(call, variableName, scopeRange, ctx);
+      if (field != null && !field.types().isEmpty()) {
+        result = result.withField(headRef, field.name(), field.types());
       }
     }
     return result;
+  }
+
+  /**
+   * Поле структуры/соответствия, добавляемое вызовом {@code X.Вставить("Ключ", Значение)}
+   * для нужного ресивера в области видимости, либо {@code null}, если вызов не подходит.
+   *
+   * @param call         разбираемый callStatement.
+   * @param variableName имя переменной-ресивера.
+   * @param scopeRange   диапазон области видимости переменной (или {@code null}).
+   * @param ctx          контекст инференса для вывода типа значения.
+   * @return добавляемое поле (имя + типы значения) либо {@code null}.
+   */
+  @Nullable
+  private KeyedTypes insertedStructureField(
+    BSLParser.CallStatementContext call,
+    String variableName,
+    @Nullable Range scopeRange,
+    InferenceContext ctx
+  ) {
+    var params = mutationCallParams(
+      call, variableName, scopeRange, extractInsertReceiverName(call), ExpressionTypeInferencer::isInsertMethodName);
+    if (params == null) {
+      return null;
+    }
+    var keyName = extractStringLiteralText(params.get(0).expression());
+    if (keyName == null || keyName.isBlank()) {
+      return null;
+    }
+    TypeSet valueTypes;
+    if (params.size() >= 2 && params.get(1).expression() != null) {
+      var valueExpr = ExpressionTreeBuildingVisitor.buildExpressionTree(params.get(1).expression());
+      valueTypes = valueExpr == null ? TypeSet.EMPTY : inferInternal(valueExpr, ctx);
+    } else {
+      valueTypes = TypeSet.of(UNDEFINED);
+    }
+    return new KeyedTypes(keyName.trim(), valueTypes);
   }
 
   /**
@@ -922,49 +931,97 @@ public class ExpressionTypeInferencer {
     boolean hasColumns = false;
 
     for (var call : callStatementByReceiverIndex.byReceiver(owner.getUri(), ast, variableName)) {
-      var name = extractColumnsAddReceiverName(call);
-      if (name == null || !name.equalsIgnoreCase(variableName)) {
-        continue;
+      var column = addedColumn(call, variableName, scopeRange, ctx);
+      if (column != null) {
+        rowSet = rowSet.withField(rowRef, column.name(), column.types());
+        hasColumns = true;
       }
-      if (scopeRange != null && !Ranges.containsRange(scopeRange, Ranges.create(call))) {
-        continue;
-      }
-      var methodCall = call.accessCall() == null ? null : call.accessCall().methodCall();
-      if (methodCall == null || !isAddMethodName(methodCall)) {
-        continue;
-      }
-      var paramList = methodCall.doCall() == null ? null : methodCall.doCall().callParamList();
-      if (paramList == null) {
-        continue;
-      }
-      var params = paramList.callParam();
-      if (params.isEmpty()) {
-        continue;
-      }
-      var keyExpr = params.get(0).expression();
-      var keyName = extractStringLiteralText(keyExpr);
-      if (keyName == null || keyName.isBlank()) {
-        continue;
-      }
-      // Второй аргумент по сигнатуре платформы — объект ОписаниеТипов. Выводим тип выражения
-      // через инференсер; если в нём есть ОписаниеТипов-ref, забираем его elementTypes
-      // (туда {@link #applyTypeDescriptionConstructorTypes} складывает имена типов из
-      // первого аргумента конструктора). Любое другое выражение (Тип(...), строковый
-      // литерал, переменная иного типа) даст пустой набор — колонка останется Неопределено.
-      TypeSet columnTypes = TypeSet.EMPTY;
-      if (params.size() >= 2) {
-        columnTypes = extractColumnTypes(params.get(1).expression(), ctx);
-      }
-      if (columnTypes.isEmpty()) {
-        columnTypes = TypeSet.of(UNDEFINED);
-      }
-      rowSet = rowSet.withField(rowRef, keyName.trim(), columnTypes);
-      hasColumns = true;
     }
     if (!hasColumns) {
       return base;
     }
     return base.withElement(headRef, rowSet);
+  }
+
+  /**
+   * Колонка таблицы значений, добавляемая вызовом {@code X.Колонки.Добавить("Имя", Тип)}
+   * для нужного ресивера в области видимости, либо {@code null}, если вызов не подходит.
+   *
+   * @param call         разбираемый callStatement.
+   * @param variableName имя переменной-ресивера.
+   * @param scopeRange   диапазон области видимости переменной (или {@code null}).
+   * @param ctx          контекст инференса для вывода типов колонки.
+   * @return добавляемая колонка (имя + типы) либо {@code null}.
+   */
+  @Nullable
+  private KeyedTypes addedColumn(
+    BSLParser.CallStatementContext call,
+    String variableName,
+    @Nullable Range scopeRange,
+    InferenceContext ctx
+  ) {
+    var params = mutationCallParams(
+      call, variableName, scopeRange, extractColumnsAddReceiverName(call), ExpressionTypeInferencer::isAddMethodName);
+    if (params == null) {
+      return null;
+    }
+    var keyName = extractStringLiteralText(params.get(0).expression());
+    if (keyName == null || keyName.isBlank()) {
+      return null;
+    }
+    // Второй аргумент по сигнатуре платформы — объект ОписаниеТипов. Выводим тип выражения
+    // через инференсер; если в нём есть ОписаниеТипов-ref, забираем его elementTypes
+    // (туда applyTypeDescriptionConstructorTypes складывает имена типов из первого аргумента
+    // конструктора). Любое другое выражение даст пустой набор — колонка останется Неопределено.
+    var columnTypes = params.size() >= 2 ? extractColumnTypes(params.get(1).expression(), ctx) : TypeSet.EMPTY;
+    return new KeyedTypes(keyName.trim(), columnTypes.isEmpty() ? TypeSet.of(UNDEFINED) : columnTypes);
+  }
+
+  /**
+   * Параметры mutation-вызова {@code X.Метод(...)}, если его базовый идентификатор совпадает
+   * с {@code receiverName}, вызов попадает в область видимости и его метод проходит предикат.
+   * Общий guard-префикс для {@link #insertedStructureField} и {@link #addedColumn}.
+   *
+   * @param call           разбираемый callStatement.
+   * @param receiverName   имя переменной-ресивера.
+   * @param scopeRange     диапазон области видимости (или {@code null} — без проверки).
+   * @param actualReceiver фактический базовый идентификатор вызова (или {@code null}).
+   * @param methodMatches  предикат на имя вызываемого метода.
+   * @return непустой список параметров вызова либо {@code null}, если вызов не подходит.
+   */
+  @Nullable
+  private static List<? extends BSLParser.CallParamContext> mutationCallParams(
+    BSLParser.CallStatementContext call,
+    String receiverName,
+    @Nullable Range scopeRange,
+    @Nullable String actualReceiver,
+    Predicate<BSLParser.MethodCallContext> methodMatches
+  ) {
+    if (actualReceiver == null || !actualReceiver.equalsIgnoreCase(receiverName)) {
+      return null;
+    }
+    if (scopeRange != null && !Ranges.containsRange(scopeRange, Ranges.create(call))) {
+      return null;
+    }
+    var methodCall = call.accessCall() == null ? null : call.accessCall().methodCall();
+    if (methodCall == null || !methodMatches.test(methodCall)) {
+      return null;
+    }
+    var paramList = methodCall.doCall() == null ? null : methodCall.doCall().callParamList();
+    if (paramList == null) {
+      return null;
+    }
+    var params = paramList.callParam();
+    return params.isEmpty() ? null : params;
+  }
+
+  /**
+   * Имя и типы поля/колонки, накапливаемых из mutation-вызова.
+   *
+   * @param name  имя ключа/колонки.
+   * @param types типы значения/колонки.
+   */
+  private record KeyedTypes(String name, TypeSet types) {
   }
 
   private static boolean isValueTableLike(String typeName) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -742,6 +742,10 @@ public class ExpressionTypeInferencer {
    * (секция {@code // Параметры:}).
    */
   private TypeSet inferVariable(VariableSymbol variable, InferenceContext ctx) {
+    // Кэш ключуется только по VariableSymbol, без fileType. Это корректно, потому что
+    // fileType документа детерминирован самой переменной (variable.getOwner().getFileType()),
+    // а inferSymbol всегда заводит ctx.documentContext == variable.getOwner() — то есть
+    // одна и та же переменная не инферится в двух разных fileType-контекстах.
     var cached = inferredVariableTypeIndex.get(variable);
     if (cached != null) {
       return cached;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
+import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
@@ -47,6 +48,7 @@ import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -60,6 +62,7 @@ import java.util.Map;
 import java.util.LinkedHashSet;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 /**
@@ -96,6 +99,24 @@ public class TypeRegistry {
   private final Map<TypeRef, Type> types = new ConcurrentHashMap<>();
   /** Тип ↔ список источников членов (один тип может расширяться многими источниками). */
   private final Map<TypeRef, List<ScopedMemberSource>> memberSources = new ConcurrentHashMap<>();
+
+  /**
+   * Мемоизация {@link #getMembers(TypeRef, FileType)}. Сборка членов
+   * (особенно переспециализация config/generic-типов) дорогая, а на горячем
+   * пути (семантические токены, completion) повторяется для одного типа тысячи
+   * раз. Инвалидация — через {@link #membersEpoch}: любая мутация
+   * {@link #memberSources} (register/unregister) бампает счётчик, и устаревшие
+   * записи пересобираются при следующем обращении. В steady-state (во время
+   * запроса, без регистраций) memo стабилен.
+   */
+  private final AtomicLong membersEpoch = new AtomicLong();
+  private final Map<MembersKey, CachedMembers> membersCache = new ConcurrentHashMap<>();
+
+  private record MembersKey(TypeRef ref, FileType fileType) {
+  }
+
+  private record CachedMembers(long epoch, List<MemberDescriptor> members) {
+  }
   /** Тип ↔ языковой скоуп (BSL/OS/BOTH). Отсутствие записи трактуется как BOTH. */
   private final Map<TypeRef, LanguageScope> typeScopes = new ConcurrentHashMap<>();
   /** Тип ↔ список описаний с их скоупом. В одном типе разные описания для BSL/OS допускаются. */
@@ -318,7 +339,19 @@ public class TypeRegistry {
    * резолвим по {@link #aliasIndex} по {@code qualifiedName} и пробуем
    * каноничный {@link TypeRef}.
    */
-  public Collection<MemberDescriptor> getMembers(TypeRef ref, com.github._1c_syntax.bsl.languageserver.context.FileType fileType) {
+  public Collection<MemberDescriptor> getMembers(TypeRef ref, FileType fileType) {
+    var epoch = membersEpoch.get();
+    var key = new MembersKey(ref, fileType);
+    var cached = membersCache.get(key);
+    if (cached != null && cached.epoch() == epoch) {
+      return cached.members();
+    }
+    var members = computeMembers(ref, fileType);
+    membersCache.put(key, new CachedMembers(epoch, members));
+    return members;
+  }
+
+  private List<MemberDescriptor> computeMembers(TypeRef ref, FileType fileType) {
     var sources = memberSources.get(ref);
     if ((sources == null || sources.isEmpty()) && ref != null) {
       var canonical = aliasIndex.get(ref.qualifiedName().toLowerCase(Locale.ROOT));
@@ -327,7 +360,7 @@ public class TypeRegistry {
       }
     }
     if (sources == null || sources.isEmpty()) {
-      return Collections.emptyList();
+      return List.of();
     }
     var byName = new LinkedHashMap<String, MemberDescriptor>();
     for (var scoped : sources) {
@@ -338,7 +371,20 @@ public class TypeRegistry {
         byName.putIfAbsent(member.name().toLowerCase(Locale.ROOT), member);
       }
     }
-    return new ArrayList<>(byName.values());
+    // Неизменяемый список: память шарится между вызовами, случайная мутация
+    // упадёт сразу (все потребители только итерируют).
+    return List.copyOf(byName.values());
+  }
+
+  /**
+   * Сбросить memo {@link #getMembers}. Member-source'ы конфигурационных модулей и
+   * OScript-библиотек лениво читают символьное дерево документа и меняют вывод при
+   * правке без ре-регистрации источника — поэтому при любом изменении содержимого
+   * документа memo надо инвалидировать.
+   */
+  @EventListener
+  public void invalidateMembersCache(DocumentContextContentChangedEvent event) {
+    membersEpoch.incrementAndGet();
   }
 
   /**
@@ -359,6 +405,7 @@ public class TypeRegistry {
     var effective = scope;
     memberSources.computeIfAbsent(ref, k -> Collections.synchronizedList(new ArrayList<>()))
       .add(new ScopedMemberSource(source, effective));
+    membersEpoch.incrementAndGet();
   }
 
   /**
@@ -760,6 +807,7 @@ public class TypeRegistry {
     var ref = intern(TypeKind.USER, qualifiedName);
     types.remove(ref);
     memberSources.remove(ref);
+    membersEpoch.incrementAndGet();
     typeScopes.remove(ref);
     aliasIndex.remove(qualifiedName.toLowerCase(Locale.ROOT));
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -362,8 +362,15 @@ public class TypeRegistry {
     if (sources == null || sources.isEmpty()) {
       return List.of();
     }
+    // sources — Collections.synchronizedList (см. registerMemberSource): итерация
+    // обязана идти под synchronized на самом списке, иначе возможен CME при
+    // конкурентной регистрации. Снимаем согласованный снимок и итерируем его.
+    List<ScopedMemberSource> snapshot;
+    synchronized (sources) {
+      snapshot = List.copyOf(sources);
+    }
     var byName = new LinkedHashMap<String, MemberDescriptor>();
-    for (var scoped : sources) {
+    for (var scoped : snapshot) {
       if (fileType != null && scoped.scope() != null && !scoped.scope().matches(fileType)) {
         continue;
       }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -369,8 +369,14 @@ public class TypeRegistry {
     if (sources.isEmpty()) {
       return List.of();
     }
+    // sources — Collections.synchronizedList (см. registerMemberSource): снимок под
+    // synchronized на самом списке, иначе при конкурентной регистрации возможен CME.
+    List<ScopedMemberSource> snapshot;
+    synchronized (sources) {
+      snapshot = List.copyOf(sources);
+    }
     var byName = new LinkedHashMap<String, MemberDescriptor>();
-    for (var scoped : snapshotOf(sources)) {
+    for (var scoped : snapshot) {
       if (fileType != null && scoped.scope() != null && !scoped.scope().matches(fileType)) {
         continue;
       }
@@ -398,21 +404,6 @@ public class TypeRegistry {
       }
     }
     return sources == null ? List.of() : sources;
-  }
-
-  /**
-   * Согласованный снимок {@code Collections.synchronizedList} (см.
-   * {@link #registerMemberSource}): итерация по synchronizedList обязана идти под
-   * {@code synchronized} на самом списке, иначе при конкурентной регистрации возможен
-   * {@code ConcurrentModificationException}.
-   *
-   * @param sources список источников членов.
-   * @return неизменяемый снимок, безопасный для итерации.
-   */
-  private static List<ScopedMemberSource> snapshotOf(List<ScopedMemberSource> sources) {
-    synchronized (sources) {
-      return List.copyOf(sources);
-    }
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -54,6 +54,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.HashMap;
@@ -112,7 +113,19 @@ public class TypeRegistry {
   private final AtomicLong membersEpoch = new AtomicLong();
   private final Map<MembersKey, CachedMembers> membersCache = new ConcurrentHashMap<>();
 
-  private record MembersKey(TypeRef ref, FileType fileType) {
+  private record MembersKey(TypeRef ref, FileType fileType) implements Comparable<MembersKey> {
+
+    // fileType штатно бывает null: одноаргументный getMembers(ref) зовёт getMembers(ref, null)
+    // («фильтрация по скоупу не применяется»). ref допускает null защитно (см. computeMembers).
+    // Поэтому естественный порядок ключа — null-safe.
+    private static final Comparator<MembersKey> NATURAL_ORDER = Comparator
+      .comparing(MembersKey::ref, Comparator.nullsFirst(Comparator.naturalOrder()))
+      .thenComparing(MembersKey::fileType, Comparator.nullsFirst(Comparator.naturalOrder()));
+
+    @Override
+    public int compareTo(MembersKey other) {
+      return NATURAL_ORDER.compare(this, other);
+    }
   }
 
   private record CachedMembers(long epoch, List<MemberDescriptor> members) {
@@ -352,25 +365,12 @@ public class TypeRegistry {
   }
 
   private List<MemberDescriptor> computeMembers(TypeRef ref, FileType fileType) {
-    var sources = memberSources.get(ref);
-    if ((sources == null || sources.isEmpty()) && ref != null) {
-      var canonical = aliasIndex.get(ref.qualifiedName().toLowerCase(Locale.ROOT));
-      if (canonical != null && !canonical.equals(ref)) {
-        sources = memberSources.get(canonical);
-      }
-    }
-    if (sources == null || sources.isEmpty()) {
+    var sources = resolveMemberSources(ref);
+    if (sources.isEmpty()) {
       return List.of();
     }
-    // sources — Collections.synchronizedList (см. registerMemberSource): итерация
-    // обязана идти под synchronized на самом списке, иначе возможен CME при
-    // конкурентной регистрации. Снимаем согласованный снимок и итерируем его.
-    List<ScopedMemberSource> snapshot;
-    synchronized (sources) {
-      snapshot = List.copyOf(sources);
-    }
     var byName = new LinkedHashMap<String, MemberDescriptor>();
-    for (var scoped : snapshot) {
+    for (var scoped : snapshotOf(sources)) {
       if (fileType != null && scoped.scope() != null && !scoped.scope().matches(fileType)) {
         continue;
       }
@@ -381,6 +381,38 @@ public class TypeRegistry {
     // Неизменяемый список: память шарится между вызовами, случайная мутация
     // упадёт сразу (все потребители только итерируют).
     return List.copyOf(byName.values());
+  }
+
+  /**
+   * Источники членов типа с fallback на канонический псевдоним.
+   *
+   * @param ref тип, для которого ищутся источники членов.
+   * @return список источников; пустой, если их нет.
+   */
+  private List<ScopedMemberSource> resolveMemberSources(TypeRef ref) {
+    var sources = memberSources.get(ref);
+    if ((sources == null || sources.isEmpty()) && ref != null) {
+      var canonical = aliasIndex.get(ref.qualifiedName().toLowerCase(Locale.ROOT));
+      if (canonical != null && !canonical.equals(ref)) {
+        sources = memberSources.get(canonical);
+      }
+    }
+    return sources == null ? List.of() : sources;
+  }
+
+  /**
+   * Согласованный снимок {@code Collections.synchronizedList} (см.
+   * {@link #registerMemberSource}): итерация по synchronizedList обязана идти под
+   * {@code synchronized} на самом списке, иначе при конкурентной регистрации возможен
+   * {@code ConcurrentModificationException}.
+   *
+   * @param sources список источников членов.
+   * @return неизменяемый снимок, безопасный для итерации.
+   */
+  private static List<ScopedMemberSource> snapshotOf(List<ScopedMemberSource> sources) {
+    synchronized (sources) {
+      return List.copyOf(sources);
+    }
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndexTest.java
@@ -1,0 +1,73 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.index;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class CallStatementByReceiverIndexTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private CallStatementByReceiverIndex index;
+
+  @Autowired
+  private ApplicationEventPublisher eventPublisher;
+
+  @Test
+  void groupsCallStatementsByReceiverAndClearsOnEvents() {
+    // given — callStatement'ы с разными базовыми идентификаторами.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Тест()
+          ТЗ.Колонки.Добавить("Имя");
+          Стр.Вставить("Ключ", 1);
+          Сообщить("без базового идентификатора");
+      КонецПроцедуры
+      """);
+    var ast = documentContext.getAst();
+    var uri = documentContext.getUri();
+    var serverContext = documentContext.getServerContext();
+
+    // then — группировка по базовому идентификатору.
+    assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(1);
+    assertThat(index.byReceiver(uri, ast, "СТР")).as("без учёта регистра").hasSize(1);
+    assertThat(index.byReceiver(uri, ast, "Нет")).isEmpty();
+
+    // when/then — каждое из 3 событий чистит индекс по URI; после него
+    // индекс пересобирается с тем же результатом.
+    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
+    assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(1);
+
+    eventPublisher.publishEvent(new ServerContextDocumentClosedEvent(serverContext, documentContext));
+    assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(1);
+
+    eventPublisher.publishEvent(new ServerContextDocumentRemovedEvent(serverContext, uri));
+    assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(1);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndexTest.java
@@ -23,12 +23,16 @@ package com.github._1c_syntax.bsl.languageserver.types.index;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.parser.BSLParser;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+
+import java.net.URI;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -55,19 +59,26 @@ class CallStatementByReceiverIndexTest extends AbstractServerContextAwareTest {
     var serverContext = documentContext.getServerContext();
 
     // then — группировка по базовому идентификатору.
+    assertAllReceivers(uri, ast);
+
+    // when/then — каждое из 4 событий чистит индекс по URI; после него
+    // индекс пересобирается целиком (проверяем все ресиверы, не один ключ).
+    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
+    assertAllReceivers(uri, ast);
+
+    eventPublisher.publishEvent(new ServerContextDocumentClearedEvent(serverContext, documentContext));
+    assertAllReceivers(uri, ast);
+
+    eventPublisher.publishEvent(new ServerContextDocumentClosedEvent(serverContext, documentContext));
+    assertAllReceivers(uri, ast);
+
+    eventPublisher.publishEvent(new ServerContextDocumentRemovedEvent(serverContext, uri));
+    assertAllReceivers(uri, ast);
+  }
+
+  private void assertAllReceivers(URI uri, BSLParser.FileContext ast) {
     assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(1);
     assertThat(index.byReceiver(uri, ast, "СТР")).as("без учёта регистра").hasSize(1);
     assertThat(index.byReceiver(uri, ast, "Нет")).isEmpty();
-
-    // when/then — каждое из 3 событий чистит индекс по URI; после него
-    // индекс пересобирается с тем же результатом.
-    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
-    assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(1);
-
-    eventPublisher.publishEvent(new ServerContextDocumentClosedEvent(serverContext, documentContext));
-    assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(1);
-
-    eventPublisher.publishEvent(new ServerContextDocumentRemovedEvent(serverContext, uri));
-    assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(1);
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndexTest.java
@@ -76,6 +76,22 @@ class CallStatementByReceiverIndexTest extends AbstractServerContextAwareTest {
     assertAllReceivers(uri, ast);
   }
 
+  @Test
+  void aggregatesMultipleCallsForSameReceiver() {
+    // given — два callStatement'а с одним базовым идентификатором ТЗ.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Тест()
+          ТЗ.Колонки.Добавить("Имя");
+          ТЗ.Очистить();
+      КонецПроцедуры
+      """);
+    var ast = documentContext.getAst();
+    var uri = documentContext.getUri();
+
+    // then — оба вызова сгруппированы под одним ресивером.
+    assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(2);
+  }
+
   private void assertAllReceivers(URI uri, BSLParser.FileContext ast) {
     assertThat(index.byReceiver(uri, ast, "ТЗ")).hasSize(1);
     assertThat(index.byReceiver(uri, ast, "СТР")).as("без учёта регистра").hasSize(1);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndexTest.java
@@ -29,6 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocu
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -65,7 +66,7 @@ class InferredVariableTypeIndexTest extends AbstractServerContextAwareTest {
 
     // after inferSymbol — тип выведен и закэширован.
     var types = inferencer.inferSymbol(variable);
-    assertThat(types.refs()).extracting(ref -> ref.qualifiedName()).contains("ТаблицаЗначений");
+    assertThat(types.refs()).extracting(TypeRef::qualifiedName).contains("ТаблицаЗначений");
     assertThat(index.get(variable)).as("после инференса тип закэширован").isEqualTo(types);
 
     // изменение документа сбрасывает кэш по URI.

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndexTest.java
@@ -1,0 +1,93 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.index;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
+import com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class InferredVariableTypeIndexTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private ExpressionTypeInferencer inferencer;
+
+  @Autowired
+  private InferredVariableTypeIndex index;
+
+  @Autowired
+  private ApplicationEventPublisher eventPublisher;
+
+  @Test
+  void cachesInferredVariableTypeAndInvalidatesByUriEvents() {
+    // given — модуль с типизированной переменной.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Тест()
+          ТЗ = Новый ТаблицаЗначений;
+          А = ТЗ.Колонки;
+      КонецПроцедуры
+      """);
+    var serverContext = documentContext.getServerContext();
+    var uri = documentContext.getUri();
+    var variable = variable(documentContext, "ТЗ");
+
+    // before — тип ещё не вычислялся.
+    assertThat(index.get(variable)).as("до инференса кэш пуст").isNull();
+
+    // after inferSymbol — тип выведен и закэширован.
+    var types = inferencer.inferSymbol(variable);
+    assertThat(types.refs()).extracting(ref -> ref.qualifiedName()).contains("ТаблицаЗначений");
+    assertThat(index.get(variable)).as("после инференса тип закэширован").isEqualTo(types);
+
+    // изменение документа сбрасывает кэш по URI.
+    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
+    assertThat(index.get(variable)).as("сброс на изменение содержимого").isNull();
+
+    // закрытие документа сбрасывает кэш по URI.
+    inferencer.inferSymbol(variable);
+    assertThat(index.get(variable)).isNotNull();
+    eventPublisher.publishEvent(new ServerContextDocumentClosedEvent(serverContext, documentContext));
+    assertThat(index.get(variable)).as("сброс на закрытие документа").isNull();
+
+    // удаление файла сбрасывает кэш по URI.
+    inferencer.inferSymbol(variable);
+    assertThat(index.get(variable)).isNotNull();
+    eventPublisher.publishEvent(new ServerContextDocumentRemovedEvent(serverContext, uri));
+    assertThat(index.get(variable)).as("сброс на удаление файла").isNull();
+  }
+
+  private static VariableSymbol variable(DocumentContext documentContext, String name) {
+    return documentContext.getSymbolTree().getVariables().stream()
+      .filter(v -> v.getName().equalsIgnoreCase(name))
+      .findFirst()
+      .orElseThrow();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndexTest.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.types.index;
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
@@ -71,6 +72,12 @@ class InferredVariableTypeIndexTest extends AbstractServerContextAwareTest {
     eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
     assertThat(index.get(variable)).as("сброс на изменение содержимого").isNull();
 
+    // освобождение вторичных данных (tryClearDocument в batch-анализе) сбрасывает кэш по URI.
+    inferencer.inferSymbol(variable);
+    assertThat(index.get(variable)).isNotNull();
+    eventPublisher.publishEvent(new ServerContextDocumentClearedEvent(serverContext, documentContext));
+    assertThat(index.get(variable)).as("сброс на освобождение вторичных данных").isNull();
+
     // закрытие документа сбрасывает кэш по URI.
     inferencer.inferSymbol(variable);
     assertThat(index.get(variable)).isNotNull();
@@ -82,6 +89,51 @@ class InferredVariableTypeIndexTest extends AbstractServerContextAwareTest {
     assertThat(index.get(variable)).isNotNull();
     eventPublisher.publishEvent(new ServerContextDocumentRemovedEvent(serverContext, uri));
     assertThat(index.get(variable)).as("сброс на удаление файла").isNull();
+  }
+
+  @Test
+  void realTryClearDocumentEvictsCacheViaAop() {
+    // given — документ с инферированной переменной в реальном ServerContext.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Тест()
+          ТЗ = Новый ТаблицаЗначений;
+      КонецПроцедуры
+      """);
+    var serverContext = documentContext.getServerContext();
+    var variable = variable(documentContext, "ТЗ");
+    inferencer.inferSymbol(variable);
+    assertThat(index.get(variable)).as("тип закэширован").isNotNull();
+
+    // when — реальный tryClearDocument на не-открытом документе; AOP-аспект
+    // публикует ServerContextDocumentClearedEvent.
+    var cleared = serverContext.tryClearDocument(documentContext);
+
+    // then — метод сообщил о реальной очистке, и кэш сброшен сквозь аспект.
+    assertThat(cleared).as("данные реально освобождены").isTrue();
+    assertThat(index.get(variable)).as("кэш сброшен событием очистки").isNull();
+  }
+
+  @Test
+  void openedDocumentIsNotClearedAndKeepsCache() {
+    // given — открытый в редакторе документ с инферированной переменной.
+    var source = """
+      Процедура Тест()
+          ТЗ = Новый ТаблицаЗначений;
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(source);
+    var serverContext = documentContext.getServerContext();
+    serverContext.openDocument(documentContext, source, 1);
+    var variable = variable(documentContext, "ТЗ");
+    inferencer.inferSymbol(variable);
+    assertThat(index.get(variable)).isNotNull();
+
+    // when — tryClearDocument на открытом документе.
+    var cleared = serverContext.tryClearDocument(documentContext);
+
+    // then — no-op: событие не публикуется, кэш открытого документа уцелел.
+    assertThat(cleared).as("открытый документ не очищается").isFalse();
+    assertThat(index.get(variable)).as("кэш открытого документа сохранён").isNotNull();
   }
 
   private static VariableSymbol variable(DocumentContext documentContext, String name) {


### PR DESCRIPTION
Три связанные оптимизации горячего пути резолва членов (`memberAt` → инференс ресивера → `getMembers`), из-за которого полный проход семантических токенов по большому модулю занимал минуты.

## 1. Ленивый кэш выведенных типов переменных (`InferredVariableTypeIndex`)

`inferVariable` пересчитывал тип ресивера с нуля на **каждый** member-доступ. Кэш `Map<URI, Map<VariableSymbol, TypeSet>>`, разрезан по URI, ленивый, пишется только для «чистого корня» инференса (`ctx.visited.size() <= 1`). Инвалидация per-URI: content-change / close / remove. На старте `populateContext` лишь чистит URI (не наполняет).

## 2. Мемоизация `TypeRegistry.getMembers` (epoch)

`getMembers` переспециализировал config/generic-члены на каждый вызов. Memo `Map<(ref,fileType),(epoch,members)>` с `AtomicLong`-epoch: бамп на мутацию `memberSources` **и** на `DocumentContextContentChangedEvent` (часть source'ов лениво читает символьное дерево/OScript-библиотеку — менялись без ре-регистрации). Кэшируется неизменяемый список.

## 3. Индекс callStatement по ресиверу (`CallStatementByReceiverIndex`)

Аккумуляторы полей структур (`X.Вставить`) и колонок ТЗ (`X.Колонки.Добавить`) сканировали весь AST модуля на каждую коллекционную переменную. Индекс `базовый идентификатор → callStatement'ы` строится раз на документ; поиск — hash-lookup. Инвалидация per-URI (держит AST-узлы): content-change / close / remove.

## Эффект (УправлениеДоступомСлужебный, SSL, 47k строк)

| Сапплаер | База | +#1 | +#1#2 | +#1#2#3 |
|---|---|---|---|---|
| PlatformMemberPropertyAccess | 195985 ms | 22375 | 13740 | **9803 ms (~20×)** |
| PlatformMemberMethodCall | 184385 ms | 40524 | 24880 | **14331 ms (~13×)** |

Результаты инференса / число токенов / конфликтов не изменились; полная регрессия (`types`, completion, signature, hover, OScript, config) зелёная. Покрытие нового кода 100%.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a per-document receiver index and a workspace-scoped inferred-variable-type cache to speed lookups.
* **Performance**
  * Faster variable type inference and member resolution via targeted caching, epoch-based memoization, and narrower call-site scanning.
* **Bug Fixes**
  * Caches and indexes now consistently clear on document content changes, server-side clears, close, and removal; server-side clear now signals only when a clear actually occurred.
* **Tests**
  * New tests validate caching, indexing, and event-driven invalidation behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/1c-syntax/bsl-language-server/pull/3997?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->