### PR TITLE
fix(BSLTextDocumentService): валидировать в didSave свежее содержимое документа

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -779,16 +779,11 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
     }
     var documentContext = maybeDocument.get();
 
-    var serverContext = getContextForDocument(params.getTextDocument().getUri());
-    if (serverContext == null) {
-      LOGGER.warn(NO_WORKSPACE_FOUND_MESSAGE, documentContext.getUri());
-      return;
-    }
-
-    WorkspaceContextHolder.run(serverContext.getWorkspaceUri(), () -> {
+    withFreshDocumentContextNullable(documentContext, () -> {
       if (configuration.getDiagnosticsOptions().getComputeTrigger() != ComputeTrigger.NEVER) {
         validate(documentContext);
       }
+      return null;
     });
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver;
 
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
@@ -484,11 +485,67 @@ class BSLTextDocumentServiceTest {
     textDocumentService.didSave(params);
 
     var expectedWorkspaceUri = Absolute.uri(new File("./src/test/resources").getAbsoluteFile().toURI());
-    assertThat(capturedWorkspaceUri.get())
-      .as("Workspace context must be set when DiagnosticProvider.computeAndPublishDiagnostics is called during "
-        + "didSave (otherwise workspace-scoped LanguageServerConfiguration cannot be resolved)")
-      .isNotNull()
-      .isEqualTo(expectedWorkspaceUri);
+    await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+      assertThat(capturedWorkspaceUri.get())
+        .as("Workspace context must be set when DiagnosticProvider.computeAndPublishDiagnostics is called during "
+          + "didSave (otherwise workspace-scoped LanguageServerConfiguration cannot be resolved)")
+        .isNotNull()
+        .isEqualTo(expectedWorkspaceUri)
+    );
+  }
+
+  /**
+   * Воспроизводит валидацию устаревшего содержимого:
+   * клиент шлёт didChange и сразу didSave; пока {@code DocumentChangeExecutor} не применил изменения
+   * (применение детерминированно заблокировано write lock документа), didSave обязан дождаться
+   * свежего содержимого, а не валидировать старый текст.
+   */
+  @Test
+  void didSave_validatesFreshContentAfterPendingDidChange() throws IOException {
+    // given - opened document and a client without pull diagnostics support
+    var textDocumentItem = getTextDocumentItem();
+    textDocumentService.didOpen(new DidOpenTextDocumentParams(textDocumentItem));
+
+    when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(new ClientCapabilities()));
+    textDocumentService.handleInitializeEvent(null);
+    clearInvocations(diagnosticProvider);
+
+    var validatedContent = new AtomicReference<String>();
+    doAnswer(invocation -> {
+      DocumentContext validatedDocument = invocation.getArgument(0);
+      validatedContent.compareAndSet(null, validatedDocument.getContent());
+      return null;
+    }).when(diagnosticProvider).computeAndPublishDiagnostics(any());
+
+    var uri = Absolute.uri(textDocumentItem.getUri());
+    var maybeContext = serverContextProvider.getServerContextUnsafe(uri);
+    assertThat(maybeContext).isPresent();
+    var documentLock = maybeContext.get().getDocumentLock(uri);
+
+    // when - didChange is still pending (blocked by the write lock) and didSave arrives immediately
+    documentLock.writeLock().lock();
+    try {
+      var changeParams = new DidChangeTextDocumentParams();
+      changeParams.setTextDocument(new VersionedTextDocumentIdentifier(textDocumentItem.getUri(), 2));
+      changeParams.setContentChanges(List.of(
+        new TextDocumentContentChangeEvent(Ranges.create(0, 0, 0, 0), "// fresh change marker\n")
+      ));
+      textDocumentService.didChange(changeParams);
+
+      var saveParams = new DidSaveTextDocumentParams();
+      saveParams.setTextDocument(new TextDocumentIdentifier(textDocumentItem.getUri()));
+      textDocumentService.didSave(saveParams);
+    } finally {
+      documentLock.writeLock().unlock();
+    }
+
+    // then - validation must see the content with the pending change applied
+    await().atMost(Duration.ofSeconds(5)).untilAsserted(() ->
+      assertThat(validatedContent.get())
+        .as("didSave must validate document content with all pending didChange applied")
+        .isNotNull()
+        .startsWith("// fresh change marker")
+    );
   }
 
   @Test


### PR DESCRIPTION
## Проблема

`didSave` вызывал `validate(documentContext)` напрямую — без барьера ожидания применённых правок (`DocumentChangeExecutor.awaitLatest()`) и без read lock документа, в отличие от всех читающих обработчиков, которые идут через `withFreshDocumentContext`. Клиенты обычно шлют `didChange` и сразу `didSave`: если в очереди `DocumentChangeExecutor` лежали непримененные изменения, диагностики считались по устаревшему содержимому и могли гоняться с `rebuildDocument` из рабочего потока.

## Решение

Валидация в `didSave` обёрнута в `withFreshDocumentContextNullable` — тот же механизм, что и у остальных обработчиков: ожидание применения всех поставленных изменений, выполнение на `taskExecutor` (поток уведомлений не блокируется), read lock документа и установка workspace-контекста. Проверка `ComputeTrigger` оставлена внутри supplier'а, так как `LanguageServerConfiguration` — workspace-scoped бин. Дублирующая проверка `serverContext == null` убрана: `withFreshDocumentContextInternal` выполняет её сам с тем же предупреждением.

## Тесты

- Новый `BSLTextDocumentServiceTest.didSave_validatesFreshContentAfterPendingDidChange` — детерминированно воспроизводит гонку: применение `didChange` блокируется write lock документа, сразу шлётся `didSave`; до фикса валидация видела устаревшее содержимое (тест падал именно на этом), после — дожидается применения правки. Честный «sleep»-вариант красного теста флаковал бы, поэтому момент «изменение ещё в очереди» зафиксирован через блокировку, которую `DocumentChangeExecutor.flushPendingChanges` берёт перед применением.
- `didSave_setsWorkspaceContextWhenValidating` адаптирован под асинхронную валидацию через `await()`.
- Прогнан весь `BSLTextDocumentServiceTest`: 66 тестов, 0 падений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)