### PR TITLE
docs(types): актуализировать javadoc-ссылки после явного FileType в API реестра типов

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/PlatformType.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/PlatformType.java
@@ -27,7 +27,7 @@ package com.github._1c_syntax.bsl.languageserver.types.model;
  * <p>
  * Сам по себе платформенный тип может расширяться пользовательскими членами
  * (см. {@code ConfigurationModuleMembersProvider}). Для запроса полного списка
- * членов используйте {@link com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry#getMembers(TypeRef)}.
+ * членов используйте {@link com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry#getMembers(TypeRef, com.github._1c_syntax.bsl.types.FileType)}.
  *
  * @param ref ссылка на тип в реестре типов
  */

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/Type.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/Type.java
@@ -30,7 +30,7 @@ package com.github._1c_syntax.bsl.languageserver.types.model;
  * <p>
  * Сами инстансы держат только {@link TypeRef} (плюс опциональные метаданные
  * вроде ссылки на исходный символ). Состав членов типа собирается через
- * {@link com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry#getMembers(TypeRef)}
+ * {@link com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry#getMembers(TypeRef, com.github._1c_syntax.bsl.types.FileType)}
  * — это позволяет нескольким источникам (платформенный синтакс-помощник,
  * пользовательский {@code ObjectModule.bsl} и т.д.) совместно расширять
  * один и тот же тип.

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
@@ -494,7 +494,7 @@ public class GlobalScopeProvider {
    * {@link GlobalSymbolScope.Role#TYPE_NAME} для каждого имени/алиаса,
    * чтобы hover/findGlobal на имени класса в {@code Новый <Класс>(...)} нашёл
    * символ с описанием класса. Сами сигнатуры конструкторов хранятся в
-   * {@link TypeRegistry#getConstructors(TypeRef)}.
+   * {@link TypeRegistry#getConstructors(TypeRef, FileType)}.
    */
   public void registerPlatformClass(TypeRef ref, Collection<String> names, FileType fileType, String description) {
     if (ref == null || names == null || names.isEmpty()) {
@@ -590,7 +590,7 @@ public class GlobalScopeProvider {
   /**
    * Зарегистрировать synthetic-symbol для библиотечного модуля OneScript
    * (записи {@code <module>} из {@code lib.config}). Symbol становится
-   * видимым через {@link #findGlobal(String)} с фильтрацией по {@link FileType}
+   * видимым через {@link #findGlobal(String, FileType)} с фильтрацией по {@link FileType}
    * (через {@link com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex}).
    * Источник {@link TypeRef} и {@code libOrigin} — {@code OScriptLibraryIndex}.
    */

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -427,7 +427,7 @@ public class TypeRegistry {
 
   /**
    * Аналог {@link #registerMemberSource}, но вставляет источник в НАЧАЛО списка,
-   * чтобы при сборе членов через {@link #getMembers(TypeRef)} он выигрывал
+   * чтобы при сборе членов через {@link #getMembers(TypeRef, FileType)} он выигрывал
    * dedup ({@code putIfAbsent} по имени). Используется для override returnType
    * у конкретного member'а уже зарегистрированного типа (например, подмена
    * {@code ОбъектМетаданныхКонфигурация.Документы} с общего
@@ -488,7 +488,7 @@ public class TypeRegistry {
    * Регистрируется ленивый {@link MemberSource} для {@code specializedRef},
    * который при каждом запросе:
    * <ol>
-   *   <li>берёт members generic-типа через {@link #getMembers(TypeRef)};</li>
+   *   <li>берёт members generic-типа через {@link #getMembers(TypeRef, FileType)};</li>
    *   <li>отфильтровывает {@link MemberDescriptor#generic()} (слотовые
    *       члены вида {@code <Имя реквизита>});</li>
    *   <li>применяет {@link MemberDescriptor#specialize(Map)} к каждому
@@ -898,7 +898,7 @@ public class TypeRegistry {
   /**
    * Зарегистрировать динамический источник конструкторов для типа (например,
    * {@code ПриСозданииОбъекта} OneScript-класса из SymbolTree).
-   * Источник вызывается каждый раз при запросе {@link #getConstructors(TypeRef)},
+   * Источник вызывается каждый раз при запросе {@link #getConstructors(TypeRef, FileType)},
    * что обеспечивает hot-reload без ручной инвалидации.
    */
   public void registerConstructorSource(


### PR DESCRIPTION
## Проблема
`build-javadoc` красный на develop (и наследуется всеми PR): после #4064 сигнатуры `TypeRegistry#getMembers`, `#getConstructors` и `GlobalScopeProvider#findGlobal` получили явный параметр `FileType`, а семь `{@link}`-ссылок в `types/model/Type`, `PlatformType`, `TypeRegistry`, `GlobalScopeProvider` остались со старыми сигнатурами — `error: reference not found`.

## Решение
Сигнатуры в ссылках актуализированы; в `Type`/`PlatformType` параметр указан полным именем `com.github._1c_syntax.bsl.types.FileType` (импорта в этих файлах нет, добавлять его ради javadoc не стал).

## Тесты
`./gradlew javadoc` локально: BUILD SUCCESSFUL (до фикса падал теми же семью ошибками).

🤖 Generated with [Claude Code](https://claude.com/claude-code)