### PR TITLE
perf(tests): initServerContextOnce в UsingSynchronousCallsDiagnosticTest

### DIFF
--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingSynchronousCallsDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UsingSynchronousCallsDiagnosticTest.java
@@ -143,7 +143,7 @@ class UsingSynchronousCallsDiagnosticTest extends AbstractDiagnosticTest<UsingSy
     var path = Absolute.path(PATH_TO_METADATA);
     var testFile = Path.of(moduleFile).toAbsolutePath();
 
-    initServerContext(path);
+    initServerContextOnce(path);
     var serverContext = spy(context);
     var configuration = spy(serverContext.getConfiguration());
     when(((Configuration) configuration).getSynchronousExtensionAndAddInCallUseMode()).thenReturn(useMode);


### PR DESCRIPTION
## Что и зачем

Продолжение серии (#4025, #4026, #4027, #4028). `UsingSynchronousCallsDiagnosticTest` — в топе дельты win/mac: **18.0s на windows-runner**. Helper `getDocumentContextWithUseFlag` создаёт **локальные** spy контекста и `documentContext`, не мутируя workspace. `@DirtiesContext` на класс-level — переиспользование контекста внутри класса безопасно.

## Что меняем

- helper `getDocumentContextWithUseFlag`: `initServerContext(path)` → `initServerContextOnce(path)`.

## Test plan

- [x] Изолированно — все тесты зелёные.
- [x] Полный suite — зелёный.
- [ ] CI-замер.

🤖 Generated with [Claude Code](https://claude.com/claude-code)