### PR TITLE
fix(diagnostics): ограничить CommonModuleVariables только BSL-файлами

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleVariablesDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/CommonModuleVariablesDiagnostic.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticMetadata;
+import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticScope;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticSeverity;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticTag;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticType;
@@ -33,6 +34,7 @@ import org.jspecify.annotations.Nullable;
 @DiagnosticMetadata(
   type = DiagnosticType.ERROR,
   severity = DiagnosticSeverity.CRITICAL,
+  scope = DiagnosticScope.BSL,
   minutesToFix = 5,
   tags = {
     DiagnosticTag.STANDARD,


### PR DESCRIPTION
## Проблема

Диагностика `CommonModuleVariables` срабатывала и в OneScript-файлах (`.os`), хотя проверяет конструкцию, специфичную для 1С:Предприятие — объявление переменных уровня модуля (`Перем`) в **общем модуле**. В OneScript понятия общего модуля нет, поэтому диагностика там неприменима.

## Исправление

Проставлен `scope = DiagnosticScope.BSL` в `@DiagnosticMetadata`. Фильтрация по диалекту выполняется инфраструктурой (`DiagnosticsConfiguration.inScope`), отдельный код в диагностике не нужен.

Тест не добавляется намеренно: фильтрация по `scope` покрыта инфраструктурными тестами (`DiagnosticsTest`), дублировать её на уровне конкретной диагностики не нужно. Существующий `CommonModuleVariablesDiagnosticTest` (BSL-фикстура) остаётся зелёным.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated diagnostic configuration to explicitly define scope, ensuring correct diagnostic categorization and behavior across the system.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->