### PR TITLE
fix(formatting): не затирать ';' при onType-форматировании, когда курсор за концом строки

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -191,36 +191,44 @@ public final class FormatProvider {
     String ch, Position position, DocumentContext documentContext
   ) {
     if ("\n".equals(ch)) {
-      if (position.getLine() == 0) {
-        return null;
-      }
-      var targetLineLsp = position.getLine() - 1;
-      var contentList = documentContext.getContentList();
-      if (targetLineLsp >= contentList.length) {
-        return null;
-      }
-      // Ограничиваем диапазон концом строки без переноса: только что набранный пользователем
-      // перевод строки не должен попасть внутрь replace-range, иначе editor может проглотить
-      // новую строку при отсутствии хвостового переноса в newText.
-      var lineLength = contentList[targetLineLsp].length();
-      var range = Ranges.create(targetLineLsp, 0, targetLineLsp, lineLength);
-      return new EditWindow(targetLineLsp, targetLineLsp + 1, range, lineLength);
+      return resolveEnterWindow(position, documentContext);
     }
     if (";".equals(ch)) {
-      var targetLineLsp = position.getLine();
-      var contentList = documentContext.getContentList();
-      if (targetLineLsp >= contentList.length) {
-        return null;
-      }
-      // Курсор может оказаться правее фактического конца синхронизированной строки (только что
-      // набранный ';' ещё не доехал до серверной копии документа — рассинхрон у LSP4IJ). Без клампа
-      // диапазон правки уехал бы за конец строки и форматтер дописал бы хвостовой перенос строки,
-      // затирая набранный символ. Зеркалим клампинг ветки "\n".
-      var cutoff = Math.min(position.getCharacter(), contentList[targetLineLsp].length());
-      var range = Ranges.create(targetLineLsp, 0, targetLineLsp, cutoff);
-      return new EditWindow(targetLineLsp, targetLineLsp + 1, range, cutoff);
+      return resolveSemicolonWindow(position, documentContext);
     }
     return null;
+  }
+
+  private static @Nullable EditWindow resolveEnterWindow(Position position, DocumentContext documentContext) {
+    if (position.getLine() == 0) {
+      return null;
+    }
+    var targetLineLsp = position.getLine() - 1;
+    var contentList = documentContext.getContentList();
+    if (targetLineLsp >= contentList.length) {
+      return null;
+    }
+    // Ограничиваем диапазон концом строки без переноса: только что набранный пользователем
+    // перевод строки не должен попасть внутрь replace-range, иначе editor может проглотить
+    // новую строку при отсутствии хвостового переноса в newText.
+    var lineLength = contentList[targetLineLsp].length();
+    var range = Ranges.create(targetLineLsp, 0, targetLineLsp, lineLength);
+    return new EditWindow(targetLineLsp, targetLineLsp + 1, range, lineLength);
+  }
+
+  private static @Nullable EditWindow resolveSemicolonWindow(Position position, DocumentContext documentContext) {
+    var targetLineLsp = position.getLine();
+    var contentList = documentContext.getContentList();
+    if (targetLineLsp >= contentList.length) {
+      return null;
+    }
+    // Курсор может оказаться правее фактического конца синхронизированной строки (только что
+    // набранный ';' ещё не доехал до серверной копии документа — рассинхрон у LSP4IJ). Без клампа
+    // диапазон правки уехал бы за конец строки и форматтер дописал бы хвостовой перенос строки,
+    // затирая набранный символ. Зеркалим клампинг ветки "\n".
+    var cutoff = Math.min(position.getCharacter(), contentList[targetLineLsp].length());
+    var range = Ranges.create(targetLineLsp, 0, targetLineLsp, cutoff);
+    return new EditWindow(targetLineLsp, targetLineLsp + 1, range, cutoff);
   }
 
   private record LineTokens(List<Token> tokens, @Nullable Token firstSignificant, int firstSignificantIndex) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -208,8 +208,17 @@ public final class FormatProvider {
     }
     if (";".equals(ch)) {
       var targetLineLsp = position.getLine();
-      var range = Ranges.create(targetLineLsp, 0, targetLineLsp, position.getCharacter());
-      return new EditWindow(targetLineLsp, targetLineLsp + 1, range, position.getCharacter());
+      var contentList = documentContext.getContentList();
+      if (targetLineLsp >= contentList.length) {
+        return null;
+      }
+      // Курсор может оказаться правее фактического конца синхронизированной строки (только что
+      // набранный ';' ещё не доехал до серверной копии документа — рассинхрон у LSP4IJ). Без клампа
+      // диапазон правки уехал бы за конец строки и форматтер дописал бы хвостовой перенос строки,
+      // затирая набранный символ. Зеркалим клампинг ветки "\n".
+      var cutoff = Math.min(position.getCharacter(), contentList[targetLineLsp].length());
+      var range = Ranges.create(targetLineLsp, 0, targetLineLsp, cutoff);
+      return new EditWindow(targetLineLsp, targetLineLsp + 1, range, cutoff);
     }
     return null;
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConf
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.utils.Absolute;
 import org.apache.commons.io.FileUtils;
 import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
@@ -429,6 +430,31 @@ class FormatProviderTest {
 
     // then: единственный токен строки выходит за курсор и отфильтрован, форматировать нечего
     assertThat(textEdits).isEmpty();
+  }
+
+  @Test
+  void testOnTypeFormattingSemicolonClampsCursorPastLineEnd() {
+    // given: рассинхрон клиента (LSP4IJ) — серверная копия строки ещё без набранной `;`,
+    // поэтому курсор (col 19) оказывается правее фактического конца строки (18 символов).
+    // Раньше ветка `;` не клампила позицию, диапазон правки уезжал за конец строки и при
+    // применении затирал только что набранную `;`.
+    String fileContent = "f = Новый Массив()";
+    var params = onTypeParams(";", 0, 19);
+
+    var documentContext = TestUtils.getDocumentContext(
+      Absolute.uri(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getOnTypeFormatting(params, documentContext);
+
+    // then: диапазон правки не выходит за конец синхронизированной строки и не содержит переноса
+    assertThat(textEdits).hasSize(1);
+    TextEdit edit = textEdits.getFirst();
+    assertThat(edit.getRange().getEnd().getCharacter()).isEqualTo(18);
+    assertThat(edit.getNewText()).doesNotContain("\n");
+    assertThat(edit.getNewText()).isEqualTo("f = Новый Массив()");
   }
 
   @Test


### PR DESCRIPTION
## Проблема

При наборе `;` после конструктора символ стирался, а вместо него вставлялся перенос строки:

```bsl
&Желудь
&Прозвище("...")
Процедура ПриСозданииОбъекта()
    f = Новый ФабрикаЛогов()   // ← ставим ';' в конце — она пропадает
КонецПроцедуры
```

## Причина

В `FormatProvider.resolveEditWindow` ветка триггера `;` строила диапазон правки от `position.getCharacter()` **без клампа** к фактической длине строки, тогда как ветка `\n` клампит к `contentList[line].length()`.

При рассинхроне клиента (наблюдается у LSP4IJ / JetBrains) только что набранная `;` ещё не доезжает до серверной копии документа: курсор оказывается правее конца синхронизированной строки. Диапазон правки уезжал за конец строки и при применении затирал набранную `;`, подставляя хвостовой перенос строки + отступ.

## Исправление

- Клампим `cutoff` и конец диапазона к длине строки — `Math.min(position.getCharacter(), contentList[targetLineLsp].length())` (зеркало ветки `\n`).
- Возвращаем `null`, если строка за пределами документа.

## Тест

`testOnTypeFormattingSemicolonClampsCursorPastLineEnd` — onType `;` с позицией курсора за концом синхронизированной строки: правка не выходит за конец строки и не содержит переноса. Проверен red→green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed on-type formatting for semicolon so edits are clamped to the server-synchronized line length, preventing formatting from extending past the line end and avoiding spurious newline/insertion beyond the real line.

* **Tests**
  * Added a unit test covering on-type semicolon formatting when the cursor is reported beyond the synchronized line end to ensure a single, correctly-clamped edit.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->