### PR TITLE
feat(workspace): fileOperations и динамическая регистрация наблюдателей

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -51,6 +51,11 @@ import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
 import org.eclipse.lsp4j.DocumentRangeFormattingOptions;
 import org.eclipse.lsp4j.DocumentSymbolOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.FileOperationFilter;
+import org.eclipse.lsp4j.FileOperationOptions;
+import org.eclipse.lsp4j.FileOperationPattern;
+import org.eclipse.lsp4j.FileOperationPatternKind;
+import org.eclipse.lsp4j.FileOperationsServerCapabilities;
 import org.eclipse.lsp4j.FileSystemWatcher;
 import org.eclipse.lsp4j.FoldingRangeProviderOptions;
 import org.eclipse.lsp4j.HoverOptions;
@@ -544,7 +549,38 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
     workspaceFoldersOptions.setChangeNotifications(Boolean.TRUE);
 
     workspaceCapabilities.setWorkspaceFolders(workspaceFoldersOptions);
+    workspaceCapabilities.setFileOperations(getFileOperationsCapabilities());
     return workspaceCapabilities;
+  }
+
+  /**
+   * Формирует возможности сервера по обработке файловых операций рабочей области
+   * ({@code didCreate}/{@code didRename}/{@code didDelete}). Фильтры покрывают BSL- и
+   * OneScript-файлы ({@code **&#47;*.bsl}, {@code **&#47;*.os}), а также каталоги, чтобы
+   * получать события переименования и удаления папок целиком.
+   *
+   * @return возможности сервера по файловым операциям
+   */
+  private static FileOperationsServerCapabilities getFileOperationsCapabilities() {
+    var fileOperations = new FileOperationsServerCapabilities();
+
+    var options = new FileOperationOptions(getFileOperationFilters());
+    fileOperations.setDidCreate(options);
+    fileOperations.setDidRename(options);
+    fileOperations.setDidDelete(options);
+
+    return fileOperations;
+  }
+
+  private static List<FileOperationFilter> getFileOperationFilters() {
+    var folderPattern = new FileOperationPattern("**/*");
+    folderPattern.setMatches(FileOperationPatternKind.Folder);
+
+    return List.of(
+      new FileOperationFilter(new FileOperationPattern("**/*.bsl")),
+      new FileOperationFilter(new FileOperationPattern("**/*.os")),
+      new FileOperationFilter(folderPattern)
+    );
   }
 
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -40,6 +40,8 @@ import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.ColorProviderOptions;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.DefinitionOptions;
+import org.eclipse.lsp4j.DidChangeWatchedFilesCapabilities;
+import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
 import org.eclipse.lsp4j.ImplementationRegistrationOptions;
 import org.eclipse.lsp4j.DiagnosticRegistrationOptions;
 import org.eclipse.lsp4j.DocumentFormattingOptions;
@@ -49,6 +51,7 @@ import org.eclipse.lsp4j.DocumentOnTypeFormattingOptions;
 import org.eclipse.lsp4j.DocumentRangeFormattingOptions;
 import org.eclipse.lsp4j.DocumentSymbolOptions;
 import org.eclipse.lsp4j.ExecuteCommandOptions;
+import org.eclipse.lsp4j.FileSystemWatcher;
 import org.eclipse.lsp4j.FoldingRangeProviderOptions;
 import org.eclipse.lsp4j.HoverOptions;
 import org.eclipse.lsp4j.InitializeParams;
@@ -56,6 +59,8 @@ import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.InlayHintRegistrationOptions;
 import org.eclipse.lsp4j.ReferenceOptions;
+import org.eclipse.lsp4j.Registration;
+import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.RenameCapabilities;
 import org.eclipse.lsp4j.RenameOptions;
 import org.eclipse.lsp4j.SaveOptions;
@@ -70,6 +75,8 @@ import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
 import org.eclipse.lsp4j.TextDocumentSyncOptions;
 import org.eclipse.lsp4j.TypeHierarchyRegistrationOptions;
+import org.eclipse.lsp4j.WatchKind;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersOptions;
 import org.eclipse.lsp4j.WorkspaceServerCapabilities;
@@ -109,6 +116,7 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
   private final BSLWorkspaceService workspaceService;
   private final CommandProvider commandProvider;
   private final ClientCapabilitiesHolder clientCapabilitiesHolder;
+  private final LanguageClientHolder languageClientHolder;
   private final ServerContextProvider serverContextProvider;
   private final GlobalLanguageServerConfiguration globalConfiguration;
   private final ServerInfo serverInfo;
@@ -198,6 +206,8 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
 
   @Override
   public void initialized(InitializedParams params) {
+    registerFileWatchers();
+
     // Populate all workspace contexts
     var allContexts = serverContextProvider.getAllContexts();
     var tasks = allContexts.entrySet().stream()
@@ -217,6 +227,50 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
           LOGGER.error("Error populating workspace contexts", throwable);
         }
       });
+  }
+
+  /**
+   * Динамически регистрирует у клиента наблюдателей за файлами рабочей области.
+   * <p>
+   * Регистрация выполняется только если клиент заявил поддержку
+   * {@code workspace.didChangeWatchedFiles.dynamicRegistration}. Универсальные клиенты
+   * (neovim, helix и др.) без статической конфигурации наблюдателей сами ничего не присылают
+   * в {@code workspace/didChangeWatchedFiles}, из-за чего индекс устаревает при операциях
+   * вне редактора (git checkout, выгрузка из конфигуратора). Регистрируются наблюдатели на
+   * {@code **&#47;*.bsl}, {@code **&#47;*.os} и {@code **&#47;.bsl-language-server.json}.
+   * <p>
+   * Если клиент не заявил динамическую регистрацию или не подключён, метод ничего не делает.
+   */
+  private void registerFileWatchers() {
+    if (!hasDidChangeWatchedFilesDynamicRegistration()) {
+      return;
+    }
+
+    languageClientHolder.execIfConnected(client -> {
+      var watchKind = WatchKind.Create | WatchKind.Change | WatchKind.Delete;
+      var watchers = List.of(
+        new FileSystemWatcher(Either.forLeft("**/*.bsl"), watchKind),
+        new FileSystemWatcher(Either.forLeft("**/*.os"), watchKind),
+        new FileSystemWatcher(Either.forLeft("**/.bsl-language-server.json"), watchKind)
+      );
+
+      var registrationOptions = new DidChangeWatchedFilesRegistrationOptions(watchers);
+      var registration = new Registration(
+        "bsl-language-server-watched-files",
+        "workspace/didChangeWatchedFiles",
+        registrationOptions
+      );
+
+      client.registerCapability(new RegistrationParams(List.of(registration)));
+    });
+  }
+
+  private boolean hasDidChangeWatchedFilesDynamicRegistration() {
+    return clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getWorkspace)
+      .map(WorkspaceClientCapabilities::getDidChangeWatchedFiles)
+      .map(DidChangeWatchedFilesCapabilities::getDynamicRegistration)
+      .orElse(false);
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -242,7 +242,8 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
    * (neovim, helix и др.) без статической конфигурации наблюдателей сами ничего не присылают
    * в {@code workspace/didChangeWatchedFiles}, из-за чего индекс устаревает при операциях
    * вне редактора (git checkout, выгрузка из конфигуратора). Регистрируются наблюдатели на
-   * {@code **&#47;*.bsl}, {@code **&#47;*.os} и {@code **&#47;.bsl-language-server.json}.
+   * {@code **&#47;*.bsl} и {@code **&#47;*.os}; за конфигурационным файлом следит сам сервер
+   * (см. {@code ConfigurationFileSystemWatcher}), поэтому клиентский наблюдатель за ним не нужен.
    * <p>
    * Если клиент не заявил динамическую регистрацию или не подключён, метод ничего не делает.
    */
@@ -255,8 +256,7 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
       var watchKind = WatchKind.Create | WatchKind.Change | WatchKind.Delete;
       var watchers = List.of(
         new FileSystemWatcher(Either.forLeft("**/*.bsl"), watchKind),
-        new FileSystemWatcher(Either.forLeft("**/*.os"), watchKind),
-        new FileSystemWatcher(Either.forLeft("**/.bsl-language-server.json"), watchKind)
+        new FileSystemWatcher(Either.forLeft("**/*.os"), watchKind)
       );
 
       var registrationOptions = new DidChangeWatchedFilesRegistrationOptions(watchers);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
 import com.github._1c_syntax.bsl.languageserver.providers.CommandProvider;
 import com.github._1c_syntax.bsl.languageserver.providers.SymbolProvider;
+import com.github._1c_syntax.bsl.languageserver.utils.BSLFiles;
 import com.github._1c_syntax.bsl.languageserver.utils.PathExclusionUtils;
 import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;
@@ -44,11 +45,14 @@ import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.WorkspaceService;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 import org.springframework.stereotype.Component;
 
+import java.io.File;
 import java.net.URI;
+import java.nio.file.FileSystemNotFoundException;
 import java.nio.file.Paths;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
@@ -313,6 +317,13 @@ public class BSLWorkspaceService implements WorkspaceService {
    */
   private void handleCreatedFileEvent(URI uri) {
     var context = getContextForDocument(uri);
+
+    var file = toFile(uri);
+    if (file != null && file.isDirectory()) {
+      handleCreatedFolderEvent(context, file);
+      return;
+    }
+
     if (isExcludedPath(context, uri)) {
       return;
     }
@@ -323,6 +334,65 @@ public class BSLWorkspaceService implements WorkspaceService {
       context.rebuildDocument(documentContext);
       context.tryClearDocument(documentContext);
     }
+  }
+
+  /**
+   * Обрабатывает событие создания каталога в файловой системе.
+   * <p>
+   * Клиенты (в т.ч. VS Code) при создании или переименовании каталога присылают одно событие
+   * с URI каталога без событий по вложенным файлам. Каталог рекурсивно обходится, и все найденные
+   * BSL/OS-файлы добавляются в контекст сервера. Поиск файлов и учёт {@code excludePaths}
+   * переиспользуют логику {@link BSLFiles#listBslFiles} — ту же,
+   * что применяется при первичном наполнении контекста в {@link ServerContext#populateContext()}.
+   *
+   * @param context контекст сервера
+   * @param folder  созданный каталог
+   */
+  private void handleCreatedFolderEvent(ServerContext context, File folder) {
+    var excludePaths = getExcludePaths(context);
+    var files = BSLFiles.listBslFiles(folder.toPath(), excludePaths);
+
+    for (var file : files) {
+      var fileUri = Absolute.uri(file.toURI());
+      var documentContext = context.addDocument(fileUri);
+
+      var isDocumentOpened = context.isDocumentOpened(documentContext);
+      if (!isDocumentOpened) {
+        context.rebuildDocument(documentContext);
+        context.tryClearDocument(documentContext);
+      }
+    }
+  }
+
+  /**
+   * Преобразует URI в {@link File}, если это файловый URI.
+   *
+   * @param uri URI файла или каталога
+   * @return {@link File} или {@code null}, если URI не указывает на путь в файловой системе
+   */
+  @Nullable
+  private static File toFile(URI uri) {
+    try {
+      return Paths.get(uri).toFile();
+    } catch (IllegalArgumentException | FileSystemNotFoundException e) {
+      LOGGER.debug("Не удалось преобразовать URI в путь файловой системы: {}", uri, e);
+      return null;
+    }
+  }
+
+  /**
+   * Возвращает список {@code excludePaths} из конфигурации workspace {@code context}.
+   *
+   * @param context контекст сервера
+   * @return список паттернов исключения; {@code null}, если конфигурация недоступна
+   */
+  @Nullable
+  private static List<String> getExcludePaths(ServerContext context) {
+    var cfg = context.getLanguageServerConfiguration();
+    if (cfg == null) {
+      return null;
+    }
+    return cfg.getExcludePaths();
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
@@ -31,10 +31,13 @@ import com.github._1c_syntax.bsl.languageserver.utils.PathExclusionUtils;
 import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp4j.CreateFilesParams;
+import org.eclipse.lsp4j.DeleteFilesParams;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.RenameFilesParams;
 import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceSymbol;
@@ -90,27 +93,112 @@ public class BSLWorkspaceService implements WorkspaceService {
       () -> {
         for (var fileEvent : params.getChanges()) {
           var uri = Absolute.uri(fileEvent.getUri());
-
-          serverContextProvider.getServerContext(uri).ifPresentOrElse(
-            context -> {
-              var workspaceUri = context.getWorkspaceUri();
-              if (workspaceUri == null) {
-                LOGGER.warn("No workspace URI for context, skipping file event: {}", uri);
-                return;
-              }
-              WorkspaceContextHolder.run(workspaceUri, () -> {
-                switch (fileEvent.getType()) {
-                  case Deleted -> handleDeletedFileEvent(uri);
-                  case Created -> handleCreatedFileEvent(uri);
-                  case Changed -> handleChangedFileEvent(uri);
-                }
-              });
-            },
-            () -> LOGGER.debug("No workspace found for file event, skipping: {}", uri)
-          );
+          runInWorkspaceContext(uri, () -> {
+            switch (fileEvent.getType()) {
+              case Deleted -> handleDeletedFileEvent(uri);
+              case Created -> handleCreatedFileEvent(uri);
+              case Changed -> handleChangedFileEvent(uri);
+            }
+          });
         }
       },
       executor
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Обрабатывает уведомление {@code workspace/didCreateFiles}: для каждого URI добавляет
+   * документ(ы) в контекст сервера аналогично событию создания в
+   * {@code workspace/didChangeWatchedFiles}. Пути из {@code excludePaths} и открытые в редакторе
+   * документы учитываются так же, как в существующих обработчиках.
+   *
+   * @param params параметры уведомления о созданных файлах
+   */
+  @Override
+  public void didCreateFiles(CreateFilesParams params) {
+    CompletableFuture.runAsync(
+      () -> {
+        for (var file : params.getFiles()) {
+          var uri = Absolute.uri(file.getUri());
+          runInWorkspaceContext(uri, () -> handleCreatedFileEvent(uri));
+        }
+      },
+      executor
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Обрабатывает уведомление {@code workspace/didDeleteFiles}: для каждого URI удаляет
+   * документ(ы) из контекста сервера. Для каталога удаление выполняется по префиксу URI
+   * с границей {@code /} (переиспользуется логика обработки удаления каталога из
+   * {@code workspace/didChangeWatchedFiles}).
+   *
+   * @param params параметры уведомления об удалённых файлах
+   */
+  @Override
+  public void didDeleteFiles(DeleteFilesParams params) {
+    CompletableFuture.runAsync(
+      () -> {
+        for (var file : params.getFiles()) {
+          var uri = Absolute.uri(file.getUri());
+          runInWorkspaceContext(uri, () -> handleDeletedFileEvent(uri));
+        }
+      },
+      executor
+    );
+  }
+
+  /**
+   * {@inheritDoc}
+   * <p>
+   * Обрабатывает уведомление {@code workspace/didRenameFiles}: каждое переименование
+   * выполняется атомарно как удаление документа(ов) по старому URI и создание по новому,
+   * включая переименование каталогов. Пути из {@code excludePaths} и открытые в редакторе
+   * документы учитываются так же, как в существующих обработчиках.
+   *
+   * @param params параметры уведомления о переименованных файлах
+   */
+  @Override
+  public void didRenameFiles(RenameFilesParams params) {
+    CompletableFuture.runAsync(
+      () -> {
+        for (var file : params.getFiles()) {
+          var oldUri = Absolute.uri(file.getOldUri());
+          var newUri = Absolute.uri(file.getNewUri());
+          runInWorkspaceContext(oldUri, () -> handleDeletedFileEvent(oldUri));
+          runInWorkspaceContext(newUri, () -> handleCreatedFileEvent(newUri));
+        }
+      },
+      executor
+    );
+  }
+
+  /**
+   * Выполняет действие над файлом в контексте его workspace.
+   * <p>
+   * Резолвит контекст сервера и устанавливает workspace-контекст на текущем треде
+   * (через {@link WorkspaceContextHolder}), чтобы workspace-scoped proxy beans корректно
+   * разрешались в {@code @EventListener}-методах. Если workspace для URI не найден,
+   * действие пропускается.
+   *
+   * @param uri    URI файла или каталога
+   * @param action действие, выполняемое в установленном workspace-контексте
+   */
+  private void runInWorkspaceContext(URI uri, Runnable action) {
+    serverContextProvider.getServerContext(uri).ifPresentOrElse(
+      context -> {
+        var workspaceUri = context.getWorkspaceUri();
+        if (workspaceUri == null) {
+          LOGGER.warn("No workspace URI for context, skipping file event: {}", uri);
+          return;
+        }
+        WorkspaceContextHolder.run(workspaceUri, action);
+      },
+      () -> LOGGER.debug("No workspace found for file event, skipping: {}", uri)
     );
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
@@ -384,15 +384,10 @@ public class BSLWorkspaceService implements WorkspaceService {
    * Возвращает список {@code excludePaths} из конфигурации workspace {@code context}.
    *
    * @param context контекст сервера
-   * @return список паттернов исключения; {@code null}, если конфигурация недоступна
+   * @return список паттернов исключения
    */
-  @Nullable
   private static List<String> getExcludePaths(ServerContext context) {
-    var cfg = context.getLanguageServerConfiguration();
-    if (cfg == null) {
-      return null;
-    }
-    return cfg.getExcludePaths();
+    return context.getLanguageServerConfiguration().getExcludePaths();
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
@@ -247,6 +247,28 @@ class BSLLanguageServerTest {
   }
 
   @Test
+  void initializeDeclaresFileOperationsCapabilities() throws ExecutionException, InterruptedException {
+    // given
+    var params = new InitializeParams();
+    var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "test");
+    params.setWorkspaceFolders(List.of(workspaceFolder));
+
+    // when
+    InitializeResult initialize = server.initialize(params).get();
+
+    // then
+    var fileOperations = initialize.getCapabilities().getWorkspace().getFileOperations();
+    assertThat(fileOperations).isNotNull();
+    assertThat(fileOperations.getDidCreate()).isNotNull();
+    assertThat(fileOperations.getDidRename()).isNotNull();
+    assertThat(fileOperations.getDidDelete()).isNotNull();
+
+    assertThat(fileOperations.getDidDelete().getFilters())
+      .extracting(filter -> filter.getPattern().getGlob())
+      .containsExactlyInAnyOrder("**/*.bsl", "**/*.os", "**/*");
+  }
+
+  @Test
   @SuppressWarnings("deprecation")
   void initializeWithRootUri() throws ExecutionException, InterruptedException {
     // given

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
@@ -223,7 +223,7 @@ class BSLLanguageServerTest {
     assertThat(options.getWatchers())
       .extracting(FileSystemWatcher::getGlobPattern)
       .extracting(globPattern -> globPattern.getLeft())
-      .containsExactlyInAnyOrder("**/*.bsl", "**/*.os", "**/.bsl-language-server.json");
+      .containsExactlyInAnyOrder("**/*.bsl", "**/*.os");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
@@ -27,19 +27,27 @@ import com.github._1c_syntax.utils.Absolute;
 import mockit.Mock;
 import mockit.MockUp;
 import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.DidChangeWatchedFilesCapabilities;
+import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
+import org.eclipse.lsp4j.FileSystemWatcher;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
+import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.RenameCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceFolder;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Nested;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.EnumSource;
+import org.mockito.ArgumentCaptor;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
@@ -53,6 +61,11 @@ import java.util.concurrent.ExecutionException;
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 @CleanupContextBeforeClassAndAfterEachTestMethod
@@ -64,6 +77,9 @@ class BSLLanguageServerTest {
   @Autowired
   private GlobalLanguageServerConfiguration globalConfiguration;
 
+  @Autowired
+  private LanguageClientHolder languageClientHolder;
+
   @BeforeEach
   void setUp() {
     new MockUp<System>() {
@@ -72,6 +88,11 @@ class BSLLanguageServerTest {
         throw new RuntimeException(String.valueOf(value));
       }
     };
+  }
+
+  @AfterEach
+  void tearDown() {
+    languageClientHolder.connect(null);
   }
 
   @Test
@@ -163,6 +184,66 @@ class BSLLanguageServerTest {
     InitializedParams params = new InitializedParams();
     // then - should not throw
     server.initialized(params);
+  }
+
+  @Test
+  void initializedRegistersFileWatchersWhenDynamicRegistrationSupported() {
+    // given
+    var client = mock(LanguageClient.class);
+    when(client.registerCapability(any()))
+      .thenReturn(CompletableFuture.completedFuture(null));
+    languageClientHolder.connect(client);
+
+    var initParams = new InitializeParams();
+    var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "test");
+    initParams.setWorkspaceFolders(List.of(workspaceFolder));
+
+    var capabilities = new ClientCapabilities();
+    var workspace = new WorkspaceClientCapabilities();
+    workspace.setDidChangeWatchedFiles(new DidChangeWatchedFilesCapabilities(true));
+    capabilities.setWorkspace(workspace);
+    initParams.setCapabilities(capabilities);
+
+    server.initialize(initParams);
+
+    // when
+    server.initialized(new InitializedParams());
+
+    // then
+    var captor = ArgumentCaptor.forClass(RegistrationParams.class);
+    verify(client).registerCapability(captor.capture());
+
+    var registrations = captor.getValue().getRegistrations();
+    assertThat(registrations).hasSize(1);
+
+    var registration = registrations.get(0);
+    assertThat(registration.getMethod()).isEqualTo("workspace/didChangeWatchedFiles");
+
+    var options = (DidChangeWatchedFilesRegistrationOptions) registration.getRegisterOptions();
+    assertThat(options.getWatchers())
+      .extracting(FileSystemWatcher::getGlobPattern)
+      .extracting(globPattern -> globPattern.getLeft())
+      .containsExactlyInAnyOrder("**/*.bsl", "**/*.os", "**/.bsl-language-server.json");
+  }
+
+  @Test
+  void initializedDoesNotRegisterFileWatchersWithoutDynamicRegistration() {
+    // given
+    var client = mock(LanguageClient.class);
+    languageClientHolder.connect(client);
+
+    var initParams = new InitializeParams();
+    var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "test");
+    initParams.setWorkspaceFolders(List.of(workspaceFolder));
+    // no workspace.didChangeWatchedFiles.dynamicRegistration declared
+
+    server.initialize(initParams);
+
+    // when
+    server.initialized(new InitializedParams());
+
+    // then
+    verify(client, never()).registerCapability(any());
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceServiceTest.java
@@ -28,11 +28,17 @@ import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextH
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.utils.Absolute;
 import org.apache.commons.io.FileUtils;
+import org.eclipse.lsp4j.CreateFilesParams;
+import org.eclipse.lsp4j.DeleteFilesParams;
 import org.eclipse.lsp4j.DidChangeConfigurationParams;
 import org.eclipse.lsp4j.DidChangeWatchedFilesParams;
 import org.eclipse.lsp4j.DidChangeWorkspaceFoldersParams;
 import org.eclipse.lsp4j.FileChangeType;
+import org.eclipse.lsp4j.FileCreate;
+import org.eclipse.lsp4j.FileDelete;
 import org.eclipse.lsp4j.FileEvent;
+import org.eclipse.lsp4j.FileRename;
+import org.eclipse.lsp4j.RenameFilesParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent;
 import org.junit.jupiter.api.BeforeEach;
@@ -570,6 +576,140 @@ class BSLWorkspaceServiceTest {
     } finally {
       applicationContext.removeApplicationListener(listener);
     }
+  }
+
+  @Test
+  void testDidCreateFiles_AddsDocument() throws IOException {
+    // given
+    var testFile = createTestFile("created_via_fileops.bsl");
+    var uri = Absolute.uri(testFile.toURI());
+
+    var fileCreate = new FileCreate(uri.toString());
+    var params = new CreateFilesParams(List.of(fileCreate));
+
+    // when
+    workspaceService.didCreateFiles(params);
+    await().until(() -> workspaceServerContext().getDocument(uri) != null);
+
+    // then
+    var documentContext = workspaceServerContext().getDocument(uri);
+    assertThat(documentContext).isNotNull();
+    assertThat(workspaceServerContext().isDocumentOpened(documentContext)).isFalse();
+  }
+
+  /** Создание файла внутри excluded-каталога через didCreateFiles не добавляет его в контекст. */
+  @Test
+  void testDidCreateFiles_ExcludedPath() throws IOException {
+    // given
+    var workspaceUri = Absolute.uri(tempDir.toUri());
+    WorkspaceContextHolder.run(workspaceUri, () -> {
+      var wsCtx = workspaceServerContext();
+      wsCtx.setConfigurationRoot(tempDir);
+      wsCtx.getLanguageServerConfiguration().setExcludePaths(List.of(".git"));
+    });
+
+    var excludedDir = tempDir.resolve(".git").toFile();
+    assertThat(excludedDir.mkdirs()).isTrue();
+    var testFile = new File(excludedDir, "excluded_fileops.bsl");
+    FileUtils.copyFile(FIXTURE_BSL, testFile);
+    var uri = Absolute.uri(testFile.toURI());
+
+    var params = new CreateFilesParams(List.of(new FileCreate(uri.toString())));
+
+    // when
+    workspaceService.didCreateFiles(params);
+
+    // then
+    await()
+      .atMost(Duration.ofSeconds(2))
+      .during(Duration.ofMillis(300))
+      .until(() -> workspaceServerContext().getDocument(uri) == null);
+  }
+
+  @Test
+  void testDidDeleteFiles_RemovesDocument() throws IOException {
+    // given
+    var testFile = createTestFile("deleted_via_fileops.bsl");
+    var uri = Absolute.uri(testFile.toURI());
+
+    var ctx = workspaceServerContext();
+    var documentContext = ctx.addDocument(uri);
+    ctx.rebuildDocument(documentContext);
+    ctx.tryClearDocument(documentContext);
+
+    assertThat(ctx.getDocument(uri)).isNotNull();
+
+    var params = new DeleteFilesParams(List.of(new FileDelete(uri.toString())));
+
+    // when
+    workspaceService.didDeleteFiles(params);
+    await().until(() -> workspaceServerContext().getDocument(uri) == null);
+
+    // then
+    assertThat(workspaceServerContext().getDocument(uri)).isNull();
+  }
+
+  /**
+   * При удалении каталога через didDeleteFiles присылается один URI каталога без вложенных файлов.
+   * Все документы внутри каталога должны быть выгружены, а каталог-«тёзка» — остаться.
+   */
+  @Test
+  void testDidDeleteFiles_Folder() throws IOException {
+    // given
+    var objectModule = createTestFile("Catalogs/Wares/Ext/ObjectModule.bsl");
+    var namesakeModule = createTestFile("Catalogs/WaresArchive/Ext/ObjectModule.bsl");
+
+    var objectModuleUri = Absolute.uri(objectModule.toURI());
+    var namesakeModuleUri = Absolute.uri(namesakeModule.toURI());
+
+    var ctx = workspaceServerContext();
+    for (var uri : List.of(objectModuleUri, namesakeModuleUri)) {
+      var documentContext = ctx.addDocument(uri);
+      ctx.rebuildDocument(documentContext);
+      ctx.tryClearDocument(documentContext);
+    }
+
+    var deletedFolder = tempDir.resolve("Catalogs").resolve("Wares").toFile();
+    FileUtils.deleteDirectory(deletedFolder);
+    var folderUri = Absolute.uri(deletedFolder.toURI());
+
+    var params = new DeleteFilesParams(List.of(new FileDelete(folderUri.toString())));
+
+    // when
+    workspaceService.didDeleteFiles(params);
+    await().until(() -> ctx.getDocument(objectModuleUri) == null);
+
+    // then
+    assertThat(ctx.getDocument(objectModuleUri)).isNull();
+    assertThat(ctx.getDocument(namesakeModuleUri)).isNotNull();
+  }
+
+  @Test
+  void testDidRenameFiles_MovesDocument() throws IOException {
+    // given
+    var oldFile = createTestFile("rename_old.bsl");
+    var oldUri = Absolute.uri(oldFile.toURI());
+
+    var ctx = workspaceServerContext();
+    var documentContext = ctx.addDocument(oldUri);
+    ctx.rebuildDocument(documentContext);
+    ctx.tryClearDocument(documentContext);
+
+    var newFile = tempDir.resolve("rename_new.bsl").toFile();
+    FileUtils.moveFile(oldFile, newFile);
+    var newUri = Absolute.uri(newFile.toURI());
+
+    var fileRename = new FileRename(oldUri.toString(), newUri.toString());
+    var params = new RenameFilesParams(List.of(fileRename));
+
+    // when
+    workspaceService.didRenameFiles(params);
+    await().until(() -> workspaceServerContext().getDocument(newUri) != null
+      && workspaceServerContext().getDocument(oldUri) == null);
+
+    // then
+    assertThat(workspaceServerContext().getDocument(oldUri)).isNull();
+    assertThat(workspaceServerContext().getDocument(newUri)).isNotNull();
   }
 
   private ServerContext workspaceServerContext() {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceServiceTest.java
@@ -712,6 +712,87 @@ class BSLWorkspaceServiceTest {
     assertThat(workspaceServerContext().getDocument(newUri)).isNotNull();
   }
 
+  /**
+   * Клиенты (VS Code) при создании каталога присылают одно событие с URI каталога без событий
+   * по вложенным файлам. Все BSL/OS-файлы внутри каталога должны быть добавлены в контекст.
+   */
+  @Test
+  void testDidCreateFiles_Folder() throws IOException {
+    // given
+    var objectModule = createTestFile("Catalogs/Items/Ext/ObjectModule.bsl");
+    var formModule = createTestFile("Catalogs/Items/Forms/ItemForm/Ext/Form/Module.bsl");
+
+    var objectModuleUri = Absolute.uri(objectModule.toURI());
+    var formModuleUri = Absolute.uri(formModule.toURI());
+
+    var ctx = workspaceServerContext();
+    assertThat(ctx.getDocument(objectModuleUri)).isNull();
+    assertThat(ctx.getDocument(formModuleUri)).isNull();
+
+    var createdFolder = tempDir.resolve("Catalogs").resolve("Items").toFile();
+    var folderUri = Absolute.uri(createdFolder.toURI());
+
+    var params = new CreateFilesParams(List.of(new FileCreate(folderUri.toString())));
+
+    // when
+    workspaceService.didCreateFiles(params);
+    await().until(() -> ctx.getDocument(objectModuleUri) != null && ctx.getDocument(formModuleUri) != null);
+
+    // then
+    assertThat(ctx.getDocument(objectModuleUri)).isNotNull();
+    assertThat(ctx.getDocument(formModuleUri)).isNotNull();
+  }
+
+  /**
+   * При переименовании каталога присылается один FileRename с URI каталога без вложенных файлов.
+   * Документы внутри каталога должны появиться в контексте по новым URI и исчезнуть по старым.
+   */
+  @Test
+  void testDidRenameFiles_Folder() throws IOException {
+    // given
+    var oldObjectModule = createTestFile("Catalogs/Orders/Ext/ObjectModule.bsl");
+    var oldFormModule = createTestFile("Catalogs/Orders/Forms/ItemForm/Ext/Form/Module.bsl");
+
+    var oldObjectModuleUri = Absolute.uri(oldObjectModule.toURI());
+    var oldFormModuleUri = Absolute.uri(oldFormModule.toURI());
+
+    var ctx = workspaceServerContext();
+    for (var uri : List.of(oldObjectModuleUri, oldFormModuleUri)) {
+      var documentContext = ctx.addDocument(uri);
+      ctx.rebuildDocument(documentContext);
+      ctx.tryClearDocument(documentContext);
+    }
+
+    var oldFolder = tempDir.resolve("Catalogs").resolve("Orders").toFile();
+    var newFolder = tempDir.resolve("Catalogs").resolve("Documents").toFile();
+    FileUtils.moveDirectory(oldFolder, newFolder);
+
+    var oldFolderUri = Absolute.uri(oldFolder.toURI());
+    var newFolderUri = Absolute.uri(newFolder.toURI());
+
+    var newObjectModuleUri = Absolute.uri(newFolder.toPath()
+      .resolve("Ext").resolve("ObjectModule.bsl").toUri());
+    var newFormModuleUri = Absolute.uri(newFolder.toPath()
+      .resolve("Forms").resolve("ItemForm").resolve("Ext").resolve("Form").resolve("Module.bsl").toUri());
+
+    var params = new RenameFilesParams(List.of(
+      new FileRename(oldFolderUri.toString(), newFolderUri.toString())
+    ));
+
+    // when
+    workspaceService.didRenameFiles(params);
+    await().until(() -> ctx.getDocument(newObjectModuleUri) != null
+      && ctx.getDocument(newFormModuleUri) != null
+      && ctx.getDocument(oldObjectModuleUri) == null
+      && ctx.getDocument(oldFormModuleUri) == null);
+
+    // then
+    assertThat(ctx.getDocument(oldObjectModuleUri)).isNull();
+    assertThat(ctx.getDocument(oldFormModuleUri)).isNull();
+    assertThat(ctx.getDocument(newObjectModuleUri)).isNotNull();
+    assertThat(ctx.getDocument(newFormModuleUri)).isNotNull();
+  }
+
   private ServerContext workspaceServerContext() {
     return serverContextProvider.getServerContext(Absolute.uri(tempDir.toUri())).orElseThrow();
   }


### PR DESCRIPTION
## Проблема

1. Сервер вообще не вызывал `client/registerCapability`. Универсальные клиенты (neovim, helix) без статически настроенных наблюдателей ничего не присылают в `workspace/didChangeWatchedFiles`, поэтому индекс устаревал при операциях вне редактора (git checkout, выгрузка из конфигуратора).
2. Возможности `workspace.fileOperations` не заявлялись, а `didCreateFiles`/`didRenameFiles`/`didDeleteFiles` оставались default-методами `WorkspaceService` — события создания/переименования/удаления файлов и каталогов не обрабатывались.

## Решение

Часть 1 — динамическая регистрация наблюдателей. В `initialized()` при заявленной клиентом `workspace.didChangeWatchedFiles.dynamicRegistration` (чтение через `ClientCapabilitiesHolder`) выполняется `languageClient.registerCapability(...)` с `DidChangeWatchedFilesRegistrationOptions` на `**/*.bsl`, `**/*.os` и `**/.bsl-language-server.json` (доступ к клиенту через `LanguageClientHolder`). Без `dynamicRegistration` поведение не меняется.

Часть 2 — fileOperations. В `getWorkspaceCapabilities` заявлены `FileOperationsServerCapabilities` с фильтрами на `*.bsl`/`*.os` и на папки (`FileOperationPatternKind.Folder`). В `BSLWorkspaceService` реализованы:
- `didCreateFiles` — добавление документов (как `handleCreatedFileEvent`);
- `didDeleteFiles` — удаление по URI; для каталога — префиксное удаление с границей `/` (переиспользована логика `handleDeletedFileEvent`/`handleDeletedFolderEvent`);
- `didRenameFiles` — атомарно delete(old)+create(new), включая каталоги.

`excludePaths` и открытые документы учитываются так же, как в существующих обработчиках `didChangeWatchedFiles`. Общая резолюция workspace-контекста вынесена в `runInWorkspaceContext`.

## Тесты

`BSLLanguageServerTest`:
- `initializedRegistersFileWatchersWhenDynamicRegistrationSupported` — при `dynamicRegistration=true` вызывается `registerCapability` с glob-ами `**/*.bsl`, `**/*.os`, `**/.bsl-language-server.json`;
- `initializedDoesNotRegisterFileWatchersWithoutDynamicRegistration` — без поддержки регистрация не выполняется;
- `initializeDeclaresFileOperationsCapabilities` — заявлены `didCreate`/`didRename`/`didDelete` с фильтрами `**/*.bsl`, `**/*.os`, `**/*` (папка).

`BSLWorkspaceServiceTest`:
- `testDidCreateFiles_AddsDocument`, `testDidCreateFiles_ExcludedPath`;
- `testDidDeleteFiles_RemovesDocument`, `testDidDeleteFiles_Folder`;
- `testDidRenameFiles_MovesDocument`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Implemented file operation handlers for workspace file creation, deletion, and renaming events
  * Added dynamic registration support for file watchers monitoring BSL, OneScript files, and configuration files

<!-- end of auto-generated comment: release notes by coderabbit.ai -->