### PR TITLE
fix(ReferencesProvider): учитывать context.includeDeclaration в textDocument/references

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/ReferencesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/ReferencesProvider.java
@@ -22,14 +22,17 @@
 package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.ReferenceContext;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.springframework.stereotype.Component;
 
+import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.stream.Collectors;
@@ -58,12 +61,43 @@ public class ReferencesProvider {
   public List<Location> getReferences(DocumentContext documentContext, ReferenceParams params) {
     var position = params.getPosition();
 
-    return referenceResolver.findReference(documentContext.getUri(), position)
-      .flatMap(Reference::getSourceDefinedSymbol)
-      .stream()
+    var maybeSymbol = referenceResolver.findReference(documentContext.getUri(), position)
+      .flatMap(Reference::getSourceDefinedSymbol);
+
+    List<Location> locations = maybeSymbol.stream()
       .map(referenceIndex::getReferencesTo)
       .flatMap(Collection::stream)
       .map(Reference::toLocation)
-      .collect(Collectors.toList());
+      .collect(Collectors.toCollection(ArrayList::new));
+
+    if (includeDeclaration(params)) {
+      maybeSymbol
+        .map(ReferencesProvider::declarationLocation)
+        .filter(declaration -> !locations.contains(declaration))
+        .ifPresent(locations::add);
+    }
+
+    return locations;
+  }
+
+  /**
+   * Определить, нужно ли включать в результат объявление символа.
+   *
+   * @param params Параметры запроса {@code textDocument/references}
+   * @return {@code true}, если контекст запроса присутствует и требует включения объявления
+   */
+  private static boolean includeDeclaration(ReferenceParams params) {
+    ReferenceContext context = params.getContext();
+    return context != null && context.isIncludeDeclaration();
+  }
+
+  /**
+   * Построить местоположение объявления символа по его {@code selectionRange}.
+   *
+   * @param symbol Символ, объявленный в исходном коде
+   * @return Местоположение строки объявления символа
+   */
+  private static Location declarationLocation(SourceDefinedSymbol symbol) {
+    return new Location(symbol.getOwner().getUri().toString(), symbol.getSelectionRange());
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/ReferencesProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/ReferencesProviderTest.java
@@ -28,6 +28,7 @@ import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.ReferenceContext;
 import org.eclipse.lsp4j.ReferenceParams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
@@ -84,6 +85,89 @@ class ReferencesProviderTest extends AbstractServerContextAwareTest {
 
     assertThat(reference.getUri()).isEqualTo(documentContext.getUri().toString());
     assertThat(reference.getRange()).isEqualTo(Ranges.create(4, 0, 10));
+  }
+
+  @Test
+  void testLocalMethodsWithIncludeDeclaration() {
+    // given
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+
+    var params = new ReferenceParams();
+    params.setPosition(new Position(0, 10));
+    params.setContext(new ReferenceContext(true));
+
+    // when
+    var references = referencesProvider.getReferences(documentContext, params);
+
+    // then
+    var declaration = new Location(documentContext.getUri().toString(), Ranges.create(0, 8, 18));
+    var call = new Location(documentContext.getUri().toString(), Ranges.create(4, 0, 10));
+
+    assertThat(references)
+      .hasSize(2)
+      .containsExactlyInAnyOrder(declaration, call);
+  }
+
+  @Test
+  void testLocalMethodsWithoutIncludeDeclaration() {
+    // given
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+
+    var params = new ReferenceParams();
+    params.setPosition(new Position(0, 10));
+    params.setContext(new ReferenceContext(false));
+
+    // when
+    var references = referencesProvider.getReferences(documentContext, params);
+
+    // then
+    var call = new Location(documentContext.getUri().toString(), Ranges.create(4, 0, 10));
+
+    assertThat(references)
+      .hasSize(1)
+      .containsExactly(call);
+  }
+
+  @Test
+  void testIncludeDeclarationWhenCursorOnDeclarationDoesNotDuplicate() {
+    // given
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+
+    var params = new ReferenceParams();
+    // курсор стоит на самом объявлении функции
+    params.setPosition(new Position(0, 12));
+    params.setContext(new ReferenceContext(true));
+
+    // when
+    var references = referencesProvider.getReferences(documentContext, params);
+
+    // then
+    var declaration = new Location(documentContext.getUri().toString(), Ranges.create(0, 8, 18));
+    var call = new Location(documentContext.getUri().toString(), Ranges.create(4, 0, 10));
+
+    assertThat(references)
+      .hasSize(2)
+      .containsExactlyInAnyOrder(declaration, call);
+  }
+
+  @Test
+  void testNullContextDoesNotFail() {
+    // given
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+
+    // context намеренно не задан — по умолчанию null
+    var params = new ReferenceParams();
+    params.setPosition(new Position(0, 10));
+
+    // when
+    var references = referencesProvider.getReferences(documentContext, params);
+
+    // then
+    var call = new Location(documentContext.getUri().toString(), Ranges.create(4, 0, 10));
+
+    assertThat(references)
+      .hasSize(1)
+      .containsExactly(call);
   }
 
   @Test


### PR DESCRIPTION
## Проблема

`ReferencesProvider` полностью игнорировал `params.getContext().isIncludeDeclaration()`. Объявления методов не индексируются как вхождения, поэтому при `includeDeclaration=true` (VS Code по умолчанию шлёт именно `true`) клиент не получал строку объявления процедуры/функции в списке ссылок. Это расходится с LSP 3.17.

## Решение

При `includeDeclaration=true` в результат добавляется `Location` по `selectionRange` найденного `SourceDefinedSymbol` (символ уже в руках после `Reference::getSourceDefinedSymbol`). При `false` поведение прежнее. Объявление не дублируется, когда курсор стоит на самом объявлении. Отсутствующий `context` (null) обрабатывается безопасно и не роняет провайдер.

## Тесты

Добавлены в `ReferencesProviderTest`:
- `testLocalMethodsWithIncludeDeclaration` — список содержит selectionRange объявления + вызов;
- `testLocalMethodsWithoutIncludeDeclaration` — только вызов (закрепление прежнего поведения);
- `testIncludeDeclarationWhenCursorOnDeclarationDoesNotDuplicate` — объявление не дублируется;
- `testNullContextDoesNotFail` — null-context не роняет провайдер.

Прогон класса `ReferencesProviderTest`: 7 тестов, все зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * References search now optionally includes symbol declaration location in results alongside reference locations, controlled by request context settings.

* **Tests**
  * Added comprehensive test coverage for declaration inclusion behavior in references search, including enabled/disabled states, cursor positioning, and edge cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->