### PR TITLE
fix(CompletionProvider): убрать текстовую пометку устаревания из documentation

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -811,11 +811,12 @@ public final class CompletionProvider {
       .filter(doc -> !doc.isBlank())
       .orElseGet(() -> member.displayDescription(scriptVariant));
     var sb = new StringBuilder();
-    if (symDesc.isDeprecated()) {
-      sb.append(scriptVariant == Language.EN ? "**Deprecated.**" : "**Устарело.**");
-      if (!symDesc.getDeprecationInfo().isBlank()) {
-        sb.append(' ').append(symDesc.getDeprecationInfo());
-      }
+    // Сам факт устаревания клиенту сообщает родной механизм LSP (markDeprecated:
+    // CompletionItemTag.Deprecated или legacy-флаг deprecated) — текстовая пометка
+    // в documentation его бы дублировала. В документацию попадает только причина
+    // устаревания, которую тегом не передать.
+    if (symDesc.isDeprecated() && !symDesc.getDeprecationInfo().isBlank()) {
+      sb.append(symDesc.getDeprecationInfo());
       if (!purpose.isBlank()) {
         sb.append("\n\n");
       }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -1205,7 +1205,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
-  void deprecatedMarkupKeptAsMarkdownForMarkdownClient() {
+  void deprecatedItemDocumentationKeepsReasonWithoutTextualMarker() {
     // given
     initServerContext(PATH_TO_METADATA);
     enableMarkdownDocumentation(true);
@@ -1215,16 +1215,20 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
     var deprecated = dotCompletionItem(documentContext, new Position(0, 18), "УстаревшаяПроцедура");
 
     // then
-    var doc = deprecated.getDocumentation();
-    assertThat(doc.isRight())
-      .as("при поддержке markdown пометка об устаревании сохраняет markdown-разметку")
+    assertThat(deprecated.getDeprecated())
+      .as("факт устаревания передаётся родным механизмом LSP, а не текстом в documentation")
       .isTrue();
+    var doc = deprecated.getDocumentation();
+    assertThat(doc.isRight()).isTrue();
     assertThat(doc.getRight().getKind()).isEqualTo(MarkupKind.MARKDOWN);
-    assertThat(doc.getRight().getValue()).contains("**Устарело.**");
+    assertThat(doc.getRight().getValue())
+      .as("в documentation остаётся только причина устаревания, без дублирующей пометки")
+      .contains("См. НеУстаревшаяПроцедура.")
+      .doesNotContain("Устарела", "Устарело", "Deprecated");
   }
 
   @Test
-  void deprecatedMarkupStrippedForPlaintextClient() {
+  void deprecatedItemReasonShownForPlaintextClient() {
     // given
     initServerContext(PATH_TO_METADATA);
     enableMarkdownDocumentation(false);
@@ -1239,8 +1243,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .as("без поддержки markdown документация отдаётся голой строкой")
       .isTrue();
     assertThat(doc.getLeft())
-      .as("звёздочки markdown должны быть убраны для plaintext-клиента")
-      .contains("Устарело.")
+      .contains("См. НеУстаревшаяПроцедура.")
       .doesNotContain("**");
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -1220,7 +1220,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .as("при поддержке markdown пометка об устаревании сохраняет markdown-разметку")
       .isTrue();
     assertThat(doc.getRight().getKind()).isEqualTo(MarkupKind.MARKDOWN);
-    assertThat(doc.getRight().getValue()).contains("**Устарела.**");
+    assertThat(doc.getRight().getValue()).contains("**Устарело.**");
   }
 
   @Test
@@ -1240,7 +1240,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .isTrue();
     assertThat(doc.getLeft())
       .as("звёздочки markdown должны быть убраны для plaintext-клиента")
-      .contains("Устарела.")
+      .contains("Устарело.")
       .doesNotContain("**");
   }
 


### PR DESCRIPTION
## Проблема
develop красный: `CompletionProviderTest.deprecatedMarkup*` (из #4061) ассертили маркер «Устарела.», тогда как `CompletionProvider.applyDocumentation` выводил «Устарело.». По ходу ревью выяснилось, что текстовый маркер в documentation вообще не нужен: факт устаревания клиенту уже передаёт родной механизм LSP — `markDeprecated` ставит `CompletionItemTag.Deprecated` (или legacy-флаг `deprecated` для клиентов без tagSupport), и оба метода (`applyDocumentation`/`markDeprecated`) вызываются для каждого item по одному и тому же признаку.

## Решение
Текстовый маркер удалён из documentation полностью (заодно отпала локализация этой строки); в документации остаётся только **причина** устаревания («См. …»), которую тегом не передать. Тесты переписаны: проверяют родной флаг устаревания и причину в documentation без дублирующей пометки (markdown- и plaintext-клиенты).

## Тесты
`CompletionProviderTest` — 67 тестов, 0 падений (локально, `-Dversioning.disable=true -Pversion=0.0.0-DEV`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)