### PR TITLE
feat(CodeActionProvider): поддержать source.fixAll для автопочинки при сохранении

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -293,7 +293,8 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
 
     var codeActionKinds = List.of(
       CodeActionKind.QuickFix,
-      CodeActionKind.Refactor
+      CodeActionKind.Refactor,
+      CodeActionKind.SourceFixAll
     );
 
     codeActionOptions.setCodeActionKinds(codeActionKinds);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/SourceFixAllCodeActionSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/SourceFixAllCodeActionSupplier.java
@@ -1,0 +1,103 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.codeactions;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.diagnostics.QuickFixProvider;
+import lombok.RequiredArgsConstructor;
+import org.eclipse.lsp4j.CodeAction;
+import org.eclipse.lsp4j.CodeActionContext;
+import org.eclipse.lsp4j.CodeActionKind;
+import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.Diagnostic;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.springframework.stereotype.Component;
+
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.stream.Collectors;
+
+/**
+ * Поставщик code action для автоматического исправления при сохранении документа.
+ * <p>
+ * Срабатывает на запросы клиента с {@code only}, содержащим {@link CodeActionKind#SourceFixAll}
+ * (например, при {@code editor.codeActionsOnSave: {"source.fixAll": true}}).
+ * Строит исправления по всем вычисленным диагностикам документа, не требуя их наличия
+ * в {@code context.diagnostics}, и выдаёт результат с kind {@code source.fixAll}.
+ */
+@Component
+@RequiredArgsConstructor
+public class SourceFixAllCodeActionSupplier implements CodeActionSupplier {
+
+  private final QuickFixSupplier quickFixSupplier;
+
+  @Override
+  public List<CodeAction> getCodeActions(CodeActionParams params, DocumentContext documentContext) {
+    List<String> only = params.getContext().getOnly();
+    if (only == null || !only.contains(CodeActionKind.SourceFixAll)) {
+      return Collections.emptyList();
+    }
+
+    List<Diagnostic> documentDiagnostics = documentContext.getDiagnostics();
+    if (documentDiagnostics.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    Map<Either<String, Integer>, List<Diagnostic>> diagnosticsByCode = documentDiagnostics.stream()
+      .collect(Collectors.groupingBy(Diagnostic::getCode));
+
+    return diagnosticsByCode.entrySet().stream()
+      .flatMap(entry -> getFixAllCodeActions(entry.getKey(), entry.getValue(), params, documentContext).stream())
+      .collect(Collectors.toList());
+  }
+
+  private List<CodeAction> getFixAllCodeActions(
+    Either<String, Integer> diagnosticCode,
+    List<Diagnostic> diagnostics,
+    CodeActionParams params,
+    DocumentContext documentContext
+  ) {
+
+    Optional<Class<? extends QuickFixProvider>> quickFixClass = quickFixSupplier.getQuickFixClass(diagnosticCode);
+    if (quickFixClass.isEmpty()) {
+      return Collections.emptyList();
+    }
+
+    CodeActionContext fixAllContext = new CodeActionContext();
+    fixAllContext.setDiagnostics(diagnostics);
+    fixAllContext.setOnly(Collections.singletonList(CodeActionKind.QuickFix));
+
+    CodeActionParams fixAllParams = new CodeActionParams();
+    fixAllParams.setTextDocument(params.getTextDocument());
+    fixAllParams.setRange(params.getRange());
+    fixAllParams.setContext(fixAllContext);
+
+    QuickFixProvider quickFixInstance = quickFixSupplier.getQuickFixInstance(quickFixClass.get());
+
+    List<CodeAction> codeActions = quickFixInstance.getQuickFixes(diagnostics, fixAllParams, documentContext);
+    codeActions.forEach(codeAction -> codeAction.setKind(CodeActionKind.SourceFixAll));
+
+    return codeActions;
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CodeActionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CodeActionProviderTest.java
@@ -167,6 +167,68 @@ class CodeActionProviderTest {
     ;
   }
 
+  @Test
+  void testSourceFixAll() {
+    // given
+    CodeActionParams params = new CodeActionParams();
+    TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(documentContext.getUri().toString());
+
+    CodeActionContext codeActionContext = new CodeActionContext();
+
+    // клиент при сохранении присылает only без context.diagnostics
+    codeActionContext.setOnly(List.of(CodeActionKind.SourceFixAll));
+    codeActionContext.setDiagnostics(Collections.emptyList());
+
+    params.setRange(new Range());
+    params.setTextDocument(textDocumentIdentifier);
+    params.setContext(codeActionContext);
+
+    // when
+    List<Either<Command, CodeAction>> codeActions = codeActionProvider.getCodeActions(params, documentContext);
+
+    // then
+    assertThat(codeActions)
+      .extracting(Either::getRight)
+      .isNotEmpty()
+      .allMatch(codeAction -> codeAction.getKind().equals(CodeActionKind.SourceFixAll))
+      .anyMatch(codeAction -> !codeAction.getEdit().getChanges().isEmpty());
+  }
+
+  @Test
+  void testQuickFixDoesNotReturnSourceFixAll() {
+    // given
+    CodeActionParams params = new CodeActionParams();
+    TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(documentContext.getUri().toString());
+
+    DiagnosticInfo diagnosticInfo = new DiagnosticInfo(
+      CanonicalSpellingKeywordsDiagnostic.class,
+      configuration,
+      stringInterner);
+    DiagnosticCode diagnosticCode = diagnosticInfo.getCode();
+
+    List<Diagnostic> diagnostics = documentContext.getDiagnostics().stream()
+      .filter(diagnostic -> diagnostic.getCode().equals(diagnosticCode))
+      .collect(Collectors.toList());
+
+    CodeActionContext codeActionContext = new CodeActionContext();
+
+    codeActionContext.setOnly(List.of(CodeActionKind.QuickFix));
+    codeActionContext.setDiagnostics(diagnostics);
+
+    params.setRange(new Range());
+    params.setTextDocument(textDocumentIdentifier);
+    params.setContext(codeActionContext);
+
+    // when
+    List<Either<Command, CodeAction>> codeActions = codeActionProvider.getCodeActions(params, documentContext);
+
+    // then
+    assertThat(codeActions)
+      .extracting(Either::getRight)
+      .isNotEmpty()
+      .noneMatch(codeAction -> codeAction.getKind().equals(CodeActionKind.SourceFixAll));
+  }
+
   private static boolean toBoolean(@Nullable Boolean value) {
     if (value == null) {
       return false;


### PR DESCRIPTION
## Проблема

Клиент с `editor.codeActionsOnSave: {"source.fixAll": true}` шлёт запрос `textDocument/codeAction` с `only=["source.fixAll"]` и, как правило, без `context.diagnostics`. Существующие поставщики (`AbstractQuickFixSupplier`, `FixAllCodeActionSupplier`) отбрасывают такой запрос: фильтр пропускает только `quickfix`, а сами действия выдаются с kind `QuickFix`. Сервер при этом не объявлял capability `source.fixAll`. В итоге автопочинка при сохранении не работала.

## Решение

- Добавлен `SourceFixAllCodeActionSupplier`: при `only`, содержащем `source.fixAll`, он группирует все вычисленные диагностики документа по коду, для каждого кода с доступным quick fix строит исправления и выставляет им kind `source.fixAll`. Совпадение с `context.diagnostics` не требуется — клиент может их не прислать при сохранении.
- В объявление capability сервера (`CodeActionOptions.codeActionKinds`) добавлен `CodeActionKind.SourceFixAll`.

## Тесты

`CodeActionProviderTest`:
- `testSourceFixAll` — запрос с `only=["source.fixAll"]` и пустым `context.diagnostics` возвращает действия kind `source.fixAll` с правками.
- `testQuickFixDoesNotReturnSourceFixAll` — запрос с `only=["quickfix"]` не получает действий `source.fixAll`.
- Существующие сценарии (`testGetCodeActions`, `testOnly`, `testEmptyDiagnosticList`) не сломаны.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Introduced "Fix All" code action support, enabling users to fix multiple diagnostics simultaneously when they share the same issue type. The server now advertises this capability and intelligently groups diagnostics by code for batch resolution.

* **Tests**
  * Added comprehensive test coverage for the new "Fix All" functionality, including validation of code action filtering and result accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->