### PR TITLE
feat(FormatProvider): поддержать insertFinalNewline и trimFinalNewlines

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -116,11 +116,41 @@ public final class FormatProvider {
     var lastToken = tokens.getLast();
 
     var locale = documentContext.getScriptVariantLocale();
-    return getTextEdits(
+    var options = params.getOptions();
+    var edits = getTextEdits(
       tokens,
       locale,
-      Ranges.create(firstToken, lastToken), firstToken.getCharPositionInLine(), params.getOptions()
+      Ranges.create(firstToken, lastToken), firstToken.getCharPositionInLine(), options
     );
+
+    if (edits.isEmpty() || !(options.isInsertFinalNewline() || options.isTrimFinalNewlines())) {
+      return edits;
+    }
+
+    var edit = edits.getFirst();
+    edit.setNewText(normalizeFinalNewlines(edit.getNewText(), options));
+    return edits;
+  }
+
+  /**
+   * Приводит хвостовые переводы строк отформатированного текста к виду, требуемому
+   * протокольными опциями {@link FormattingOptions}.
+   * <p>
+   * Диапазон правки полного форматирования всегда покрывает документ до конца, поэтому достаточно
+   * нормализовать сам текст: {@code insertFinalNewline} гарантирует ровно один завершающий перевод
+   * строки, а {@code trimFinalNewlines} (когда первый не взведён) удаляет все переводы строк после
+   * последней содержательной строки.
+   *
+   * @param text    отформатированный текст без нормализации хвоста
+   * @param options протокольные опции форматирования с взведённым флагом хвоста
+   * @return текст с нормализованным хвостом переводов строк
+   */
+  private static String normalizeFinalNewlines(String text, FormattingOptions options) {
+    var body = StringUtils.stripEnd(text, "\r\n");
+    if (options.isInsertFinalNewline()) {
+      return body + "\n";
+    }
+    return body;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -515,7 +515,30 @@ public final class FormatProvider {
       }
     }
 
-    return newTextBuilder.toString();
+    var result = newTextBuilder.toString();
+    if (options.isTrimTrailingWhitespace()) {
+      result = trimTrailingWhitespacePerLine(result);
+    }
+
+    return result;
+  }
+
+  /**
+   * Удаляет хвостовые пробелы и табуляции в каждой строке текста, сохраняя сами переводы строк.
+   * <p>
+   * Применяется при включённой опции {@code trimTrailingWhitespace} протокольных
+   * {@link FormattingOptions}: форматтер не должен оставлять строки, состоящие из одних пробелов
+   * (например выровненные пустые строки внутри блоков).
+   *
+   * @param text исходный текст результата форматирования
+   * @return текст, в котором ни одна строка не оканчивается пробелом или табуляцией
+   */
+  private static String trimTrailingWhitespacePerLine(String text) {
+    var lines = text.split("\n", -1);
+    for (var i = 0; i < lines.length; i++) {
+      lines[i] = StringUtils.stripEnd(lines[i], " \t");
+    }
+    return String.join("\n", lines);
   }
 
   private String checkAndFormatKeyword(Token token, Locale languageLocale) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -155,6 +155,59 @@ class FormatProviderTest {
   }
 
   @Test
+  void testFormatInsertsFinalNewline() {
+    // given
+    String fileContent = "А = 1;";
+    DocumentFormattingParams params = new DocumentFormattingParams();
+    params.setTextDocument(getTextDocumentIdentifier());
+    var options = new FormattingOptions(4, true);
+    options.setInsertFinalNewline(true);
+    params.setOptions(options);
+
+    var documentContext = TestUtils.getDocumentContext(
+      Absolute.uri(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).hasSize(1);
+
+    TextEdit textEdit = textEdits.getFirst();
+    assertThat(textEdit.getNewText()).endsWith("\n");
+    assertThat(textEdit.getNewText()).doesNotEndWith("\n\n");
+  }
+
+  @Test
+  void testFormatTrimsFinalNewlinesKeepsSingleNewline() {
+    // given: документ с лишними пустыми строками в конце и обе хвостовые опции взведены
+    String fileContent = "А = 1;\n\n\n\n";
+    DocumentFormattingParams params = new DocumentFormattingParams();
+    params.setTextDocument(getTextDocumentIdentifier());
+    var options = new FormattingOptions(4, true);
+    options.setInsertFinalNewline(true);
+    options.setTrimFinalNewlines(true);
+    params.setOptions(options);
+
+    var documentContext = TestUtils.getDocumentContext(
+      Absolute.uri(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getFormatting(params, documentContext);
+
+    // then: на хвосте ровно один перевод строки, без лишних пустых строк
+    assertThat(textEdits).hasSize(1);
+
+    TextEdit textEdit = textEdits.getFirst();
+    assertThat(textEdit.getNewText()).endsWith("\n");
+    assertThat(textEdit.getNewText()).doesNotEndWith("\n\n");
+  }
+
+  @Test
   void testFormatRuKeywords() throws IOException {
     var originalFile = new File("./src/test/resources/providers/formatKeywordsRu.bsl");
     var formattedFile = new File("./src/test/resources/providers/format_formattedKeywordsRu.bsl");

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -124,6 +124,37 @@ class FormatProviderTest {
   }
 
   @Test
+  void testFormatTrimsTrailingWhitespace() throws IOException {
+    // given
+    DocumentFormattingParams params = new DocumentFormattingParams();
+    params.setTextDocument(getTextDocumentIdentifier());
+    var options = new FormattingOptions(4, true);
+    options.setTrimTrailingWhitespace(true);
+    params.setOptions(options);
+
+    String fileContent = FileUtils.readFileToString(getTestFile(), StandardCharsets.UTF_8);
+
+    var documentContext = TestUtils.getDocumentContext(
+      Absolute.uri(params.getTextDocument().getUri()),
+      fileContent
+    );
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getFormatting(params, documentContext);
+
+    // then
+    assertThat(textEdits).hasSize(1);
+
+    TextEdit textEdit = textEdits.getFirst();
+    String[] resultLines = textEdit.getNewText().split("\n", -1);
+    for (String line : resultLines) {
+      assertThat(line)
+        .as("line must not have trailing whitespace: <%s>", line)
+        .isEqualTo(line.stripTrailing());
+    }
+  }
+
+  @Test
   void testFormatRuKeywords() throws IOException {
     var originalFile = new File("./src/test/resources/providers/formatKeywordsRu.bsl");
     var formattedFile = new File("./src/test/resources/providers/format_formattedKeywordsRu.bsl");


### PR DESCRIPTION
## Проблема

`FormatProvider` при полном форматировании игнорировал протокольные `FormattingOptions` `trimTrailingWhitespace`, `insertFinalNewline` и `trimFinalNewlines`. При пропуске пустых строк форматтер дописывал отступ, из-за чего возникали строки, состоящие из одних пробелов, а хвостовые переводы строк не нормализовались под запрошенные клиентом опции.

## Решение

- При взведённой опции `trimTrailingWhitespace` результат построчно очищается от хвостовых пробелов и табуляций (`trimTrailingWhitespacePerLine`), так что строки из одних пробелов больше не появляются.
- При `insertFinalNewline` результат гарантированно завершается ровно одним переводом строки; при `trimFinalNewlines` лишние пустые строки в конце документа не остаются (`normalizeFinalNewlines`).
- Содержимое документа берётся через `documentContext.getContentList()`.

Поведение по умолчанию (без взведённых опций) намеренно не меняется — существующие эталонные фикстуры (включая строки из одних пробелов в `format_formatted.bsl`) остаются валидными.

## Тесты

Добавлены три теста с явно взведёнными опциями (структура given/when/then):
- `testFormatTrimsTrailingWhitespace` — ни одна строка результата не оканчивается пробелом;
- `testFormatInsertsFinalNewline` — на хвосте ровно один перевод строки;
- `testFormatTrimsFinalNewlinesKeepsSingleNewline` — лишние пустые строки схлопываются до одного перевода строки.

Краснота доказана: при временно убранной прод-правке все три новых теста падают по правильной причине. Финальный прогон всего `FormatProviderTest` — 26 тестов, 0 падений (`-Dversioning.disable=true -Pversion=0.0.0-DEV`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)