### PR TITLE
feat(types): bsl-context 0.7.0 + поддержка нового MDO ЦветПалитры

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -92,7 +92,7 @@ dependencies {
     api("io.github.1c-syntax:mdclasses:0.19.0")
     api("io.github.1c-syntax:bsl-common-library:0.11.0")
     api("io.github.1c-syntax:supportconf:0.16.0")
-    api("io.github.1c-syntax:bsl-context:0.6.0")
+    api("io.github.1c-syntax:bsl-context:0.7.0")
 
     // nullability annotations
     api("org.jspecify:jspecify:1.0.0")

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -116,7 +116,8 @@ public class ConfigurationTypesProvider {
     MDOType.SETTINGS_STORAGE,
     MDOType.WS_REFERENCE,
     MDOType.INTEGRATION_SERVICE,
-    MDOType.INTEGRATION_SERVICE_CHANNEL
+    MDOType.INTEGRATION_SERVICE_CHANNEL,
+    MDOType.PALETTE_COLOR
   );
 
   private final TypeRegistry typeRegistry;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderHelpersTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderHelpersTest.java
@@ -216,6 +216,42 @@ class ConfigurationTypesProviderHelpersTest {
   }
 
   @Test
+  void tryRegister_withPaletteColorChild_registersManager() {
+    var workspaceUri = java.net.URI.create("file:///test-cfg-palette/");
+    WorkspaceContextHolder.registerWorkspace(workspaceUri, "t");
+    WorkspaceContextHolder.set(workspaceUri);
+    try {
+      var paletteColor = (MD) com.github._1c_syntax.bsl.mdo.PaletteColor.builder()
+        .name("ПервичныйЦвет").build();
+      var configuration = Mockito.mock(Configuration.class);
+      Mockito.when(configuration.isEmpty()).thenReturn(false);
+      Mockito.when(configuration.getChildrenByMdoRef())
+        .thenReturn(java.util.Map.of(paletteColor.getMdoReference(), paletteColor));
+      var serverContext = Mockito.mock(ServerContext.class);
+      Mockito.when(serverContext.getConfiguration()).thenReturn(configuration);
+      var serverProvider = Mockito.mock(ServerContextProvider.class);
+      Mockito.when(serverProvider.getAllContexts())
+        .thenReturn(java.util.Map.of(workspaceUri, serverContext));
+
+      var registry = new TypeRegistry(List.of(),
+        Mockito.mock(GlobalScopeProvider.class),
+        Mockito.mock(MemberMetadataIndex.class));
+      var globalScope = Mockito.mock(GlobalScopeProvider.class);
+      var lsConfig = Mockito.mock(
+        com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration.class);
+      var mcs = Mockito.mock(MetadataCollectionSpecializer.class);
+      var provider = new ConfigurationTypesProvider(registry, serverProvider, globalScope,
+        lsConfig, mcs, new ConfigurationGenericExpander(registry, serverProvider));
+
+      provider.tryRegister();
+      assertThat(registry.resolve("ЦветПалитрыМенеджер.ПервичныйЦвет")).isPresent();
+    } finally {
+      WorkspaceContextHolder.clear();
+      WorkspaceContextHolder.unregisterWorkspace(workspaceUri);
+    }
+  }
+
+  @Test
   void tryRegister_withMultipleMdoTypes_registersAll() {
     var workspaceUri = java.net.URI.create("file:///test-cfg-all/");
     WorkspaceContextHolder.registerWorkspace(workspaceUri, "t");


### PR DESCRIPTION
## Summary

- Поднята зависимость `bsl-context` до `0.7.0` (релиз с поддержкой платформы 1С:Предприятие 8.5.4: корректный разбор разбитого FileStorage у `shlang_ru.hbk`, восстановленные аннотации `&Перед/&После/&Вместо/&ИзменениеИКонтроль`, новые аннотации обработки ошибок расширения `&ПриОшибкеРасширения*`).
- `MDOType.PALETTE_COLOR` добавлен в `MANAGER_TYPES` — для нового MDO «ЦветПалитры» из 8.5.4 регистрируется специализация менеджера `ЦветПалитрыМенеджер.<ИмяЦвета>` (по аналогии с `СправочникМенеджер.X`, `ДокументМенеджер.X`).

## Test plan

- [x] `ConfigurationTypesProviderHelpersTest.tryRegister_withPaletteColorChild_registersManager` — проверяет, что при наличии в конфигурации `PaletteColor` с именем `ПервичныйЦвет` в реестре появляется тип `ЦветПалитрыМенеджер.ПервичныйЦвет`.
- [x] `MetadataChainInferenceTest` — зелёный после апгрейда bsl-context.

🤖 Generated with [Claude Code](https://claude.com/claude-code)