### PR TITLE
fix(CodeActionProvider): учитывать context.triggerKind при формировании быстрых действий

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/DisableDiagnosticTriggeringSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/DisableDiagnosticTriggeringSupplier.java
@@ -30,6 +30,7 @@ import org.antlr.v4.runtime.Token;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.CodeActionTriggerKind;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
@@ -78,7 +79,15 @@ public class DisableDiagnosticTriggeringSupplier implements CodeActionSupplier {
   public List<CodeAction> getCodeActions(CodeActionParams params, DocumentContext documentContext) {
     List<CodeAction> result = new ArrayList<>();
 
-    if (!params.getContext().getDiagnostics().isEmpty()) {
+    var diagnosticsPresent = !params.getContext().getDiagnostics().isEmpty();
+
+    // При автоматическом вызове (лампочка при движении курсора) предлагаем действия
+    // только если в контексте есть диагностики, иначе меню действий замусоривается на каждой строке.
+    if (isAutomaticTrigger(params) && !diagnosticsPresent) {
+      return result;
+    }
+
+    if (diagnosticsPresent) {
       if (params.getRange().getStart() != null && params.getRange().getEnd() != null) {
         var selectedLineNumber = params.getRange().getEnd().getLine() + 1;
 
@@ -117,6 +126,10 @@ public class DisableDiagnosticTriggeringSupplier implements CodeActionSupplier {
       )
     );
     return new ArrayList<>(result);
+  }
+
+  private static boolean isAutomaticTrigger(CodeActionParams params) {
+    return params.getContext().getTriggerKind() == CodeActionTriggerKind.Automatic;
   }
 
   private List<CodeAction> getDisableActionForLine(

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplier.java
@@ -32,6 +32,7 @@ import com.github._1c_syntax.bsl.types.ScriptVariant;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.CodeActionTriggerKind;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextEdit;
@@ -69,6 +70,13 @@ public class GenerateStandardRegionsSupplier implements CodeActionSupplier {
    */
   @Override
   public List<CodeAction> getCodeActions(CodeActionParams params, DocumentContext documentContext) {
+
+    // Генерация областей предлагается только при явном вызове меню действий (Invoked либо устаревший
+    // клиент без triggerKind). При автоматическом вызове (лампочка при движении курсора) действие
+    // не предлагается, чтобы не замусоривать меню на каждой строке.
+    if (params.getContext().getTriggerKind() == CodeActionTriggerKind.Automatic) {
+      return Collections.emptyList();
+    }
 
     var moduleType = documentContext.getModuleType();
     var fileType = documentContext.getFileType();

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/codeactions/DisableDiagnosticTriggeringSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/codeactions/DisableDiagnosticTriggeringSupplierTest.java
@@ -29,6 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.CodeActionTriggerKind;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -211,6 +212,91 @@ class DisableDiagnosticTriggeringSupplierTest {
 
     List<CodeAction> codeActions = codeActionSupplier.getCodeActions(params, documentContext);
 
+    assertThat(codeActions)
+      .hasSize(1)
+      .anyMatch(codeAction -> codeAction.getTitle().equals("Disable all diagnostic in file"));
+  }
+
+  @Test
+  void testAutomaticTriggerWithoutDiagnosticsReturnsNothing() {
+
+    // given
+    var documentContext = TestUtils.getDocumentContextFromFile(
+      "./src/test/resources/suppliers/disableDiagnosticTriggeringEmpty.bsl"
+    );
+    configuration.setLanguage(Language.EN);
+
+    TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(documentContext.getUri().toString());
+
+    CodeActionContext codeActionContext = new CodeActionContext();
+    codeActionContext.setDiagnostics(List.of());
+    codeActionContext.setTriggerKind(CodeActionTriggerKind.Automatic);
+
+    CodeActionParams params = new CodeActionParams();
+    params.setRange(new Range());
+    params.setTextDocument(textDocumentIdentifier);
+    params.setContext(codeActionContext);
+
+    // when
+    List<CodeAction> codeActions = codeActionSupplier.getCodeActions(params, documentContext);
+
+    // then
+    assertThat(codeActions).isEmpty();
+  }
+
+  @Test
+  void testAutomaticTriggerWithDiagnosticsReturnsDisableInFile() {
+
+    // given
+    var documentContext = TestUtils.getDocumentContextFromFile(
+      "./src/test/resources/suppliers/disableDiagnosticTriggering.bsl"
+    );
+    configuration.setLanguage(Language.EN);
+
+    TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(documentContext.getUri().toString());
+
+    CodeActionContext codeActionContext = new CodeActionContext();
+    codeActionContext.setDiagnostics(documentContext.getDiagnostics());
+    codeActionContext.setTriggerKind(CodeActionTriggerKind.Automatic);
+
+    CodeActionParams params = new CodeActionParams();
+    params.setRange(new Range());
+    params.setTextDocument(textDocumentIdentifier);
+    params.setContext(codeActionContext);
+
+    // when
+    List<CodeAction> codeActions = codeActionSupplier.getCodeActions(params, documentContext);
+
+    // then
+    assertThat(codeActions)
+      .isNotEmpty()
+      .anyMatch(codeAction -> codeAction.getTitle().equals("Disable all diagnostic in file"));
+  }
+
+  @Test
+  void testInvokedTriggerWithoutDiagnosticsReturnsDisableAllInFile() {
+
+    // given
+    var documentContext = TestUtils.getDocumentContextFromFile(
+      "./src/test/resources/suppliers/disableDiagnosticTriggeringEmpty.bsl"
+    );
+    configuration.setLanguage(Language.EN);
+
+    TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(documentContext.getUri().toString());
+
+    CodeActionContext codeActionContext = new CodeActionContext();
+    codeActionContext.setDiagnostics(List.of());
+    codeActionContext.setTriggerKind(CodeActionTriggerKind.Invoked);
+
+    CodeActionParams params = new CodeActionParams();
+    params.setRange(new Range());
+    params.setTextDocument(textDocumentIdentifier);
+    params.setContext(codeActionContext);
+
+    // when
+    List<CodeAction> codeActions = codeActionSupplier.getCodeActions(params, documentContext);
+
+    // then
     assertThat(codeActions)
       .hasSize(1)
       .anyMatch(codeAction -> codeAction.getTitle().equals("Disable all diagnostic in file"));

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplierTest.java
@@ -28,6 +28,7 @@ import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
+import org.eclipse.lsp4j.CodeActionTriggerKind;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
@@ -77,4 +78,59 @@ class GenerateStandardRegionsSupplierTest {
       .hasSize(1)
       .anyMatch(codeAction -> codeAction.getTitle().equals("Generate missing regions"));
   }
+
+  @Test
+  void testAutomaticTriggerReturnsNothing() {
+
+    // given
+    String filePath = "./src/test/resources/suppliers/generateRegion.bsl";
+    var documentContext = TestUtils.getDocumentContextFromFile(filePath);
+    configuration.setLanguage(Language.EN);
+
+    TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(documentContext.getUri().toString());
+
+    CodeActionContext codeActionContext = new CodeActionContext();
+    codeActionContext.setDiagnostics(new ArrayList<>());
+    codeActionContext.setTriggerKind(CodeActionTriggerKind.Automatic);
+
+    CodeActionParams params = new CodeActionParams();
+    params.setRange(new Range());
+    params.setTextDocument(textDocumentIdentifier);
+    params.setContext(codeActionContext);
+
+    // when
+    List<CodeAction> codeActions = codeActionSupplier.getCodeActions(params, documentContext);
+
+    // then
+    assertThat(codeActions).isEmpty();
+  }
+
+  @Test
+  void testInvokedTriggerReturnsRegions() {
+
+    // given
+    String filePath = "./src/test/resources/suppliers/generateRegion.bsl";
+    var documentContext = TestUtils.getDocumentContextFromFile(filePath);
+    configuration.setLanguage(Language.EN);
+
+    TextDocumentIdentifier textDocumentIdentifier = new TextDocumentIdentifier(documentContext.getUri().toString());
+
+    CodeActionContext codeActionContext = new CodeActionContext();
+    codeActionContext.setDiagnostics(new ArrayList<>());
+    codeActionContext.setTriggerKind(CodeActionTriggerKind.Invoked);
+
+    CodeActionParams params = new CodeActionParams();
+    params.setRange(new Range());
+    params.setTextDocument(textDocumentIdentifier);
+    params.setContext(codeActionContext);
+
+    // when
+    List<CodeAction> codeActions = codeActionSupplier.getCodeActions(params, documentContext);
+
+    // then
+    assertThat(codeActions)
+      .hasSize(1)
+      .anyMatch(codeAction -> codeAction.getTitle().equals("Generate missing regions"));
+  }
+
 }


### PR DESCRIPTION
## Проблема

При автоматическом вызове code actions (`CodeActionTriggerKind.Automatic` — лампочка, всплывающая при движении курсора) клиент получал действия, которые в этом режиме только замусоривают меню на каждой строке:

- `DisableDiagnosticTriggeringSupplier` всегда добавлял «Disable all diagnostic in file», даже когда в контексте нет ни одной диагностики;
- `GenerateStandardRegionsSupplier` всегда предлагал генерацию стандартных областей.

## Решение

Оба сапплаера теперь учитывают `context.triggerKind`:

- `DisableDiagnosticTriggeringSupplier`: при `Automatic` без диагностик в контексте возвращает пустой список; если диагностики есть — поведение прежнее. При `Invoked` (и при отсутствии triggerKind) «Disable all diagnostic in file» предлагается как раньше.
- `GenerateStandardRegionsSupplier`: при `Automatic` возвращает пустой список; при `Invoked`/отсутствии triggerKind — прежнее поведение.

Отсутствующий `triggerKind` (`null`) трактуется как `Invoked`, поэтому поведение старых клиентов, не передающих это поле, не меняется.

## Тесты

Добавлены тесты в `DisableDiagnosticTriggeringSupplierTest` и `GenerateStandardRegionsSupplierTest` на ветки Automatic (с диагностиками и без) и Invoked. Перед реализацией доказана краснота: со спрятанными прод-правками падали ровно два «Automatic»-теста, остальные (включая Invoked-обратную совместимость) проходили. Финальный прогон `DisableDiagnosticTriggeringSupplierTest`, `GenerateStandardRegionsSupplierTest`, `CodeActionProviderTest` — BUILD SUCCESSFUL, все тесты зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)