### PR TITLE
fix(oscript): не терять первый module/class в lib.config при чередовании

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser.java
@@ -23,11 +23,14 @@ package com.github._1c_syntax.bsl.languageserver.types.oscript;
 
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.stereotype.Component;
-import tools.jackson.dataformat.xml.XmlMapper;
-import tools.jackson.dataformat.xml.annotation.JacksonXmlElementWrapper;
-import tools.jackson.dataformat.xml.annotation.JacksonXmlProperty;
+
+import javax.xml.stream.XMLInputFactory;
+import javax.xml.stream.XMLStreamConstants;
+import javax.xml.stream.XMLStreamException;
+import javax.xml.stream.XMLStreamReader;
 
 import java.io.IOException;
+import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -49,46 +52,63 @@ import java.util.List;
 @Component
 public final class LibConfigParser {
 
-  private final XmlMapper xmlMapper = XmlMapper.builder().build();
+  private static final String MODULE_ELEMENT = "module";
+  private static final String CLASS_ELEMENT = "class";
+  private static final String NAME_ATTRIBUTE = "name";
+  private static final String FILE_ATTRIBUTE = "file";
+
+  private static final XMLInputFactory XML_INPUT_FACTORY = createXmlInputFactory();
+
+  private static XMLInputFactory createXmlInputFactory() {
+    var factory = XMLInputFactory.newDefaultFactory();
+    // Защита от XXE: lib.config не должен подтягивать DTD/внешние сущности.
+    factory.setProperty(XMLInputFactory.SUPPORT_DTD, false);
+    factory.setProperty(XMLInputFactory.IS_SUPPORTING_EXTERNAL_ENTITIES, false);
+    return factory;
+  }
 
   /**
+   * Разобрать манифест {@code lib.config}.
+   * <p>
+   * Элементы {@code <module>}/{@code <class>} читаются потоково в документном порядке, поэтому
+   * любое их чередование обрабатывается корректно (Jackson-десериализация двух unwrapped-списков
+   * теряла первый элемент каждого типа при интерливинге). Поток также корректно отрабатывает BOM.
+   *
    * @param libConfigPath абсолютный путь к {@code lib.config}
-   * @return распарсенный манифест либо пустой, если файл не читается
+   * @return распарсенный манифест либо пустой, если файл не читается или некорректен
    */
   public LibConfig parse(Path libConfigPath) {
-    try {
-      var content = Files.readString(libConfigPath);
-      var raw = xmlMapper.readValue(content, RawPackageDef.class);
-      return toLibConfig(raw);
+    var modules = new ArrayList<LibEntry>();
+    var classes = new ArrayList<LibEntry>();
+
+    try (InputStream input = Files.newInputStream(libConfigPath)) {
+      var reader = XML_INPUT_FACTORY.createXMLStreamReader(input);
+      try {
+        while (reader.hasNext()) {
+          if (reader.next() != XMLStreamConstants.START_ELEMENT) {
+            continue;
+          }
+          var element = reader.getLocalName();
+          if (!MODULE_ELEMENT.equals(element) && !CLASS_ELEMENT.equals(element)) {
+            continue;
+          }
+          var name = reader.getAttributeValue(null, NAME_ATTRIBUTE);
+          var file = reader.getAttributeValue(null, FILE_ATTRIBUTE);
+          if (name != null && file != null) {
+            (MODULE_ELEMENT.equals(element) ? modules : classes).add(new LibEntry(name, file));
+          }
+        }
+      } finally {
+        reader.close();
+      }
     } catch (IOException e) {
       LOGGER.warn("Failed to parse lib.config: {}", libConfigPath, e);
       return new LibConfig(List.of(), List.of());
-    } catch (RuntimeException e) {
+    } catch (XMLStreamException e) {
       LOGGER.warn("Malformed lib.config: {}", libConfigPath, e);
       return new LibConfig(List.of(), List.of());
     }
-  }
 
-  private static LibConfig toLibConfig(RawPackageDef raw) {
-    if (raw == null) {
-      return new LibConfig(List.of(), List.of());
-    }
-    var modules = new ArrayList<LibEntry>();
-    if (raw.module != null) {
-      for (var m : raw.module) {
-        if (m.name != null && m.file != null) {
-          modules.add(new LibEntry(m.name, m.file));
-        }
-      }
-    }
-    var classes = new ArrayList<LibEntry>();
-    if (raw.klass != null) {
-      for (var c : raw.klass) {
-        if (c.name != null && c.file != null) {
-          classes.add(new LibEntry(c.name, c.file));
-        }
-      }
-    }
     return new LibConfig(List.copyOf(modules), List.copyOf(classes));
   }
 
@@ -108,25 +128,6 @@ public final class LibConfigParser {
    * @param file путь к {@code .os}-файлу
    */
   public record LibEntry(String name, String file) {
-  }
-
-  /** Внутренняя POJO для парсинга XML. */
-  public static final class RawPackageDef {
-    @JacksonXmlElementWrapper(useWrapping = false)
-    public List<RawEntry> module;
-
-    @JacksonXmlElementWrapper(useWrapping = false)
-    @JacksonXmlProperty(localName = "class")
-    public List<RawEntry> klass;
-  }
-
-  /** Внутренняя POJO для одной записи. */
-  public static final class RawEntry {
-    @JacksonXmlProperty(isAttribute = true)
-    public String name;
-
-    @JacksonXmlProperty(isAttribute = true)
-    public String file;
   }
 }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser.java
@@ -30,7 +30,6 @@ import javax.xml.stream.XMLStreamException;
 import javax.xml.stream.XMLStreamReader;
 
 import java.io.IOException;
-import java.io.InputStream;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.ArrayList;
@@ -81,27 +80,8 @@ public final class LibConfigParser {
 
     // Фабрика создаётся на вызов: XMLInputFactory не гарантирует потокобезопасность,
     // а newDefaultFactory() дёшев (без ServiceLoader), parse() не на горячем пути.
-    var factory = createXmlInputFactory();
-    try (InputStream input = Files.newInputStream(libConfigPath)) {
-      var reader = factory.createXMLStreamReader(input);
-      try {
-        while (reader.hasNext()) {
-          if (reader.next() != XMLStreamConstants.START_ELEMENT) {
-            continue;
-          }
-          var element = reader.getLocalName();
-          if (!MODULE_ELEMENT.equals(element) && !CLASS_ELEMENT.equals(element)) {
-            continue;
-          }
-          var name = reader.getAttributeValue(null, NAME_ATTRIBUTE);
-          var file = reader.getAttributeValue(null, FILE_ATTRIBUTE);
-          if (name != null && file != null) {
-            (MODULE_ELEMENT.equals(element) ? modules : classes).add(new LibEntry(name, file));
-          }
-        }
-      } finally {
-        reader.close();
-      }
+    try (var input = Files.newInputStream(libConfigPath)) {
+      readEntries(createXmlInputFactory().createXMLStreamReader(input), modules, classes);
     } catch (IOException e) {
       LOGGER.warn("Failed to parse lib.config: {}", libConfigPath, e);
       return new LibConfig(List.of(), List.of());
@@ -111,6 +91,36 @@ public final class LibConfigParser {
     }
 
     return new LibConfig(List.copyOf(modules), List.copyOf(classes));
+  }
+
+  private static void readEntries(XMLStreamReader reader, List<LibEntry> modules, List<LibEntry> classes)
+    throws XMLStreamException {
+    try {
+      while (reader.hasNext()) {
+        if (reader.next() == XMLStreamConstants.START_ELEMENT) {
+          addEntry(reader, modules, classes);
+        }
+      }
+    } finally {
+      reader.close();
+    }
+  }
+
+  private static void addEntry(XMLStreamReader reader, List<LibEntry> modules, List<LibEntry> classes) {
+    var element = reader.getLocalName();
+    List<LibEntry> target;
+    if (MODULE_ELEMENT.equals(element)) {
+      target = modules;
+    } else if (CLASS_ELEMENT.equals(element)) {
+      target = classes;
+    } else {
+      return;
+    }
+    var name = reader.getAttributeValue(null, NAME_ATTRIBUTE);
+    var file = reader.getAttributeValue(null, FILE_ATTRIBUTE);
+    if (name != null && file != null) {
+      target.add(new LibEntry(name, file));
+    }
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParser.java
@@ -57,8 +57,6 @@ public final class LibConfigParser {
   private static final String NAME_ATTRIBUTE = "name";
   private static final String FILE_ATTRIBUTE = "file";
 
-  private static final XMLInputFactory XML_INPUT_FACTORY = createXmlInputFactory();
-
   private static XMLInputFactory createXmlInputFactory() {
     var factory = XMLInputFactory.newDefaultFactory();
     // Защита от XXE: lib.config не должен подтягивать DTD/внешние сущности.
@@ -81,8 +79,11 @@ public final class LibConfigParser {
     var modules = new ArrayList<LibEntry>();
     var classes = new ArrayList<LibEntry>();
 
+    // Фабрика создаётся на вызов: XMLInputFactory не гарантирует потокобезопасность,
+    // а newDefaultFactory() дёшев (без ServiceLoader), parse() не на горячем пути.
+    var factory = createXmlInputFactory();
     try (InputStream input = Files.newInputStream(libConfigPath)) {
-      var reader = XML_INPUT_FACTORY.createXMLStreamReader(input);
+      var reader = factory.createXMLStreamReader(input);
       try {
         while (reader.hasNext()) {
           if (reader.next() != XMLStreamConstants.START_ELEMENT) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParserTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParserTest.java
@@ -77,6 +77,26 @@ class LibConfigParserTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void parsesInterleavedModulesAndClasses(@TempDir Path tmp) throws IOException {
+    // module и class идут вперемешку (как в реальном logos/lib.config)
+    var libConfig = tmp.resolve("lib.config");
+    Files.writeString(libConfig,
+      "<package-def>"
+        + "<module name=\"M1\" file=\"m1.os\"/>"
+        + "<class name=\"C1\" file=\"c1.os\"/>"
+        + "<module name=\"M2\" file=\"m2.os\"/>"
+        + "<class name=\"C2\" file=\"c2.os\"/>"
+        + "</package-def>");
+
+    var result = parser.parse(libConfig);
+
+    assertThat(result.modules()).extracting(LibConfigParser.LibEntry::name)
+      .containsExactly("M1", "M2");
+    assertThat(result.classes()).extracting(LibConfigParser.LibEntry::name)
+      .containsExactly("C1", "C2");
+  }
+
+  @Test
   void returnsEmptyOnMalformedXml(@TempDir Path tmp) throws IOException {
     var libConfig = tmp.resolve("lib.config");
     Files.writeString(libConfig, "<package-def><module name='broken");

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParserTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/LibConfigParserTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.io.TempDir;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.io.IOException;
+import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -94,6 +95,41 @@ class LibConfigParserTest extends AbstractServerContextAwareTest {
       .containsExactly("M1", "M2");
     assertThat(result.classes()).extracting(LibConfigParser.LibEntry::name)
       .containsExactly("C1", "C2");
+  }
+
+  @Test
+  void parsesConfigWithUtf8Bom(@TempDir Path tmp) throws IOException {
+    // lib.config с UTF-8 BOM перед <package-def> (как у logos/lib.config)
+    var libConfig = tmp.resolve("lib.config");
+    var bom = new byte[]{(byte) 0xEF, (byte) 0xBB, (byte) 0xBF};
+    var xml = "<package-def><class name=\"Лог\" file=\"src/log.os\"/></package-def>"
+      .getBytes(StandardCharsets.UTF_8);
+    var bytes = new byte[bom.length + xml.length];
+    System.arraycopy(bom, 0, bytes, 0, bom.length);
+    System.arraycopy(xml, 0, bytes, bom.length, xml.length);
+    Files.write(libConfig, bytes);
+
+    var result = parser.parse(libConfig);
+
+    assertThat(result.classes()).extracting(LibConfigParser.LibEntry::name)
+      .containsExactly("Лог");
+  }
+
+  @Test
+  void rejectsDtdToPreventXxe(@TempDir Path tmp) throws IOException {
+    // Внешняя сущность не должна раскрываться: DTD отключён, документ с DOCTYPE отвергается.
+    var secret = tmp.resolve("secret.txt");
+    Files.writeString(secret, "<class name=\"Утечка\" file=\"leak.os\"/>");
+    var libConfig = tmp.resolve("lib.config");
+    Files.writeString(libConfig,
+      "<?xml version=\"1.0\"?>"
+        + "<!DOCTYPE package-def [<!ENTITY xxe SYSTEM \"" + secret.toUri() + "\">]>"
+        + "<package-def><class name=\"OK\" file=\"OK.os\">&xxe;</class></package-def>");
+
+    var result = parser.parse(libConfig);
+
+    assertThat(result.modules()).isEmpty();
+    assertThat(result.classes()).isEmpty();
   }
 
   @Test


### PR DESCRIPTION
## Проблема

`LibConfigParser` десериализовал `lib.config` через Jackson XML двумя `useWrapping = false`-списками (`<module>` и `<class>`). При **чередовании** этих элементов в манифесте Jackson терял **первый элемент каждого типа**.

Пример — реальный `logos/lib.config` (порядок `module, class, module, module, class, …`):

```xml
<package-def>
  <module name="УровниЛога" file="src/levels.os"/>   <!-- терялся -->
  <class  name="Лог"        file="src/log.os"/>      <!-- терялся -->
  <module name="Логирование" file="src/log-manager.os"/>
  <class  name="JSONРаскладкаСообщения" file="src/json-layout.os"/>
  ...
</package-def>
```

Из индекса выпадали класс `Лог` и модуль `УровниЛога`, из-за чего тип `Лог` не резолвился (ломался вывод типов для зависящих от него мест, например DI-внедрений `&Лог` фреймворка «ОСень»). Остальные классы/модули индексировались нормально, поэтому проблема была неочевидной (соседний `СобытиеЛога` резолвился).

Сгруппированные манифесты (все `<module>`, затем все `<class>`) багу не подвержены — поэтому тесты и большинство библиотек его не вскрывали.

## Решение

`LibConfigParser` переписан с Jackson-десериализации на потоковый обход StAX: элементы `<module>`/`<class>` читаются в документном порядке, поэтому **любое чередование** обрабатывается корректно. Поток также корректно отрабатывает UTF-8 BOM. Парсер сконфигурирован без DTD/внешних сущностей (защита от XXE).

## Тесты

Добавлен `parsesInterleavedModulesAndClasses` (чередующиеся `module`/`class`) — красный до фикса, зелёный после. Прежние тесты парсера (группировка, malformed, отсутствующий файл, пропуск записей без атрибутов) сохранены и проходят.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Security Enhancements**
  * lib.config parsing now blocks XML external entity/DTD attacks (XXE) and fails safely, returning an empty result on unsafe input.

* **Improvements**
  * XML parsing preserves document order for interleaved module and class entries and correctly handles UTF-8 BOM–prefixed files for reliable loading.

* **Tests**
  * Added coverage for interleaved entries, BOM handling, and XXE rejection to ensure safer, predictable parsing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->