### PR TITLE
fix(SelectionRangeProvider): находить токен при каретке сразу после идентификатора

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SelectionRangeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SelectionRangeProvider.java
@@ -27,6 +27,8 @@ import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.SelectionRange;
 import org.eclipse.lsp4j.SelectionRangeParams;
 import org.jspecify.annotations.Nullable;
@@ -84,10 +86,32 @@ public class SelectionRangeProvider {
 
     // Result must contains all elements from input
     return positions.stream()
-      .map(position -> Trees.findTerminalNodeContainsPosition(ast, position))
-      .map(terminalNode -> terminalNode.orElse(null))
+      .map(position -> findTerminalNodeAtPosition(ast, position))
       .map(SelectionRangeProvider::toSelectionRange)
       .collect(Collectors.toList());
+  }
+
+  @Nullable
+  private static TerminalNode findTerminalNodeAtPosition(ParserRuleContext ast, Position position) {
+    var node = Trees.findTerminalNodeContainsPosition(ast, position).orElse(null);
+    if (node != null && !Ranges.create(node).getStart().equals(position)) {
+      return node;
+    }
+
+    // Каретка не внутри токена, а на границе (самый частый случай — сразу после идентификатора).
+    // Поиск по позиции содержит начало токена и исключает конец, поэтому отдельно ищем токен,
+    // заканчивающийся ровно в этой позиции, и предпочитаем его.
+    return findTerminalNodeEndingAtPosition(ast, position).orElse(node);
+  }
+
+  private static Optional<TerminalNode> findTerminalNodeEndingAtPosition(ParserRuleContext ast, Position position) {
+    if (position.getCharacter() == 0) {
+      return Optional.empty();
+    }
+
+    var positionInsideToken = new Position(position.getLine(), position.getCharacter() - 1);
+    return Trees.findTerminalNodeContainsPosition(ast, positionInsideToken)
+      .filter(terminalNode -> Ranges.create(terminalNode).getEnd().equals(position));
   }
 
   @Nullable

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SelectionRangeProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SelectionRangeProviderTest.java
@@ -35,6 +35,7 @@ import java.util.List;
 import java.util.Objects;
 
 import static com.github._1c_syntax.bsl.languageserver.util.Assertions.assertThatSelectionRanges;
+import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
 class SelectionRangeProviderTest {
@@ -140,6 +141,43 @@ class SelectionRangeProviderTest {
       .extractParent() // sub
       .extractParent() // file
       .hasRange(documentContext.getSymbolTree().getModule().getRange())
+    ;
+  }
+
+  @Test
+  void caretRightAfterIdentifierBehavesLikeCaretInsideIdentifier() {
+    // given
+    var paramsInsideIdentifier = selection(18, 10);
+    var paramsAfterIdentifier = selection(18, 12);
+
+    // when
+    var rangesInsideIdentifier = provider.getSelectionRange(documentContext, paramsInsideIdentifier);
+    var rangesAfterIdentifier = provider.getSelectionRange(documentContext, paramsAfterIdentifier);
+
+    // then
+    assertThatSelectionRanges(rangesAfterIdentifier)
+      .hasSize(1)
+      .element(0)
+      .hasRange(18, 4, 12)
+      .hasParentWithRange(18, 4, 17)
+    ;
+    assertThat(rangesAfterIdentifier).isEqualTo(rangesInsideIdentifier);
+  }
+
+  @Test
+  void caretRightAfterLastTokenOnLineSelectsThatToken() {
+    // given
+    var params = selection(18, 17);
+
+    // when
+    var selectionRanges = provider.getSelectionRange(documentContext, params);
+
+    // then
+    assertThatSelectionRanges(selectionRanges)
+      .hasSize(1)
+      .element(0)
+      .hasRange(18, 16, 17)
+      .hasParentWithRange(18, 4, 17)
     ;
   }
 


### PR DESCRIPTION
## Проблема

`selectionRange` («расширить выделение») не находил узел, когда каретка стоит вплотную после идентификатора — самое частое положение курсора. Причина: `Ranges.containsPosition` исключает конец диапазона, а `Trees.findTerminalNodeContainsPosition` опирается именно на неё. В результате при каретке сразу после слова выбирался следующий токен (если он начинается ровно в этой позиции, например `(` или `;`) либо возвращался `null`.

## Решение

Локальный фикс в `SelectionRangeProvider`, без изменения общей семантики `Trees`/`Ranges` (на `containsPosition` завязаны другие фичи): если каретка не находится строго внутри токена, провайдер дополнительно ищет токен, заканчивающийся ровно в позиции каретки, и предпочитает его — так же ведут себя серверы других языков.

## Тесты

- `caretRightAfterIdentifierBehavesLikeCaretInsideIdentifier` — позиция сразу после идентификатора даёт ту же цепочку диапазонов, что и позиция внутри него (до фикса выбирался следующий токен `(`).
- `caretRightAfterLastTokenOnLineSelectsThatToken` — каретка после `;` в конце строки выбирает `;` и расширяется до выражения (до фикса — `null`).
- Полный прогон `SelectionRangeProviderTest`: 11 тестов, все зелёные, включая закреплённый кейс `emptySelection`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved selection range accuracy when the cursor is positioned at token boundaries, ensuring consistent behavior at common text edges.

* **Tests**
  * Added test coverage for cursor positioning scenarios at token boundaries to verify expected selection behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->