### PR TITLE
feat(CompletionProvider): ранжирование кандидатов автодополнения через sortText

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -88,6 +88,20 @@ public final class CompletionProvider {
 
   private static final String TRIGGER_PARAMETER_HINTS_COMMAND = "editor.action.triggerParameterHints";
 
+  // sortText-«корзины» для no-dot completion. Клиент сортирует пункты по sortText
+  // лексикографически, поэтому меньший префикс = выше в списке. Без sortText всё
+  // сортируется по label, и локальные имена документа тонут среди сотен глобальных.
+  // Порядок: локальные имена документа → глобальные функции/контексты → классы и
+  // MD-имена → ключевые слова. Внутри корзины — стабильно по label.
+  private static final String BUCKET_LOCAL = "1";
+  private static final String BUCKET_GLOBAL = "2";
+  private static final String BUCKET_TYPE = "3";
+  private static final String BUCKET_KEYWORD = "4";
+  // Корзина членов типа в dot-completion: пользовательские/декларированные поля
+  // приоритетнее дефолтных членов того же типа.
+  private static final String BUCKET_MEMBER_FIELD = "1";
+  private static final String BUCKET_MEMBER_DEFAULT = "2";
+
   private final TypeService typeService;
   private final GlobalScopeProvider globalScopeProvider;
   private final OScriptLibraryIndex oScriptLibraryIndex;
@@ -298,6 +312,9 @@ public final class CompletionProvider {
 
     var scriptVariant = documentContext.getScriptVariantLanguage();
     var members = new LinkedHashMap<String, MemberDescriptor>();
+    // Имена декларированных полей — для приоритетной корзины sortText: пользовательские
+    // ключи должны ранжироваться выше дефолтных членов того же типа.
+    var localFieldNames = new java.util.HashSet<String>();
     for (TypeRef ref : typeSet.refs()) {
       for (var member : typeService.getMembers(ref, fileType, scriptVariant)) {
         members.putIfAbsent(member.name(), member);
@@ -311,7 +328,9 @@ public final class CompletionProvider {
         var fieldName = entry.getKey();
         var fieldTypes = entry.getValue();
         var fieldRef = fieldTypes.refs().stream().findFirst().orElse(null);
-        members.putIfAbsent(fieldName, MemberDescriptor.property(fieldName, fieldRef, ""));
+        if (members.putIfAbsent(fieldName, MemberDescriptor.property(fieldName, fieldRef, "")) == null) {
+          localFieldNames.add(fieldName);
+        }
       }
     }
 
@@ -325,7 +344,13 @@ public final class CompletionProvider {
       // зачёркнутыми).
       .filter(m -> !PlatformMemberVersions.firesUnavailable(m.metadata().sinceVersion(), target))
       .toList();
-    return toCompletionItems(filtered, scriptVariant, target);
+    var items = toCompletionItems(filtered, scriptVariant, target);
+    for (int i = 0; i < filtered.size(); i++) {
+      var member = filtered.get(i);
+      var bucket = localFieldNames.contains(member.name()) ? BUCKET_MEMBER_FIELD : BUCKET_MEMBER_DEFAULT;
+      applySortText(items.get(i), bucket, isMemberDeprecated(member, target));
+    }
+    return items;
   }
 
   /**
@@ -398,7 +423,9 @@ public final class CompletionProvider {
           continue;
         }
         if (matches(className, prefix)) {
-          items.add(buildPlatformClassCompletionItem(className, fileType, scriptVariant));
+          var item = buildPlatformClassCompletionItem(className, fileType, scriptVariant);
+          applySortText(item, BUCKET_TYPE, false);
+          items.add(item);
         }
       }
       for (var classEntry : oScriptLibraryIndex.findEntries(OScriptLibraryIndex.EntryKind.CLASS)) {
@@ -411,6 +438,7 @@ public final class CompletionProvider {
           item.setKind(CompletionItemKind.Class);
           // Данных о конструкторе библиотечного класса здесь нет — сохраняем курсор между скобок.
           applyCallableInsertText(item, libClassName, true);
+          applySortText(item, BUCKET_TYPE, false);
           items.add(item);
         }
       }
@@ -426,6 +454,7 @@ public final class CompletionProvider {
         if (matches(qualified, prefix)) {
           var item = new CompletionItem(qualified);
           item.setKind(CompletionItemKind.Module);
+          applySortText(item, BUCKET_TYPE, false);
           items.add(item);
         }
       }
@@ -448,6 +477,7 @@ public final class CompletionProvider {
       }
       var item = new CompletionItem(name);
       item.setKind(completionKindForSynthetic(ctx.getSyntheticKind()));
+      applySortText(item, BUCKET_GLOBAL, false);
       items.add(item);
     }
 
@@ -462,7 +492,9 @@ public final class CompletionProvider {
       }
       var displayName = fn.displayName(scriptVariant);
       if (matches(displayName, prefix)) {
-        items.add(toCompletionItem(fn, scriptVariant, target));
+        var item = toCompletionItem(fn, scriptVariant, target);
+        applySortText(item, BUCKET_GLOBAL, isMemberDeprecated(fn, target));
+        items.add(item);
       }
     }
 
@@ -475,6 +507,7 @@ public final class CompletionProvider {
         if (method.isDeprecated()) {
           markDeprecatedItem(item);
         }
+        applySortText(item, BUCKET_LOCAL, method.isDeprecated());
         items.add(item);
       }
     }
@@ -484,6 +517,7 @@ public final class CompletionProvider {
       if (matches(variable.getName(), prefix)) {
         var item = new CompletionItem(variable.getName());
         item.setKind(CompletionItemKind.Variable);
+        applySortText(item, BUCKET_LOCAL, false);
         items.add(item);
       }
     }
@@ -493,6 +527,7 @@ public final class CompletionProvider {
       if (matches(keyword, prefix)) {
         var item = new CompletionItem(keyword);
         item.setKind(CompletionItemKind.Keyword);
+        applySortText(item, BUCKET_KEYWORD, false);
         items.add(item);
       }
     }
@@ -636,6 +671,22 @@ public final class CompletionProvider {
    * платформенным, глобальным функциям, членам конфигурации и
    * пользовательским методам oscript-классов.
    */
+  /**
+   * Проставляет {@code sortText} пункту автодополнения по схеме «корзина + флаг
+   * устаревания + label». Клиент сортирует пункты лексикографически по
+   * {@code sortText}: меньший префикс корзины поднимает группу выше, а
+   * устаревшие члены внутри корзины опускаются вниз (флаг {@code 1} против
+   * {@code 0}), даже если их имя лексикографически меньше неустаревшего соседа.
+   * Внутри корзины при равном статусе порядок стабилен по {@code label}.
+   *
+   * @param item       пункт автодополнения, которому проставляется {@code sortText}.
+   * @param bucket     префикс корзины ранжирования (см. {@code BUCKET_*}).
+   * @param deprecated {@code true}, если член устарел и должен опускаться вниз корзины.
+   */
+  private static void applySortText(CompletionItem item, String bucket, boolean deprecated) {
+    item.setSortText(bucket + (deprecated ? "1" : "0") + "_" + item.getLabel());
+  }
+
   private void markDeprecatedItem(CompletionItem item) {
     if (deprecatedTagSupport) {
       item.setTags(List.of(CompletionItemTag.Deprecated));

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -63,6 +63,7 @@ import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.Collection;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -314,7 +315,7 @@ public final class CompletionProvider {
     var members = new LinkedHashMap<String, MemberDescriptor>();
     // Имена декларированных полей — для приоритетной корзины sortText: пользовательские
     // ключи должны ранжироваться выше дефолтных членов того же типа.
-    var localFieldNames = new java.util.HashSet<String>();
+    var localFieldNames = new HashSet<String>();
     for (TypeRef ref : typeSet.refs()) {
       for (var member : typeService.getMembers(ref, fileType, scriptVariant)) {
         members.putIfAbsent(member.name(), member);
@@ -485,7 +486,7 @@ public final class CompletionProvider {
     // под ru- и en-ключом, поэтому в values() встречается дважды — дедуп по
     // primary-имени через seenFn.
     var target = PlatformMemberVersions.targetCompatibilityMode(documentContext, configuration);
-    var seenFn = new java.util.HashSet<String>();
+    var seenFn = new HashSet<String>();
     for (var fn : globalScopeProvider.getFunctions(fileType)) {
       if (!seenFn.add(fn.name())) {
         continue;
@@ -664,14 +665,6 @@ public final class CompletionProvider {
   }
 
   /**
-   * Помечает completion item устаревшим: при поддержке клиентом тегов —
-   * {@link CompletionItemTag#Deprecated}, иначе legacy-флагом
-   * {@link CompletionItem#setDeprecated}. Клиент рисует такой пункт
-   * зачёркнутым. Применяется ко всем устаревшим членам автодополнения —
-   * платформенным, глобальным функциям, членам конфигурации и
-   * пользовательским методам oscript-классов.
-   */
-  /**
    * Проставляет {@code sortText} пункту автодополнения по схеме «корзина + флаг
    * устаревания + label». Клиент сортирует пункты лексикографически по
    * {@code sortText}: меньший префикс корзины поднимает группу выше, а
@@ -687,6 +680,14 @@ public final class CompletionProvider {
     item.setSortText(bucket + (deprecated ? "1" : "0") + "_" + item.getLabel());
   }
 
+  /**
+   * Помечает completion item устаревшим: при поддержке клиентом тегов —
+   * {@link CompletionItemTag#Deprecated}, иначе legacy-флагом
+   * {@link CompletionItem#setDeprecated}. Клиент рисует такой пункт
+   * зачёркнутым. Применяется ко всем устаревшим членам автодополнения —
+   * платформенным, глобальным функциям, членам конфигурации и
+   * пользовательским методам oscript-классов.
+   */
   private void markDeprecatedItem(CompletionItem item) {
     if (deprecatedTagSupport) {
       item.setTags(List.of(CompletionItemTag.Deprecated));

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -1656,6 +1656,104 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void noDotCompletionRanksLocalMethodAboveGlobalFunctionAndKeyword() {
+    // sortText-«корзины»: локальный метод документа должен ранжироваться выше
+    // (лексикографически меньший sortText) глобальной функции и ключевого слова,
+    // чтобы не тонуть среди сотен платформенных кандидатов.
+    // given
+    var content = """
+      Процедура Сообщение() Экспорт
+      КонецПроцедуры
+
+      Сооб""";
+    var documentContext = TestUtils.getDocumentContext(content);
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(3, 4));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+    var localMethod = sortTextOf(items, "Сообщение");
+    var globalFunction = sortTextOf(items, "Сообщить");
+
+    // then
+    assertThat(localMethod)
+      .as("sortText локального метода и глобальной функции должны быть проставлены")
+      .isNotNull();
+    assertThat(globalFunction).isNotNull();
+    assertThat(localMethod)
+      .as("локальный метод документа ранжируется выше глобальной функции")
+      .isLessThan(globalFunction);
+  }
+
+  @Test
+  void noDotCompletionRanksLocalVariableAboveKeyword() {
+    // Локальная переменная документа должна ранжироваться выше ключевого слова.
+    // given
+    var content = """
+      Перем ЕслиЧтоТо;
+
+      Е""";
+    var documentContext = TestUtils.getDocumentContext(content);
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(2, 1));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+    var localVariable = sortTextOf(items, "ЕслиЧтоТо");
+    var keyword = sortTextOf(items, "Если");
+
+    // then
+    assertThat(localVariable).isNotNull();
+    assertThat(keyword).as("ключевое слово Если должно быть в выдаче").isNotNull();
+    assertThat(localVariable)
+      .as("локальная переменная ранжируется выше ключевого слова")
+      .isLessThan(keyword);
+  }
+
+  @Test
+  void noDotCompletionDemotesDeprecatedLocalMethodBelowNonDeprecatedNeighbor() {
+    // Устаревший локальный метод получает sortText хуже неустаревшего соседа той же
+    // корзины. Имя устаревшего («МетодА») лексикографически меньше неустаревшего
+    // («МетодБ») — значит, перестановку обеспечивает именно пометка устаревания.
+    // given
+    var content = """
+      // Устарела. См. МетодБ.
+      Процедура МетодА() Экспорт
+      КонецПроцедуры
+
+      Процедура МетодБ() Экспорт
+      КонецПроцедуры
+
+      Мет""";
+    var documentContext = TestUtils.getDocumentContext(content);
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(7, 3));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+    var deprecated = sortTextOf(items, "МетодА");
+    var fresh = sortTextOf(items, "МетодБ");
+
+    // then
+    assertThat(deprecated).as("устаревший метод должен быть в выдаче").isNotNull();
+    assertThat(fresh).isNotNull();
+    assertThat(deprecated)
+      .as("устаревший метод ранжируется ниже неустаревшего соседа, несмотря на меньшее имя")
+      .isGreaterThan(fresh);
+  }
+
+  private static String sortTextOf(List<CompletionItem> items, String label) {
+    return items.stream()
+      .filter(it -> label.equals(it.getLabel()))
+      .map(CompletionItem::getSortText)
+      .findFirst()
+      .orElse(null);
+  }
+
+  @Test
   void positionBeyondEndOfFileReturnsEmptyOrSafe() {
     // given — позиция за пределами файла.
     var documentContext = TestUtils.getDocumentContext("Сооб");


### PR DESCRIPTION
## Проблема

Ни один completion item не получал `sortText`, поэтому клиент сортировал выдачу по алфавиту (по `label`). В no-dot completion локальные методы и переменные документа тонули среди сотен глобальных функций, MD-имён и ключевых слов — всё складывалось в один плоский список (`CompletionProvider.noDotCompletion`).

## Решение

Введены префиксные «корзины» `sortText` по схеме `корзина + флаг устаревания + "_" + label` (стандартная практика TS LS / rust-analyzer; формат — простые цифровые префиксы):

**no-dot completion** (меньший префикс — выше в списке):
- `1_` — локальные переменные и методы документа;
- `2_` — глобальные функции и контексты (property/enum/library-module);
- `3_` — классы (в т.ч. после `Новый`) и квалифицированные MD-имена;
- `4_` — ключевые слова.

**Понижение устаревших**: внутри корзины устаревший член получает флаг `1` против `0` у неустаревшего, поэтому уходит вниз даже если его имя лексикографически меньше соседа. Применено к локальным методам и глобальным функциям.

**dot-completion**: члены типа тоже получают `sortText` — декларированные/пользовательские поля (`1_`) ранжируются выше дефолтных членов того же типа (`2_`), а устаревшие члены опускаются вниз своей корзины. Это сохраняет уже существующий приоритет полей (через `putIfAbsent`) теперь и в порядке клиента, и единообразно демотирует устаревшие члены.

Правки локальны для мест выдачи item-ов; вспомогательный метод `applySortText` ставит `sortText` по корзине и флагу устаревания. Внутри корзины при равном статусе порядок стабилен по `label`.

## Тесты

`CompletionProviderTest`, попарные сравнения `sortText` (без завязки на полный порядок):
- `noDotCompletionRanksLocalMethodAboveGlobalFunctionAndKeyword` — `sortText` локального метода `<` глобальной функции;
- `noDotCompletionRanksLocalVariableAboveKeyword` — локальная переменная `<` ключевого слова;
- `noDotCompletionDemotesDeprecatedLocalMethodBelowNonDeprecatedNeighbor` — устаревший `МетодА` `>` неустаревшего `МетодБ`, несмотря на меньшее имя.

Тесты сначала падали с NPE на `null` sortText (фича отсутствует), затем зелёные. Полный класс `CompletionProviderTest` проходит без регрессий.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Code completion items are now sorted more intelligently to prioritize user-defined fields and local methods ahead of type members, with improved handling of deprecated items.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->