### PR TITLE
fix(ReferenceIndex): починить поиск ссылок на общий модуль в getReferencesTo

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/ModuleSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/ModuleSymbolComputer.java
@@ -66,8 +66,23 @@ public class ModuleSymbolComputer implements Computer<ModuleSymbol> {
   }
 
   private static String getName(DocumentContext documentContext) {
-    var name = documentContext.getMdoRef();
-    var moduleType = documentContext.getModuleType();
+    return name(documentContext.getMdoRef(), documentContext.getModuleType());
+  }
+
+  /**
+   * Вычислить имя символа модуля по ссылке на объект-метаданные и типу модуля.
+   * <p>
+   * Имя является чистой производной от {@code mdoRef} и {@code moduleType}: к {@code mdoRef}
+   * для отдельных типов модулей дописывается квалификатор-тип, чтобы различать несколько модулей
+   * одного объекта метаданных. Метод детерминирован и не зависит от загрузки самого документа,
+   * поэтому одинаково применим как при построении символа, так и при индексации ссылок на модуль.
+   *
+   * @param mdoRef     Ссылка на объект-метаданные модуля (например, {@code CommonModule.ОбщийМодуль1}).
+   * @param moduleType Тип модуля (например, {@link ModuleType#CommonModule}).
+   * @return Имя символа модуля, совпадающее с {@link ModuleSymbol#getName()}.
+   */
+  public static String name(String mdoRef, ModuleType moduleType) {
+    var name = mdoRef;
     if (MODULE_TYPES_TO_APPEND_NAME.contains(moduleType)) {
       name += "." + moduleType.name();
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/ModuleSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/ModuleSymbolComputer.java
@@ -25,21 +25,12 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ModuleSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.parser.BSLLexer;
-import com.github._1c_syntax.bsl.types.ModuleType;
 import org.antlr.v4.runtime.Token;
-
-import java.util.EnumSet;
-import java.util.Set;
 
 /**
  * Компьютер символа модуля документа.
  */
 public class ModuleSymbolComputer implements Computer<ModuleSymbol> {
-
-  private static final Set<ModuleType> MODULE_TYPES_TO_APPEND_NAME = EnumSet.of(
-    ModuleType.ObjectModule,
-    ModuleType.ManagerModule
-  );
 
   private final DocumentContext documentContext;
 
@@ -66,26 +57,6 @@ public class ModuleSymbolComputer implements Computer<ModuleSymbol> {
   }
 
   private static String getName(DocumentContext documentContext) {
-    return name(documentContext.getMdoRef(), documentContext.getModuleType());
-  }
-
-  /**
-   * Вычислить имя символа модуля по ссылке на объект-метаданные и типу модуля.
-   * <p>
-   * Имя является чистой производной от {@code mdoRef} и {@code moduleType}: к {@code mdoRef}
-   * для отдельных типов модулей дописывается квалификатор-тип, чтобы различать несколько модулей
-   * одного объекта метаданных. Метод детерминирован и не зависит от загрузки самого документа,
-   * поэтому одинаково применим как при построении символа, так и при индексации ссылок на модуль.
-   *
-   * @param mdoRef     Ссылка на объект-метаданные модуля (например, {@code CommonModule.ОбщийМодуль1}).
-   * @param moduleType Тип модуля (например, {@link ModuleType#CommonModule}).
-   * @return Имя символа модуля, совпадающее с {@link ModuleSymbol#getName()}.
-   */
-  public static String name(String mdoRef, ModuleType moduleType) {
-    var name = mdoRef;
-    if (MODULE_TYPES_TO_APPEND_NAME.contains(moduleType)) {
-      name += "." + moduleType.name();
-    }
-    return name;
+    return ModuleSymbol.nameOf(documentContext.getMdoRef(), documentContext.getModuleType());
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/ModuleSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/ModuleSymbol.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.context.symbol;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.types.ModuleType;
 import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -30,8 +31,10 @@ import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 
 import java.util.ArrayList;
+import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 /**
  * Символ модуля документа.
@@ -41,6 +44,12 @@ import java.util.Optional;
 @EqualsAndHashCode(onlyExplicitlyIncluded = true)
 @ToString(exclude = {"children"})
 public class ModuleSymbol implements SourceDefinedSymbol {
+
+  private static final Set<ModuleType> MODULE_TYPES_TO_APPEND_NAME = EnumSet.of(
+    ModuleType.ObjectModule,
+    ModuleType.ManagerModule
+  );
+
   /**
    * Имя символа.
    * <p>
@@ -82,6 +91,26 @@ public class ModuleSymbol implements SourceDefinedSymbol {
   @Override
   public void accept(SymbolTreeVisitor visitor) {
     visitor.visitModule(this);
+  }
+
+  /**
+   * Вычислить имя символа модуля по ссылке на объект-метаданные и типу модуля.
+   * <p>
+   * Имя является чистой производной от {@code mdoRef} и {@code moduleType}: к {@code mdoRef}
+   * для отдельных типов модулей дописывается квалификатор-тип, чтобы различать несколько модулей
+   * одного объекта метаданных. Метод детерминирован и не зависит от загрузки самого документа,
+   * поэтому одинаково применим как при построении символа, так и при индексации ссылок на модуль.
+   *
+   * @param mdoRef     Ссылка на объект-метаданные модуля (например, {@code CommonModule.ОбщийМодуль1}).
+   * @param moduleType Тип модуля (например, {@link ModuleType#CommonModule}).
+   * @return Имя символа модуля, совпадающее с {@link ModuleSymbol#getName()}.
+   */
+  public static String nameOf(String mdoRef, ModuleType moduleType) {
+    var name = mdoRef;
+    if (MODULE_TYPES_TO_APPEND_NAME.contains(moduleType)) {
+      name += "." + moduleType.name();
+    }
+    return name;
   }
 
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
@@ -24,9 +24,11 @@ package com.github._1c_syntax.bsl.languageserver.references;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.bsl.languageserver.context.computer.ModuleSymbolComputer;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Exportable;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.ModuleSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
 import com.github._1c_syntax.bsl.languageserver.references.model.Location;
@@ -75,11 +77,7 @@ public class ReferenceIndex {
   public List<Reference> getReferencesTo(SourceDefinedSymbol symbol) {
     var mdoRef = symbol.getOwner().getMdoRef();
     var moduleType = symbol.getOwner().getModuleType();
-    // Ссылки на модуль сохраняются с пустым symbolName (см. addModuleReference),
-    // поэтому ключ поиска должен строиться симметрично.
-    var symbolName = symbol.getSymbolKind() == SymbolKind.Module
-      ? ""
-      : symbol.getName().toLowerCase(Locale.ENGLISH);
+    var symbolName = symbol.getName().toLowerCase(Locale.ENGLISH);
     var scopeName = "";
 
     if (symbol.getSymbolKind() == SymbolKind.Variable) {
@@ -208,6 +206,10 @@ public class ReferenceIndex {
 
   /**
    * Добавить ссылку на модуль в индекс.
+   * <p>
+   * Имя символа вычисляется детерминированно из {@code mdoRef} и {@code moduleType}
+   * ({@link ModuleSymbolComputer#name}) и совпадает с {@link ModuleSymbol#getName()}, поэтому
+   * запись и поиск ({@link #getReferencesTo}) симметричны без какой-либо спецобработки.
    *
    * @param uri        URI документа, откуда произошло обращение к модулю.
    * @param mdoRef     Ссылка на объект-метаданных модуля (например, CommonModule.ОбщийМодуль1).
@@ -215,12 +217,16 @@ public class ReferenceIndex {
    * @param range      Диапазон, в котором происходит обращение к модулю.
    */
   public void addModuleReference(URI uri, String mdoRef, ModuleType moduleType, Range range) {
+    var symbolName = stringInterner.intern(
+      ModuleSymbolComputer.name(mdoRef, moduleType).toLowerCase(Locale.ENGLISH)
+    );
+
     var symbol = Symbol.builder()
       .mdoRef(mdoRef)
       .moduleType(moduleType)
       .scopeName("")
       .symbolKind(SymbolKind.Module)
-      .symbolName("")
+      .symbolName(symbolName)
       .build()
       .intern();
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
@@ -24,7 +24,6 @@ package com.github._1c_syntax.bsl.languageserver.references;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
-import com.github._1c_syntax.bsl.languageserver.context.computer.ModuleSymbolComputer;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Exportable;
@@ -208,7 +207,7 @@ public class ReferenceIndex {
    * Добавить ссылку на модуль в индекс.
    * <p>
    * Имя символа вычисляется детерминированно из {@code mdoRef} и {@code moduleType}
-   * ({@link ModuleSymbolComputer#name}) и совпадает с {@link ModuleSymbol#getName()}, поэтому
+   * ({@link ModuleSymbol#nameOf}) и совпадает с {@link ModuleSymbol#getName()}, поэтому
    * запись и поиск ({@link #getReferencesTo}) симметричны без какой-либо спецобработки.
    *
    * @param uri        URI документа, откуда произошло обращение к модулю.
@@ -218,7 +217,7 @@ public class ReferenceIndex {
    */
   public void addModuleReference(URI uri, String mdoRef, ModuleType moduleType, Range range) {
     var symbolName = stringInterner.intern(
-      ModuleSymbolComputer.name(mdoRef, moduleType).toLowerCase(Locale.ENGLISH)
+      ModuleSymbol.nameOf(mdoRef, moduleType).toLowerCase(Locale.ENGLISH)
     );
 
     var symbol = Symbol.builder()

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
@@ -75,7 +75,11 @@ public class ReferenceIndex {
   public List<Reference> getReferencesTo(SourceDefinedSymbol symbol) {
     var mdoRef = symbol.getOwner().getMdoRef();
     var moduleType = symbol.getOwner().getModuleType();
-    var symbolName = symbol.getName().toLowerCase(Locale.ENGLISH);
+    // Ссылки на модуль сохраняются с пустым symbolName (см. addModuleReference),
+    // поэтому ключ поиска должен строиться симметрично.
+    var symbolName = symbol.getSymbolKind() == SymbolKind.Module
+      ? ""
+      : symbol.getName().toLowerCase(Locale.ENGLISH);
     var scopeName = "";
 
     if (symbol.getSymbolKind() == SymbolKind.Variable) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexTest.java
@@ -307,6 +307,29 @@ class ReferenceIndexTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void getReferencesToCommonModule() {
+    // given
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+    var methodSymbol = documentContext.getSymbolTree().getMethodSymbol("ИмяПроцедуры").orElseThrow();
+
+    var commonModuleContext = context.getDocument("CommonModule.ПервыйОбщийМодуль", ModuleType.CommonModule).orElseThrow();
+    var commonModuleSymbol = commonModuleContext.getSymbolTree().getModule();
+
+    var uri = documentContext.getUri().toString();
+    var firstModuleNameLocation = new Location(uri, Ranges.create(2, 4, 21)); // ПервыйОбщийМодуль on line 3
+    var secondModuleNameLocation = new Location(uri, Ranges.create(4, 4, 21)); // ПервыйОбщийМодуль on line 5
+
+    // when
+    var references = referenceIndex.getReferencesTo(commonModuleSymbol);
+
+    // then
+    assertThat(references)
+      .contains(Reference.of(methodSymbol, commonModuleSymbol, firstModuleNameLocation))
+      .contains(Reference.of(methodSymbol, commonModuleSymbol, secondModuleNameLocation))
+    ;
+  }
+
+  @Test
   void testGetReferencesFromCommonModule() {
     // given
     var commonModuleContext = context.getDocument("CommonModule.ПервыйОбщийМодуль", ModuleType.CommonModule).orElseThrow();


### PR DESCRIPTION
## Проблема

«Найти все ссылки» с курсором на имени общего модуля всегда возвращал пустой список. При записи ссылки на модуль в индекс (`ReferenceIndex.addModuleReference`) `symbolName` сохраняется пустым, а при поиске в `getReferencesTo` ключ строился из `symbol.getName()` — для `ModuleSymbol` это непустая mdoRef-подобная строка. Лукап в `SymbolOccurrenceRepository` — строгое равенство record `Symbol`, поэтому ключи никогда не совпадали, хотя вхождения в индексе были.

## Решение

В `getReferencesTo` для символов с `SymbolKind.Module` ключ поиска строится с пустым `symbolName` — симметрично `addModuleReference`.

## Тесты

- Добавлен тест `ReferenceIndexTest.getReferencesToCommonModule`: курсорные обращения к `ПервыйОбщийМодуль` в фикстуре `ReferenceIndex.bsl` находятся через `getReferencesTo(ModuleSymbol)`. До фикса тест падал (пустой список), после — зелёный.
- Прогнаны: `references.*` (ReferenceIndexTest, ReferenceIndexFillerTest и др.), `ReferencesProviderTest`, `RenameProviderTest`, `CallHierarchyProviderTest`, а также диагностики, использующие `getReferencesTo` (`UnusedLocalVariableDiagnosticTest`, `RewriteMethodParameterDiagnosticTest`, `TransferringParametersBetweenClientAndServerDiagnosticTest`, `ExpressionTypeInferencer*`). Все зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved module symbol computation for more consistent and accurate symbol naming.
  * Enhanced reference indexing to correctly track module references with deterministic symbol names.

* **Tests**
  * Added test coverage for module reference tracking and retrieval.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->