### PR TITLE
perf(tests): initServerContextOnce в CachedPublicDiagnosticTest

### DIFF
--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/CachedPublicDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/CachedPublicDiagnosticTest.java
@@ -145,7 +145,7 @@ class CachedPublicDiagnosticTest extends AbstractDiagnosticTest<CachedPublicDiag
     Path path = Absolute.path(PATH_TO_METADATA);
     Path moduleFile = Path.of(PATH_TO_MODULE_FILE).toAbsolutePath();
 
-    initServerContext(path);
+    initServerContextOnce(path);
     var configuration = context.getConfiguration();
     documentContext = spy(TestUtils.getDocumentContext(
       testFile.toUri(),


### PR DESCRIPTION
## Что и зачем

Продолжение серии (#4025, #4026, #4027). `CachedPublicDiagnosticTest` — топ-7 в дельте win/mac: **22.9s на windows-runner**. 4 теста, все read-only — `getDocumentContextFromFile` создаёт локальный `DocumentContext` через `TestUtils.getDocumentContext`. `@DirtiesContext` на класс-level — переиспользование контекста внутри класса безопасно.

## Что меняем

- helper `getDocumentContextFromFile`: `initServerContext(path)` → `initServerContextOnce(path)`.

## Test plan

- [x] Изолированно `CachedPublicDiagnosticTest` — все 4 зелёных, 7.4s.
- [x] Полный suite — зелёный.
- [ ] CI-замер.

🤖 Generated with [Claude Code](https://claude.com/claude-code)