### PR TITLE
fix(CompletionProvider): documentation как MarkupContent с учётом documentationFormat

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -53,6 +53,8 @@ import org.eclipse.lsp4j.CompletionItemTagSupportCapabilities;
 import org.eclipse.lsp4j.CompletionList;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.InsertTextFormat;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.jspecify.annotations.Nullable;
@@ -100,6 +102,11 @@ public final class CompletionProvider {
   // если нет, помечаем устаревший член legacy-флагом setDeprecated.
   private boolean deprecatedTagSupport;
 
+  // Кэшируется на initialize. Поддерживает ли клиент markdown в documentation completion item.
+  // Если да — documentation отдаётся как MarkupContent(MARKDOWN), иначе голой строкой
+  // (plaintext) с вырезанной markdown-разметкой, чтобы клиент не показывал звёздочки буквально.
+  private boolean markdownDocumentationSupport;
+
   @EventListener(LanguageServerInitializeRequestReceivedEvent.class)
   public void handleInitializeEvent() {
     var completionItem = clientCapabilitiesHolder.getCapabilities()
@@ -114,6 +121,10 @@ public final class CompletionProvider {
       .map(CompletionItemTagSupportCapabilities::getValueSet)
       .filter(valueSet -> valueSet.contains(CompletionItemTag.Deprecated))
       .isPresent();
+    markdownDocumentationSupport = completionItem
+      .map(CompletionItemCapabilities::getDocumentationFormat)
+      .map(formats -> formats.contains(MarkupKind.MARKDOWN))
+      .orElse(Boolean.FALSE);
   }
 
   /**
@@ -680,7 +691,7 @@ public final class CompletionProvider {
       }
       var desc = typeService.getDescription(ref, scriptVariant);
       if (!desc.isEmpty()) {
-        item.setDocumentation(desc);
+        setDocumentation(item, desc);
       }
     }
     applyCallableInsertText(item, className, ctorHasParameters);
@@ -788,7 +799,7 @@ public final class CompletionProvider {
     return count + " " + word + " синтаксиса";
   }
 
-  private static void applyDocumentation(CompletionItem item, MemberDescriptor member, Language scriptVariant) {
+  private void applyDocumentation(CompletionItem item, MemberDescriptor member, Language scriptVariant) {
     var symDesc = member.getSymbolDescription();
     // У source-defined членов (пользовательские методы/свойства) описание —
     // это doc-comment в коде пользователя, он на языке проекта as-is.
@@ -813,7 +824,37 @@ public final class CompletionProvider {
       sb.append(purpose);
     }
     if (sb.length() > 0) {
-      item.setDocumentation(sb.toString());
+      setDocumentation(item, sb.toString());
     }
+  }
+
+  /**
+   * Проставляет documentation completion item с учётом клиентских capabilities.
+   * Если клиент поддерживает markdown в documentation completion item — текст отдаётся
+   * как {@link MarkupContent} с {@link MarkupKind#MARKDOWN}. Иначе документация отдаётся
+   * голой строкой (plaintext) с вырезанной markdown-разметкой, иначе клиент покажет
+   * управляющие символы (например, {@code **}) буквально.
+   *
+   * @param item     completion item, которому проставляется документация.
+   * @param markdown текст документации в формате markdown (без экранирования).
+   */
+  private void setDocumentation(CompletionItem item, String markdown) {
+    if (markdownDocumentationSupport) {
+      item.setDocumentation(new MarkupContent(MarkupKind.MARKDOWN, markdown));
+    } else {
+      item.setDocumentation(stripMarkdownEmphasis(markdown));
+    }
+  }
+
+  /**
+   * Убирает markdown-разметку жирного начертания ({@code **...**}) из текста для
+   * plaintext-клиентов. В формируемой документации {@code **} используется только как
+   * обрамление жирного, поэтому достаточно удалить все вхождения {@code **}.
+   *
+   * @param value исходный текст с markdown-разметкой.
+   * @return текст без обрамляющих {@code **}.
+   */
+  private static String stripMarkdownEmphasis(String value) {
+    return value.replace("**", "");
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -34,6 +34,7 @@ import org.eclipse.lsp4j.CompletionItemCapabilities;
 import org.eclipse.lsp4j.CompletionItemKind;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.InsertTextFormat;
+import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -41,6 +42,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
+import java.util.List;
 import java.util.Set;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
@@ -66,6 +68,19 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   private void enableSnippetSupport(boolean enabled) {
     var itemCaps = new CompletionItemCapabilities();
     itemCaps.setSnippetSupport(enabled);
+    var completionCaps = new CompletionCapabilities();
+    completionCaps.setCompletionItem(itemCaps);
+    var textDocumentCaps = new TextDocumentClientCapabilities();
+    textDocumentCaps.setCompletion(completionCaps);
+    var caps = new ClientCapabilities();
+    caps.setTextDocument(textDocumentCaps);
+    clientCapabilitiesHolder.setCapabilities(caps);
+    completionProvider.handleInitializeEvent();
+  }
+
+  private void enableMarkdownDocumentation(boolean enabled) {
+    var itemCaps = new CompletionItemCapabilities();
+    itemCaps.setDocumentationFormat(enabled ? List.of(MarkupKind.MARKDOWN) : List.of(MarkupKind.PLAINTEXT));
     var completionCaps = new CompletionCapabilities();
     completionCaps.setCompletionItem(itemCaps);
     var textDocumentCaps = new TextDocumentClientCapabilities();
@@ -1152,6 +1167,81 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
     var doc = item.getDocumentation();
     assertThat(doc).as("у члена должна быть проставлена документация").isNotNull();
     return doc.isLeft() ? doc.getLeft() : doc.getRight().getValue();
+  }
+
+  @Test
+  void documentationReturnedAsMarkdownMarkupWhenClientSupportsMarkdown() {
+    // given
+    enableMarkdownDocumentation(true);
+    var documentContext = TestUtils.getDocumentContext("М = Новый Массив;\nМ.");
+
+    // when
+    var add = dotCompletionItem(documentContext, new Position(1, 2), "Добавить");
+
+    // then
+    var doc = add.getDocumentation();
+    assertThat(doc.isRight())
+      .as("при поддержке markdown документация отдаётся как MarkupContent, а не голой строкой")
+      .isTrue();
+    assertThat(doc.getRight().getKind()).isEqualTo(MarkupKind.MARKDOWN);
+    assertThat(doc.getRight().getValue()).contains("Добавляет значение");
+  }
+
+  @Test
+  void documentationReturnedAsPlainStringWhenClientLacksMarkdown() {
+    // given
+    enableMarkdownDocumentation(false);
+    var documentContext = TestUtils.getDocumentContext("М = Новый Массив;\nМ.");
+
+    // when
+    var add = dotCompletionItem(documentContext, new Position(1, 2), "Добавить");
+
+    // then
+    var doc = add.getDocumentation();
+    assertThat(doc.isLeft())
+      .as("без поддержки markdown документация отдаётся голой строкой (plaintext)")
+      .isTrue();
+    assertThat(doc.getLeft()).contains("Добавляет значение");
+  }
+
+  @Test
+  void deprecatedMarkupKeptAsMarkdownForMarkdownClient() {
+    // given
+    initServerContext(PATH_TO_METADATA);
+    enableMarkdownDocumentation(true);
+    var documentContext = TestUtils.getDocumentContext("ПервыйОбщийМодуль.");
+
+    // when
+    var deprecated = dotCompletionItem(documentContext, new Position(0, 18), "УстаревшаяПроцедура");
+
+    // then
+    var doc = deprecated.getDocumentation();
+    assertThat(doc.isRight())
+      .as("при поддержке markdown пометка об устаревании сохраняет markdown-разметку")
+      .isTrue();
+    assertThat(doc.getRight().getKind()).isEqualTo(MarkupKind.MARKDOWN);
+    assertThat(doc.getRight().getValue()).contains("**Устарело.**");
+  }
+
+  @Test
+  void deprecatedMarkupStrippedForPlaintextClient() {
+    // given
+    initServerContext(PATH_TO_METADATA);
+    enableMarkdownDocumentation(false);
+    var documentContext = TestUtils.getDocumentContext("ПервыйОбщийМодуль.");
+
+    // when
+    var deprecated = dotCompletionItem(documentContext, new Position(0, 18), "УстаревшаяПроцедура");
+
+    // then
+    var doc = deprecated.getDocumentation();
+    assertThat(doc.isLeft())
+      .as("без поддержки markdown документация отдаётся голой строкой")
+      .isTrue();
+    assertThat(doc.getLeft())
+      .as("звёздочки markdown должны быть убраны для plaintext-клиента")
+      .contains("Устарело.")
+      .doesNotContain("**");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -1220,7 +1220,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .as("при поддержке markdown пометка об устаревании сохраняет markdown-разметку")
       .isTrue();
     assertThat(doc.getRight().getKind()).isEqualTo(MarkupKind.MARKDOWN);
-    assertThat(doc.getRight().getValue()).contains("**Устарело.**");
+    assertThat(doc.getRight().getValue()).contains("**Устарела.**");
   }
 
   @Test
@@ -1240,7 +1240,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .isTrue();
     assertThat(doc.getLeft())
       .as("звёздочки markdown должны быть убраны для plaintext-клиента")
-      .contains("Устарело.")
+      .contains("Устарела.")
       .doesNotContain("**");
   }
 


### PR DESCRIPTION
## Проблема

`applyDocumentation` вставляет markdown-разметку (`**Устарело.**` / `**Deprecated.**`) в `documentation`, но кладёт её голой строкой (`item.setDocumentation(String)`). По LSP голая строка трактуется как plaintext — клиенты, не понимающие markdown как таковой, показывают звёздочки буквально. Описание класса (`buildPlatformClassCompletionItem`) тоже отдавалось голой строкой без учёта формата.

## Решение

На `initialize` кэшируется флаг `markdownDocumentationSupport` из `clientCapabilities.textDocument.completion.completionItem.documentationFormat` (рядом с уже кэшируемыми `snippetSupport`/`tagSupport`). Новый хелпер `setDocumentation`:

- при поддержке markdown отдаёт `MarkupContent(MarkupKind.MARKDOWN, ...)` (как hover-билдеры);
- иначе отдаёт plaintext-строку с вырезанной markdown-разметкой (звёздочки убираются).

Оба места (`buildPlatformClassCompletionItem` и `applyDocumentation`) переведены на новый хелпер.

## Тесты

`CompletionProviderTest` (helper `enableMarkdownDocumentation`, по образцу `enableSnippetSupport`):

- `documentationReturnedAsMarkdownMarkupWhenClientSupportsMarkdown` — markdown-клиент получает `MarkupContent` с `kind=markdown`;
- `documentationReturnedAsPlainStringWhenClientLacksMarkdown` — plaintext-клиент получает голую строку;
- `deprecatedMarkupKeptAsMarkdownForMarkdownClient` — пометка об устаревании сохраняет `**` в markdown;
- `deprecatedMarkupStrippedForPlaintextClient` — для plaintext `**` вырезаны.

Прогон класса `CompletionProviderTest`: 67 тестов, 0 падений.

🤖 Generated with [Claude Code](https://claude.com/claude-code)