### PR TITLE
fix(semantictokens): обновлять токены после наполнения контекста сервера

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProvider.java
@@ -21,12 +21,16 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
+import com.github._1c_syntax.bsl.languageserver.LanguageClientHolder;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClosedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopulatedEvent;
 import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokenEntry;
 import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokensSupplier;
 import lombok.RequiredArgsConstructor;
+import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokens;
 import org.eclipse.lsp4j.SemanticTokensDelta;
@@ -34,7 +38,10 @@ import org.eclipse.lsp4j.SemanticTokensDeltaParams;
 import org.eclipse.lsp4j.SemanticTokensEdit;
 import org.eclipse.lsp4j.SemanticTokensParams;
 import org.eclipse.lsp4j.SemanticTokensRangeParams;
+import org.eclipse.lsp4j.SemanticTokensWorkspaceCapabilities;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.eclipse.lsp4j.services.LanguageClient;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -75,6 +82,9 @@ public class SemanticTokensProvider {
 
   @Qualifier("semanticTokensExecutor")
   private final ExecutorService executor;
+
+  private final ClientCapabilitiesHolder clientCapabilitiesHolder;
+  private final LanguageClientHolder clientHolder;
 
   /**
    * Cache for storing previous token data by resultId.
@@ -264,6 +274,40 @@ public class SemanticTokensProvider {
   @EventListener
   public void handleDocumentRemoved(ServerContextDocumentRemovedEvent event) {
     clearCache(event.getUri());
+  }
+
+  /**
+   * Обрабатывает событие завершения наполнения контекста сервера.
+   * <p>
+   * Часть сапплаеров (например, подсветка вызовов методов) опирается на индекс ссылок,
+   * который наполняется только после {@code populateContext}. Если клиент запросил токены
+   * до наполнения индекса, подсветка остаётся устаревшей до следующей правки файла.
+   * Поэтому по завершении наполнения контекста инициируется запрос
+   * {@code workspace/semanticTokens/refresh}.
+   *
+   * @param event Событие завершения наполнения контекста сервера.
+   */
+  @EventListener
+  public void handleServerContextPopulated(ServerContextPopulatedEvent event) {
+    refreshSemanticTokens();
+  }
+
+  /**
+   * Отправить запрос на обновление семантических токенов.
+   * <p>
+   * Запрос отправляется только в случае поддержки клиентом возможности
+   * {@code workspace.semanticTokens.refreshSupport}.
+   */
+  public void refreshSemanticTokens() {
+    boolean refreshSupport = clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getWorkspace)
+      .map(WorkspaceClientCapabilities::getSemanticTokens)
+      .map(SemanticTokensWorkspaceCapabilities::getRefreshSupport)
+      .orElse(Boolean.FALSE);
+
+    if (refreshSupport) {
+      clientHolder.execIfConnected(LanguageClient::refreshSemanticTokens);
+    }
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
@@ -21,14 +21,19 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
+import com.github._1c_syntax.bsl.languageserver.LanguageClientHolder;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopulatedEvent;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndexFiller;
 import com.github._1c_syntax.bsl.languageserver.semantictokens.SemanticTokenEntry;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.utils.Absolute;
 import org.apache.commons.io.FileUtils;
+import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
@@ -38,10 +43,15 @@ import org.eclipse.lsp4j.SemanticTokensDeltaParams;
 import org.eclipse.lsp4j.SemanticTokensLegend;
 import org.eclipse.lsp4j.SemanticTokensParams;
 import org.eclipse.lsp4j.SemanticTokensRangeParams;
+import org.eclipse.lsp4j.SemanticTokensWorkspaceCapabilities;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+import org.eclipse.lsp4j.services.LanguageClient;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.context.ApplicationEventPublisher;
 
 import java.io.File;
 import java.io.IOException;
@@ -53,6 +63,10 @@ import java.util.List;
 import java.util.Set;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatNoException;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
 
 @SpringBootTest
 @CleanupContextBeforeClassAndAfterEachTestMethod
@@ -69,6 +83,18 @@ class SemanticTokensProviderTest {
 
   @Autowired
   private ServerContextProvider serverContextProvider;
+
+  @Autowired
+  private ServerContext serverContext;
+
+  @Autowired
+  private ApplicationEventPublisher applicationEventPublisher;
+
+  @Autowired
+  private ClientCapabilitiesHolder clientCapabilitiesHolder;
+
+  @Autowired
+  private LanguageClientHolder clientHolder;
 
   // region Helper types and methods
 
@@ -1905,6 +1931,63 @@ class SemanticTokensProviderTest {
 
     // then — пересечение на строке-продолжении найдено (без multiline-учёта было бы 0).
     assertThat(overlaps).hasSize(1);
+  }
+
+  // endregion
+
+  // region Refresh on populated context
+
+  @Test
+  void testSemanticTokensRefreshOnServerContextPopulated() {
+    // given
+    var languageClient = mock(LanguageClient.class);
+    clientHolder.connect(languageClient);
+
+    prepareSemanticTokensRefreshSupport(true);
+
+    // when
+    applicationEventPublisher.publishEvent(new ServerContextPopulatedEvent(serverContext));
+
+    // then
+    verify(languageClient).refreshSemanticTokens();
+  }
+
+  @Test
+  void testSemanticTokensDoNotRefreshOnServerContextPopulated_ifClientDoesNotSupportRefresh() {
+    // given
+    var languageClient = mock(LanguageClient.class);
+    clientHolder.connect(languageClient);
+
+    prepareSemanticTokensRefreshSupport(false);
+
+    // when
+    applicationEventPublisher.publishEvent(new ServerContextPopulatedEvent(serverContext));
+
+    // then
+    verify(languageClient, never()).refreshSemanticTokens();
+  }
+
+  @Test
+  void testSemanticTokensRefresh_ifLanguageClientIsNotConnected() {
+    // given
+    // no connected language client
+
+    // when
+    var event = new ServerContextPopulatedEvent(serverContext);
+
+    // then
+    assertThatNoException().isThrownBy(() -> provider.handleServerContextPopulated(event));
+  }
+
+  private void prepareSemanticTokensRefreshSupport(boolean refreshSupport) {
+    var workspaceClientCapabilities = new WorkspaceClientCapabilities();
+    workspaceClientCapabilities.setSemanticTokens(new SemanticTokensWorkspaceCapabilities(refreshSupport));
+    var clientCapabilities = new ClientCapabilities(
+      workspaceClientCapabilities,
+      mock(TextDocumentClientCapabilities.class),
+      mock(Object.class)
+    );
+    clientCapabilitiesHolder.setCapabilities(clientCapabilities);
   }
 
   // endregion


### PR DESCRIPTION
## Проблема

`MethodCallSemanticTokensSupplier` раскрашивает вызовы методов по `ReferenceIndex`, который наполняется только после `populateContext`. Клиент, запросивший семантические токены до наполнения индекса, оставался с устаревшей подсветкой вплоть до следующей правки файла. В `src/main` не было ни одного вызова `LanguageClient.refreshSemanticTokens`, хотя инфраструктура (`LanguageClientHolder`, `ClientCapabilitiesHolder`) уже использовалась для аналогичных refresh в `CodeLensProvider` и `InlayHintProvider`.

## Решение

`SemanticTokensProvider` теперь слушает `ServerContextPopulatedEvent` и по нему инициирует запрос `workspace/semanticTokens/refresh`. Запрос отправляется только при заявленной клиентом возможности `workspace.semanticTokens.refreshSupport` — проверка сделана единообразно с `CodeLensProvider`/`InlayHintProvider` через `ClientCapabilitiesHolder`.

## Тесты

`SemanticTokensProviderTest`:
- `testSemanticTokensRefreshOnServerContextPopulated` — при `refreshSupport=true` событие приводит к вызову `refreshSemanticTokens()`;
- `testSemanticTokensDoNotRefreshOnServerContextPopulated_ifClientDoesNotSupportRefresh` — при `refreshSupport=false` вызова нет;
- `testSemanticTokensRefresh_ifLanguageClientIsNotConnected` — без подключённого клиента обработчик не падает.

Прогон `SemanticTokensProviderTest` — BUILD SUCCESSFUL. Красный тест подтверждён: при отключённой реализации позитивный тест падает по верной причине (refresh не вызван).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Semantic tokens now automatically refresh when the language server context is fully initialized, ensuring accurate syntax highlighting in the editor.

* **Tests**
  * Added comprehensive tests for semantic tokens refresh functionality, including scenarios with varying client capabilities.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->