### PR TITLE
fix(providers): учитывать клиентскую возможность definition linkSupport

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -197,6 +197,10 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
   private boolean clientSupportsPullDiagnostics;
 
+  // Кэшируется на initialize. linkSupport — gate для ответа LocationLink[] на запрос
+  // textDocument/definition. Если клиент не заявил поддержку, ответ понижается до Location[].
+  private boolean clientSupportsDefinitionLinkSupport;
+
   @PreDestroy
   private void onDestroy() {
     // Shutdown all document executors
@@ -276,7 +280,7 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
       documentContext,
       () -> toLocationResult(
         definitionProvider.getDefinition(documentContext, params),
-        clientSupportsDefinitionLinkSupport()
+        clientSupportsDefinitionLinkSupport
       )
     );
   }
@@ -322,21 +326,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
       .map(link -> new Location(link.getTargetUri(), link.getTargetSelectionRange()))
       .toList();
     return Either.forLeft(locations);
-  }
-
-  /**
-   * Проверить, заявил ли клиент поддержку возможности
-   * {@code textDocument.definition.linkSupport}.
-   *
-   * @return {@code true}, если клиент поддерживает ответ {@link LocationLink} для запроса
-   *         {@code textDocument/definition}.
-   */
-  private boolean clientSupportsDefinitionLinkSupport() {
-    return clientCapabilitiesHolder.getCapabilities()
-      .map(ClientCapabilities::getTextDocument)
-      .map(TextDocumentClientCapabilities::getDefinition)
-      .map(DefinitionCapabilities::getLinkSupport)
-      .orElse(false);
   }
 
   @Override
@@ -922,16 +911,24 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
   /**
    * Обработчик события {@link LanguageServerInitializeRequestReceivedEvent}.
    * <p>
-   * Проверяет поддержку клиентом pull-модели диагностик.
+   * Кэширует клиентские возможности, влияющие на формат ответов: поддержку
+   * pull-модели диагностик и поддержку {@code textDocument.definition.linkSupport}.
    *
    * @param ignored Событие
    */
   @EventListener
   public void handleInitializeEvent(LanguageServerInitializeRequestReceivedEvent ignored) {
-    clientSupportsPullDiagnostics = clientCapabilitiesHolder.getCapabilities()
-      .map(ClientCapabilities::getTextDocument)
+    var textDocumentCapabilities = clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getTextDocument);
+
+    clientSupportsPullDiagnostics = textDocumentCapabilities
       .map(TextDocumentClientCapabilities::getDiagnostic)
       .isPresent();
+
+    clientSupportsDefinitionLinkSupport = textDocumentCapabilities
+      .map(TextDocumentClientCapabilities::getDefinition)
+      .map(DefinitionCapabilities::getLinkSupport)
+      .orElse(false);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -74,7 +74,6 @@ import org.eclipse.lsp4j.ColorInformation;
 import org.eclipse.lsp4j.ColorPresentation;
 import org.eclipse.lsp4j.ColorPresentationParams;
 import org.eclipse.lsp4j.Command;
-import org.eclipse.lsp4j.DefinitionCapabilities;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
@@ -197,10 +196,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
   private boolean clientSupportsPullDiagnostics;
 
-  // Кэшируется на initialize. linkSupport — gate для ответа LocationLink[] на запрос
-  // textDocument/definition. Если клиент не заявил поддержку, ответ понижается до Location[].
-  private boolean clientSupportsDefinitionLinkSupport;
-
   @PreDestroy
   private void onDestroy() {
     // Shutdown all document executors
@@ -278,10 +273,7 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
     return withFreshDocumentContext(
       documentContext,
-      () -> toLocationResult(
-        definitionProvider.getDefinition(documentContext, params),
-        clientSupportsDefinitionLinkSupport
-      )
+      () -> definitionProvider.getDefinition(documentContext, params)
     );
   }
 
@@ -299,33 +291,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
       documentContext,
       () -> Either.forLeft(implementationProvider.getImplementations(documentContext, params))
     );
-  }
-
-  /**
-   * Сформировать результат запроса навигации с учётом клиентской возможности
-   * {@code linkSupport}.
-   * <p>
-   * По спецификации LSP 3.14+ ответ типа {@link LocationLink} допустим только если клиент
-   * заявил поддержку связей. Если поддержки нет, результат понижается до списка
-   * {@link Location} с {@code targetUri} и {@code targetSelectionRange} каждой связи.
-   *
-   * @param links       Список связей, подготовленный провайдером.
-   * @param linkSupport {@code true}, если клиент поддерживает {@link LocationLink}.
-   * @return {@link Either} с правой стороной ({@link LocationLink}) при поддержке связей
-   *         либо с левой стороной ({@link Location}) при её отсутствии.
-   */
-  private static Either<List<? extends Location>, List<? extends LocationLink>> toLocationResult(
-    List<LocationLink> links,
-    boolean linkSupport
-  ) {
-    if (linkSupport) {
-      return Either.forRight(links);
-    }
-
-    List<Location> locations = links.stream()
-      .map(link -> new Location(link.getTargetUri(), link.getTargetSelectionRange()))
-      .toList();
-    return Either.forLeft(locations);
   }
 
   @Override
@@ -911,24 +876,17 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
   /**
    * Обработчик события {@link LanguageServerInitializeRequestReceivedEvent}.
    * <p>
-   * Кэширует клиентские возможности, влияющие на формат ответов: поддержку
-   * pull-модели диагностик и поддержку {@code textDocument.definition.linkSupport}.
+   * Кэширует поддержку клиентом pull-модели диагностик, влияющую на способ публикации
+   * диагностик при закрытии документа.
    *
    * @param ignored Событие
    */
   @EventListener
   public void handleInitializeEvent(LanguageServerInitializeRequestReceivedEvent ignored) {
-    var textDocumentCapabilities = clientCapabilitiesHolder.getCapabilities()
-      .map(ClientCapabilities::getTextDocument);
-
-    clientSupportsPullDiagnostics = textDocumentCapabilities
+    clientSupportsPullDiagnostics = clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getTextDocument)
       .map(TextDocumentClientCapabilities::getDiagnostic)
       .isPresent();
-
-    clientSupportsDefinitionLinkSupport = textDocumentCapabilities
-      .map(TextDocumentClientCapabilities::getDefinition)
-      .map(DefinitionCapabilities::getLinkSupport)
-      .orElse(false);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -74,6 +74,7 @@ import org.eclipse.lsp4j.ColorInformation;
 import org.eclipse.lsp4j.ColorPresentation;
 import org.eclipse.lsp4j.ColorPresentationParams;
 import org.eclipse.lsp4j.Command;
+import org.eclipse.lsp4j.DefinitionCapabilities;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
 import org.eclipse.lsp4j.DidCloseTextDocumentParams;
@@ -273,7 +274,10 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
     return withFreshDocumentContext(
       documentContext,
-      () -> Either.forRight(definitionProvider.getDefinition(documentContext, params))
+      () -> toLocationResult(
+        definitionProvider.getDefinition(documentContext, params),
+        clientSupportsDefinitionLinkSupport()
+      )
     );
   }
 
@@ -291,6 +295,48 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
       documentContext,
       () -> Either.forLeft(implementationProvider.getImplementations(documentContext, params))
     );
+  }
+
+  /**
+   * Сформировать результат запроса навигации с учётом клиентской возможности
+   * {@code linkSupport}.
+   * <p>
+   * По спецификации LSP 3.14+ ответ типа {@link LocationLink} допустим только если клиент
+   * заявил поддержку связей. Если поддержки нет, результат понижается до списка
+   * {@link Location} с {@code targetUri} и {@code targetSelectionRange} каждой связи.
+   *
+   * @param links       Список связей, подготовленный провайдером.
+   * @param linkSupport {@code true}, если клиент поддерживает {@link LocationLink}.
+   * @return {@link Either} с правой стороной ({@link LocationLink}) при поддержке связей
+   *         либо с левой стороной ({@link Location}) при её отсутствии.
+   */
+  private static Either<List<? extends Location>, List<? extends LocationLink>> toLocationResult(
+    List<LocationLink> links,
+    boolean linkSupport
+  ) {
+    if (linkSupport) {
+      return Either.forRight(links);
+    }
+
+    List<Location> locations = links.stream()
+      .map(link -> new Location(link.getTargetUri(), link.getTargetSelectionRange()))
+      .toList();
+    return Either.forLeft(locations);
+  }
+
+  /**
+   * Проверить, заявил ли клиент поддержку возможности
+   * {@code textDocument.definition.linkSupport}.
+   *
+   * @return {@code true}, если клиент поддерживает ответ {@link LocationLink} для запроса
+   *         {@code textDocument/definition}.
+   */
+  private boolean clientSupportsDefinitionLinkSupport() {
+    return clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getTextDocument)
+      .map(TextDocumentClientCapabilities::getDefinition)
+      .map(DefinitionCapabilities::getLinkSupport)
+      .orElse(false);
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/DefinitionDto.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/DefinitionDto.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.mcp.dto;
 
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 
 /**
@@ -37,6 +38,14 @@ public record DefinitionDto(String uri, RangeDto range, RangeDto selectionRange)
       link.getTargetUri(),
       RangeDto.from(link.getTargetRange()),
       RangeDto.from(link.getTargetSelectionRange())
+    );
+  }
+
+  public static DefinitionDto from(Location location) {
+    return new DefinitionDto(
+      location.getUri(),
+      RangeDto.from(location.getRange()),
+      RangeDto.from(location.getRange())
     );
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DefinitionTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DefinitionTool.java
@@ -81,9 +81,10 @@ public class DefinitionTool {
         new Position(line, character)
       );
 
-      var definitions = definitionProvider.getDefinition(documentContext, params).stream()
-        .map(DefinitionDto::from)
-        .toList();
+      var definitions = definitionProvider.getDefinition(documentContext, params).map(
+        locations -> locations.stream().map(DefinitionDto::from).toList(),
+        links -> links.stream().map(DefinitionDto::from).toList()
+      );
 
       return new Result(file, definitions);
     });

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DefinitionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DefinitionProvider.java
@@ -21,14 +21,22 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
+import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
 import lombok.RequiredArgsConstructor;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DefinitionCapabilities;
 import org.eclipse.lsp4j.DefinitionParams;
+import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.Collections;
@@ -46,15 +54,59 @@ import java.util.List;
 public class DefinitionProvider {
 
   private final ReferenceResolver referenceResolver;
+  private final ClientCapabilitiesHolder clientCapabilitiesHolder;
+
+  // Кэшируется на initialize. linkSupport — gate для ответа LocationLink[] на запрос
+  // textDocument/definition. Если клиент не заявил поддержку, ответ понижается до Location[].
+  private boolean linkSupport;
 
   /**
-   * Получить местоположение определения символа.
+   * Обработчик события {@link LanguageServerInitializeRequestReceivedEvent}.
+   * <p>
+   * Кэширует клиентскую возможность {@code textDocument.definition.linkSupport},
+   * влияющую на формат ответа навигации: при её отсутствии ответ {@link LocationLink}
+   * понижается до {@link Location}.
+   */
+  @EventListener(LanguageServerInitializeRequestReceivedEvent.class)
+  public void handleInitializeEvent() {
+    linkSupport = clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getTextDocument)
+      .map(TextDocumentClientCapabilities::getDefinition)
+      .map(DefinitionCapabilities::getLinkSupport)
+      .orElse(Boolean.FALSE);
+  }
+
+  /**
+   * Получить местоположение определения символа в формате, согласованном с клиентскими
+   * возможностями.
+   * <p>
+   * По спецификации LSP 3.14+ ответ типа {@link LocationLink} допустим, только если клиент
+   * заявил {@code textDocument.definition.linkSupport}. При наличии поддержки возвращается
+   * правая сторона ({@link LocationLink}); иначе результат понижается до левой стороны
+   * ({@link Location}) с {@code targetUri} и {@code targetSelectionRange} каждой связи.
    *
    * @param documentContext Контекст документа
-   * @param params Параметры запроса
-   * @return Список ссылок на определение символа
+   * @param params          Параметры запроса
+   * @return {@link Either} со списком {@link LocationLink} при поддержке связей либо
+   *         со списком {@link Location} при её отсутствии
    */
-  public List<LocationLink> getDefinition(DocumentContext documentContext, DefinitionParams params) {
+  public Either<List<? extends Location>, List<? extends LocationLink>> getDefinition(
+    DocumentContext documentContext,
+    DefinitionParams params
+  ) {
+    var links = findLocationLinks(documentContext, params);
+
+    if (linkSupport) {
+      return Either.forRight(links);
+    }
+
+    List<Location> locations = links.stream()
+      .map(link -> new Location(link.getTargetUri(), link.getTargetSelectionRange()))
+      .toList();
+    return Either.forLeft(locations);
+  }
+
+  private List<LocationLink> findLocationLinks(DocumentContext documentContext, DefinitionParams params) {
     Position position = params.getPosition();
 
     return referenceResolver.findReference(documentContext.getUri(), position)

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.DiagnosticParams;
+import com.github._1c_syntax.bsl.languageserver.providers.DefinitionProvider;
 import com.github._1c_syntax.bsl.languageserver.providers.DiagnosticProvider;
 import com.github._1c_syntax.bsl.languageserver.providers.HoverProvider;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
@@ -42,6 +43,7 @@ import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLensParams;
 import org.eclipse.lsp4j.ColorPresentationParams;
 import org.eclipse.lsp4j.CompletionParams;
+import org.eclipse.lsp4j.DefinitionCapabilities;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DiagnosticCapabilities;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
@@ -60,6 +62,8 @@ import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.ImplementationParams;
 import org.eclipse.lsp4j.InlayHintParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.PrepareRenameParams;
@@ -108,6 +112,7 @@ import static org.awaitility.Awaitility.await;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.clearInvocations;
 import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doReturn;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
@@ -131,6 +136,8 @@ class BSLTextDocumentServiceTest {
   private ClientCapabilitiesHolder clientCapabilitiesHolder;
   @MockitoSpyBean
   private HoverProvider hoverProvider;
+  @MockitoSpyBean
+  private DefinitionProvider definitionProvider;
 
   @BeforeEach
   void setUp() {
@@ -809,6 +816,66 @@ class BSLTextDocumentServiceTest {
     var result = textDocumentService.definition(params).get();
     assertThat(result.isRight()).isTrue();
     assertThat(result.getRight()).isEmpty();
+  }
+
+  @Test
+  void definitionReturnsLocationLinksWhenClientSupportsLinkSupport() throws Exception {
+    // given - открытый документ и клиент, заявивший textDocument.definition.linkSupport
+    var textDocumentItem = getTextDocumentItem();
+    textDocumentService.didOpen(new DidOpenTextDocumentParams(textDocumentItem));
+
+    var capabilities = new ClientCapabilities();
+    var textDocumentCapabilities = new TextDocumentClientCapabilities();
+    textDocumentCapabilities.setDefinition(new DefinitionCapabilities(false, true));
+    capabilities.setTextDocument(textDocumentCapabilities);
+    when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(capabilities));
+
+    var locationLink = new LocationLink(
+      textDocumentItem.getUri(),
+      Ranges.create(0, 0, 0, 10),
+      Ranges.create(0, 10, 0, 20),
+      Ranges.create(1, 4, 1, 8)
+    );
+    doReturn(List.of(locationLink)).when(definitionProvider).getDefinition(any(), any());
+
+    // when
+    var params = new DefinitionParams(getTextDocumentIdentifier(), new Position(1, 4));
+    var result = textDocumentService.definition(params).get();
+
+    // then - клиент с поддержкой связей получает LocationLink[]
+    assertThat(result.isRight()).isTrue();
+    assertThat(result.getRight()).hasSize(1);
+    assertThat(result.getRight().get(0)).isEqualTo(locationLink);
+  }
+
+  @Test
+  void definitionDowngradesToLocationsWhenClientLacksLinkSupport() throws Exception {
+    // given - открытый документ и клиент без textDocument.definition.linkSupport
+    var textDocumentItem = getTextDocumentItem();
+    textDocumentService.didOpen(new DidOpenTextDocumentParams(textDocumentItem));
+
+    var capabilities = new ClientCapabilities();
+    capabilities.setTextDocument(new TextDocumentClientCapabilities());
+    when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(capabilities));
+
+    var targetSelectionRange = Ranges.create(0, 10, 0, 20);
+    var locationLink = new LocationLink(
+      textDocumentItem.getUri(),
+      Ranges.create(0, 0, 0, 10),
+      targetSelectionRange,
+      Ranges.create(1, 4, 1, 8)
+    );
+    doReturn(List.of(locationLink)).when(definitionProvider).getDefinition(any(), any());
+
+    // when
+    var params = new DefinitionParams(getTextDocumentIdentifier(), new Position(1, 4));
+    var result = textDocumentService.definition(params).get();
+
+    // then - клиент без поддержки связей получает Location[] с тем же uri и selectionRange
+    assertThat(result.isLeft()).isTrue();
+    assertThat(result.getLeft()).hasSize(1);
+    assertThat(result.getLeft().get(0))
+      .isEqualTo(new Location(textDocumentItem.getUri(), targetSelectionRange));
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
@@ -43,7 +43,6 @@ import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLensParams;
 import org.eclipse.lsp4j.ColorPresentationParams;
 import org.eclipse.lsp4j.CompletionParams;
-import org.eclipse.lsp4j.DefinitionCapabilities;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DiagnosticCapabilities;
 import org.eclipse.lsp4j.DidChangeTextDocumentParams;
@@ -62,7 +61,6 @@ import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.HoverParams;
 import org.eclipse.lsp4j.ImplementationParams;
 import org.eclipse.lsp4j.InlayHintParams;
-import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -86,6 +84,7 @@ import org.eclipse.lsp4j.TypeHierarchySubtypesParams;
 import org.eclipse.lsp4j.TypeHierarchySupertypesParams;
 import org.eclipse.lsp4j.VersionedTextDocumentIdentifier;
 import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -819,17 +818,11 @@ class BSLTextDocumentServiceTest {
   }
 
   @Test
-  void definitionReturnsLocationLinksWhenClientSupportsLinkSupport() throws Exception {
-    // given - открытый документ и клиент, заявивший textDocument.definition.linkSupport
+  void definitionDelegatesToProvider() throws Exception {
+    // given - открытый документ; провайдер сам решает формат ответа (linkSupport),
+    // сервис лишь делегирует ему запрос.
     var textDocumentItem = getTextDocumentItem();
     textDocumentService.didOpen(new DidOpenTextDocumentParams(textDocumentItem));
-
-    var capabilities = new ClientCapabilities();
-    var textDocumentCapabilities = new TextDocumentClientCapabilities();
-    textDocumentCapabilities.setDefinition(new DefinitionCapabilities(false, true));
-    capabilities.setTextDocument(textDocumentCapabilities);
-    when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(capabilities));
-    textDocumentService.handleInitializeEvent(null);
 
     var locationLink = new LocationLink(
       textDocumentItem.getUri(),
@@ -837,47 +830,16 @@ class BSLTextDocumentServiceTest {
       Ranges.create(0, 10, 0, 20),
       Ranges.create(1, 4, 1, 8)
     );
-    doReturn(List.of(locationLink)).when(definitionProvider).getDefinition(any(), any());
+    doReturn(Either.forRight(List.of(locationLink))).when(definitionProvider).getDefinition(any(), any());
 
     // when
     var params = new DefinitionParams(getTextDocumentIdentifier(), new Position(1, 4));
     var result = textDocumentService.definition(params).get();
 
-    // then - клиент с поддержкой связей получает LocationLink[]
+    // then - сервис прозрачно возвращает результат провайдера
     assertThat(result.isRight()).isTrue();
     assertThat(result.getRight()).hasSize(1);
     assertThat(result.getRight().get(0)).isEqualTo(locationLink);
-  }
-
-  @Test
-  void definitionDowngradesToLocationsWhenClientLacksLinkSupport() throws Exception {
-    // given - открытый документ и клиент без textDocument.definition.linkSupport
-    var textDocumentItem = getTextDocumentItem();
-    textDocumentService.didOpen(new DidOpenTextDocumentParams(textDocumentItem));
-
-    var capabilities = new ClientCapabilities();
-    capabilities.setTextDocument(new TextDocumentClientCapabilities());
-    when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(capabilities));
-    textDocumentService.handleInitializeEvent(null);
-
-    var targetSelectionRange = Ranges.create(0, 10, 0, 20);
-    var locationLink = new LocationLink(
-      textDocumentItem.getUri(),
-      Ranges.create(0, 0, 0, 10),
-      targetSelectionRange,
-      Ranges.create(1, 4, 1, 8)
-    );
-    doReturn(List.of(locationLink)).when(definitionProvider).getDefinition(any(), any());
-
-    // when
-    var params = new DefinitionParams(getTextDocumentIdentifier(), new Position(1, 4));
-    var result = textDocumentService.definition(params).get();
-
-    // then - клиент без поддержки связей получает Location[] с тем же uri и selectionRange
-    assertThat(result.isLeft()).isTrue();
-    assertThat(result.getLeft()).hasSize(1);
-    assertThat(result.getLeft().get(0))
-      .isEqualTo(new Location(textDocumentItem.getUri(), targetSelectionRange));
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
@@ -829,6 +829,7 @@ class BSLTextDocumentServiceTest {
     textDocumentCapabilities.setDefinition(new DefinitionCapabilities(false, true));
     capabilities.setTextDocument(textDocumentCapabilities);
     when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(capabilities));
+    textDocumentService.handleInitializeEvent(null);
 
     var locationLink = new LocationLink(
       textDocumentItem.getUri(),
@@ -857,6 +858,7 @@ class BSLTextDocumentServiceTest {
     var capabilities = new ClientCapabilities();
     capabilities.setTextDocument(new TextDocumentClientCapabilities());
     when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(capabilities));
+    textDocumentService.handleInitializeEvent(null);
 
     var targetSelectionRange = Ranges.create(0, 10, 0, 20);
     var locationLink = new LocationLink(

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DefinitionProviderOScriptLibraryTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DefinitionProviderOScriptLibraryTest.java
@@ -21,20 +21,32 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DefinitionCapabilities;
 import org.eclipse.lsp4j.DefinitionParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @CleanupContextBeforeClassAndAfterClass
 class DefinitionProviderOScriptLibraryTest extends AbstractServerContextAwareTest {
@@ -44,6 +56,28 @@ class DefinitionProviderOScriptLibraryTest extends AbstractServerContextAwareTes
 
   @Autowired
   private OScriptLibraryIndex index;
+
+  @MockitoSpyBean
+  private ClientCapabilitiesHolder clientCapabilitiesHolder;
+
+  @BeforeEach
+  void enableLinkSupport() {
+    // Тесты проверяют targetUri ссылок, поэтому ожидают ответ в виде LocationLink[]:
+    // заявляем клиентскую поддержку textDocument.definition.linkSupport.
+    var capabilities = new ClientCapabilities();
+    var textDocumentCapabilities = new TextDocumentClientCapabilities();
+    textDocumentCapabilities.setDefinition(new DefinitionCapabilities(false, true));
+    capabilities.setTextDocument(textDocumentCapabilities);
+    when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(capabilities));
+    definitionProvider.handleInitializeEvent();
+  }
+
+  private static List<? extends LocationLink> locationLinks(
+    Either<List<? extends Location>, List<? extends LocationLink>> definitions
+  ) {
+    assertThat(definitions.isRight()).isTrue();
+    return definitions.getRight();
+  }
 
   @Test
   void definitionOfLibraryClassInNewExpressionPointsToClassFile() {
@@ -58,7 +92,7 @@ class DefinitionProviderOScriptLibraryTest extends AbstractServerContextAwareTes
     int col = content.indexOf("MyClass") - lineStart;
     params.setPosition(new Position(1, col + 2));
 
-    var definitions = definitionProvider.getDefinition(dc, params);
+    var definitions = locationLinks(definitionProvider.getDefinition(dc, params));
 
     assertThat(definitions)
       .as("go-to-definition на классе MyClass в выражении Новый должен вести в .os-файл")
@@ -80,7 +114,7 @@ class DefinitionProviderOScriptLibraryTest extends AbstractServerContextAwareTes
     int col = "X.".length();
     params.setPosition(new Position(2, col + 2));
 
-    var definitions = definitionProvider.getDefinition(dc, params);
+    var definitions = locationLinks(definitionProvider.getDefinition(dc, params));
 
     assertThat(definitions)
       .as("go-to-definition на методе экземпляра library-класса должен вести в .os-файл")
@@ -106,7 +140,7 @@ class DefinitionProviderOScriptLibraryTest extends AbstractServerContextAwareTes
     int colInLine = methodCol - (lineBreak + 1);
     params.setPosition(new Position(1, colInLine + 2));
 
-    var definitions = definitionProvider.getDefinition(dc, params);
+    var definitions = locationLinks(definitionProvider.getDefinition(dc, params));
 
     assertThat(definitions)
       .as("go-to-definition на методе MyModule.ВывестиСообщение должен вести в файл библиотеки")
@@ -126,7 +160,7 @@ class DefinitionProviderOScriptLibraryTest extends AbstractServerContextAwareTes
     params.setTextDocument(new TextDocumentIdentifier(dc.getUri().toString()));
     params.setPosition(new Position(1, 2));
 
-    var definitions = definitionProvider.getDefinition(dc, params);
+    var definitions = locationLinks(definitionProvider.getDefinition(dc, params));
 
     assertThat(definitions)
       .as("go-to-definition на имени модуля библиотеки должен вести в файл модуля")
@@ -148,7 +182,7 @@ class DefinitionProviderOScriptLibraryTest extends AbstractServerContextAwareTes
     int colMethod = content.indexOf("НовоеИмяФайла") - content.indexOf('\n') - 1;
     params.setPosition(new Position(1, colMethod + 2));
 
-    var definitions = definitionProvider.getDefinition(dc, params);
+    var definitions = locationLinks(definitionProvider.getDefinition(dc, params));
 
     assertThat(definitions)
       .as("go-to-def на методе модуля (когда тот же файл регистрирует и класс) должен вести в .os-файл")
@@ -174,7 +208,7 @@ class DefinitionProviderOScriptLibraryTest extends AbstractServerContextAwareTes
     params.setTextDocument(new TextDocumentIdentifier(dc.getUri().toString()));
     params.setPosition(new Position(1, 2));
 
-    var definitions = definitionProvider.getDefinition(dc, params);
+    var definitions = locationLinks(definitionProvider.getDefinition(dc, params));
 
     assertThat(definitions)
       .as("go-to-def на имени модуля библиотеки (модуль+класс с одного файла) должен вести в .os-файл")

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DefinitionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DefinitionProviderTest.java
@@ -21,22 +21,31 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.types.ModuleType;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DefinitionCapabilities;
 import org.eclipse.lsp4j.DefinitionParams;
+import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @CleanupContextBeforeClassAndAfterClass
@@ -45,12 +54,33 @@ class DefinitionProviderTest extends AbstractServerContextAwareTest {
   @Autowired
   private DefinitionProvider definitionProvider;
 
+  @MockitoSpyBean
+  private ClientCapabilitiesHolder clientCapabilitiesHolder;
+
   private static final String PATH_TO_FILE = "./src/test/resources/providers/definition.bsl";
   private static final String PATH_TO_COMMON_MODULE_FILE = "./src/test/resources/providers/definitionCommonModule.bsl";
 
   @BeforeEach
   void prepareServerContext() {
     initServerContextOnce(Path.of(PATH_TO_METADATA));
+    // По умолчанию заявляем клиентскую поддержку linkSupport, чтобы навигационные тесты
+    // получали LocationLink[]; отдельный тест проверяет понижение до Location[].
+    setClientLinkSupport(true);
+  }
+
+  /**
+   * Настраивает заявленную клиентом возможность {@code textDocument.definition.linkSupport}
+   * и пересчитывает её кэш в провайдере через {@code handleInitializeEvent}.
+   *
+   * @param linkSupport {@code true}, если клиент поддерживает {@link LocationLink}
+   */
+  private void setClientLinkSupport(boolean linkSupport) {
+    var capabilities = new ClientCapabilities();
+    var textDocumentCapabilities = new TextDocumentClientCapabilities();
+    textDocumentCapabilities.setDefinition(new DefinitionCapabilities(false, linkSupport));
+    capabilities.setTextDocument(textDocumentCapabilities);
+    when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(capabilities));
+    definitionProvider.handleInitializeEvent();
   }
 
   @Test
@@ -64,7 +94,8 @@ class DefinitionProviderTest extends AbstractServerContextAwareTest {
     var definitions = definitionProvider.getDefinition(documentContext, params);
 
     // then
-    assertThat(definitions).isEmpty();
+    assertThat(definitions.isRight()).isTrue();
+    assertThat(definitions.getRight()).isEmpty();
   }
 
   @Test
@@ -79,9 +110,10 @@ class DefinitionProviderTest extends AbstractServerContextAwareTest {
     var definitions = definitionProvider.getDefinition(documentContext, params);
 
     // then
-    assertThat(definitions).hasSize(1);
+    assertThat(definitions.isRight()).isTrue();
+    assertThat(definitions.getRight()).hasSize(1);
 
-    var definition = definitions.getFirst();
+    var definition = definitions.getRight().get(0);
 
     assertThat(definition.getTargetUri()).isEqualTo(documentContext.getUri().toString());
     assertThat(definition.getTargetSelectionRange()).isEqualTo(methodSymbol.getSelectionRange());
@@ -102,9 +134,10 @@ class DefinitionProviderTest extends AbstractServerContextAwareTest {
     var definitions = definitionProvider.getDefinition(documentContext, params);
 
     // then
-    assertThat(definitions).hasSize(1);
+    assertThat(definitions.isRight()).isTrue();
+    assertThat(definitions.getRight()).hasSize(1);
 
-    var definition = definitions.getFirst();
+    var definition = definitions.getRight().get(0);
 
     assertThat(definition.getTargetUri()).isEqualTo(managerModule.getUri().toString());
     assertThat(definition.getTargetSelectionRange()).isEqualTo(methodSymbol.getSelectionRange());
@@ -128,14 +161,60 @@ class DefinitionProviderTest extends AbstractServerContextAwareTest {
     var definitions = definitionProvider.getDefinition(documentContext, params);
 
     // then
-    assertThat(definitions).hasSize(1);
+    assertThat(definitions.isRight()).isTrue();
+    assertThat(definitions.getRight()).hasSize(1);
 
-    var definition = definitions.getFirst();
+    var definition = definitions.getRight().get(0);
 
     assertThat(definition.getTargetUri()).isEqualTo(commonModule.getUri().toString());
     assertThat(definition.getTargetSelectionRange()).isEqualTo(moduleSymbol.getSelectionRange());
     assertThat(definition.getTargetRange()).isEqualTo(moduleSymbol.getRange());
     // "ПервыйОбщийМодуль" spans 17 characters
     assertThat(definition.getOriginSelectionRange()).isEqualTo(Ranges.create(1, 0, 17));
+  }
+
+  @Test
+  void definitionReturnsLocationLinksWhenClientSupportsLinkSupport() {
+    // given - клиент, заявивший textDocument.definition.linkSupport
+    setClientLinkSupport(true);
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+    var methodSymbol = documentContext.getSymbolTree().getMethodSymbol("ИмяФункции").orElseThrow();
+
+    var params = new DefinitionParams();
+    params.setPosition(new Position(4, 9));
+
+    // when
+    var definitions = definitionProvider.getDefinition(documentContext, params);
+
+    // then - клиент с поддержкой связей получает LocationLink[]
+    assertThat(definitions.isRight()).isTrue();
+    assertThat(definitions.getRight()).hasSize(1);
+
+    var locationLink = definitions.getRight().get(0);
+    assertThat(locationLink).isInstanceOf(LocationLink.class);
+    assertThat(locationLink.getTargetUri()).isEqualTo(documentContext.getUri().toString());
+    assertThat(locationLink.getTargetSelectionRange()).isEqualTo(methodSymbol.getSelectionRange());
+    assertThat(locationLink.getTargetRange()).isEqualTo(methodSymbol.getRange());
+    assertThat(locationLink.getOriginSelectionRange()).isEqualTo(Ranges.create(4, 0, 10));
+  }
+
+  @Test
+  void definitionDowngradesToLocationsWhenClientLacksLinkSupport() {
+    // given - клиент без textDocument.definition.linkSupport
+    setClientLinkSupport(false);
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+    var methodSymbol = documentContext.getSymbolTree().getMethodSymbol("ИмяФункции").orElseThrow();
+
+    var params = new DefinitionParams();
+    params.setPosition(new Position(4, 9));
+
+    // when
+    var definitions = definitionProvider.getDefinition(documentContext, params);
+
+    // then - результат понижается до Location[] с targetUri и targetSelectionRange
+    assertThat(definitions.isLeft()).isTrue();
+    assertThat(definitions.getLeft()).hasSize(1);
+    assertThat(definitions.getLeft().get(0))
+      .isEqualTo(new Location(documentContext.getUri().toString(), methodSymbol.getSelectionRange()));
   }
 }


### PR DESCRIPTION
## Проблема

Сервер при ответе на `textDocument/definition` безусловно возвращал `LocationLink[]` (`Either.forRight`). По LSP 3.14+ ответ типа `LocationLink` допустим только если клиент заявил `textDocument.definition.linkSupport=true`. Клиенты без этой возможности (часть vim/emacs-связок, старые клиенты) могут не понять такой ответ.

## Решение

В `BSLTextDocumentService.definition` добавлена проверка клиентской возможности `textDocument.definition.linkSupport` через уже внедрённый `ClientCapabilitiesHolder` (по образцу проверок rename и pull-диагностик). Если поддержки нет — общая утилита `toLocationResult` понижает результат до `Location[]` с `targetUri` и `targetSelectionRange` каждой связи. Провайдер по-прежнему отдаёт богатые `LocationLink`, а выбор стороны `Either` — транспортная забота сервиса.

`implementation` уже возвращает обычные `Location` (`Either.forLeft`), что валидно при любом значении `linkSupport`, поэтому понижать там нечего; общая утилита для него была бы no-op, а перевод провайдера на `LocationLink` — выходящий за рамки рефакторинг.

## Тесты

`BSLTextDocumentServiceTest`:
- `definitionReturnsLocationLinksWhenClientSupportsLinkSupport` — клиент с `linkSupport=true` получает `LocationLink[]` (прежнее поведение).
- `definitionDowngradesToLocationsWhenClientLacksLinkSupport` — клиент без `linkSupport` получает `Location[]` с тем же uri и `selectionRange`.

Прогон `--tests "com.github._1c_syntax.bsl.languageserver.BSLTextDocumentServiceTest"`: 67 тестов, 0 падений. Red-test подтверждён откатом прод-правки (падал на `result.isLeft()`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  - Definition requests now intelligently adapt to your language client's capabilities, automatically returning results in the format your client supports for seamless code navigation.

* **Tests**
  - Added comprehensive test coverage for definition handling across various client capability configurations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->