### PR TITLE
fix(BSLWorkspaceService): выгружать документы при удалении каталога в didChangeWatchedFiles

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver;
 
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
@@ -152,16 +153,58 @@ public class BSLWorkspaceService implements WorkspaceService {
    * <p>
    * Если файл был открыт в редакторе, сначала закрывает его и очищает вторичные данные.
    * Затем полностью удаляет документ из контекста сервера, включая все связанные метаданные.
+   * <p>
+   * Если документ с таким URI в контексте отсутствует, URI трактуется как удаленный каталог:
+   * клиенты (в т.ч. VS Code) при удалении каталога присылают одно событие Deleted с URI каталога
+   * без событий по вложенным файлам.
    *
-   * @param uri URI удаленного файла
+   * @param uri URI удаленного файла или каталога
    */
   private void handleDeletedFileEvent(URI uri) {
     var context = getContextForDocument(uri);
     var documentContext = context.getDocument(uri);
     if (documentContext == null) {
+      handleDeletedFolderEvent(context, uri);
       return;
     }
 
+    removeDocument(context, uri, documentContext);
+  }
+
+  /**
+   * Обрабатывает событие удаления каталога из файловой системы.
+   * <p>
+   * Удаляет из контекста сервера все документы, расположенные внутри каталога.
+   * Принадлежность каталогу определяется по префиксу URI с границей {@code /},
+   * чтобы не зацепить каталог-«тёзку» с общим строковым префиксом.
+   *
+   * @param context   контекст сервера
+   * @param folderUri URI удаленного каталога
+   */
+  private void handleDeletedFolderEvent(ServerContext context, URI folderUri) {
+    var folderUriString = folderUri.toString();
+    var prefix = folderUriString.endsWith("/") ? folderUriString : folderUriString + "/";
+
+    var deletedUris = context.getDocuments().keySet().stream()
+      .filter(documentUri -> documentUri.toString().startsWith(prefix))
+      .toList();
+
+    for (var documentUri : deletedUris) {
+      var documentContext = context.getDocument(documentUri);
+      if (documentContext != null) {
+        removeDocument(context, documentUri, documentContext);
+      }
+    }
+  }
+
+  /**
+   * Удаляет документ из контекста сервера, предварительно закрыв его, если он открыт в редакторе.
+   *
+   * @param context         контекст сервера
+   * @param uri             URI документа
+   * @param documentContext контекст документа
+   */
+  private static void removeDocument(ServerContext context, URI uri, DocumentContext documentContext) {
     var isDocumentOpened = context.isDocumentOpened(documentContext);
     if (isDocumentOpened) {
       context.closeDocument(documentContext);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceServiceTest.java
@@ -267,6 +267,73 @@ class BSLWorkspaceServiceTest {
     assertThat(serverContextProvider.getServerContext(uri).map(c -> c.getDocument(uri))).isEmpty();
   }
 
+  /**
+   * Клиенты (VS Code) при удалении каталога присылают одно событие Deleted с URI каталога,
+   * без событий по вложенным файлам. Все документы внутри каталога должны быть выгружены
+   * из контекста, а документы каталога-«тёзки» с общим строковым префиксом — остаться.
+   */
+  @Test
+  void testDidChangeWatchedFiles_Deleted_Folder() throws IOException {
+    // given
+    var objectModule = createTestFile("Catalogs/Goods/Ext/ObjectModule.bsl");
+    var formModule = createTestFile("Catalogs/Goods/Forms/ItemForm/Ext/Form/Module.bsl");
+    var namesakeModule = createTestFile("Catalogs/GoodsArchive/Ext/ObjectModule.bsl");
+
+    var objectModuleUri = Absolute.uri(objectModule.toURI());
+    var formModuleUri = Absolute.uri(formModule.toURI());
+    var namesakeModuleUri = Absolute.uri(namesakeModule.toURI());
+
+    var ctx = workspaceServerContext();
+    for (var uri : List.of(objectModuleUri, formModuleUri, namesakeModuleUri)) {
+      var documentContext = ctx.addDocument(uri);
+      ctx.rebuildDocument(documentContext);
+      ctx.tryClearDocument(documentContext);
+    }
+
+    var deletedFolder = tempDir.resolve("Catalogs").resolve("Goods").toFile();
+    FileUtils.deleteDirectory(deletedFolder);
+    var folderUri = Absolute.uri(deletedFolder.toURI());
+
+    var fileEvent = new FileEvent(folderUri.toString(), FileChangeType.Deleted);
+    var params = new DidChangeWatchedFilesParams(List.of(fileEvent));
+
+    // when
+    workspaceService.didChangeWatchedFiles(params);
+    await().until(() -> ctx.getDocument(objectModuleUri) == null);
+
+    // then
+    assertThat(ctx.getDocument(objectModuleUri)).isNull();
+    assertThat(ctx.getDocument(formModuleUri)).isNull();
+    assertThat(ctx.getDocument(namesakeModuleUri)).isNotNull();
+  }
+
+  /** Открытый в редакторе документ внутри удалённого каталога тоже должен быть закрыт и выгружен. */
+  @Test
+  void testDidChangeWatchedFiles_Deleted_FolderWithOpenedDocument() throws IOException {
+    // given
+    var openedModule = createTestFile("Catalogs/Products/Ext/ObjectModule.bsl");
+    var openedModuleUri = Absolute.uri(openedModule.toURI());
+    var content = FileUtils.readFileToString(openedModule, StandardCharsets.UTF_8);
+
+    var ctx = workspaceServerContext();
+    var documentContext = ctx.addDocument(openedModuleUri);
+    ctx.openDocument(documentContext, content, 1);
+
+    var deletedFolder = tempDir.resolve("Catalogs").resolve("Products").toFile();
+    FileUtils.deleteDirectory(deletedFolder);
+    var folderUri = Absolute.uri(deletedFolder.toURI());
+
+    var fileEvent = new FileEvent(folderUri.toString(), FileChangeType.Deleted);
+    var params = new DidChangeWatchedFilesParams(List.of(fileEvent));
+
+    // when
+    workspaceService.didChangeWatchedFiles(params);
+    await().until(() -> ctx.getDocument(openedModuleUri) == null);
+
+    // then
+    assertThat(ctx.getDocument(openedModuleUri)).isNull();
+  }
+
   @Test
   void testDidChangeWatchedFiles_MultipleEvents() throws IOException {
     // given


### PR DESCRIPTION
## Проблема

`handleDeletedFileEvent` удалял из контекста только документ с точно совпадающим URI. Клиенты (в т.ч. VS Code) при удалении каталога присылают одно событие `Deleted` с URI каталога, без событий по вложенным файлам. В типовом для 1С случае — удаление каталога объекта метаданных с `Ext/ObjectModule.bsl` и формами — все документы внутри удалённой папки оставались в контексте и индексах как «живые»: битые references, workspace-символы, диагностики.

## Решение

Если по URI документа в контексте нет, URI трактуется как удалённый каталог: за один линейный проход по документам контекста удаляются все документы, чей URI начинается с URI каталога с границей `/` (чтобы `Catalogs/Товар` не зацепил `Catalogs/ТоварыПрочие`). Открытые в редакторе документы предварительно закрываются — той же логикой, что и при удалении одиночного файла (вынесена в общий приватный метод `removeDocument`). Без квадратичных проходов: O(N) по числу документов на событие.

## Тесты

- `testDidChangeWatchedFiles_Deleted_Folder` — три документа (`Catalogs/Goods/Ext/ObjectModule.bsl`, форма внутри `Catalogs/Goods`, и «тёзка» `Catalogs/GoodsArchive/Ext/ObjectModule.bsl`); после события `Deleted` с URI каталога `Catalogs/Goods` оба вложенных документа выгружены, документ «тёзки» остался.
- `testDidChangeWatchedFiles_Deleted_FolderWithOpenedDocument` — открытый в редакторе документ внутри удалённого каталога тоже закрывается и выгружается.

Оба теста до фикса падали (документы оставались в контексте). После фикса весь класс `BSLWorkspaceServiceTest` (18 тестов) зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)