### PR TITLE
ci(test): отключить Defender на windows-runner — ускорение тестов

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -45,6 +45,21 @@ jobs:
         java-version: ${{ matrix.java_version }}
         distribution: 'corretto'
         cache: gradle
+    - name: Disable Defender real-time scan on Windows runner
+      # На windows-latest runner'е защитник в реальном времени сканирует
+      # каждый файл, открываемый Gradle/JVM. На тестах LS, которые обходят
+      # фикстуры metadata (134 каталога / 157 файлов) и интенсивно работают
+      # с tmp и gradle-cache, это даёт x2-3 замедление относительно
+      # ubuntu/macOS-runner'ов. Исключаем рабочую директорию, TEMP, gradle-cache
+      # и JVM/Gradle процессы — runner создаётся одноразово, эффект только
+      # в рамках текущего job'а.
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        Add-MpPreference -ExclusionPath "${{ github.workspace }}"
+        Add-MpPreference -ExclusionPath "$env:TEMP"
+        Add-MpPreference -ExclusionPath "$env:USERPROFILE\.gradle"
+        Add-MpPreference -ExclusionProcess "java.exe","javaw.exe","gradle.bat","gradle"
     - name: Build with Gradle
       run: ./gradlew check --stacktrace
     - name: Archive test results

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -56,10 +56,14 @@ jobs:
       if: runner.os == 'Windows'
       shell: pwsh
       run: |
+        Write-Host "=== Defender state BEFORE:"
+        Get-MpPreference | Select-Object DisableRealtimeMonitoring, ExclusionPath, ExclusionProcess | Format-List
         Add-MpPreference -ExclusionPath "${{ github.workspace }}"
         Add-MpPreference -ExclusionPath "$env:TEMP"
         Add-MpPreference -ExclusionPath "$env:USERPROFILE\.gradle"
         Add-MpPreference -ExclusionProcess "java.exe","javaw.exe","gradle.bat","gradle"
+        Write-Host "=== Defender state AFTER:"
+        Get-MpPreference | Select-Object DisableRealtimeMonitoring, ExclusionPath, ExclusionProcess | Format-List
     - name: Build with Gradle
       run: ./gradlew check --stacktrace
     - name: Archive test results


### PR DESCRIPTION
## Что и зачем

Полный прогон тестов LS на `windows-latest` идёт **~2.8× дольше**, чем на `macOS-latest` (1078s vs 384s — данные из run [27168441718](https://github.com/1c-syntax/bsl-language-server/actions/runs/27168441718), develop).

Топовые «лидеры» дельты:

| Test | win21 | mac21 | × |
|---|---|---|---|
| `ConfigurationTypesProviderTest` | 83.4s | 17.4s | **4.8×** |
| `BSLTextDocumentServiceTest` | 74.6s | 34.5s | 2.16× |
| `MetadataObjectNameLengthDiagnosticTest` | 56.3s | 10.3s | **5.5×** |
| `ScheduledJobHandlerDiagnosticTest` | 36.4s | n/a | ≥4× |
| `NonStandardRegionDiagnosticTest` | 34.7s | 15.4s | 2.25× |

Все «лидеры» — это диагностики/registry, переподнимающие `ServerContext` на тестовой фикстуре `src/test/resources/metadata` (134 каталога / 157 файлов). На каждое поднятие — массовый `Files.walk` + чтение. Windows Defender перехватывает каждое открытие файла и **на порядок** замедляет такой workload по сравнению с APFS/ext4.

## Что делаем

Добавлен один step в `gradle.yml` (job `build`, только для `runner.os == 'Windows'`):

```yaml
- name: Disable Defender real-time scan on Windows runner
  if: runner.os == 'Windows'
  shell: pwsh
  run: |
    Add-MpPreference -ExclusionPath "${{ github.workspace }}"
    Add-MpPreference -ExclusionPath "$env:TEMP"
    Add-MpPreference -ExclusionPath "$env:USERPROFILE\.gradle"
    Add-MpPreference -ExclusionProcess "java.exe","javaw.exe","gradle.bat","gradle"
```

`runner.os == 'Windows'` гарантирует no-op для ubuntu/macOS-runner'ов. На самом runner'е изменение действует только до конца job'а — runner'ы github-hosted одноразовые.

## Test plan

- [ ] PR-run отрабатывает зелёным на всех трёх ОС (без regressions).
- [ ] Сверить wall-clock `build (21, windows-latest)` и `build (25, windows-latest)` с прошлыми run'ами на develop (`27168441718` — 22m04s / 17m47s). Ожидаемое — x1.5-2 ускорение.
- [ ] Сверить «лидеров» дельты (`ConfigurationTypesProviderTest`, `MetadataObjectNameLengthDiagnosticTest`, `BSLTextDocumentServiceTest`) — должны просесть пропорционально.

## Ссылки и подтверждения

- [actions/runner-images#842](https://github.com/actions/runner-images/issues/842) — Microsoft Reps подтверждают workaround для slow IO.
- [community discussions/8166](https://github.com/orgs/community/discussions/8166) — обзор стратегий ускорения win-runner'ов.
- Используется в dotnet, rust-lang, microsoft/STL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)