### PR TITLE
fix(infrastructure): корректная обработка destruction callbacks в WorkspaceBeanScope

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceBeanScope.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceBeanScope.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.infrastructure;
 
+import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.ObjectFactory;
 import org.springframework.beans.factory.config.Scope;
@@ -37,6 +38,7 @@ import java.util.concurrent.ConcurrentHashMap;
  * Ключ scope — workspace URI из {@link WorkspaceContextHolder}.
  * Если workspace URI не установлен, выбрасывается исключение.
  */
+@Slf4j
 public class WorkspaceBeanScope implements Scope {
 
   public static final String SCOPE_NAME = "workspace";
@@ -76,6 +78,12 @@ public class WorkspaceBeanScope implements Scope {
   @Override
   public @Nullable Object remove(String name) {
     var key = resolveKey();
+    // Контракт Scope.remove: вместе с бином снимаем и его destruction callback,
+    // иначе он останется в карте и повторно выполнится при removeWorkspace().
+    var callbacks = destructionCallbacks.get(key);
+    if (callbacks != null) {
+      callbacks.remove(name);
+    }
     var beans = store.get(key);
     return beans != null ? beans.remove(name) : null;
   }
@@ -103,7 +111,15 @@ public class WorkspaceBeanScope implements Scope {
   public void removeWorkspace(URI workspaceUri) {
     var callbacks = destructionCallbacks.remove(workspaceUri);
     if (callbacks != null) {
-      callbacks.values().forEach(Runnable::run);
+      // Каждый callback изолируем: падение одного не должно срывать остальные
+      // и последующую очистку store (иначе workspace-scoped бины протекают между запусками/тестами).
+      callbacks.forEach((name, callback) -> {
+        try {
+          callback.run();
+        } catch (RuntimeException e) {
+          LOGGER.warn("Destruction callback for bean '{}' in workspace {} failed", name, workspaceUri, e);
+        }
+      });
     }
     store.remove(workspaceUri);
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceBeanScopeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/WorkspaceBeanScopeTest.java
@@ -1,0 +1,75 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.infrastructure;
+
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.concurrent.atomic.AtomicInteger;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+
+class WorkspaceBeanScopeTest {
+
+  private static final URI WORKSPACE = URI.create("file:///ws");
+
+  @Test
+  void removeAlsoDropsDestructionCallback() {
+    // given
+    var scope = new WorkspaceBeanScope();
+    var destroyed = new AtomicInteger();
+    try (var ignored = WorkspaceContextHolder.forUri(WORKSPACE, "ws")) {
+      var bean = new Object();
+      scope.get("bean", () -> bean);
+      scope.registerDestructionCallback("bean", destroyed::incrementAndGet);
+
+      // when
+      scope.remove("bean");
+    }
+
+    // then: контракт Scope.remove требует удалить и destruction callback,
+    // поэтому teardown workspace его уже не выполнит.
+    scope.removeWorkspace(WORKSPACE);
+    assertThat(destroyed).hasValue(0);
+  }
+
+  @Test
+  void removeWorkspaceRunsAllCallbacksEvenIfOneThrows() {
+    // given
+    var scope = new WorkspaceBeanScope();
+    var destroyed = new AtomicInteger();
+    try (var ignored = WorkspaceContextHolder.forUri(WORKSPACE, "ws")) {
+      scope.get("boom", Object::new);
+      scope.get("ok", Object::new);
+      scope.registerDestructionCallback("boom", () -> {
+        throw new IllegalStateException("boom");
+      });
+      scope.registerDestructionCallback("ok", destroyed::incrementAndGet);
+    }
+
+    // when / then: исключение одного callback не должно срывать остальные и очистку store.
+    assertThatNoException().isThrownBy(() -> scope.removeWorkspace(WORKSPACE));
+    assertThat(destroyed).hasValue(1);
+    assertThat(scope.getRegisteredWorkspaceUris()).isEmpty();
+  }
+}


### PR DESCRIPTION
Follow-up к #4003 (замечания CodeRabbit не успели войти в squash-merge).

## Что чинится

Две проблемы в `WorkspaceBeanScope` (выявлены ревью #4003):

1. **`remove(name)` оставлял destruction callback.** По контракту `Scope.remove` реализация должна снимать и зарегистрированный destruction callback. Сейчас он оставался в `destructionCallbacks` и выполнялся повторно при `removeWorkspace()` (double-destroy, рост карты).

2. **`removeWorkspace()` не был exception-safe.** `forEach(Runnable::run)` при исключении в одном callback прерывал цикл, и `store.remove()` не выполнялся → workspace-scoped бины протекали между запусками/тестами. Теперь каждый callback изолирован в своём `try/catch` (лог + продолжение), `store.remove()` выполняется всегда.

## Проверки
- `WorkspaceBeanScopeTest` — новый юнит-тест (чистый JUnit, без Spring), red до фикса, green после
- `spotlessJavaCheck` — зелёный

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved workspace cleanup reliability by executing destruction callbacks individually with error handling, preventing failures from blocking subsequent cleanup operations
  * Fixed issue where removal callbacks could execute after being explicitly removed

* **Tests**
  * Added test coverage for workspace destruction callback lifecycle

<!-- end of auto-generated comment: release notes by coderabbit.ai -->