### PR TITLE
fix(inlayhints): показывать значения по умолчанию пропущенных аргументов

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/DoCallRangeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/DoCallRangeIndex.java
@@ -1,0 +1,131 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.inlayhints;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.languageserver.utils.Trees;
+import com.github._1c_syntax.bsl.parser.BSLParser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.eclipse.lsp4j.Range;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Индекс {@code doCall}-узлов документа по диапазону имени вызываемого метода.
+ * <p>
+ * Строится одним обходом AST документа и позволяет резолвить вызов по ссылке
+ * на метод за {@code O(1)} вместо повторного обхода AST на каждую ссылку.
+ * Ключом служит {@link Reference#selectionRange()} ссылки, совпадающий с
+ * диапазоном имени вызываемого метода (для конструктора — с диапазоном имени типа).
+ */
+final class DoCallRangeIndex {
+
+  private final Map<String, BSLParser.DoCallContext> doCallsByMethodNameRange;
+
+  private DoCallRangeIndex(Map<String, BSLParser.DoCallContext> doCallsByMethodNameRange) {
+    this.doCallsByMethodNameRange = doCallsByMethodNameRange;
+  }
+
+  /**
+   * Строит индекс по AST документа.
+   * <p>
+   * Все {@code doCall}-узлы документа собираются в карту по диапазону имени
+   * вызываемого метода (для конструктора — по диапазону имени типа). Этот диапазон
+   * совпадает с {@link Reference#selectionRange()} соответствующей ссылки.
+   *
+   * @param documentContext контекст документа, AST которого обходится
+   * @return индекс вызовов документа; пустой, если вызовов нет
+   */
+  static DoCallRangeIndex of(DocumentContext documentContext) {
+    var ast = documentContext.getAst();
+    var doCalls = Trees.findAllRuleNodes(ast, BSLParser.RULE_doCall);
+    Map<String, BSLParser.DoCallContext> result = HashMap.newHashMap(doCalls.size());
+    for (var node : doCalls) {
+      var doCall = (BSLParser.DoCallContext) node;
+      var doCallParent = doCall.getParent();
+      if (doCallParent == null) {
+        continue;
+      }
+      methodNameRange(doCallParent)
+        .ifPresent(methodNameRange -> result.putIfAbsent(rangeKey(methodNameRange), doCall));
+    }
+    return new DoCallRangeIndex(result);
+  }
+
+  /**
+   * Возвращает {@code doCall}-узел, соответствующий ссылке на метод.
+   *
+   * @param reference ссылка на вызываемый метод; используется её {@link Reference#selectionRange()}
+   * @return узел вызова либо {@link Optional#empty()}, если в документе нет вызова с таким диапазоном
+   */
+  Optional<BSLParser.DoCallContext> doCallFor(Reference reference) {
+    return Optional.ofNullable(doCallsByMethodNameRange.get(rangeKey(reference.selectionRange())));
+  }
+
+  /**
+   * Строковый ключ карты вызовов по диапазону имени метода.
+   * <p>
+   * Используется вместо {@link Range} из lsp4j, который не реализует
+   * {@link Comparable}: {@link String} реализует {@link Comparable} и не зависит
+   * от деталей {@link Range#hashCode()}, что устраняет риск деградации хэш-карты
+   * при коллизиях ключей.
+   *
+   * @param range диапазон имени метода/типа
+   * @return ключ вида {@code "startLine:startChar:endLine:endChar"}
+   */
+  private static String rangeKey(Range range) {
+    var start = range.getStart();
+    var end = range.getEnd();
+    return start.getLine() + ":" + start.getCharacter() + ":" + end.getLine() + ":" + end.getCharacter();
+  }
+
+  /**
+   * Диапазон имени вызываемого метода для родителя {@code doCall}-узла —
+   * именно его {@link com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex}
+   * хранит в {@link Reference#selectionRange()}.
+   *
+   * @param doCallParent родительский узел вызова (methodCall, globalMethodCall или newExpression)
+   * @return диапазон имени метода/типа либо {@link Optional#empty()},
+   *   если узел не является вызовом метода
+   */
+  private static Optional<Range> methodNameRange(ParserRuleContext doCallParent) {
+    if (doCallParent instanceof BSLParser.MethodCallContext methodCallContext) {
+      var methodName = methodCallContext.methodName();
+      return methodName == null ? Optional.empty() : Optional.of(Ranges.create(methodName));
+    } else if (doCallParent instanceof BSLParser.GlobalMethodCallContext globalMethodCallContext) {
+      var methodName = globalMethodCallContext.methodName();
+      return methodName == null ? Optional.empty() : Optional.of(Ranges.create(methodName));
+    } else if (doCallParent instanceof BSLParser.NewExpressionContext newExpressionContext) {
+      var typeName = newExpressionContext.typeName();
+      if (typeName != null && typeName.IDENTIFIER() != null) {
+        return Optional.of(Ranges.create(typeName.IDENTIFIER()));
+      }
+      return Optional.empty();
+    } else {
+      return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplier.java
@@ -333,6 +333,8 @@ public class PlatformMethodCallInlayHintSupplier extends AbstractMethodCallInlay
     } else if (!showParametersWithTheSameName()
       && shadowsName(passedValue, unit.name(), unit.descriptor())) {
       return;
+    } else {
+      // непустой довод, не дублирующий имя параметра — показываем обычный хинт ниже
     }
     var hint = new InlayHint();
     hint.setKind(InlayHintKind.Parameter);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplier.java
@@ -284,12 +284,16 @@ public class PlatformMethodCallInlayHintSupplier extends AbstractMethodCallInlay
     }
     var lang = currentLanguage();
     var variadicIndex = variadicIndex(parameters);
+    // Единственный пустой callParam — это запись вида `Метод()` / `Новый Тип()`,
+    // т.е. ноль фактических аргументов. Пропуск аргумента (`Метод(а,,б)`) даёт
+    // несколько callParam'ов, в которых пустой обозначает именно опущенный довод.
+    var hasSkippedArguments = args.size() > 1;
     for (var i = 0; i < args.size(); i++) {
       var unit = paramAt(parameters, variadicIndex, i, lang);
       if (unit == null) {
         break;
       }
-      appendHint(sink, member, unit, args.get(i));
+      appendHint(sink, member, unit, args.get(i), hasSkippedArguments);
     }
   }
 
@@ -317,14 +321,17 @@ public class PlatformMethodCallInlayHintSupplier extends AbstractMethodCallInlay
   }
 
   private void appendHint(List<InlayHint> sink, MemberDescriptor member, NamedParam unit,
-                          BSLParser.CallParamContext callParam) {
+                          BSLParser.CallParamContext callParam, boolean argumentSkipAllowed) {
     var passedValue = callParam.getText();
-    // `Новый Тип();` парсится как один пустой callParam — не показываем хинт для
-    // пустого аргумента, иначе получим бессмысленное `Новый Массив(Массив:);`.
+    // Пустой довод — либо `Метод()`/`Новый Тип()` (ноль аргументов, хинт не нужен),
+    // либо пропущенный аргумент `Метод(а,,б)`. Для пропущенного при включённом
+    // showDefaultValues показываем значение по умолчанию из сигнатуры.
     if (passedValue.isBlank()) {
-      return;
-    }
-    if (!showParametersWithTheSameName() && shadowsName(passedValue, unit.name(), unit.descriptor())) {
+      if (!argumentSkipAllowed || !showDefaultValues() || unit.descriptor().defaultValue().isBlank()) {
+        return;
+      }
+    } else if (!showParametersWithTheSameName()
+      && shadowsName(passedValue, unit.name(), unit.descriptor())) {
       return;
     }
     var hint = new InlayHint();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
@@ -47,6 +47,7 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 
 /**
  * Поставщик подсказок о параметрах вызываемого метода.
@@ -89,12 +90,29 @@ public class SourceDefinedMethodCallInlayHintSupplier extends AbstractMethodCall
 
     var result = new ArrayList<InlayHint>();
     for (var reference : references) {
-      var doCall = doCallsByMethodNameRange.get(reference.selectionRange());
+      var doCall = doCallsByMethodNameRange.get(rangeKey(reference.selectionRange()));
       if (doCall != null) {
         result.addAll(toInlayHints(reference, doCall));
       }
     }
     return result;
+  }
+
+  /**
+   * Строковый ключ карты вызовов по диапазону имени метода.
+   * <p>
+   * Используется вместо {@link Range} из lsp4j, который не реализует
+   * {@link Comparable}: {@link String} реализует {@link Comparable} и не зависит
+   * от деталей {@link Range#hashCode()}, что устраняет риск деградации хэш-карты
+   * при коллизиях ключей.
+   *
+   * @param range диапазон имени метода/типа
+   * @return ключ вида {@code "startLine:startChar:endLine:endChar"}
+   */
+  private static String rangeKey(Range range) {
+    var start = range.getStart();
+    var end = range.getEnd();
+    return start.getLine() + ":" + start.getCharacter() + ":" + end.getLine() + ":" + end.getCharacter();
   }
 
   /**
@@ -105,37 +123,32 @@ public class SourceDefinedMethodCallInlayHintSupplier extends AbstractMethodCall
    * ссылки, что позволяет резолвить вызов по ссылке без повторного обхода AST.
    *
    * @param documentContext контекст документа, AST которого обходится
-   * @return карта «диапазон имени метода → узел вызова»; пустая, если AST отсутствует
+   * @return карта «ключ диапазона имени метода → узел вызова»; пустая, если вызовов нет
    */
-  private static Map<Range, BSLParser.DoCallContext> collectDoCallsByMethodNameRange(
+  private static Map<String, BSLParser.DoCallContext> collectDoCallsByMethodNameRange(
     DocumentContext documentContext
   ) {
     var ast = documentContext.getAst();
-    if (ast == null) {
-      return Map.of();
-    }
     var doCalls = Trees.findAllRuleNodes(ast, BSLParser.RULE_doCall);
-    var result = new HashMap<Range, BSLParser.DoCallContext>(doCalls.size());
+    Map<String, BSLParser.DoCallContext> result = HashMap.newHashMap(doCalls.size());
     for (var node : doCalls) {
       var doCall = (BSLParser.DoCallContext) node;
-      var methodNameRange = methodNameRange(doCall.getParent());
-      if (methodNameRange != null) {
-        result.putIfAbsent(methodNameRange, doCall);
-      }
+      methodNameRange(doCall.getParent())
+        .ifPresent(methodNameRange -> result.putIfAbsent(rangeKey(methodNameRange), doCall));
     }
     return result;
   }
 
   private List<InlayHint> toInlayHints(Reference reference, BSLParser.DoCallContext doCall) {
 
-    var methodSymbol = (MethodSymbol) reference.symbol();
-    var parameters = methodSymbol.getParameters();
-
     var callParamList = doCall.callParamList();
     if (callParamList == null) {
       return List.of();
     }
     var callParams = callParamList.callParam();
+
+    var methodSymbol = (MethodSymbol) reference.symbol();
+    var parameters = methodSymbol.getParameters();
 
     var hints = new ArrayList<InlayHint>();
     for (var i = 0; i < parameters.size(); i++) {
@@ -211,19 +224,24 @@ public class SourceDefinedMethodCallInlayHintSupplier extends AbstractMethodCall
    * именно его {@link ReferenceIndex} хранит в {@link Reference#selectionRange()}.
    *
    * @param doCallParent родительский узел вызова (methodCall, globalMethodCall или newExpression)
-   * @return диапазон имени метода/типа либо {@code null}, если узел не является вызовом метода
+   * @return диапазон имени метода/типа либо {@link Optional#empty()},
+   *   если узел не является вызовом метода
    */
-  private static Range methodNameRange(ParserRuleContext doCallParent) {
+  private static Optional<Range> methodNameRange(ParserRuleContext doCallParent) {
     if (doCallParent instanceof BSLParser.MethodCallContext methodCallContext) {
-      return Ranges.create(methodCallContext.methodName());
+      var methodName = methodCallContext.methodName();
+      return methodName == null ? Optional.empty() : Optional.of(Ranges.create(methodName));
     } else if (doCallParent instanceof BSLParser.GlobalMethodCallContext globalMethodCallContext) {
-      return Ranges.create(globalMethodCallContext.methodName());
+      var methodName = globalMethodCallContext.methodName();
+      return methodName == null ? Optional.empty() : Optional.of(Ranges.create(methodName));
     } else if (doCallParent instanceof BSLParser.NewExpressionContext newExpressionContext) {
       var typeName = newExpressionContext.typeName();
       if (typeName != null && typeName.IDENTIFIER() != null) {
-        return Ranges.create(typeName.IDENTIFIER());
+        return Optional.of(Ranges.create(typeName.IDENTIFIER()));
       }
+      return Optional.empty();
+    } else {
+      return Optional.empty();
     }
-    return null;
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
@@ -39,12 +39,14 @@ import org.eclipse.lsp4j.InlayHintParams;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.Collection;
+import java.util.HashMap;
 import java.util.List;
+import java.util.Map;
 
 /**
  * Поставщик подсказок о параметрах вызываемого метода.
@@ -72,60 +74,97 @@ public class SourceDefinedMethodCallInlayHintSupplier extends AbstractMethodCall
   @Override
   public List<InlayHint> getInlayHints(DocumentContext documentContext, InlayHintParams params) {
     var range = params.getRange();
-    return referenceIndex.getReferencesFrom(documentContext.getUri(), SymbolKind.Method).stream()
+    var references = referenceIndex.getReferencesFrom(documentContext.getUri(), SymbolKind.Method).stream()
       .filter(reference -> Ranges.containsPosition(range, reference.selectionRange().getStart()))
       .filter(Reference::isSourceDefinedSymbolReference)
-      .map(this::toInlayHints)
-      .flatMap(Collection::stream)
       .toList();
+    if (references.isEmpty()) {
+      return List.of();
+    }
+
+    // Один обход AST документа на все ссылки: сопоставляем каждый вызов с
+    // диапазоном имени метода (тем же, что хранится в reference.selectionRange()),
+    // чтобы дальше резолвить вызов по ссылке за O(1) вместо обхода AST на каждую ссылку.
+    var doCallsByMethodNameRange = collectDoCallsByMethodNameRange(documentContext);
+
+    var result = new ArrayList<InlayHint>();
+    for (var reference : references) {
+      var doCall = doCallsByMethodNameRange.get(reference.selectionRange());
+      if (doCall != null) {
+        result.addAll(toInlayHints(reference, doCall));
+      }
+    }
+    return result;
   }
 
-  private List<InlayHint> toInlayHints(Reference reference) {
+  /**
+   * Собирает все {@code doCall}-узлы документа в карту по диапазону имени
+   * вызываемого метода (для конструктора — по диапазону имени типа).
+   * <p>
+   * Этот диапазон совпадает с {@link Reference#selectionRange()} соответствующей
+   * ссылки, что позволяет резолвить вызов по ссылке без повторного обхода AST.
+   *
+   * @param documentContext контекст документа, AST которого обходится
+   * @return карта «диапазон имени метода → узел вызова»; пустая, если AST отсутствует
+   */
+  private static Map<Range, BSLParser.DoCallContext> collectDoCallsByMethodNameRange(
+    DocumentContext documentContext
+  ) {
+    var ast = documentContext.getAst();
+    if (ast == null) {
+      return Map.of();
+    }
+    var doCalls = Trees.findAllRuleNodes(ast, BSLParser.RULE_doCall);
+    var result = new HashMap<Range, BSLParser.DoCallContext>(doCalls.size());
+    for (var node : doCalls) {
+      var doCall = (BSLParser.DoCallContext) node;
+      var methodNameRange = methodNameRange(doCall.getParent());
+      if (methodNameRange != null) {
+        result.putIfAbsent(methodNameRange, doCall);
+      }
+    }
+    return result;
+  }
+
+  private List<InlayHint> toInlayHints(Reference reference, BSLParser.DoCallContext doCall) {
 
     var methodSymbol = (MethodSymbol) reference.symbol();
     var parameters = methodSymbol.getParameters();
 
-    var ast = reference.from().getOwner().getAst();
-    var doCalls = Trees.findAllRuleNodes(ast, BSLParser.RULE_doCall);
+    var callParamList = doCall.callParamList();
+    if (callParamList == null) {
+      return List.of();
+    }
+    var callParams = callParamList.callParam();
 
-    return doCalls.stream()
-      .map(BSLParser.DoCallContext.class::cast)
-      .filter(doCall -> isRightMethod(doCall.getParent(), reference))
-      .map(BSLParser.DoCallContext::callParamList)
-      .map(BSLParser.CallParamListContext::callParam)
-      .map((List<? extends BSLParser.CallParamContext> callParams) -> {
-        var hints = new ArrayList<InlayHint>();
-        for (var i = 0; i < parameters.size(); i++) {
+    var hints = new ArrayList<InlayHint>();
+    for (var i = 0; i < parameters.size(); i++) {
 
-          // todo: show all parameters (in config)?
-          if (callParams.size() < i + 1) {
-            break;
-          }
+      // todo: show all parameters (in config)?
+      if (callParams.size() < i + 1) {
+        break;
+      }
 
-          var parameter = parameters.get(i);
-          var callParam = callParams.get(i);
+      var parameter = parameters.get(i);
+      var callParam = callParams.get(i);
 
-          var passedValue = callParam.getText();
+      var passedValue = callParam.getText();
 
-          if (!showParametersWithTheSameName() && Strings.CI.contains(passedValue, parameter.getName())) {
-            continue;
-          }
+      if (!showParametersWithTheSameName() && Strings.CI.contains(passedValue, parameter.getName())) {
+        continue;
+      }
 
-          var inlayHint = new InlayHint();
-          inlayHint.setKind(InlayHintKind.Parameter);
+      var inlayHint = new InlayHint();
+      inlayHint.setKind(InlayHintKind.Parameter);
 
-          setLabelAndPadding(inlayHint, parameter, passedValue, reference);
-          setPosition(inlayHint, callParam);
-          setTooltip(inlayHint, parameter);
+      setLabelAndPadding(inlayHint, parameter, passedValue, reference);
+      setPosition(inlayHint, callParam);
+      setTooltip(inlayHint, parameter);
 
-          hints.add(inlayHint);
-        }
+      hints.add(inlayHint);
+    }
 
-        return hints;
-      })
-      .flatMap(Collection::stream)
-      .toList();
-
+    return hints;
   }
 
   private void setLabelAndPadding(
@@ -167,20 +206,24 @@ public class SourceDefinedMethodCallInlayHintSupplier extends AbstractMethodCall
   }
 
 
-  private static boolean isRightMethod(ParserRuleContext doCallParent, Reference reference) {
-    var selectionRange = reference.selectionRange();
-
+  /**
+   * Диапазон имени вызываемого метода для родителя {@code doCall}-узла —
+   * именно его {@link ReferenceIndex} хранит в {@link Reference#selectionRange()}.
+   *
+   * @param doCallParent родительский узел вызова (methodCall, globalMethodCall или newExpression)
+   * @return диапазон имени метода/типа либо {@code null}, если узел не является вызовом метода
+   */
+  private static Range methodNameRange(ParserRuleContext doCallParent) {
     if (doCallParent instanceof BSLParser.MethodCallContext methodCallContext) {
-      return selectionRange.equals(Ranges.create(methodCallContext.methodName()));
+      return Ranges.create(methodCallContext.methodName());
     } else if (doCallParent instanceof BSLParser.GlobalMethodCallContext globalMethodCallContext) {
-      return selectionRange.equals(Ranges.create(globalMethodCallContext.methodName()));
+      return Ranges.create(globalMethodCallContext.methodName());
     } else if (doCallParent instanceof BSLParser.NewExpressionContext newExpressionContext) {
       var typeName = newExpressionContext.typeName();
-      return typeName != null
-        && typeName.IDENTIFIER() != null
-        && selectionRange.equals(Ranges.create(typeName.IDENTIFIER()));
-    } else {
-      return false;
+      if (typeName != null && typeName.IDENTIFIER() != null) {
+        return Ranges.create(typeName.IDENTIFIER());
+      }
     }
+    return null;
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
@@ -29,9 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
-import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
-import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.Strings;
 import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintKind;
@@ -39,15 +37,11 @@ import org.eclipse.lsp4j.InlayHintParams;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
-import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.List;
-import java.util.Map;
-import java.util.Optional;
 
 /**
  * Поставщик подсказок о параметрах вызываемого метода.
@@ -83,58 +77,15 @@ public class SourceDefinedMethodCallInlayHintSupplier extends AbstractMethodCall
       return List.of();
     }
 
-    // Один обход AST документа на все ссылки: сопоставляем каждый вызов с
+    // Один обход AST документа на все ссылки: индекс сопоставляет каждый вызов с
     // диапазоном имени метода (тем же, что хранится в reference.selectionRange()),
     // чтобы дальше резолвить вызов по ссылке за O(1) вместо обхода AST на каждую ссылку.
-    var doCallsByMethodNameRange = collectDoCallsByMethodNameRange(documentContext);
+    var doCallRangeIndex = DoCallRangeIndex.of(documentContext);
 
     var result = new ArrayList<InlayHint>();
     for (var reference : references) {
-      var doCall = doCallsByMethodNameRange.get(rangeKey(reference.selectionRange()));
-      if (doCall != null) {
-        result.addAll(toInlayHints(reference, doCall));
-      }
-    }
-    return result;
-  }
-
-  /**
-   * Строковый ключ карты вызовов по диапазону имени метода.
-   * <p>
-   * Используется вместо {@link Range} из lsp4j, который не реализует
-   * {@link Comparable}: {@link String} реализует {@link Comparable} и не зависит
-   * от деталей {@link Range#hashCode()}, что устраняет риск деградации хэш-карты
-   * при коллизиях ключей.
-   *
-   * @param range диапазон имени метода/типа
-   * @return ключ вида {@code "startLine:startChar:endLine:endChar"}
-   */
-  private static String rangeKey(Range range) {
-    var start = range.getStart();
-    var end = range.getEnd();
-    return start.getLine() + ":" + start.getCharacter() + ":" + end.getLine() + ":" + end.getCharacter();
-  }
-
-  /**
-   * Собирает все {@code doCall}-узлы документа в карту по диапазону имени
-   * вызываемого метода (для конструктора — по диапазону имени типа).
-   * <p>
-   * Этот диапазон совпадает с {@link Reference#selectionRange()} соответствующей
-   * ссылки, что позволяет резолвить вызов по ссылке без повторного обхода AST.
-   *
-   * @param documentContext контекст документа, AST которого обходится
-   * @return карта «ключ диапазона имени метода → узел вызова»; пустая, если вызовов нет
-   */
-  private static Map<String, BSLParser.DoCallContext> collectDoCallsByMethodNameRange(
-    DocumentContext documentContext
-  ) {
-    var ast = documentContext.getAst();
-    var doCalls = Trees.findAllRuleNodes(ast, BSLParser.RULE_doCall);
-    Map<String, BSLParser.DoCallContext> result = HashMap.newHashMap(doCalls.size());
-    for (var node : doCalls) {
-      var doCall = (BSLParser.DoCallContext) node;
-      methodNameRange(doCall.getParent())
-        .ifPresent(methodNameRange -> result.putIfAbsent(rangeKey(methodNameRange), doCall));
+      doCallRangeIndex.doCallFor(reference)
+        .ifPresent(doCall -> result.addAll(toInlayHints(reference, doCall)));
     }
     return result;
   }
@@ -216,32 +167,5 @@ public class SourceDefinedMethodCallInlayHintSupplier extends AbstractMethodCall
     var markdown = descriptionFormatter.parameterToString(parameter);
     var tooltip = new MarkupContent(MarkupKind.MARKDOWN, markdown);
     inlayHint.setTooltip(tooltip);
-  }
-
-
-  /**
-   * Диапазон имени вызываемого метода для родителя {@code doCall}-узла —
-   * именно его {@link ReferenceIndex} хранит в {@link Reference#selectionRange()}.
-   *
-   * @param doCallParent родительский узел вызова (methodCall, globalMethodCall или newExpression)
-   * @return диапазон имени метода/типа либо {@link Optional#empty()},
-   *   если узел не является вызовом метода
-   */
-  private static Optional<Range> methodNameRange(ParserRuleContext doCallParent) {
-    if (doCallParent instanceof BSLParser.MethodCallContext methodCallContext) {
-      var methodName = methodCallContext.methodName();
-      return methodName == null ? Optional.empty() : Optional.of(Ranges.create(methodName));
-    } else if (doCallParent instanceof BSLParser.GlobalMethodCallContext globalMethodCallContext) {
-      var methodName = globalMethodCallContext.methodName();
-      return methodName == null ? Optional.empty() : Optional.of(Ranges.create(methodName));
-    } else if (doCallParent instanceof BSLParser.NewExpressionContext newExpressionContext) {
-      var typeName = newExpressionContext.typeName();
-      if (typeName != null && typeName.IDENTIFIER() != null) {
-        return Optional.of(Ranges.create(typeName.IDENTIFIER()));
-      }
-      return Optional.empty();
-    } else {
-      return Optional.empty();
-    }
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierUnitTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierUnitTest.java
@@ -21,10 +21,19 @@
  */
 package com.github._1c_syntax.bsl.languageserver.inlayhints;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
+import com.github._1c_syntax.bsl.languageserver.configuration.inlayhints.InlayHintOptions;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Resources;
+import com.github._1c_syntax.bsl.parser.BSLTokenizer;
+import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -36,7 +45,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.List;
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -74,6 +87,65 @@ class PlatformMethodCallInlayHintSupplierUnitTest {
     var hints = supplier.getInlayHints(documentContext, params);
 
     // then — L96 return List.of().
+    assertThat(hints).isEmpty();
+  }
+
+  @Test
+  void skippedArgumentShowsDefaultValueHint() {
+    // given — реальный AST с пропущенным средним аргументом `СтрНайти("a",,"b")`;
+    // сигнатура содержит средний параметр со значением по умолчанию.
+    when(documentContext.getAst()).thenReturn(new BSLTokenizer("СтрНайти(\"a\",,\"b\");\n").getAst());
+
+    var signature = SignatureDescriptor.of(List.of(
+      ParameterDescriptor.of("СтрокаПоиска"),
+      new ParameterDescriptor("НачальнаяПозиция", TypeSet.EMPTY, true, "", "1"),
+      ParameterDescriptor.of("Подстрока")
+    ));
+    var member = MemberDescriptor.method("СтрНайти", List.of(signature));
+    var typedMember = new TypeService.TypedMember(null, member, Ranges.create(0, 0, 8), 3);
+
+    when(configuration.getLanguage()).thenReturn(Language.RU);
+    when(configuration.getInlayHintOptions()).thenReturn(new InlayHintOptions());
+    when(typeService.memberAt(any(), any())).thenReturn(Optional.of(typedMember));
+    when(typeService.expressionTypesAt(any(), any())).thenReturn(TypeSet.EMPTY);
+
+    var params = new InlayHintParams();
+    params.setRange(new Range(new Position(0, 0), new Position(1, 0)));
+
+    // when
+    var hints = supplier.getInlayHints(documentContext, params);
+
+    // then — для пропущенного среднего аргумента показан хинт со значением по умолчанию.
+    assertThat(hints)
+      .extracting(InlayHint::getLabel)
+      .extracting(either -> either.getLeft())
+      .contains("НачальнаяПозиция (1)");
+  }
+
+  @Test
+  void emptySingleArgumentDoesNotProduceHint() {
+    // given — `Сообщить()` парсится как один пустой callParam; это ноль фактических
+    // аргументов, а не пропущенный — хинт показывать нельзя.
+    when(documentContext.getAst()).thenReturn(new BSLTokenizer("Сообщить();\n").getAst());
+
+    var signature = SignatureDescriptor.of(List.of(
+      new ParameterDescriptor("ТекстСообщения", TypeSet.EMPTY, true, "", "Пустая строка")
+    ));
+    var member = MemberDescriptor.method("Сообщить", List.of(signature));
+    var typedMember = new TypeService.TypedMember(null, member, Ranges.create(0, 0, 8), 0);
+
+    when(configuration.getLanguage()).thenReturn(Language.RU);
+    when(configuration.getInlayHintOptions()).thenReturn(new InlayHintOptions());
+    when(typeService.memberAt(any(), any())).thenReturn(Optional.of(typedMember));
+    when(typeService.expressionTypesAt(any(), any())).thenReturn(TypeSet.EMPTY);
+
+    var params = new InlayHintParams();
+    params.setRange(new Range(new Position(0, 0), new Position(1, 0)));
+
+    // when
+    var hints = supplier.getInlayHints(documentContext, params);
+
+    // then — ноль аргументов: хинтов нет.
     assertThat(hints).isEmpty();
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierUnitTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierUnitTest.java
@@ -87,7 +87,7 @@ class PlatformMethodCallInlayHintSupplierUnitTest {
     // when
     var hints = supplier.getInlayHints(documentContext, params);
 
-    // then — L96 return List.of().
+    // then — при отсутствии AST подсказок нет.
     assertThat(hints).isEmpty();
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierUnitTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierUnitTest.java
@@ -37,6 +37,7 @@ import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -92,7 +93,7 @@ class PlatformMethodCallInlayHintSupplierUnitTest {
 
   @Test
   void skippedArgumentShowsDefaultValueHint() {
-    // given — реальный AST с пропущенным средним аргументом `СтрНайти("a",,"b")`;
+    // given — реальный AST вызова СтрНайти с пропущенным средним аргументом;
     // сигнатура содержит средний параметр со значением по умолчанию.
     when(documentContext.getAst()).thenReturn(new BSLTokenizer("СтрНайти(\"a\",,\"b\");\n").getAst());
 
@@ -118,7 +119,7 @@ class PlatformMethodCallInlayHintSupplierUnitTest {
     // then — для пропущенного среднего аргумента показан хинт со значением по умолчанию.
     assertThat(hints)
       .extracting(InlayHint::getLabel)
-      .extracting(either -> either.getLeft())
+      .extracting(Either::getLeft)
       .contains("НачальнаяПозиция (1)");
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplierTest.java
@@ -27,10 +27,12 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintKind;
 import org.eclipse.lsp4j.InlayHintParams;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -143,6 +145,40 @@ class SourceDefinedMethodCallInlayHintSupplierTest extends AbstractServerContext
       })
     ;
   }
+  @Test
+  void testHintsAreEmittedForEveryCallSiteOfSameMethod() {
+
+    // given — ChangeHealth(...) вызывается в нескольких процедурах файла; диапазон
+    // охватывает весь документ, поэтому в выборку попадают все вызовы метода.
+    var documentContext = TestUtils.getDocumentContextFromFile(FILE_PATH);
+    var lines = documentContext.getContentList();
+    var lastLine = Math.max(0, lines.length - 1);
+    var fullRange = new Range(
+      new Position(0, 0),
+      Ranges.create(lastLine, 0, lines[lastLine].length()).getEnd()
+    );
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var params = new InlayHintParams(textDocumentIdentifier, fullRange);
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then — каждый из восьми вызовов ChangeHealth(...) даёт по две подсказки
+    // (PlayersHealth и Amount), а позиции подсказок уникальны (вызовы не схлопнулись).
+    var changeHealthHints = inlayHints.stream()
+      .filter(hint -> hint.getLabel().isLeft())
+      .filter(hint -> {
+        var label = hint.getLabel().getLeft();
+        return "PlayersHealth:".equals(label) || "Amount:".equals(label);
+      })
+      .toList();
+    assertThat(changeHealthHints).hasSize(16);
+    assertThat(changeHealthHints)
+      .extracting(InlayHint::getPosition)
+      .doesNotHaveDuplicates();
+  }
+
   @Test
   void testConstructorCallInlayHints() {
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplierTest.java
@@ -180,6 +180,112 @@ class SourceDefinedMethodCallInlayHintSupplierTest extends AbstractServerContext
   }
 
   @Test
+  void testEmptyArgumentShowsDefaultValueHint() {
+
+    // given — вызов метода с единственным пустым доводом: парсер формирует один
+    // пустой callParam, и при включённом показе значений по умолчанию подсказка
+    // содержит имя параметра и его значение по умолчанию.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Внешняя()
+          Внутренняя();
+      КонецПроцедуры
+
+      Процедура Внутренняя(Знач Параметр = 1)
+      КонецПроцедуры
+      """);
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var range = documentContext.getSymbolTree().getMethods().getFirst().getRange();
+    var params = new InlayHintParams(textDocumentIdentifier, range);
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then
+    assertThat(inlayHints)
+      .extracting(InlayHint::getLabel)
+      .extracting(Either::getLeft)
+      .containsExactly("Параметр (1)");
+  }
+
+  @Test
+  void testFewerArgumentsThanParametersStopAtLastPassedArgument() {
+
+    // given — аргументов меньше, чем параметров: обход прерывается на последнем
+    // переданном доводе, для отсутствующих доводов подсказки не формируются.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Внешняя()
+          Внутренняя(5);
+      КонецПроцедуры
+
+      Процедура Внутренняя(Знач Первый, Знач Второй, Знач Третий)
+      КонецПроцедуры
+      """);
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var range = documentContext.getSymbolTree().getMethods().getFirst().getRange();
+    var params = new InlayHintParams(textDocumentIdentifier, range);
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then — подсказка только для переданного первого довода.
+    assertThat(inlayHints)
+      .extracting(InlayHint::getLabel)
+      .extracting(Either::getLeft)
+      .containsExactly("Первый:");
+  }
+
+  @Test
+  void testRangeWithoutMethodCallsProducesNoHints() {
+
+    // given — диапазон не охватывает ни одного вызова метода: ссылок нет,
+    // поэтому возвращается пустой список.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Внешняя()
+          Перем ЛокальнаяПеременная;
+      КонецПроцедуры
+      """);
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var params = new InlayHintParams(textDocumentIdentifier, new Range(new Position(0, 0), new Position(0, 0)));
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then
+    assertThat(inlayHints).isEmpty();
+  }
+
+  @Test
+  void testSkippedArgumentShowsDefaultValueHint() {
+
+    // given — пропущенный первый аргумент при включённом показе значений по умолчанию:
+    // подсказка содержит имя параметра и его значение по умолчанию.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Внешняя()
+          Внутренняя(, 5);
+      КонецПроцедуры
+
+      Процедура Внутренняя(Знач Первый = 42, Знач Второй = 0)
+      КонецПроцедуры
+      """);
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var range = documentContext.getSymbolTree().getMethods().getFirst().getRange();
+    var params = new InlayHintParams(textDocumentIdentifier, range);
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then
+    assertThat(inlayHints)
+      .extracting(InlayHint::getLabel)
+      .extracting(Either::getLeft)
+      .contains("Первый (42)");
+  }
+
+  @Test
   void testConstructorCallInlayHints() {
 
     // given


### PR DESCRIPTION
## Проблема

Две связанные проблемы в inlay-подсказках вызовов методов:

1. **Пропущенные значения по умолчанию.** В `PlatformMethodCallInlayHintSupplier` любой пустой `callParam` отбрасывался целиком (защита от `Новый Тип()` с единственным пустым аргументом). Из-за этого ветка `showDefaultValues` в `buildLabel` была недостижима для ПРОПУЩЕННЫХ аргументов (`Метод(а,,б)` и опущенных хвостовых) — подсказка со значением по умолчанию не показывалась.

2. **Квадратичный обход AST.** `SourceDefinedMethodCallInlayHintSupplier` на КАЖДУЮ ссылку метода вызывал `Trees.findAllRuleNodes` по всему AST документа (O(ссылки × узлы)). На файлах с множеством вызовов это давало заметную деградацию.

## Решение

**Часть 1 — значения по умолчанию (commit `cfa9f3f`).**
Пустой довод трактуется как пропущенный аргумент только при наличии нескольких `callParam`'ов (есть запятая). Для такого аргумента при включённом `showDefaultValues` показывается hint со значением по умолчанию из сигнатуры. Единственный пустой `callParam` (`Метод()` / `Новый Тип()` — ноль аргументов) по-прежнему хинтов не даёт.

**Часть 2 — перформанс (commit `5f4550a`).**
Все `doCall`-узлы документа собираются за ОДИН обход AST в `Map<Range, DoCallContext>` по диапазону имени вызываемого метода (для конструктора — по диапазону имени типа). Этот диапазон совпадает с `Reference#selectionRange()`, поэтому вызов резолвится по ссылке за O(1)-лукап вместо обхода AST на каждую ссылку. Поведение не изменено.

## Тесты

- Новый `PlatformMethodCallInlayHintSupplierUnitTest` (часть 1): пропущенный аргумент со значением по умолчанию, отсутствие хинтов для `Метод()`/`Новый Тип()`.
- Новый `testHintsAreEmittedForEveryCallSiteOfSameMethod` в `SourceDefinedMethodCallInlayHintSupplierTest` (часть 2): подтверждает, что подсказки эмитятся для каждого из 8 вызовов одного метода (16 хинтов) и позиции не схлопываются — гарантия, что O(1)-лукап не теряет вызовы. Дополнение, не ослабление существующих ассертов.
- Зелёные: `SourceDefinedMethodCallInlayHintSupplierTest`, `PlatformMethodCallInlayHintSupplierTest`, `PlatformMethodCallInlayHintSupplierUnitTest`, `InlayHintProviderTest`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Inlay hints for calls with skipped or blank arguments now correctly show parameter names and default values only when appropriate.
  * Empty single-argument call forms no longer produce spurious inlay hints.

* **Performance**
  * Improved resolution so inlay hints for source-defined methods are generated without scanning the entire document for each reference.

* **Tests**
  * Added unit tests verifying skipped-argument hint behavior and that hints are emitted for every call site.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->