### PR TITLE
fix: устранить S2583 reliability-issue и почистить nullability/scope-аннотации

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -25,8 +25,8 @@ import com.github._1c_syntax.bsl.languageserver.WorkDoneProgressHelper;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentAddedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceBeanScope;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
-import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.utils.Absolute;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.WorkspaceFolder;
@@ -55,7 +55,7 @@ public class ServerContextProvider {
 
   private final ObjectProvider<ServerContext> serverContextObjectProvider;
   private final LanguageServerConfiguration languageServerConfiguration;
-  private final WorkspaceScope workspaceScope;
+  private final WorkspaceBeanScope workspaceScope;
 
   private final Map<URI, ServerContext> contexts = new ConcurrentHashMap<>();
   private final Map<URI, Path> workspaceRoots = new ConcurrentHashMap<>();
@@ -64,7 +64,7 @@ public class ServerContextProvider {
   public ServerContextProvider(
     ObjectProvider<ServerContext> serverContextObjectProvider,
     LanguageServerConfiguration languageServerConfiguration,
-    WorkspaceScope workspaceScope
+    WorkspaceBeanScope workspaceScope
   ) {
     this.serverContextObjectProvider = serverContextObjectProvider;
     this.languageServerConfiguration = languageServerConfiguration;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MissedRequiredParameterDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MissedRequiredParameterDiagnostic.java
@@ -39,6 +39,7 @@ import org.antlr.v4.runtime.tree.ParseTree;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
+import org.jspecify.annotations.Nullable;
 
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -95,7 +96,7 @@ public class MissedRequiredParameterDiagnostic extends AbstractVisitorDiagnostic
     return super.visitNewExpression(ctx);
   }
 
-  private void appendMethodCall(Token methodName, BSLParser.DoCallContext doCallContext, ParserRuleContext node) {
+  private void appendMethodCall(Token methodName, BSLParser.@Nullable DoCallContext doCallContext, ParserRuleContext node) {
     var methodCall = new MethodCall();
     methodCall.arguments = arguments(doCallContext);
     methodCall.range = Ranges.create(node);
@@ -178,7 +179,7 @@ public class MissedRequiredParameterDiagnostic extends AbstractVisitorDiagnostic
       .toList();
   }
 
-  private static Boolean[] arguments(BSLParser.DoCallContext doCallContext) {
+  private static Boolean[] arguments(BSLParser.@Nullable DoCallContext doCallContext) {
     if (doCallContext == null) {
       return new Boolean[0];
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/infrastructure/DiagnosticInfos.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/infrastructure/DiagnosticInfos.java
@@ -29,8 +29,6 @@ import com.github._1c_syntax.utils.StringInterner;
 import jakarta.annotation.PostConstruct;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.Map;
@@ -41,7 +39,7 @@ import java.util.stream.Collectors;
  * Per-workspace collection of DiagnosticInfo instances.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class DiagnosticInfos {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration.java
@@ -24,7 +24,6 @@ package com.github._1c_syntax.bsl.languageserver.infrastructure;
 import io.sentry.spring7.SentryTaskDecorator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
-import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.core.task.TaskDecorator;
 import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
@@ -92,7 +91,7 @@ public class ExecutorConfiguration {
   // so parallelStream forks always have correct ThreadLocal context.
 
   @Bean(destroyMethod = "shutdown")
-  @Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.INTERFACES)
+  @WorkspaceScope(proxyMode = ScopedProxyMode.INTERFACES)
   public ExecutorService populateContextExecutor() {
     return createWorkspaceForkJoinPool("populate-context-");
   }
@@ -104,25 +103,25 @@ public class ExecutorConfiguration {
   }
 
   @Bean(destroyMethod = "shutdown")
-  @Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.INTERFACES)
+  @WorkspaceScope(proxyMode = ScopedProxyMode.INTERFACES)
   public ExecutorService diagnosticComputerExecutor() {
     return createWorkspaceForkJoinPool("diagnostic-computer-");
   }
 
   @Bean(destroyMethod = "shutdown")
-  @Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.INTERFACES)
+  @WorkspaceScope(proxyMode = ScopedProxyMode.INTERFACES)
   public ExecutorService analyzeOnStartExecutor() {
     return createWorkspaceForkJoinPool("analyze-on-start-");
   }
 
   @Bean(destroyMethod = "shutdown")
-  @Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.INTERFACES)
+  @WorkspaceScope(proxyMode = ScopedProxyMode.INTERFACES)
   public ExecutorService semanticTokensExecutor() {
     return createWorkspaceForkJoinPool("semantic-tokens-");
   }
 
   @Bean(destroyMethod = "shutdown")
-  @Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.INTERFACES)
+  @WorkspaceScope(proxyMode = ScopedProxyMode.INTERFACES)
   public ExecutorService cliExecutor() {
     return createWorkspaceForkJoinPool("cli-");
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceBeanScope.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceBeanScope.java
@@ -1,0 +1,143 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.infrastructure;
+
+import org.jspecify.annotations.Nullable;
+import org.springframework.beans.factory.ObjectFactory;
+import org.springframework.beans.factory.config.Scope;
+
+import java.net.URI;
+import java.util.Collection;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
+
+/**
+ * Custom Spring Scope для per-workspace бинов.
+ * <p>
+ * Ключ scope — workspace URI из {@link WorkspaceContextHolder}.
+ * Если workspace URI не установлен, выбрасывается исключение.
+ */
+public class WorkspaceBeanScope implements Scope {
+
+  public static final String SCOPE_NAME = "workspace";
+
+  private final ConcurrentHashMap<URI, Map<String, Object>> store = new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<URI, Map<String, Runnable>> destructionCallbacks = new ConcurrentHashMap<>();
+
+  @Override
+  public Object get(String name, ObjectFactory<?> objectFactory) {
+    var key = resolveKey();
+    var beans = getOrCreate(store, key);
+    var existing = beans.get(name);
+    if (existing != null) {
+      return existing;
+    }
+    // ВАЖНО: фабрика бина может рекурсивно запросить другой workspace-scoped бин
+    // (например, через CGLIB-прокси), поэтому здесь нельзя использовать
+    // computeIfAbsent — он держит bin-lock CHM и при рекурсивном входе с другим
+    // ключом, попадающим в тот же bin, приводит к дедлоку между параллельными
+    // потоками. Создаём бин ВНЕ блокировки и атомарно регистрируем через
+    // putIfAbsent; в редкой гонке другой поток вернёт уже созданный экземпляр.
+    var created = objectFactory.getObject();
+    var previous = beans.putIfAbsent(name, created);
+    return previous != null ? previous : created;
+  }
+
+  private static <K, V> Map<K, V> getOrCreate(ConcurrentHashMap<URI, Map<K, V>> outer, URI key) {
+    var inner = outer.get(key);
+    if (inner != null) {
+      return inner;
+    }
+    Map<K, V> fresh = new ConcurrentHashMap<>();
+    var previous = outer.putIfAbsent(key, fresh);
+    return previous != null ? previous : fresh;
+  }
+
+  @Override
+  public @Nullable Object remove(String name) {
+    var key = resolveKey();
+    var beans = store.get(key);
+    return beans != null ? beans.remove(name) : null;
+  }
+
+  @Override
+  public void registerDestructionCallback(String name, Runnable callback) {
+    var key = resolveKey();
+    getOrCreate(destructionCallbacks, key).put(name, callback);
+  }
+
+  @Override
+  public @Nullable Object resolveContextualObject(String key) {
+    return null;
+  }
+
+  @Override
+  public @Nullable String getConversationId() {
+    var uri = WorkspaceContextHolder.get();
+    return uri != null ? uri.toString() : null;
+  }
+
+  /**
+   * Удалить все бины workspace, предварительно вызвав destruction callbacks.
+   */
+  public void removeWorkspace(URI workspaceUri) {
+    var callbacks = destructionCallbacks.remove(workspaceUri);
+    if (callbacks != null) {
+      callbacks.values().forEach(Runnable::run);
+    }
+    store.remove(workspaceUri);
+  }
+
+  /**
+   * Get all instances of a bean across all workspaces.
+   *
+   * @param beanName the bean name
+   * @param type the expected type
+   * @return collection of all instances
+   */
+  public <T> Collection<T> getAllInstances(String beanName, Class<T> type) {
+    return store.values().stream()
+      .map(beans -> beans.get(beanName))
+      .filter(Objects::nonNull)
+      .map(type::cast)
+      .toList();
+  }
+
+  /**
+   * @return URI всех зарегистрированных в scope workspace'ов. Полезно для test-cleanup'а,
+   * который должен пройтись по каждому scope для сброса состояния workspace-scoped beans.
+   */
+  public Collection<URI> getRegisteredWorkspaceUris() {
+    return java.util.List.copyOf(store.keySet());
+  }
+
+  private static URI resolveKey() {
+    var key = WorkspaceContextHolder.get();
+    if (key == null) {
+      throw new IllegalStateException(
+        "Workspace context is not set. Use WorkspaceContextHolder.forUri() before accessing workspace-scoped beans."
+      );
+    }
+    return key;
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceContextHolder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceContextHolder.java
@@ -30,7 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 
 /**
  * ThreadLocal-хранилище текущего workspace URI и имени.
- * Используется {@link WorkspaceScope} для определения ключа scope,
+ * Используется {@link WorkspaceBeanScope} для определения ключа scope,
  * а также для именования потоков в per-workspace ForkJoinPool.
  * <p>
  * URI должен быть нормализован вызывающим кодом перед передачей в {@code set()}.

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceContextHolder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceContextHolder.java
@@ -21,7 +21,8 @@
  */
 package com.github._1c_syntax.bsl.languageserver.infrastructure;
 
-import javax.annotation.Nullable;
+import org.jspecify.annotations.Nullable;
+
 import java.net.URI;
 import java.util.Map;
 import java.util.concurrent.Callable;
@@ -169,13 +170,11 @@ public final class WorkspaceContextHolder {
     CURRENT_WORKSPACE_NAME.set(name);
   }
 
-  @Nullable
-  public static URI get() {
+  public static @Nullable URI get() {
     return CURRENT_WORKSPACE.get();
   }
 
-  @Nullable
-  public static String getName() {
+  public static @Nullable String getName() {
     return CURRENT_WORKSPACE_NAME.get();
   }
 
@@ -190,10 +189,8 @@ public final class WorkspaceContextHolder {
    * При закрытии восстанавливает предыдущее значение ThreadLocal.
    */
   public static final class WorkspaceContext implements AutoCloseable {
-    @Nullable
-    private final URI previousUri;
-    @Nullable
-    private final String previousName;
+    private final @Nullable URI previousUri;
+    private final @Nullable String previousName;
 
     private WorkspaceContext(@Nullable URI previousUri, @Nullable String previousName) {
       this.previousUri = previousUri;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceScope.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceScope.java
@@ -21,123 +21,37 @@
  */
 package com.github._1c_syntax.bsl.languageserver.infrastructure;
 
-import org.jspecify.annotations.Nullable;
-import org.springframework.beans.factory.ObjectFactory;
-import org.springframework.beans.factory.config.Scope;
+import org.springframework.context.annotation.Scope;
+import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.core.annotation.AliasFor;
 
-import java.net.URI;
-import java.util.Collection;
-import java.util.Map;
-import java.util.Objects;
-import java.util.concurrent.ConcurrentHashMap;
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
 
 /**
- * Custom Spring Scope для per-workspace бинов.
+ * Помечает бин как принадлежащий per-workspace scope {@code "workspace"}
+ * (см. {@link WorkspaceBeanScope}).
  * <p>
- * Ключ scope — workspace URI из {@link WorkspaceContextHolder}.
- * Если workspace URI не установлен, выбрасывается исключение.
+ * Композитная замена для повторяющегося
+ * {@code @Scope(value = WorkspaceBeanScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)}.
+ * По умолчанию создаётся CGLIB-прокси ({@link ScopedProxyMode#TARGET_CLASS});
+ * для бинов, объявленных через интерфейс (например {@code @Bean}-методы,
+ * возвращающие интерфейс), укажите {@link ScopedProxyMode#INTERFACES}.
  */
-public class WorkspaceScope implements Scope {
-
-  public static final String SCOPE_NAME = "workspace";
-
-  private final ConcurrentHashMap<URI, Map<String, Object>> store = new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<URI, Map<String, Runnable>> destructionCallbacks = new ConcurrentHashMap<>();
-
-  @Override
-  public Object get(String name, ObjectFactory<?> objectFactory) {
-    var key = resolveKey();
-    var beans = getOrCreate(store, key);
-    var existing = beans.get(name);
-    if (existing != null) {
-      return existing;
-    }
-    // ВАЖНО: фабрика бина может рекурсивно запросить другой workspace-scoped бин
-    // (например, через CGLIB-прокси), поэтому здесь нельзя использовать
-    // computeIfAbsent — он держит bin-lock CHM и при рекурсивном входе с другим
-    // ключом, попадающим в тот же bin, приводит к дедлоку между параллельными
-    // потоками. Создаём бин ВНЕ блокировки и атомарно регистрируем через
-    // putIfAbsent; в редкой гонке другой поток вернёт уже созданный экземпляр.
-    var created = objectFactory.getObject();
-    var previous = beans.putIfAbsent(name, created);
-    return previous != null ? previous : created;
-  }
-
-  private static <K, V> Map<K, V> getOrCreate(ConcurrentHashMap<URI, Map<K, V>> outer, URI key) {
-    var inner = outer.get(key);
-    if (inner != null) {
-      return inner;
-    }
-    Map<K, V> fresh = new ConcurrentHashMap<>();
-    var previous = outer.putIfAbsent(key, fresh);
-    return previous != null ? previous : fresh;
-  }
-
-  @Override
-  public @Nullable Object remove(String name) {
-    var key = resolveKey();
-    var beans = store.get(key);
-    return beans != null ? beans.remove(name) : null;
-  }
-
-  @Override
-  public void registerDestructionCallback(String name, Runnable callback) {
-    var key = resolveKey();
-    getOrCreate(destructionCallbacks, key).put(name, callback);
-  }
-
-  @Override
-  public @Nullable Object resolveContextualObject(String key) {
-    return null;
-  }
-
-  @Override
-  public @Nullable String getConversationId() {
-    var uri = WorkspaceContextHolder.get();
-    return uri != null ? uri.toString() : null;
-  }
+@Target({ElementType.TYPE, ElementType.METHOD})
+@Retention(RetentionPolicy.RUNTIME)
+@Documented
+@Scope(WorkspaceBeanScope.SCOPE_NAME)
+public @interface WorkspaceScope {
 
   /**
-   * Удалить все бины workspace, предварительно вызвав destruction callbacks.
-   */
-  public void removeWorkspace(URI workspaceUri) {
-    var callbacks = destructionCallbacks.remove(workspaceUri);
-    if (callbacks != null) {
-      callbacks.values().forEach(Runnable::run);
-    }
-    store.remove(workspaceUri);
-  }
-
-  /**
-   * Get all instances of a bean across all workspaces.
+   * Режим создания scoped-прокси для бина.
    *
-   * @param beanName the bean name
-   * @param type the expected type
-   * @return collection of all instances
+   * @return режим прокси; по умолчанию {@link ScopedProxyMode#TARGET_CLASS}
    */
-  public <T> Collection<T> getAllInstances(String beanName, Class<T> type) {
-    return store.values().stream()
-      .map(beans -> beans.get(beanName))
-      .filter(Objects::nonNull)
-      .map(type::cast)
-      .toList();
-  }
-
-  /**
-   * @return URI всех зарегистрированных в scope workspace'ов. Полезно для test-cleanup'а,
-   * который должен пройтись по каждому scope для сброса состояния workspace-scoped beans.
-   */
-  public Collection<URI> getRegisteredWorkspaceUris() {
-    return java.util.List.copyOf(store.keySet());
-  }
-
-  private static URI resolveKey() {
-    var key = WorkspaceContextHolder.get();
-    if (key == null) {
-      throw new IllegalStateException(
-        "Workspace context is not set. Use WorkspaceContextHolder.forUri() before accessing workspace-scoped beans."
-      );
-    }
-    return key;
-  }
+  @AliasFor(annotation = Scope.class, attribute = "proxyMode")
+  ScopedProxyMode proxyMode() default ScopedProxyMode.TARGET_CLASS;
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceScope.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceScope.java
@@ -21,10 +21,10 @@
  */
 package com.github._1c_syntax.bsl.languageserver.infrastructure;
 
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.config.Scope;
 
-import javax.annotation.Nullable;
 import java.net.URI;
 import java.util.Collection;
 import java.util.Map;
@@ -74,8 +74,7 @@ public class WorkspaceScope implements Scope {
   }
 
   @Override
-  @Nullable
-  public Object remove(String name) {
+  public @Nullable Object remove(String name) {
     var key = resolveKey();
     var beans = store.get(key);
     return beans != null ? beans.remove(name) : null;
@@ -88,14 +87,12 @@ public class WorkspaceScope implements Scope {
   }
 
   @Override
-  @Nullable
-  public Object resolveContextualObject(String key) {
+  public @Nullable Object resolveContextualObject(String key) {
     return null;
   }
 
   @Override
-  @Nullable
-  public String getConversationId() {
+  public @Nullable String getConversationId() {
     var uri = WorkspaceContextHolder.get();
     return uri != null ? uri.toString() : null;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceScopeConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceScopeConfiguration.java
@@ -32,14 +32,14 @@ import org.springframework.context.annotation.Configuration;
 public class WorkspaceScopeConfiguration {
 
   @Bean
-  public WorkspaceScope workspaceScope() {
-    return new WorkspaceScope();
+  public WorkspaceBeanScope workspaceScope() {
+    return new WorkspaceBeanScope();
   }
 
   @Bean
-  public static CustomScopeConfigurer workspaceScopeConfigurer(WorkspaceScope workspaceScope) {
+  public static CustomScopeConfigurer workspaceScopeConfigurer(WorkspaceBeanScope workspaceScope) {
     var configurer = new CustomScopeConfigurer();
-    configurer.addScope(WorkspaceScope.SCOPE_NAME, workspaceScope);
+    configurer.addScope(WorkspaceBeanScope.SCOPE_NAME, workspaceScope);
     return configurer;
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/AnnotationRepository.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/AnnotationRepository.java
@@ -23,8 +23,6 @@ package com.github._1c_syntax.bsl.languageserver.references.model;
 
 import com.github._1c_syntax.bsl.languageserver.context.symbol.AnnotationSymbol;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -40,7 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * регистре, а поиск ведётся регистронезависимо.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class AnnotationRepository {
 
   private final Map<String, AnnotationSymbol> annotations = new ConcurrentHashMap<>();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/LocationRepository.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/LocationRepository.java
@@ -22,8 +22,6 @@
 package com.github._1c_syntax.bsl.languageserver.references.model;
 
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -37,7 +35,7 @@ import java.util.stream.Stream;
  * Хранилище расположений обращений к символам.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class LocationRepository {
   /**
    * Список обращений к символу, сгруппированный по URI.

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/SymbolOccurrenceRepository.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/SymbolOccurrenceRepository.java
@@ -22,8 +22,6 @@
 package com.github._1c_syntax.bsl.languageserver.references.model;
 
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -36,7 +34,7 @@ import java.util.concurrent.ConcurrentSkipListSet;
  * Хранилище обращений к символам.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class SymbolOccurrenceRepository {
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/DereferenceMemberMatcher.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/DereferenceMemberMatcher.java
@@ -40,11 +40,11 @@ import com.github._1c_syntax.bsl.languageserver.utils.expressiontree.ExpressionN
 import com.github._1c_syntax.bsl.languageserver.utils.expressiontree.MethodCallNode;
 import com.github._1c_syntax.bsl.languageserver.utils.expressiontree.SkippedCallArgumentNode;
 import com.github._1c_syntax.bsl.languageserver.utils.expressiontree.TerminalSymbolNode;
-import jakarta.annotation.Nullable;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.jspecify.annotations.Nullable;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
@@ -99,8 +99,7 @@ public class DereferenceMemberMatcher {
     return Optional.of(inferencer.infer(dereference.getLeft(), documentContext));
   }
 
-  @Nullable
-  private static BinaryOperationNode findDereferenceTree(DocumentContext documentContext, Position position,
+  private static @Nullable BinaryOperationNode findDereferenceTree(DocumentContext documentContext, Position position,
                                                          TerminalNode terminal) {
     var expression = ExpressionAtPosition.findExpressionTree(documentContext, position).orElse(null);
     if (expression == null) {
@@ -203,8 +202,7 @@ public class DereferenceMemberMatcher {
     return result;
   }
 
-  @Nullable
-  private static BinaryOperationNode findDereferenceForTerminal(BslExpression root, TerminalNode terminal) {
+  private static @Nullable BinaryOperationNode findDereferenceForTerminal(BslExpression root, TerminalNode terminal) {
     if (root instanceof BinaryOperationNode binary
       && binary.getOperator() == BslOperator.DEREFERENCE
       && rightMatchesTerminal(binary.getRight(), terminal)) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/DereferenceMemberMatcher.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/DereferenceMemberMatcher.java
@@ -45,8 +45,6 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -60,7 +58,7 @@ import java.util.Optional;
  * чтобы фасад типов оставался в рамках одного класса.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class DereferenceMemberMatcher {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
@@ -49,8 +49,6 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -63,7 +61,7 @@ import java.util.Optional;
  * {@link ExpressionTypeInferencer}/{@link TypeRegistry}.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class TypeService {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
@@ -48,11 +48,10 @@ import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.jspecify.annotations.Nullable;
 import org.springframework.context.annotation.Scope;
 import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
-
-import jakarta.annotation.Nullable;
 
 import java.util.Collection;
 import java.util.List;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/CallStatementByReceiverIndex.java
@@ -24,8 +24,6 @@ package com.github._1c_syntax.bsl.languageserver.types.index;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -55,7 +53,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Строится лениво.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class CallStatementByReceiverIndex extends AbstractDocumentLifecycleClearableIndex {
 
   private final Map<URI, Map<String, List<BSLParser.CallStatementContext>>> byUri = new ConcurrentHashMap<>();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/InferredVariableTypeIndex.java
@@ -25,8 +25,6 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -60,7 +58,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * модель, что у {@link SymbolTypeIndex}.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class InferredVariableTypeIndex extends AbstractDocumentLifecycleClearableIndex {
 
   private final Map<URI, Map<VariableSymbol, TypeSet>> typesByUri = new ConcurrentHashMap<>();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndex.java
@@ -37,8 +37,6 @@ import com.github._1c_syntax.bsl.parser.description.CollectionTypeDescription;
 import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -62,7 +60,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * {@code ExpressionTypeInferencer}'ом по выражению инициализации.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class SymbolTypeIndex {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -64,8 +64,6 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -90,7 +88,7 @@ import java.util.function.Predicate;
  * накапливает finder'ы из всего проекта (variable, method, module и т.д.).
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class ExpressionTypeInferencer {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/autumn/AutumnBeanIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/autumn/AutumnBeanIndex.java
@@ -37,8 +37,6 @@ import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryInde
 import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndexedEvent;
 import com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -79,7 +77,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * {@code AnnotationRepository}.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class AutumnBeanIndex {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/autumn/AutumnCollectionIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/autumn/AutumnCollectionIndex.java
@@ -37,8 +37,6 @@ import com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry;
 import com.github._1c_syntax.bsl.parser.description.MethodDescription;
 import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -74,7 +72,7 @@ import java.util.concurrent.atomic.AtomicReference;
  * аннотации.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class AutumnCollectionIndex {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/autumn/AutumnComponentInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/autumn/AutumnComponentInferencer.java
@@ -27,8 +27,6 @@ import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.List;
@@ -59,7 +57,7 @@ import java.util.List;
  * вроде {@code Массив}/{@code ТаблицаЗначений} это даёт корректный платформенный тип).
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class AutumnComponentInferencer {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/autumn/AutumnMetaAnnotationResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/autumn/AutumnMetaAnnotationResolver.java
@@ -33,8 +33,6 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.annotations.Annot
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.references.model.AnnotationRepository;
 import lombok.RequiredArgsConstructor;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -70,7 +68,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * пересчитывать цепочку на каждый запрос.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class AutumnMetaAnnotationResolver {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
@@ -30,8 +30,6 @@ import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -72,7 +70,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Slf4j
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class OScriptLibraryIndex {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptModuleMembersProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptModuleMembersProvider.java
@@ -39,8 +39,6 @@ import com.github._1c_syntax.bsl.types.ModuleType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.apache.commons.io.FilenameUtils;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -71,7 +69,7 @@ import java.util.concurrent.ConcurrentHashMap;
  */
 @Slf4j
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class OScriptModuleMembersProvider {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptModuleTypeResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptModuleTypeResolver.java
@@ -23,8 +23,6 @@ package com.github._1c_syntax.bsl.languageserver.types.oscript;
 
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.types.ModuleType;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -44,7 +42,7 @@ import java.util.concurrent.ConcurrentMap;
  * {@link com.github._1c_syntax.bsl.languageserver.context.DocumentContext}.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class OScriptModuleTypeResolver {
 
   private final ConcurrentMap<URI, ModuleType> typesByUri = new ConcurrentHashMap<>();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextHolder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextHolder.java
@@ -26,8 +26,6 @@ import com.github._1c_syntax.bsl.languageserver.configuration.platform.V8Platfor
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.utils.Lazy;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.Optional;
@@ -49,7 +47,7 @@ import java.util.Optional;
  */
 @Slf4j
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class BslContextHolder {
 
   private final PlatformContextProviderFactory factory;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BslContextPlatformTypesProvider.java
@@ -49,8 +49,6 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.utils.Lazy;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -92,7 +90,7 @@ import java.util.Set;
  */
 @Slf4j
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class BslContextPlatformTypesProvider implements PlatformTypesProvider {
 
   private final BslContextHolder contextHolder;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinOScriptPlatformTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinOScriptPlatformTypesProvider.java
@@ -23,8 +23,6 @@ package com.github._1c_syntax.bsl.languageserver.types.registry;
 
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.LanguageScope;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -42,7 +40,7 @@ import java.util.List;
  * {@code language-gating}, в этом провайдере не реализуется.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class BuiltinOScriptPlatformTypesProvider implements PlatformTypesProvider {
 
   private static final String RESOURCE_PATH =

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinPlatformTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinPlatformTypesProvider.java
@@ -37,8 +37,6 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.json.JsonMapper;
@@ -63,7 +61,7 @@ import java.util.Set;
  */
 @Slf4j
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class BuiltinPlatformTypesProvider implements PlatformTypesProvider {
 
   private static final String RESOURCE_PATH =

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
@@ -34,8 +34,6 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -58,7 +56,7 @@ import java.util.function.Supplier;
  * ручной инвалидации.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 @Slf4j
 public class ConfigurationModuleMembersProvider {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -45,8 +45,6 @@ import com.github._1c_syntax.bsl.types.value.PrimitiveValueType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -72,7 +70,7 @@ import java.util.concurrent.atomic.AtomicBoolean;
  * выполняется отдельным провайдером — {@code ConfigurationModuleMembersProvider}.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 @Slf4j
 public class ConfigurationTypesProvider {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
@@ -51,8 +51,6 @@ import com.github._1c_syntax.bsl.languageserver.types.symbol.SyntheticSymbol;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.json.JsonMapper;
@@ -87,7 +85,7 @@ import java.util.function.Supplier;
  */
 @Slf4j
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class GlobalScopeProvider {
 
   private static final String RESOURCE_PATH =

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MemberMetadataIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MemberMetadataIndex.java
@@ -25,8 +25,6 @@ import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.AccessMode;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.Locale;
@@ -46,7 +44,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * сюда не попадают (у них нет accessMode/версий).
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class MemberMetadataIndex {
 
   private final Map<TypeRef, Set<String>> readOnlyByType = new ConcurrentHashMap<>();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformContextProviderFactory.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlatformContextProviderFactory.java
@@ -28,8 +28,6 @@ import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.io.IOException;
@@ -48,7 +46,7 @@ import java.util.Optional;
  */
 @Slf4j
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class PlatformContextProviderFactory {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -46,8 +46,6 @@ import com.github._1c_syntax.bsl.languageserver.types.symbol.SyntheticKind;
 import jakarta.annotation.PostConstruct;
 import lombok.RequiredArgsConstructor;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
@@ -76,7 +74,7 @@ import java.util.function.Supplier;
  * несколькими источниками членов ({@link MemberSource}).
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 @RequiredArgsConstructor
 public class TypeRegistry {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/scope/GlobalSymbolScope.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/scope/GlobalSymbolScope.java
@@ -24,8 +24,6 @@ package com.github._1c_syntax.bsl.languageserver.types.scope;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import org.jspecify.annotations.Nullable;
-import org.springframework.context.annotation.Scope;
-import org.springframework.context.annotation.ScopedProxyMode;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
@@ -62,7 +60,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * единой Symbol-точкой входа.
  */
 @Component
-@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)
+@WorkspaceScope
 public class GlobalSymbolScope {
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/symbol/PlatformMemberSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/symbol/PlatformMemberSymbol.java
@@ -27,11 +27,11 @@ import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
-import jakarta.annotation.Nullable;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.SymbolKind;
+import org.jspecify.annotations.Nullable;
 
 import java.util.List;
 
@@ -50,8 +50,7 @@ public final class PlatformMemberSymbol implements Symbol {
 
   private final String name;
   /** {@code null} для глобальных функций/свойств без owner-типа. */
-  @Nullable
-  private final TypeRef owner;
+  private final @Nullable TypeRef owner;
   private final MemberDescriptor descriptor;
   /** Число фактических аргументов в текущем вызове; {@code -1} если не вызов. */
   private final int callArgCount;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/util/AbstractDirtyContextTestExecutionListener.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/util/AbstractDirtyContextTestExecutionListener.java
@@ -23,8 +23,8 @@ package com.github._1c_syntax.bsl.languageserver.util;
 
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceBeanScope;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
-import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import org.springframework.core.Ordered;
 import org.springframework.test.annotation.DirtiesContext;
 import org.springframework.test.context.TestContext;
@@ -50,7 +50,7 @@ public class AbstractDirtyContextTestExecutionListener extends AbstractTestExecu
    *       {@code ServerContextDocumentRemovedEvent} через AOP, на котором
    *       зависят downstream-индексы ({@code ReferenceIndex},
    *       {@code OScriptLibraryIndex}, и т.п.);</li>
-   *   <li>{@code WorkspaceScope.removeWorkspace(uri)} — уничтожает
+   *   <li>{@code WorkspaceBeanScope.removeWorkspace(uri)} — уничтожает
    *       workspace-scoped beans (TypeRegistry, GlobalScopeProvider,
    *       BslContextHolder, ...) с их destruction callbacks. При следующем
    *       обращении они создадутся заново.</li>
@@ -64,11 +64,11 @@ public class AbstractDirtyContextTestExecutionListener extends AbstractTestExecu
    */
   protected static void liteCleanup(TestContext testContext) {
     ServerContextProvider provider;
-    WorkspaceScope workspaceScope;
+    WorkspaceBeanScope workspaceScope;
     LanguageServerConfiguration configBean;
     try {
       provider = testContext.getApplicationContext().getBean(ServerContextProvider.class);
-      workspaceScope = testContext.getApplicationContext().getBean(WorkspaceScope.class);
+      workspaceScope = testContext.getApplicationContext().getBean(WorkspaceBeanScope.class);
       configBean = testContext.getApplicationContext().getBean(LanguageServerConfiguration.class);
     } catch (Exception e) {
       return; // Spring контекст ещё не готов.
@@ -77,7 +77,7 @@ public class AbstractDirtyContextTestExecutionListener extends AbstractTestExecu
     // Workspace-scoped beans живы пока scope их держит. Сбрасываем конфигурацию КАЖДОГО
     // workspace в scope (включая искусственный file:///test-workspace из
     // WorkspaceContextTestExecutionListener'а), затем сносим всё через provider.clear().
-    // Перебираем uris из самого WorkspaceScope, а не из provider.getAllContexts() —
+    // Перебираем uris из самого WorkspaceBeanScope, а не из provider.getAllContexts() —
     // часть workspace'ов (test-default) проходят мимо ServerContextProvider.
     for (var uri : workspaceScope.getRegisteredWorkspaceUris()) {
       // two-arg forUri — чтобы не зависеть от наличия URI в WORKSPACE_NAMES
@@ -94,7 +94,7 @@ public class AbstractDirtyContextTestExecutionListener extends AbstractTestExecu
     // provider.clear() уничтожает workspace-scoped beans только для тех URI, что были
     // зарегистрированы через addWorkspace (живут в provider.contexts). Виртуальные
     // workspace'ы — например, file:///test-workspace из WorkspaceContextTestExecutionListener'а
-    // или async-propagated — обходят provider, но создают beans в WorkspaceScope.store.
+    // или async-propagated — обходят provider, но создают beans в WorkspaceBeanScope.store.
     // Без явного removeWorkspace их TypeRegistry / OScriptLibraryIndex / GlobalScopeProvider
     // переживают cleanup и подкидывают флэйк (см. ConventionalLibraryDiscoveryTest pollution).
     for (var uri : workspaceScope.getRegisteredWorkspaceUris()) {


### PR DESCRIPTION
## Зачем

Quality gate на `develop` падал из-за `new_reliability_rating = C` — единственная reliability-issue в новом коде: **S2583** в `MissedRequiredParameterDiagnostic` («condition always evaluates to false»). По ходу разбора заодно убраны связанные шероховатости с nullability- и scope-аннотациями.

## Что сделано

### 1. Фикс S2583 (reliability) — `fix(diagnostics)`
`@Nullable` на параметрах `arguments(...)`/`appendMethodCall(...)`. `doCall()` у ANTLR реально может быть `null` — и легитимно (опциональный `doCall?` в `newExpression`, например `Новый Массив` без скобок), и при восстановлении парсера после ошибок даже для обязательных правил. Null-guard нужен; аннотация документирует это и снимает ложное срабатывание, не удаляя защитную проверку.

### 2. Миграция `@Nullable` на JSpecify — `refactor`
`jakarta.annotation.Nullable` / `javax.annotation.Nullable` → `org.jspecify.annotations.Nullable` (стандарт проекта, 110+ использований). Аннотации переведены в TYPE_USE-позицию.

### 3. Мета-аннотация `@WorkspaceScope` — `refactor(infrastructure)`
Композитная замена повторяющегося `@Scope(value = WorkspaceScope.SCOPE_NAME, proxyMode = ScopedProxyMode.TARGET_CLASS)` (~30 бинов). `proxyMode` через `@AliasFor` (по умолчанию `TARGET_CLASS`); interface-proxied `@Bean`-executors используют `@WorkspaceScope(proxyMode = ScopedProxyMode.INTERFACES)`. Класс-реализация Spring Scope переименован `WorkspaceScope` → `WorkspaceBeanScope`, чтобы освободить имя под аннотацию.

## Проверки
- `compileJava` / `compileTestJava` — зелёные
- `spotlessJavaCheck` — зелёный
- `TypeServiceTest` (TARGET_CLASS-бины) и `AnalyzeProjectOnStartTest` (per-workspace INTERFACES-executors) — проходят, подтверждая, что Spring корректно понимает мета-аннотацию в рантайме

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved workspace bean dependency injection scoping mechanism for better performance and maintainability.
  * Standardized nullability annotations across the codebase to enhance code quality and IDE support.
  * Streamlined component configuration for workspace-scoped services.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->