### PR TITLE
perf(ci): перенести TEMP и Gradle cache на D: drive на Windows-runner

### DIFF
--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -39,6 +39,19 @@ jobs:
     - uses: actions/checkout@v6
       with:
         fetch-depth: 0
+    - name: Redirect TEMP and Gradle cache to D: drive on Windows runner
+      # На windows-runner GA рабочий dir уже на D: (через actions/checkout),
+      # но TEMP и .gradle cache по умолчанию остаются на C: — медленный диск
+      # (актуально с 2025-08, см. actions/runner-images#12744). Перенос heavy-IO
+      # на D: (Dev Drive ReFS) даёт до 30% ускорения CI с интенсивным file IO.
+      if: runner.os == 'Windows'
+      shell: pwsh
+      run: |
+        New-Item -ItemType Directory -Force -Path "D:\tmp" | Out-Null
+        New-Item -ItemType Directory -Force -Path "D:\gradle" | Out-Null
+        "TEMP=D:\tmp"           | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "TMP=D:\tmp"            | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
+        "GRADLE_USER_HOME=D:\gradle" | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
     - name: Set up JDK ${{ matrix.java_version }}
       uses: actions/setup-java@v5
       with:

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -5,6 +5,7 @@ on:
     branches-ignore:
       - "translations_*"
   pull_request:
+  workflow_dispatch:
 
 jobs:
   gatekeeper:


### PR DESCRIPTION
## Что и зачем

Тесты на windows-runner стабильно ×2.75 медленнее macOS-runner (7 последних develop-runs: win21 1292-1806s, mac21 488-770s).

После [PR #4024 closed](https://github.com/1c-syntax/bsl-language-server/pull/4024) подтвердилось, что Defender уже выключен в base image. После [PR #4030 closed](https://github.com/1c-syntax/bsl-language-server/pull/4030) подтвердилось, что параллельные форки и `-XX:TieredStopAtLevel=1` либо noise, либо регрессия.

Новая зацепка из расследования инфры GA:
- [actions/runner-images#12744](https://github.com/actions/runner-images/issues/12744): с 2025-08-18 D: drive (Dev Drive ReFS) снова доступен на windows-runner.
- [Richard Si: «Speeding up pip's Windows CI by setting TEMP to the D: drive»](https://ichard26.github.io/blog/2025/03/faster-pip-ci-on-windows-d-drive/) — **-30%** wall-clock на CI с интенсивным file IO.
- [actions/runner-images#12647](https://github.com/actions/runner-images/issues/12647): подтверждённый ×~30 разрыв IO между C: и D: drives.

В нашем CI:
- Рабочая директория уже на `D:\a\bsl-language-server\bsl-language-server` (через `actions/checkout`).
- Но **`TEMP` и `.gradle` cache остаются на C:** (видно из вывода Defender step в PR #4024: `$env:TEMP = C:\Users\RUNNER~1\AppData\Local\Temp`, `$env:USERPROFILE\.gradle = C:\Users\runneradmin\.gradle`).
- Spring TestContexts, JaCoCo `exec`, временные файлы тестов — всё бьёт по медленному C:.

## Что меняем

Step `Redirect TEMP and Gradle cache to D: drive` до `setup-java` (только на Windows):

```yaml
- if: runner.os == 'Windows'
  shell: pwsh
  run: |
    New-Item -ItemType Directory -Force -Path "D:\tmp"    | Out-Null
    New-Item -ItemType Directory -Force -Path "D:\gradle" | Out-Null
    "TEMP=D:\tmp"               | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
    "TMP=D:\tmp"                | Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
    "GRADLE_USER_HOME=D:\gradle"| Out-File -FilePath $env:GITHUB_ENV -Append -Encoding utf8
```

Step выставляет env vars через `GITHUB_ENV`, поэтому `setup-java cache=gradle` уже использует новый `GRADLE_USER_HOME=D:\gradle` для cache restore/save.

## Ожидаемый эффект

По аналогии с pip: -20-30% wall-clock на windows-job (с ~22m → ~15-17m). На mac/ubuntu — no-op (`if: runner.os == 'Windows'`).

## Test plan

- [x] Меняется только Windows-step, синтаксис проверен локально.
- [ ] CI-замер на этой ветке + сравнить с baseline.

## Источники
- [actions/runner-images#12744 — D: drive restored 2025-08-18](https://github.com/actions/runner-images/issues/12744)
- [Richard Si — Speeding up pip's Windows CI by setting TEMP to D: drive](https://ichard26.github.io/blog/2025/03/faster-pip-ci-on-windows-d-drive/)
- [actions/runner-images#12647 — Windows-2025 slowdown](https://github.com/actions/runner-images/issues/12647)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Added a manual trigger for the Gradle CI workflow to allow on-demand runs.
  * Updated Windows CI configuration to redirect build temporary/cache storage, improving reliability and performance on Windows runners.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->