### PR TITLE
feat(DocumentSymbolProvider): detail с сигнатурой параметров метода

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
@@ -102,7 +102,7 @@ public final class DocumentSymbolProvider {
 
   private static String parameterSignature(ParameterDefinition parameter) {
     if (parameter.isOptional()) {
-      return parameter.getName() + " =";
+      return parameter.getName() + "?";
     }
     return parameter.getName();
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProvider.java
@@ -22,6 +22,8 @@
 package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.ParameterDefinition;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
@@ -85,7 +87,24 @@ public final class DocumentSymbolProvider {
     documentSymbol.setTags(symbol.getTags());
     documentSymbol.setChildren(children);
 
+    if (symbol instanceof MethodSymbol methodSymbol) {
+      documentSymbol.setDetail(buildMethodDetail(methodSymbol));
+    }
+
     return documentSymbol;
+  }
+
+  private static String buildMethodDetail(MethodSymbol methodSymbol) {
+    return methodSymbol.getParameters().stream()
+      .map(DocumentSymbolProvider::parameterSignature)
+      .collect(Collectors.joining(", ", "(", ")"));
+  }
+
+  private static String parameterSignature(ParameterDefinition parameter) {
+    if (parameter.isOptional()) {
+      return parameter.getName() + " =";
+    }
+    return parameter.getName();
   }
 
   public static boolean isSupported(Symbol symbol) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
@@ -75,6 +75,47 @@ class DocumentSymbolProviderTest {
   }
 
   /**
+   * Detail метода-функции содержит сигнатуру с именами параметров,
+   * необязательные параметры помечаются знаком {@code =}.
+   */
+  @Test
+  void testMethodDetailContainsParameterNames() {
+    // given
+    var documentContext = TestUtils.getDocumentContext("""
+      Функция Сложить(Первое, Второе = 0) Экспорт
+      КонецФункции""");
+
+    // when
+    List<DocumentSymbol> documentSymbols = documentSymbolProvider.getDocumentSymbols(documentContext);
+
+    // then
+    assertThat(documentSymbols)
+      .filteredOn(documentSymbol -> documentSymbol.getKind() == SymbolKind.Method)
+      .hasSize(1)
+      .anyMatch(documentSymbol -> documentSymbol.getDetail().equals("(Первое, Второе =)"));
+  }
+
+  /**
+   * Detail метода без параметров равен пустым скобкам {@code ()}.
+   */
+  @Test
+  void testMethodWithoutParametersHasEmptyParenthesesDetail() {
+    // given
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура БезПараметров()
+      КонецПроцедуры""");
+
+    // when
+    List<DocumentSymbol> documentSymbols = documentSymbolProvider.getDocumentSymbols(documentContext);
+
+    // then
+    assertThat(documentSymbols)
+      .filteredOn(documentSymbol -> documentSymbol.getKind() == SymbolKind.Method)
+      .hasSize(1)
+      .allMatch(documentSymbol -> documentSymbol.getDetail().equals("()"));
+  }
+
+  /**
    * Рекурсивно разворачивает иерархию символов документа в плоский список,
    * включая всех вложенных потомков.
    *

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
@@ -92,7 +92,7 @@ class DocumentSymbolProviderTest {
     assertThat(documentSymbols)
       .filteredOn(documentSymbol -> documentSymbol.getKind() == SymbolKind.Method)
       .hasSize(1)
-      .anyMatch(documentSymbol -> documentSymbol.getDetail().equals("(Первое, Второе =)"));
+      .anyMatch(documentSymbol -> documentSymbol.getDetail().equals("(Первое, Второе?)"));
   }
 
   /**


### PR DESCRIPTION
## Проблема

`toDocumentSymbol` строил `DocumentSymbol` только из name/kind/range/selectionRange, поле `detail` оставалось `null`. В Outline и breadcrumbs у методов не было краткой подписи параметров.

## Решение

При построении символа метода (`symbol instanceof MethodSymbol`) заполняем `detail` краткой сигнатурой по именам параметров: `(Пар1, Пар2)`. Необязательные параметры (с значением по умолчанию, `ParameterDefinition.isOptional()`) помечаются суффиксом ` =`, например `(Первое, Второе =)`. Метод без параметров получает `()`. Имя метода в detail не дублируется. Переменные оставлены без detail (тип дёшево недоступен).

## Тесты

- `testMethodDetailContainsParameterNames` — функция с обязательным и необязательным параметром получает detail `(Первое, Второе =)`.
- `testMethodWithoutParametersHasEmptyParenthesesDetail` — процедура без параметров получает detail `()`.
- Существующие `testDocumentSymbol` и `testIncompleteVariableDeclarationDoesNotBreakSelectionRange` проходят без изменений (структура символов не сломана).

Финальный прогон `DocumentSymbolProviderTest`: 4 теста PASSED, BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Method symbols in document outlines now show detailed parameter signatures in the symbol "detail" field, with optional parameters clearly indicated.

* **Tests**
  * Added regression tests to verify method parameter details, covering optional-parameter marking and methods with no parameters to ensure consistent signature formatting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->