### PR TITLE
perf(tests): initServerContextOnce в NonStandardRegionDiagnosticTest

### DIFF
--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/NonStandardRegionDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/NonStandardRegionDiagnosticTest.java
@@ -243,7 +243,7 @@ class NonStandardRegionDiagnosticTest extends AbstractDiagnosticTest<NonStandard
       pathByModuleType.getOrDefault(moduleType, "Module.bsl")
     );
 
-    initServerContext(CONFIGURATION_PATH.toRealPath());
+    initServerContextOnce(CONFIGURATION_PATH.toRealPath());
     return TestUtils.getDocumentContext(
       tempFile.toRealPath().toUri(),
       FileUtils.readFileToString(tempFile.toFile(), StandardCharsets.UTF_8),


### PR DESCRIPTION
## Что и зачем

Продолжение серии (#4025, #4026) — по одному классу из топа win/mac-дельты.

`NonStandardRegionDiagnosticTest` — топ-4: **34.7s на windows-runner vs 15.4s на mac** (×2.25). 12 тестов, все read-only к workspace — каждый зовёт helper `getFixtureDocumentContextByModuleType`, который читает фикстуру metadata и создаёт локальный DocumentContext через `TestUtils.getDocumentContext`. Workspace не мутируется.

`@DirtiesContext` на класс-level — Spring контекст помечается dirty после всего класса, между классами свежий, внутри переиспользуется.

## Что меняем

- `getFixtureDocumentContextByModuleType`: `initServerContext(CONFIGURATION_PATH.toRealPath())` → `initServerContextOnce(...)`.

## Test plan

- [x] Изолированно `NonStandardRegionDiagnosticTest` — все 12 зелёных, 10.8s.
- [x] Полный suite — зелёный.
- [ ] CI-замер.

🤖 Generated with [Claude Code](https://claude.com/claude-code)