### PR TITLE
perf(tests): initServerContextOnce в MetadataObjectNameLengthDiagnosticTest

### DIFF
--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MetadataObjectNameLengthDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MetadataObjectNameLengthDiagnosticTest.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.mdo.CommonModule;
 import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.mdo.children.ObjectModule;
 import com.github._1c_syntax.bsl.types.ModuleType;
+import com.github._1c_syntax.utils.Absolute;
 import lombok.SneakyThrows;
 import org.eclipse.lsp4j.Diagnostic;
 import org.junit.jupiter.api.Test;
@@ -153,7 +154,7 @@ class MetadataObjectNameLengthDiagnosticTest extends AbstractDiagnosticTest<Meta
   @Test
   void testWithoutModules() {
 
-    initServerContext(PATH_TO_METADATA);
+    initServerContextOnce(Absolute.path(PATH_TO_METADATA));
 
     documentContext = spy(getDocumentContext());
 
@@ -188,7 +189,7 @@ class MetadataObjectNameLengthDiagnosticTest extends AbstractDiagnosticTest<Meta
 
   @SneakyThrows
   void getDocumentContextFromFile(String modulePath, String content) {
-    initServerContext(PATH_TO_METADATA);
+    initServerContextOnce(Absolute.path(PATH_TO_METADATA));
     var testFile = new File(PATH_TO_METADATA, modulePath).getAbsoluteFile();
     documentContext = spy(TestUtils.getDocumentContext(testFile.toURI(), content, context));
     var moduleByUri = Objects.requireNonNull(context).getConfiguration()


### PR DESCRIPTION
## Что и зачем

Продолжение #4025 — по одному классу из топа win/mac-дельты, точечный переход на `initServerContextOnce`.

`MetadataObjectNameLengthDiagnosticTest` — топ-2 в дельте: **56.3s на windows-runner vs 10.3s на mac** (×5.5). Все 16 тестов read-only к workspace, мутируют только локальные spy-переменные (`documentContext`, `module`, `configuration` внутри `testWithoutModules`). Helper `getDocumentContextFromFile` создаёт новый `DocumentContext` per test через `TestUtils.getDocumentContext(...)` — не зависит от свежего workspace.

## Что меняем

- `getDocumentContextFromFile`: `initServerContext(PATH_TO_METADATA)` → `initServerContextOnce(Absolute.path(PATH_TO_METADATA))`.
- `testWithoutModules`: то же.

## Замер

- Изолированно локально: **18.26s → 13.0s** (×1.4).
- Полный прогон `./gradlew test` — 3m51s, все 2895 тестов зелёные.
- CI-замер — после прогона этого PR.

## Не вошло

Тот же паттерн пробовался батчем (см. amended #4025 history) и вызвал регрессию на CI. Делаем по одному классу — гарантированно red-green-проверяемый шаг.

## Test plan

- [x] Изолированно `MetadataObjectNameLengthDiagnosticTest` — все 16 зелёных.
- [x] Полный suite — все 2895 зелёных.
- [ ] CI-замер — обновить таблицу.

🤖 Generated with [Claude Code](https://claude.com/claude-code)