### PR TITLE
fix(SymbolProvider): откатываться на буквальный поиск при невалидном regex в workspace/symbol

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
@@ -42,7 +42,6 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
-import java.util.Collections;
 import java.util.EnumSet;
 import java.util.List;
 import java.util.Optional;
@@ -75,13 +74,7 @@ public class SymbolProvider {
     var queryString = Optional.ofNullable(params.getQuery())
       .orElse("");
 
-    Pattern pattern;
-    try {
-      pattern = CaseInsensitivePattern.compile(queryString);
-    } catch (PatternSyntaxException e) {
-      LOGGER.debug(e.getMessage(), e);
-      return Collections.emptyList();
-    }
+    var pattern = compilePattern(queryString);
 
     // Search for symbols in all workspace contexts
     return serverContextProvider.getAllContexts().values().stream()
@@ -90,6 +83,25 @@ public class SymbolProvider {
       .filter(symbolEntry -> queryString.isEmpty() || pattern.matcher(symbolEntry.symbol().getName()).find())
       .map(SymbolProvider::createWorkspaceSymbol)
       .collect(Collectors.toList());
+  }
+
+  /**
+   * Компилирует запрос {@code workspace/symbol} в шаблон для сопоставления имён символов.
+   * <p>
+   * Запрос трактуется как регулярное выражение. Если оно невалидно, спецификация LSP допускает
+   * "расслабленную" обработку, поэтому вместо возврата пустого результата выполняется откат на
+   * буквальное сопоставление подстроки.
+   *
+   * @param queryString строка запроса пользователя
+   * @return скомпилированный шаблон с флагами {@code CASE_INSENSITIVE} и {@code UNICODE_CASE}
+   */
+  private static Pattern compilePattern(String queryString) {
+    try {
+      return CaseInsensitivePattern.compile(queryString);
+    } catch (PatternSyntaxException e) {
+      LOGGER.debug(e.getMessage(), e);
+      return Pattern.compile(Pattern.quote(queryString), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+    }
   }
 
   private static Stream<SymbolEntry> getSymbolEntries(DocumentContext documentContext) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
@@ -100,7 +100,7 @@ public class SymbolProvider {
       return CaseInsensitivePattern.compile(queryString);
     } catch (PatternSyntaxException e) {
       LOGGER.debug(e.getMessage(), e);
-      return Pattern.compile(Pattern.quote(queryString), Pattern.CASE_INSENSITIVE | Pattern.UNICODE_CASE);
+      return CaseInsensitivePattern.compile(Pattern.quote(queryString));
     }
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
@@ -21,9 +21,15 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
+import com.github._1c_syntax.utils.Absolute;
 import lombok.SneakyThrows;
+import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.WorkspaceFolder;
@@ -37,9 +43,13 @@ import org.springframework.boot.test.context.SpringBootTest;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.List;
+import java.util.Map;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class SymbolProviderTest {
@@ -162,7 +172,11 @@ class SymbolProviderTest {
   void getSymbolsQueryStringErrorRegex() {
 
     // given
-    var params = new WorkspaceSymbolParams("\\");
+    // Запрос «Метод(» невалиден как регулярное выражение (незакрытая группа),
+    // поэтому обрабатывается как буквальная подстрока. В фикстурах нет символов,
+    // имя которых содержит литерал «Метод(», поэтому ожидаем пустой результат,
+    // но без исключения и без отбрасывания валидных совпадений.
+    var params = new WorkspaceSymbolParams("Метод(");
 
     // when
     var symbols = symbolProvider.getSymbols(params);
@@ -171,5 +185,54 @@ class SymbolProviderTest {
     assertThat(symbols).isEmpty();
   }
 
+  @Test
+  void getSymbolsQueryWithRegexSpecialCharsFallsBackToLiteralMatch() {
+
+    // given
+    // Имя символа содержит литерал «(», а сам запрос невалиден как регулярное выражение.
+    // До исправления такой запрос приводил к PatternSyntaxException и пустому результату.
+    var symbolName = "Метод(Параметр";
+    var symbolUri = Absolute.uri("file:///module.bsl");
+    var symbol = mockMethodSymbol(symbolName);
+
+    var symbolTree = mock(SymbolTree.class);
+    when(symbolTree.getChildrenFlat()).thenReturn(List.of(symbol));
+
+    var documentContext = mock(DocumentContext.class);
+    when(documentContext.getUri()).thenReturn(symbolUri);
+    when(documentContext.getSymbolTree()).thenReturn(symbolTree);
+
+    var serverContext = mock(ServerContext.class);
+    when(serverContext.getDocuments()).thenReturn(Map.of(symbolUri, documentContext));
+
+    var serverContextProvider = mock(ServerContextProvider.class);
+    when(serverContextProvider.getAllContexts()).thenReturn(Map.of(symbolUri, serverContext));
+
+    var provider = new SymbolProvider(serverContextProvider);
+    var params = new WorkspaceSymbolParams("Метод(");
+
+    // when
+    var symbols = provider.getSymbols(params);
+
+    // then
+    assertThat(symbols)
+      .hasSize(1)
+      .anyMatch(symbolInformation -> symbolInformation.getName().equals(symbolName));
+  }
+
+  /**
+   * Создаёт mock символа-метода с заданным именем для проверки сопоставления имён.
+   *
+   * @param name имя символа, возвращаемое методом {@link SourceDefinedSymbol#getName()}
+   * @return настроенный mock {@link SourceDefinedSymbol} с типом {@link SymbolKind#Method}
+   */
+  private static SourceDefinedSymbol mockMethodSymbol(String name) {
+    var symbol = mock(SourceDefinedSymbol.class);
+    when(symbol.getName()).thenReturn(name);
+    when(symbol.getSymbolKind()).thenReturn(SymbolKind.Method);
+    when(symbol.getRange()).thenReturn(new Range(new Position(0, 0), new Position(0, 0)));
+    when(symbol.getTags()).thenReturn(List.of());
+    return symbol;
+  }
 
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
@@ -45,6 +45,7 @@ import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -201,6 +202,8 @@ class SymbolProviderTest {
     var documentContext = mock(DocumentContext.class);
     when(documentContext.getUri()).thenReturn(symbolUri);
     when(documentContext.getSymbolTree()).thenReturn(symbolTree);
+    when(documentContext.getMdObject()).thenReturn(Optional.empty());
+    when(symbol.getOwner()).thenReturn(documentContext);
 
     var serverContext = mock(ServerContext.class);
     when(serverContext.getDocuments()).thenReturn(Map.of(symbolUri, documentContext));


### PR DESCRIPTION
## Проблема

Строка запроса `workspace/symbol` напрямую компилировалась как регулярное выражение
(`CaseInsensitivePattern.compile(query)`). Если пользователь вводил подстроку со
спецсимволом регулярного выражения (например «Получить(» или «Метод[»), компиляция
бросала `PatternSyntaxException`, и провайдер возвращал пустой список. Из-за этого
обычный пользовательский ввод приводил к "ничего не найдено", хотя спецификация LSP
рекомендует трактовать query в "расслабленной" манере и доверять клиенту дофильтрацию.

## Решение

Компиляция шаблона вынесена в `compilePattern(...)`. При `PatternSyntaxException`
выполняется откат на буквальное сопоставление: `Pattern.compile(Pattern.quote(query),
CASE_INSENSITIVE | UNICODE_CASE)` — те же флаги, что и у `CaseInsensitivePattern`.
Полноценный fuzzy-поиск намеренно не вводится. Правка строго локальна в месте
компиляции/матчинга паттерна, `createWorkspaceSymbol` не затронут.

## Тесты

- Обновлён `getSymbolsQueryStringErrorRegex`: запрос «Метод(» теперь не вызывает
  исключения, а трактуется как литерал. В фикстурах нет имён символов с литералом
  «Метод(», поэтому ожидается пустой результат — но уже без отбрасывания валидных
  совпадений. Имена методов/переменных в BSL не могут содержать спецсимволы regex,
  поэтому литеральное совпадение по реальным фикстурам пустое по объективной причине.
- Добавлен `getSymbolsQueryWithRegexSpecialCharsFallsBackToLiteralMatch` (Mockito):
  символ с именем «Метод(Параметр» и невалидный запрос «Метод(». До правки тест падал
  (пустой результат из-за `PatternSyntaxException`), после — находит символ.

Прогон `SymbolProviderTest` (5 тестов) — BUILD SUCCESSFUL, все PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Bug Fixes
* Symbol search now gracefully handles queries containing regex special characters. Invalid regex patterns automatically fall back to literal substring matching, preventing empty results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->