### PR TITLE
fix(javadoc): исправить сломанные @link-ссылки в сборке javadoc

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/PlatformType.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/PlatformType.java
@@ -27,7 +27,7 @@ package com.github._1c_syntax.bsl.languageserver.types.model;
  * <p>
  * Сам по себе платформенный тип может расширяться пользовательскими членами
  * (см. {@code ConfigurationModuleMembersProvider}). Для запроса полного списка
- * членов используйте {@link com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry#getMembers(TypeRef)}.
+ * членов используйте {@link com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry#getMembers(TypeRef, com.github._1c_syntax.bsl.languageserver.context.FileType)}.
  *
  * @param ref ссылка на тип в реестре типов
  */

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/Type.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/Type.java
@@ -30,7 +30,7 @@ package com.github._1c_syntax.bsl.languageserver.types.model;
  * <p>
  * Сами инстансы держат только {@link TypeRef} (плюс опциональные метаданные
  * вроде ссылки на исходный символ). Состав членов типа собирается через
- * {@link com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry#getMembers(TypeRef)}
+ * {@link com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry#getMembers(TypeRef, com.github._1c_syntax.bsl.languageserver.context.FileType)}
  * — это позволяет нескольким источникам (платформенный синтакс-помощник,
  * пользовательский {@code ObjectModule.bsl} и т.д.) совместно расширять
  * один и тот же тип.

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
@@ -494,7 +494,7 @@ public class GlobalScopeProvider {
    * {@link GlobalSymbolScope.Role#TYPE_NAME} для каждого имени/алиаса,
    * чтобы hover/findGlobal на имени класса в {@code Новый <Класс>(...)} нашёл
    * символ с описанием класса. Сами сигнатуры конструкторов хранятся в
-   * {@link TypeRegistry#getConstructors(TypeRef)}.
+   * {@link TypeRegistry#getConstructors(TypeRef, FileType)}.
    */
   public void registerPlatformClass(TypeRef ref, Collection<String> names, FileType fileType, String description) {
     if (ref == null || names == null || names.isEmpty()) {
@@ -590,7 +590,7 @@ public class GlobalScopeProvider {
   /**
    * Зарегистрировать synthetic-symbol для библиотечного модуля OneScript
    * (записи {@code <module>} из {@code lib.config}). Symbol становится
-   * видимым через {@link #findGlobal(String)} с фильтрацией по {@link FileType}
+   * видимым через {@link #findGlobal(String, FileType)} с фильтрацией по {@link FileType}
    * (через {@link com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex}).
    * Источник {@link TypeRef} и {@code libOrigin} — {@code OScriptLibraryIndex}.
    */

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -427,7 +427,7 @@ public class TypeRegistry {
 
   /**
    * Аналог {@link #registerMemberSource}, но вставляет источник в НАЧАЛО списка,
-   * чтобы при сборе членов через {@link #getMembers(TypeRef)} он выигрывал
+   * чтобы при сборе членов через {@link #getMembers(TypeRef, FileType)} он выигрывал
    * dedup ({@code putIfAbsent} по имени). Используется для override returnType
    * у конкретного member'а уже зарегистрированного типа (например, подмена
    * {@code ОбъектМетаданныхКонфигурация.Документы} с общего
@@ -488,7 +488,7 @@ public class TypeRegistry {
    * Регистрируется ленивый {@link MemberSource} для {@code specializedRef},
    * который при каждом запросе:
    * <ol>
-   *   <li>берёт members generic-типа через {@link #getMembers(TypeRef)};</li>
+   *   <li>берёт members generic-типа через {@link #getMembers(TypeRef, FileType)};</li>
    *   <li>отфильтровывает {@link MemberDescriptor#generic()} (слотовые
    *       члены вида {@code <Имя реквизита>});</li>
    *   <li>применяет {@link MemberDescriptor#specialize(Map)} к каждому
@@ -898,7 +898,7 @@ public class TypeRegistry {
   /**
    * Зарегистрировать динамический источник конструкторов для типа (например,
    * {@code ПриСозданииОбъекта} OneScript-класса из SymbolTree).
-   * Источник вызывается каждый раз при запросе {@link #getConstructors(TypeRef)},
+   * Источник вызывается каждый раз при запросе {@link #getConstructors(TypeRef, FileType)},
    * что обеспечивает hot-reload без ручной инвалидации.
    */
   public void registerConstructorSource(


### PR DESCRIPTION
## Проблема

Задача `./gradlew javadoc` падала с `BUILD FAILED` — 7 ошибок `error: reference not found`:

```
PlatformType.java: ... {@link ...TypeRegistry#getMembers(TypeRef)}
Type.java: ... {@link ...TypeRegistry#getMembers(TypeRef)}
TypeRegistry.java: {@link #getMembers(TypeRef)}        (x2)
TypeRegistry.java: {@link #getConstructors(TypeRef)}
GlobalScopeProvider.java: {@link TypeRegistry#getConstructors(TypeRef)}
GlobalScopeProvider.java: {@link #findGlobal(String)}
```

## Причина

`@link`-ссылки указывали на устаревшие **одноаргументные** сигнатуры методов, тогда как фактические методы принимают второй параметр `FileType`:

- `getMembers(TypeRef, FileType)`
- `getConstructors(TypeRef, FileType)`
- `findGlobal(String, FileType)`

Поскольку методов с одним аргументом больше не существует, javadoc не мог разрешить ссылки и валил сборку.

## Решение

Все 7 ссылок приведены к актуальным двухаргументным сигнатурам. В `PlatformType` и `Type` (пакет `types.model`) тип `FileType` указан полным именем, чтобы не добавлять `import` исключительно ради javadoc.

## Проверка

```
$ ./gradlew javadoc
BUILD SUCCESSFUL
```

Ошибок `reference not found` больше нет; остались только предсуществовавшие предупреждения про unnamed module (не влияют на статус сборки).

https://claude.ai/code/session_01PnGtd7nFc74Ngw3LkabpeU

---
_Generated by [Claude Code](https://claude.ai/code/session_01PnGtd7nFc74Ngw3LkabpeU)_