### PR TITLE
fix(CallHierarchyProvider): раскрывать узел кода модуля в иерархии вызовов

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CallHierarchyProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CallHierarchyProvider.java
@@ -36,6 +36,7 @@ import org.eclipse.lsp4j.CallHierarchyItem;
 import org.eclipse.lsp4j.CallHierarchyOutgoingCall;
 import org.eclipse.lsp4j.CallHierarchyOutgoingCallsParams;
 import org.eclipse.lsp4j.CallHierarchyPrepareParams;
+import org.eclipse.lsp4j.SymbolKind;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -43,6 +44,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Optional;
 
 import static java.util.stream.Collectors.groupingBy;
 import static java.util.stream.Collectors.mapping;
@@ -101,12 +103,9 @@ public class CallHierarchyProvider {
     CallHierarchyIncomingCallsParams params
   ) {
 
-    var uri = documentContext.getUri();
     var item = params.getItem();
-    var position = item.getSelectionRange().getStart();
 
-    return referenceResolver.findReference(uri, position)
-      .flatMap(Reference::getSourceDefinedSymbol)
+    return resolveSymbol(documentContext, item)
       .stream()
       .map(referenceIndex::getReferencesTo)
       .flatMap(Collection::stream)
@@ -133,10 +132,9 @@ public class CallHierarchyProvider {
     CallHierarchyOutgoingCallsParams params
   ) {
 
-    var uri = documentContext.getUri();
-    var position = params.getItem().getSelectionRange().getStart();
-    return referenceResolver.findReference(uri, position)
-      .flatMap(Reference::getSourceDefinedSymbol)
+    var item = params.getItem();
+
+    return resolveSymbol(documentContext, item)
       .stream()
       .map(referenceIndex::getReferencesFrom)
       .flatMap(Collection::stream)
@@ -151,6 +149,28 @@ public class CallHierarchyProvider {
       .map(entry -> new CallHierarchyOutgoingCall(getCallHierarchyItem(entry.getKey()), entry.getValue()))
       .sorted((o1, o2) -> callHierarchyItemComparator.compare(o1.getTo(), o2.getTo()))
       .toList();
+  }
+
+  /**
+   * Разрешить символ, соответствующий элементу иерархии вызовов.
+   * <p>
+   * Для элементов-методов символ повторно резолвится по позиции {@code selectionRange.getStart()}
+   * через {@link ReferenceResolver}. Для элемента-модуля ({@link SymbolKind#Module}) символ модуля
+   * не находится по позиции (первый токен тела модуля не является ссылкой), поэтому он берётся
+   * напрямую из символьного дерева документа.
+   *
+   * @param documentContext Контекст документа, которому принадлежит элемент иерархии.
+   * @param item            Элемент иерархии вызовов.
+   * @return Символ, соответствующий элементу, либо пустое значение, если символ не найден.
+   */
+  private Optional<SourceDefinedSymbol> resolveSymbol(DocumentContext documentContext, CallHierarchyItem item) {
+    if (item.getKind() == SymbolKind.Module) {
+      return Optional.of(documentContext.getSymbolTree().getModule());
+    }
+
+    var position = item.getSelectionRange().getStart();
+    return referenceResolver.findReference(documentContext.getUri(), position)
+      .flatMap(Reference::getSourceDefinedSymbol);
   }
 
   private static CallHierarchyItem getCallHierarchyItem(SourceDefinedSymbol sourceDefinedSymbol) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CallHierarchyProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CallHierarchyProviderTest.java
@@ -210,6 +210,50 @@ class CallHierarchyProviderTest {
   }
 
   @Test
+  void testOutgoingCallsFromModuleEntryNode() {
+
+    // given
+    var methodItem = getCallHierarchyItem(secondFunctionDeclarationPosition);
+    var incomingParams = new CallHierarchyIncomingCallsParams(methodItem);
+    var moduleItem = provider.incomingCalls(documentContext, incomingParams).stream()
+      .map(CallHierarchyIncomingCall::getFrom)
+      .filter(item -> item.getKind().equals(SymbolKind.Module))
+      .findFirst()
+      .orElseThrow();
+    var params = new CallHierarchyOutgoingCallsParams(moduleItem);
+
+    // when
+    List<CallHierarchyOutgoingCall> outgoingCalls = provider.outgoingCalls(documentContext, params);
+
+    // then
+    assertThat(outgoingCalls)
+      .filteredOn(outgoingCall -> outgoingCall.getTo().getName().equals("ВтораяФункция"))
+      .flatExtracting(CallHierarchyOutgoingCall::getFromRanges)
+      .hasSize(1)
+    ;
+  }
+
+  @Test
+  void testIncomingCallsToModuleEntryNode() {
+
+    // given
+    var methodItem = getCallHierarchyItem(secondFunctionDeclarationPosition);
+    var incomingParams = new CallHierarchyIncomingCallsParams(methodItem);
+    var moduleItem = provider.incomingCalls(documentContext, incomingParams).stream()
+      .map(CallHierarchyIncomingCall::getFrom)
+      .filter(item -> item.getKind().equals(SymbolKind.Module))
+      .findFirst()
+      .orElseThrow();
+    var params = new CallHierarchyIncomingCallsParams(moduleItem);
+
+    // when
+    List<CallHierarchyIncomingCall> incomingCalls = provider.incomingCalls(documentContext, params);
+
+    // then
+    assertThat(incomingCalls).isEmpty();
+  }
+
+  @Test
   void testOutgoingCallsLocalMethodCall() {
 
     // given


### PR DESCRIPTION
## Проблема

В иерархии вызовов, когда вызывающим оказывался код тела модуля, в incoming попадал элемент с `kind=Module` (закреплено тестом `testIncomingCallsToMethodCalledFromModuleEntry`). Однако раскрыть этот узел в клиенте было нельзя: `incomingCalls`/`outgoingCalls` повторно резолвили символ по позиции `selectionRange.getStart()` через `ReferenceResolver`, а на позиции первого токена тела модуля ссылка не находится (`SourceDefinedSymbolDeclarationReferenceFinder` обходит только `getChildrenFlat()`, исключающий сам символ модуля). В результате `ModuleSymbol` не возвращался, и узел становился тупиковым — исходящие вызовы из тела модуля не раскрывались.

## Решение

В `CallHierarchyProvider` выделен метод `resolveSymbol(documentContext, item)`. Для элемента `kind=Module` символ берётся напрямую из символьного дерева документа (`SymbolTree.getModule()`), минуя резолв по позиции. Для остальных элементов поведение прежнее — резолв через `ReferenceResolver` по `selectionRange.getStart()`.

Благодаря этому:
- исходящие вызовы из тела модуля (`outgoingCalls`) корректно раскрываются;
- входящие вызовы к телу модуля (`incomingCalls`) для BSL корректно отдают пустой список (никто не вызывает тело модуля) и не падают.

## Тесты

- `testOutgoingCallsFromModuleEntryNode` — берёт Module-узел из incoming метода `ВтораяФункция`, проверяет, что `outgoingCalls` возвращает вызов `ВтораяФункция()` из тела модуля (до фикса — пусто).
- `testIncomingCallsToModuleEntryNode` — проверяет, что `incomingCalls` на Module-узле не падает и возвращает пустой список.

Финальный прогон `CallHierarchyProviderTest`: BUILD SUCCESSFUL, 10 тестов зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)