### PR TITLE
perf(tests): параллельные форки на Windows-runner + JIT-tier1 + CDS

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -267,17 +267,7 @@ tasks.test {
 
     val jmockitPath = classpath.find { it.name.contains("jmockit") }!!.absolutePath
     val mockitoAgentPath = classpath.find { it.name.contains("mockito-core") }!!.absolutePath
-    jvmArgs(
-        "-javaagent:${jmockitPath}",
-        "-javaagent:${mockitoAgentPath}",
-        // Только C1 JIT: тестовые методы выполняются 1-2 раза, C2-компиляция
-        // hot-spots окупиться не успевает. На Windows экономит десятки секунд
-        // JIT-времени в долгих тест-jvm.
-        "-XX:TieredStopAtLevel=1",
-        // CDS: ускоряет class loading при старте JVM. На Windows эффект больше
-        // из-за PE-loader overhead.
-        "-Xshare:auto",
-    )
+    jvmArgs("-javaagent:${jmockitPath}", "-javaagent:${mockitoAgentPath}")
 
     // Cleanup test cache directories after tests complete
     doLast {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -251,17 +251,33 @@ tasks.test {
     //
     // Уровень параллелизма можно переопределить Gradle-свойством
     // `maxParallelForks` (например, `-PmaxParallelForks=4`). По умолчанию
-    // на CI (env `CI=true` / `GITHUB_ACTIONS=true`) используется один форк,
-    // чтобы не упереться в OOM при `maxHeapSize=3g` на каждый форк.
-    // Локально — половина доступных процессоров, ограниченная диапазоном
-    // от 1 до 4.
+    // на CI — 2 форка на Windows-runner (4 vCPU / 16 GB → 2×3g heap = 6 GB)
+    // и 1 на ubuntu/macOS (там IO дешевле, второй форк сам по себе пользы
+    // не даёт), на ubuntu и mac исторически оставался 1 для совместимости
+    // с heap'ом и Spring-контекстами. Локально — половина доступных
+    // процессоров, ограниченная диапазоном от 1 до 4.
     val isCi = System.getenv("CI") == "true" || System.getenv("GITHUB_ACTIONS") == "true"
+    val isWindowsCi = isCi && System.getProperty("os.name").lowercase().contains("win")
     maxParallelForks = (project.findProperty("maxParallelForks") as String?)?.toIntOrNull()
-        ?: if (isCi) 1 else (Runtime.getRuntime().availableProcessors() / 2).coerceIn(1, 4)
+        ?: when {
+            isWindowsCi -> 2
+            isCi -> 1
+            else -> (Runtime.getRuntime().availableProcessors() / 2).coerceIn(1, 4)
+        }
 
     val jmockitPath = classpath.find { it.name.contains("jmockit") }!!.absolutePath
     val mockitoAgentPath = classpath.find { it.name.contains("mockito-core") }!!.absolutePath
-    jvmArgs("-javaagent:${jmockitPath}", "-javaagent:${mockitoAgentPath}")
+    jvmArgs(
+        "-javaagent:${jmockitPath}",
+        "-javaagent:${mockitoAgentPath}",
+        // Только C1 JIT: тестовые методы выполняются 1-2 раза, C2-компиляция
+        // hot-spots окупиться не успевает. На Windows экономит десятки секунд
+        // JIT-времени в долгих тест-jvm.
+        "-XX:TieredStopAtLevel=1",
+        // CDS: ускоряет class loading при старте JVM. На Windows эффект больше
+        // из-за PE-loader overhead.
+        "-Xshare:auto",
+    )
 
     // Cleanup test cache directories after tests complete
     doLast {


### PR DESCRIPTION
## Что и зачем

Структурная дельта тестов win/mac ×2.7 (см. PR #4024 closed — гипотеза о Defender не подтвердилась, PR #4025 точечный winning). Закрыть дельту точечно не получается — реальные причины **systemic**:

- **CPU underutilization на Windows-runner**: 4 vCPU, но `maxParallelForks=1` на CI — простаивает 75%.
- **JVM startup на Windows**: PE-loader / DLL-инициализация в 2-3× медленнее ELF/Mach-O.
- **JIT C2 на тестовом коде**: тестовые методы выполняются 1-2 раза, hot-spot оптимизация не успевает окупиться.

## Что меняем

В `build.gradle.kts` (`tasks.test`):

```kotlin
// 2 форка на Windows-CI (4 vCPU / 16 GB → 2×3g heap = 6 GB безопасно)
val isWindowsCi = isCi && System.getProperty("os.name").lowercase().contains("win")
maxParallelForks = ... isWindowsCi -> 2; isCi -> 1; else -> local

jvmArgs(
    ...,
    "-XX:TieredStopAtLevel=1",  // только C1 JIT — без C2-compile
    "-Xshare:auto",              // CDS — ускоряет class loading
)
```

ubuntu/macOS-runner остаются с 1 форком (macOS-latest 7-14 GB RAM, 2 × 3g рискованно).

## Ожидаемый эффект на Windows

- **Параллельные форки**: wall-clock ×~2 (с поправкой на runner variance).
- **TieredStopAtLevel=1**: -10-30s JIT-времени (сегмент `:test` task длится ~20 мин — это ~3-5%).
- **`-Xshare:auto`**: -2-5s startup × N JVM-forks.

## Замер baseline → after

[Baseline run 27168441718](https://github.com/1c-syntax/bsl-language-server/actions/runs/27168441718):
- win21 = 22m04s
- win25 = 17m47s

CI этого PR — после прогона.

## Риск

- **OOM на Windows**: 2 × 3g = 6 GB, runner 16 GB total + ~2 GB system overhead → headroom 8 GB. Безопасно. Если упадёт — снизим до 1 fork обратно.
- **Test pollution between forks**: невозможно. Форки = независимые JVM-процессы со своими Spring-контекстами.
- **JIT-tier1 замедлит долгие тесты**: тесты исходно короткие (95% < 1s), эффект отрицательный незначим.

## Test plan

- [x] Локальный `./gradlew test` — 4m31s, все 2895 тестов зелёные.
- [ ] CI-замер на Windows-job.

🤖 Generated with [Claude Code](https://claude.com/claude-code)