### PR TITLE
fix(SignatureHelpProvider): учитывать SignatureHelpContext при retrigger

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
@@ -139,31 +139,64 @@ public final class SignatureHelpProvider {
     int activeParameter,
     int serverActiveSignature
   ) {
-    var context = params.getContext();
-    if (context == null || !context.isRetrigger()) {
+    int picked = retriggerPickedIndex(params.getContext(), signatures);
+    if (picked < 0) {
       return serverActiveSignature;
     }
-    var previous = context.getActiveSignatureHelp();
-    if (previous == null || previous.getActiveSignature() == null) {
-      return serverActiveSignature;
-    }
-    int picked = previous.getActiveSignature();
-    if (picked < 0 || picked >= signatures.size()) {
-      return serverActiveSignature;
-    }
-    var previousSignatures = previous.getSignatures();
-    if (previousSignatures == null || picked >= previousSignatures.size()) {
-      return serverActiveSignature;
-    }
-    var previousLabel = previousSignatures.get(picked).getLabel();
     var currentSignature = signatures.get(picked);
-    if (previousLabel == null || !previousLabel.equals(currentSignature.getLabel())) {
+    if (!matchesByLabel(params.getContext().getActiveSignatureHelp(), picked, currentSignature)) {
       return serverActiveSignature;
     }
     if (activeParameter >= currentSignature.getParameters().size()) {
       return serverActiveSignature;
     }
     return picked;
+  }
+
+  /**
+   * Определяет индекс сигнатуры, которую пользователь выбрал в предыдущем (retrigger) показе и
+   * которая по индексу всё ещё попадает в заново построенный список сигнатур.
+   *
+   * @param context    контекст запроса signature help (может быть {@code null})
+   * @param signatures заново построенные сигнатуры для текущей позиции
+   * @return индекс выбранной пользователем сигнатуры, либо {@code -1}, если выбор неприменим
+   */
+  private static int retriggerPickedIndex(SignatureHelpContext context, List<SignatureInformation> signatures) {
+    if (context == null || !context.isRetrigger()) {
+      return -1;
+    }
+    var previous = context.getActiveSignatureHelp();
+    if (previous == null || previous.getActiveSignature() == null) {
+      return -1;
+    }
+    int picked = previous.getActiveSignature();
+    if (picked < 0 || picked >= signatures.size()) {
+      return -1;
+    }
+    return picked;
+  }
+
+  /**
+   * Проверяет, что метка сигнатуры из предыдущего показа по индексу {@code picked} совпадает с
+   * меткой заново построенной сигнатуры (то есть пользовательский выбор всё ещё актуален).
+   *
+   * @param previous         signature help из предыдущего показа (может быть {@code null})
+   * @param picked           индекс выбранной пользователем сигнатуры
+   * @param currentSignature заново построенная сигнатура по тому же индексу
+   * @return {@code true}, если метки совпадают
+   */
+  private static boolean matchesByLabel(
+    SignatureHelp previous, int picked, SignatureInformation currentSignature
+  ) {
+    if (previous == null) {
+      return false;
+    }
+    var previousSignatures = previous.getSignatures();
+    if (previousSignatures == null || picked >= previousSignatures.size()) {
+      return false;
+    }
+    var previousLabel = previousSignatures.get(picked).getLabel();
+    return previousLabel != null && previousLabel.equals(currentSignature.getLabel());
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
@@ -43,6 +43,7 @@ import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.ParameterInformation;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpContext;
 import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SignatureInformation;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
@@ -107,11 +108,62 @@ public final class SignatureHelpProvider {
       signatures.add(toSignatureInformation(descriptor.displayName(lang), sig, lang, argCount));
     }
 
+    var activeSignature = pickActiveSignature(descriptor.signatures(), doCall, activeParameter, documentContext);
+    activeSignature = applyRetriggerContext(params, signatures, activeParameter, activeSignature);
+
     var help = new SignatureHelp();
     help.setSignatures(signatures);
-    help.setActiveSignature(pickActiveSignature(descriptor.signatures(), doCall, activeParameter, documentContext));
+    help.setActiveSignature(activeSignature);
     help.setActiveParameter(activeParameter);
     return help;
+  }
+
+  /**
+   * Учитывает {@link SignatureHelpContext} повторного вызова (retrigger): если клиент прислал
+   * сигнатуру, выбранную пользователем стрелками, и она всё ещё подходит для текущей позиции,
+   * сохраняет пользовательский выбор вместо серверного пересчёта.
+   * <p>
+   * Выбор пользователя сохраняется только когда вызов — retrigger, присланная активная сигнатура
+   * по индексу и метке совпадает с заново построенной сигнатурой и её число параметров вмещает
+   * текущий активный параметр. Иначе возвращается серверный {@code serverActiveSignature}.
+   *
+   * @param params                 параметры запроса signature help (источник контекста retrigger)
+   * @param signatures             заново построенные сигнатуры для текущей позиции
+   * @param activeParameter        индекс активного параметра под курсором (0-based)
+   * @param serverActiveSignature  активная сигнатура, вычисленная серверной логикой
+   * @return индекс активной сигнатуры с учётом пользовательского выбора при retrigger
+   */
+  private static int applyRetriggerContext(
+    SignatureHelpParams params,
+    List<SignatureInformation> signatures,
+    int activeParameter,
+    int serverActiveSignature
+  ) {
+    var context = params.getContext();
+    if (context == null || !context.isRetrigger()) {
+      return serverActiveSignature;
+    }
+    var previous = context.getActiveSignatureHelp();
+    if (previous == null || previous.getActiveSignature() == null) {
+      return serverActiveSignature;
+    }
+    int picked = previous.getActiveSignature();
+    if (picked < 0 || picked >= signatures.size()) {
+      return serverActiveSignature;
+    }
+    var previousSignatures = previous.getSignatures();
+    if (previousSignatures == null || picked >= previousSignatures.size()) {
+      return serverActiveSignature;
+    }
+    var previousLabel = previousSignatures.get(picked).getLabel();
+    var currentSignature = signatures.get(picked);
+    if (previousLabel == null || !previousLabel.equals(currentSignature.getLabel())) {
+      return serverActiveSignature;
+    }
+    if (activeParameter >= currentSignature.getParameters().size()) {
+      return serverActiveSignature;
+    }
+    return picked;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
@@ -139,12 +139,20 @@ public final class SignatureHelpProvider {
     int activeParameter,
     int serverActiveSignature
   ) {
-    int picked = retriggerPickedIndex(params.getContext(), signatures);
+    var context = params.getContext();
+    if (context == null || !context.isRetrigger()) {
+      return serverActiveSignature;
+    }
+    var previous = context.getActiveSignatureHelp();
+    if (previous == null) {
+      return serverActiveSignature;
+    }
+    int picked = retriggerPickedIndex(previous, signatures);
     if (picked < 0) {
       return serverActiveSignature;
     }
     var currentSignature = signatures.get(picked);
-    if (!matchesByLabel(params.getContext().getActiveSignatureHelp(), picked, currentSignature)) {
+    if (!matchesByLabel(previous, picked, currentSignature)) {
       return serverActiveSignature;
     }
     if (activeParameter >= currentSignature.getParameters().size()) {
@@ -157,19 +165,16 @@ public final class SignatureHelpProvider {
    * Определяет индекс сигнатуры, которую пользователь выбрал в предыдущем (retrigger) показе и
    * которая по индексу всё ещё попадает в заново построенный список сигнатур.
    *
-   * @param context    контекст запроса signature help (может быть {@code null})
+   * @param previous   signature help из предыдущего показа (выбор пользователя)
    * @param signatures заново построенные сигнатуры для текущей позиции
    * @return индекс выбранной пользователем сигнатуры, либо {@code -1}, если выбор неприменим
    */
-  private static int retriggerPickedIndex(SignatureHelpContext context, List<SignatureInformation> signatures) {
-    if (context == null || !context.isRetrigger()) {
+  private static int retriggerPickedIndex(SignatureHelp previous, List<SignatureInformation> signatures) {
+    var activeSignature = previous.getActiveSignature();
+    if (activeSignature == null) {
       return -1;
     }
-    var previous = context.getActiveSignatureHelp();
-    if (previous == null || previous.getActiveSignature() == null) {
-      return -1;
-    }
-    int picked = previous.getActiveSignature();
+    int picked = activeSignature;
     if (picked < 0 || picked >= signatures.size()) {
       return -1;
     }
@@ -180,7 +185,7 @@ public final class SignatureHelpProvider {
    * Проверяет, что метка сигнатуры из предыдущего показа по индексу {@code picked} совпадает с
    * меткой заново построенной сигнатуры (то есть пользовательский выбор всё ещё актуален).
    *
-   * @param previous         signature help из предыдущего показа (может быть {@code null})
+   * @param previous         signature help из предыдущего показа
    * @param picked           индекс выбранной пользователем сигнатуры
    * @param currentSignature заново построенная сигнатура по тому же индексу
    * @return {@code true}, если метки совпадают
@@ -188,9 +193,6 @@ public final class SignatureHelpProvider {
   private static boolean matchesByLabel(
     SignatureHelp previous, int picked, SignatureInformation currentSignature
   ) {
-    if (previous == null) {
-      return false;
-    }
     var previousSignatures = previous.getSignatures();
     if (previousSignatures == null || picked >= previousSignatures.size()) {
       return false;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProviderTest.java
@@ -25,7 +25,11 @@ import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpContext;
 import org.eclipse.lsp4j.SignatureHelpParams;
+import org.eclipse.lsp4j.SignatureHelpTriggerKind;
+import org.eclipse.lsp4j.SignatureInformation;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -522,5 +526,103 @@ class SignatureHelpProviderTest {
     var paramDoc = sig.getParameters().get(0).getDocumentation();
     assertThat(paramDoc).isNotNull();
     assertThat(paramDoc.getLeft()).contains("первичный документ");
+  }
+
+  @Test
+  void retriggerKeepsUserSelectedSignatureWhenStillValid() {
+    // given — Разделить имеет 2 перегрузки: [separator] и [separator, encoding];
+    // курсор на первом параметре (после открывающей скобки), где сервер по arity
+    // выбрал бы 0-ю перегрузку, но пользователь стрелками выбрал 1-ю.
+    var content =
+      "ЧД = Новый ЧтениеДанных(\"path\");\n"
+        + "ЧД.Разделить(\"|\");\n";
+    var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var col = content.split("\n")[1].indexOf("Разделить(") + "Разделить(".length();
+    params.setPosition(new Position(1, col));
+
+    var previous = signatureHelpProvider.getSignatureHelp(documentContext, params);
+    var userPicked = userPickedContext(previous, 1);
+    params.setContext(userPicked);
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — выбор пользователя (1) сохранён, активный параметр пересчитан (0).
+    assertThat(help.getSignatures()).hasSize(2);
+    assertThat(help.getActiveParameter()).isZero();
+    assertThat(help.getActiveSignature()).isEqualTo(1);
+  }
+
+  @Test
+  void retriggerFallsBackToServerWhenUserSignatureInvalid() {
+    // given — курсор на втором параметре (после первой запятой); пользователь ранее
+    // выбрал 0-ю перегрузку с одним параметром, для которой второй параметр невалиден.
+    var content =
+      "ЧД = Новый ЧтениеДанных(\"path\");\n"
+        + "ЧД.Разделить(\"|\", \"UTF-8\");\n";
+    var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var col = content.split("\n")[1].indexOf("\"UTF-8\"");
+    params.setPosition(new Position(1, col));
+
+    var previous = signatureHelpProvider.getSignatureHelp(documentContext, params);
+    var userPicked = userPickedContext(previous, 0);
+    params.setContext(userPicked);
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — 0-я перегрузка невалидна (один параметр), сервер пересчитывает на 1-ю.
+    assertThat(help.getSignatures()).hasSize(2);
+    assertThat(help.getActiveParameter()).isEqualTo(1);
+    assertThat(help.getActiveSignature()).isEqualTo(1);
+  }
+
+  @Test
+  void nonRetriggerIgnoresProvidedContextSignature() {
+    // given — тот же контекст с выбором 1, но без флага retrigger.
+    var content =
+      "ЧД = Новый ЧтениеДанных(\"path\");\n"
+        + "ЧД.Разделить(\"|\");\n";
+    var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var col = content.split("\n")[1].indexOf("Разделить(") + "Разделить(".length();
+    params.setPosition(new Position(1, col));
+
+    var previous = signatureHelpProvider.getSignatureHelp(documentContext, params);
+    var context = userPickedContext(previous, 1);
+    context.setIsRetrigger(false);
+    context.setTriggerKind(SignatureHelpTriggerKind.TriggerCharacter);
+    params.setContext(context);
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — контекст игнорируется, активная сигнатура по серверной логике (0).
+    assertThat(help.getActiveSignature()).isZero();
+  }
+
+  private static SignatureHelpContext userPickedContext(SignatureHelp previous, int activeSignature) {
+    var activeHelp = new SignatureHelp();
+    activeHelp.setSignatures(previous.getSignatures().stream()
+      .map(SignatureHelpProviderTest::copySignatureInformation)
+      .toList());
+    activeHelp.setActiveSignature(activeSignature);
+    activeHelp.setActiveParameter(previous.getActiveParameter());
+    var context = new SignatureHelpContext(SignatureHelpTriggerKind.TriggerCharacter, true);
+    context.setActiveSignatureHelp(activeHelp);
+    return context;
+  }
+
+  private static SignatureInformation copySignatureInformation(SignatureInformation source) {
+    var copy = new SignatureInformation();
+    copy.setLabel(source.getLabel());
+    copy.setParameters(source.getParameters());
+    copy.setDocumentation(source.getDocumentation());
+    return copy;
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProviderTest.java
@@ -530,12 +530,14 @@ class SignatureHelpProviderTest {
 
   @Test
   void retriggerKeepsUserSelectedSignatureWhenStillValid() {
-    // given — Разделить имеет 2 перегрузки: [separator] и [separator, encoding];
-    // курсор на первом параметре (после открывающей скобки), где сервер по arity
-    // выбрал бы 0-ю перегрузку, но пользователь стрелками выбрал 1-ю.
-    var content =
-      "ЧД = Новый ЧтениеДанных(\"path\");\n"
-        + "ЧД.Разделить(\"|\");\n";
+    // given — у метода Разделить две перегрузки: одна с разделителем и одна
+    // с разделителем и кодировкой; курсор на первом параметре (после открывающей
+    // скобки), где сервер по числу аргументов выбрал бы нулевую перегрузку,
+    // но пользователь стрелками выбрал первую.
+    var content = """
+      ЧД = Новый ЧтениеДанных("path");
+      ЧД.Разделить("|");
+      """;
     var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
     var params = new SignatureHelpParams();
     params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
@@ -559,9 +561,10 @@ class SignatureHelpProviderTest {
   void retriggerFallsBackToServerWhenUserSignatureInvalid() {
     // given — курсор на втором параметре (после первой запятой); пользователь ранее
     // выбрал 0-ю перегрузку с одним параметром, для которой второй параметр невалиден.
-    var content =
-      "ЧД = Новый ЧтениеДанных(\"path\");\n"
-        + "ЧД.Разделить(\"|\", \"UTF-8\");\n";
+    var content = """
+      ЧД = Новый ЧтениеДанных("path");
+      ЧД.Разделить("|", "UTF-8");
+      """;
     var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
     var params = new SignatureHelpParams();
     params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
@@ -584,9 +587,10 @@ class SignatureHelpProviderTest {
   @Test
   void nonRetriggerIgnoresProvidedContextSignature() {
     // given — тот же контекст с выбором 1, но без флага retrigger.
-    var content =
-      "ЧД = Новый ЧтениеДанных(\"path\");\n"
-        + "ЧД.Разделить(\"|\");\n";
+    var content = """
+      ЧД = Новый ЧтениеДанных("path");
+      ЧД.Разделить("|");
+      """;
     var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
     var params = new SignatureHelpParams();
     params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
@@ -603,6 +607,114 @@ class SignatureHelpProviderTest {
     var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
 
     // then — контекст игнорируется, активная сигнатура по серверной логике (0).
+    assertThat(help.getActiveSignature()).isZero();
+  }
+
+  @Test
+  void retriggerWithoutActiveSignatureHelpFallsBackToServer() {
+    // given — retrigger без присланного activeSignatureHelp в контексте.
+    var content = """
+      ЧД = Новый ЧтениеДанных("path");
+      ЧД.Разделить("|");
+      """;
+    var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var col = content.split("\n")[1].indexOf("Разделить(") + "Разделить(".length();
+    params.setPosition(new Position(1, col));
+    var context = new SignatureHelpContext(SignatureHelpTriggerKind.TriggerCharacter, true);
+    params.setContext(context);
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — присланной сигнатуры нет, используется серверная логика (0).
+    assertThat(help.getActiveSignature()).isZero();
+  }
+
+  @Test
+  void retriggerWithNullActiveSignatureFallsBackToServer() {
+    // given — retrigger с activeSignatureHelp, но без выбранной активной сигнатуры.
+    var content = """
+      ЧД = Новый ЧтениеДанных("path");
+      ЧД.Разделить("|");
+      """;
+    var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var col = content.split("\n")[1].indexOf("Разделить(") + "Разделить(".length();
+    params.setPosition(new Position(1, col));
+
+    var previous = signatureHelpProvider.getSignatureHelp(documentContext, params);
+    var activeHelp = new SignatureHelp();
+    activeHelp.setSignatures(previous.getSignatures());
+    activeHelp.setActiveSignature(null);
+    var context = new SignatureHelpContext(SignatureHelpTriggerKind.TriggerCharacter, true);
+    context.setActiveSignatureHelp(activeHelp);
+    params.setContext(context);
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — активная сигнатура не задана, используется серверная логика (0).
+    assertThat(help.getActiveSignature()).isZero();
+  }
+
+  @Test
+  void retriggerWithActiveSignatureOutOfRangeFallsBackToServer() {
+    // given — присланный индекс активной сигнатуры за границами текущего списка.
+    var content = """
+      ЧД = Новый ЧтениеДанных("path");
+      ЧД.Разделить("|");
+      """;
+    var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var col = content.split("\n")[1].indexOf("Разделить(") + "Разделить(".length();
+    params.setPosition(new Position(1, col));
+
+    var previous = signatureHelpProvider.getSignatureHelp(documentContext, params);
+    var context = userPickedContext(previous, 99);
+    params.setContext(context);
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — индекс невалиден, используется серверная логика (0).
+    assertThat(help.getActiveSignature()).isZero();
+  }
+
+  @Test
+  void retriggerWithDifferentLabelFallsBackToServer() {
+    // given — присланная по тому же индексу сигнатура имеет другую метку,
+    // значит пользовательский выбор более не актуален.
+    var content = """
+      ЧД = Новый ЧтениеДанных("path");
+      ЧД.Разделить("|");
+      """;
+    var documentContext = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var col = content.split("\n")[1].indexOf("Разделить(") + "Разделить(".length();
+    params.setPosition(new Position(1, col));
+
+    var previous = signatureHelpProvider.getSignatureHelp(documentContext, params);
+    var activeHelp = new SignatureHelp();
+    var staleSignatures = previous.getSignatures().stream()
+      .map(SignatureHelpProviderTest::copySignatureInformation)
+      .toList();
+    staleSignatures.get(1).setLabel("OtherMethod(args)");
+    activeHelp.setSignatures(staleSignatures);
+    activeHelp.setActiveSignature(1);
+    activeHelp.setActiveParameter(previous.getActiveParameter());
+    var context = new SignatureHelpContext(SignatureHelpTriggerKind.TriggerCharacter, true);
+    context.setActiveSignatureHelp(activeHelp);
+    params.setContext(context);
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — метка не совпадает, используется серверная логика (0).
     assertThat(help.getActiveSignature()).isZero();
   }
 


### PR DESCRIPTION
## Проблема

Сервер объявляет `retriggerCharacters`, но `params.getContext()` полностью игнорировался: при каждом запросе `activeSignature` пересчитывался серверной логикой (`pickActiveSignature`). Если пользователь стрелками выбирал другую перегрузку (клиент присылает её в `context.activeSignatureHelp.activeSignature`), при вводе следующей запятой выбор сбрасывался на серверный.

## Решение

В `SignatureHelpProvider.getSignatureHelp` добавлен шаг `applyRetriggerContext`:
- срабатывает только при `isRetrigger == true` и наличии `context.activeSignatureHelp` с непустым `activeSignature`;
- «та же ли это сигнатура» проверяется по индексу + label из присланного `activeSignatureHelp` (сопоставление с заново построенным списком);
- выбор пользователя сохраняется, только если сигнатура всё ещё валидна — её число параметров вмещает текущий `activeParameter`;
- иначе возвращается серверный пересчёт.

`activeParameter` по-прежнему вычисляется по позиции курсора.

## Тесты

`SignatureHelpProviderTest` (новые, на oscript-перегрузках `Разделить` — `[separator]` и `[separator, encoding]`):
- `retriggerKeepsUserSelectedSignatureWhenStillValid` — retrigger с `context.activeSignature=1` (валидная перегрузка) → в ответе `activeSignature` остаётся 1;
- `retriggerFallsBackToServerWhenUserSignatureInvalid` — выбранная 0-я перегрузка невалидна для второго параметра → серверный пересчёт на 1;
- `nonRetriggerIgnoresProvidedContextSignature` — не-retrigger → контекст игнорируется, прежнее поведение.

Финальный прогон затронутого класса: `BUILD SUCCESSFUL`, все 22 теста (включая 3 новых) PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved signature help retrigger behavior to preserve user-selected signatures when valid, with automatic fallback to server-computed selection when the signature becomes invalid.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->