### PR TITLE
feat(CompletionProvider): сигнатура и тип в labelDetails (LSP 3.17)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -38,6 +38,7 @@ import org.eclipse.lsp4j.CodeActionKind;
 import org.eclipse.lsp4j.CodeActionOptions;
 import org.eclipse.lsp4j.CodeLensOptions;
 import org.eclipse.lsp4j.ColorProviderOptions;
+import org.eclipse.lsp4j.CompletionItemOptions;
 import org.eclipse.lsp4j.CompletionOptions;
 import org.eclipse.lsp4j.DefinitionOptions;
 import org.eclipse.lsp4j.DidChangeWatchedFilesCapabilities;
@@ -417,6 +418,9 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
     var completionOptions = new CompletionOptions();
     completionOptions.setResolveProvider(Boolean.TRUE);
     completionOptions.setTriggerCharacters(List.of("."));
+    var completionItemOptions = new CompletionItemOptions();
+    completionItemOptions.setLabelDetailsSupport(Boolean.TRUE);
+    completionOptions.setCompletionItem(completionItemOptions);
     return completionOptions;
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -49,6 +49,7 @@ import org.eclipse.lsp4j.CompletionCapabilities;
 import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionItemCapabilities;
 import org.eclipse.lsp4j.CompletionItemKind;
+import org.eclipse.lsp4j.CompletionItemLabelDetails;
 import org.eclipse.lsp4j.CompletionItemResolveSupportCapabilities;
 import org.eclipse.lsp4j.CompletionItemTag;
 import org.eclipse.lsp4j.CompletionItemTagSupportCapabilities;
@@ -133,6 +134,13 @@ public final class CompletionProvider {
   // иначе строится жадно, как раньше (клиент без resolve должен получить её сразу).
   private boolean documentationResolveSupport;
 
+  // Кэшируется на initialize. Поддерживает ли клиент completionItem.labelDetailsSupport
+  // (LSP 3.17). Если да — сигнатура метода и возвращаемый тип / тип свойства кладутся в
+  // CompletionItemLabelDetails (detail/description) рядом с именем, а плоский detail не
+  // заполняется, чтобы клиент не показывал ту же сигнатуру дважды. Иначе — прежнее поведение
+  // с записью сигнатуры в плоский detail.
+  private boolean labelDetailsSupport;
+
   @EventListener(LanguageServerInitializeRequestReceivedEvent.class)
   public void handleInitializeEvent() {
     var completionItem = clientCapabilitiesHolder.getCapabilities()
@@ -155,6 +163,9 @@ public final class CompletionProvider {
       .map(CompletionItemCapabilities::getResolveSupport)
       .map(CompletionItemResolveSupportCapabilities::getProperties)
       .map(properties -> properties.contains("documentation"))
+      .orElse(Boolean.FALSE);
+    labelDetailsSupport = completionItem
+      .map(CompletionItemCapabilities::getLabelDetailsSupport)
       .orElse(Boolean.FALSE);
   }
 
@@ -700,8 +711,11 @@ public final class CompletionProvider {
    * <p>
    * Разделение полей по LSP-конвенции:
    * <ul>
-   *   <li>{@code detail} — техническая сводка: сигнатура {@code (param1, [optional])}
-   *       и возвращаемый тип для методов; имя типа для свойств. Никогда не дублирует описание.</li>
+   *   <li>сигнатура {@code (param1, optional?)} и возвращаемый тип для методов, имя типа для
+   *       свойств — техническая сводка. При поддержке клиентом {@code labelDetailsSupport}
+   *       (LSP 3.17) она кладётся в {@code labelDetails} (detail/description) рядом с именем,
+   *       иначе — в плоский {@code detail} (см. {@link #applyDetail}). Никогда не дублирует
+   *       описание.</li>
    *   <li>{@code documentation} — содержательное описание (с deprecation-блоком, если есть).</li>
    * </ul>
    * Раньше {@code purposeDescription} писалось одновременно в {@code detail} и в
@@ -719,16 +733,10 @@ public final class CompletionProvider {
     if (member.kind() == MemberKind.METHOD) {
       item.setKind(methodKind);
       applyCallableInsertText(item, displayName, memberHasParameters(member));
-      var detail = methodDetail(member, scriptVariant);
-      if (!detail.isBlank()) {
-        item.setDetail(detail);
-      }
+      applyMethodDetail(item, member, scriptVariant);
     } else {
       item.setKind(propertyKind);
-      var detail = propertyDetail(member, scriptVariant);
-      if (!detail.isBlank()) {
-        item.setDetail(detail);
-      }
+      applyPropertyDetail(item, member, scriptVariant);
     }
     // documentation тяжела для широких типов (Глобальный контекст, union типов):
     // если клиент умеет lazy-resolve и член резолвим обратно по owner-типу —
@@ -865,18 +873,91 @@ public final class CompletionProvider {
     return !signatures.get(0).parameters().isEmpty();
   }
 
-  private String methodDetail(MemberDescriptor member, Language scriptVariant) {
+  /**
+   * Заполняет детали пункта автодополнения для метода. При поддержке клиентом
+   * {@code completionItem.labelDetailsSupport} сигнатура «{@code (Пар1, Пар2?)}» кладётся в
+   * {@link CompletionItemLabelDetails#setDetail}, возвращаемый тип — в
+   * {@link CompletionItemLabelDetails#setDescription}, а плоский {@code detail} не заполняется,
+   * чтобы клиент не показывал сигнатуру дважды. Иначе сигнатура и тип возврата записываются в
+   * плоский {@code detail} строкой «{@code (Пар1, Пар2?): Тип}» (прежнее поведение). Несколько
+   * перегрузок передаются строкой-счётчиком вариантов синтаксиса.
+   *
+   * @param item          пункт автодополнения, которому проставляются детали.
+   * @param member        описатель члена-метода, из которого берутся сигнатуры.
+   * @param scriptVariant язык отображаемых имён параметров и типа возврата.
+   */
+  private void applyMethodDetail(CompletionItem item, MemberDescriptor member, Language scriptVariant) {
     var signatures = member.signatures();
     if (signatures.size() > 1) {
-      return formatSignaturesCount(signatures.size(), scriptVariant);
+      var count = formatSignaturesCount(signatures.size(), scriptVariant);
+      applyDetail(item, count, "");
+      return;
     }
     if (signatures.isEmpty()) {
-      return "";
+      return;
     }
-    return formatSignature(signatures.get(0), scriptVariant);
+    var signature = signatures.get(0);
+    var paramList = formatParameterList(signature, scriptVariant);
+    var returnTypeName = formatTypeName(signature.returnType(), scriptVariant);
+    applyDetail(item, paramList, returnTypeName);
   }
 
-  private String formatSignature(SignatureDescriptor signature, Language scriptVariant) {
+  /**
+   * Заполняет детали пункта автодополнения для свойства. При поддержке клиентом
+   * {@code completionItem.labelDetailsSupport} имя типа члена кладётся в
+   * {@link CompletionItemLabelDetails#setDescription}, а плоский {@code detail} не заполняется.
+   * Иначе имя типа записывается в плоский {@code detail} (прежнее поведение).
+   *
+   * @param item          пункт автодополнения, которому проставляются детали.
+   * @param member        описатель члена-свойства, из которого берётся тип.
+   * @param scriptVariant язык отображаемого имени типа.
+   */
+  private void applyPropertyDetail(CompletionItem item, MemberDescriptor member, Language scriptVariant) {
+    var typeName = formatTypeName(member.returnType(), scriptVariant);
+    applyDetail(item, "", typeName);
+  }
+
+  /**
+   * Раскладывает сигнатуру и тип по полям пункта автодополнения с учётом клиентских
+   * capabilities. При поддержке {@code completionItem.labelDetailsSupport} {@code signature}
+   * (например, «{@code (Пар1, Пар2?)}») идёт в {@link CompletionItemLabelDetails#setDetail}, а
+   * {@code type} — в {@link CompletionItemLabelDetails#setDescription}; плоский {@code detail}
+   * не трогается. Иначе оба склеиваются в плоский {@code detail} строкой
+   * «{@code signature: type}», а если signature пустая — записывается только {@code type}.
+   *
+   * @param item      пункт автодополнения, которому проставляются детали.
+   * @param signature сигнатура «{@code (...)}» либо строка-счётчик вариантов; может быть пустой.
+   * @param type      возвращаемый тип метода или тип свойства; может быть пустым.
+   */
+  private void applyDetail(CompletionItem item, String signature, String type) {
+    if (labelDetailsSupport) {
+      if (signature.isBlank() && type.isBlank()) {
+        return;
+      }
+      var labelDetails = new CompletionItemLabelDetails();
+      if (!signature.isBlank()) {
+        labelDetails.setDetail(signature);
+      }
+      if (!type.isBlank()) {
+        labelDetails.setDescription(type);
+      }
+      item.setLabelDetails(labelDetails);
+      return;
+    }
+    var sb = new StringBuilder(signature);
+    if (!type.isBlank()) {
+      if (sb.length() > 0) {
+        sb.append(": ");
+      }
+      sb.append(type);
+    }
+    if (sb.length() > 0) {
+      item.setDetail(sb.toString());
+    }
+  }
+
+  /** Сигнатура «{@code (Пар1, Пар2?)}» с пометкой «?» у необязательных параметров. */
+  private String formatParameterList(SignatureDescriptor signature, Language scriptVariant) {
     var sb = new StringBuilder();
     sb.append('(');
     var params = signature.parameters();
@@ -893,15 +974,7 @@ public final class CompletionProvider {
       }
     }
     sb.append(')');
-    var returnTypeName = formatTypeName(signature.returnType(), scriptVariant);
-    if (!returnTypeName.isEmpty()) {
-      sb.append(": ").append(returnTypeName);
-    }
     return sb.toString();
-  }
-
-  private String propertyDetail(MemberDescriptor member, Language scriptVariant) {
-    return formatTypeName(member.returnType(), scriptVariant);
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -92,6 +92,19 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
     completionProvider.handleInitializeEvent();
   }
 
+  private void enableLabelDetailsSupport(boolean enabled) {
+    var itemCaps = new CompletionItemCapabilities();
+    itemCaps.setLabelDetailsSupport(enabled);
+    var completionCaps = new CompletionCapabilities();
+    completionCaps.setCompletionItem(itemCaps);
+    var textDocumentCaps = new TextDocumentClientCapabilities();
+    textDocumentCaps.setCompletion(completionCaps);
+    var caps = new ClientCapabilities();
+    caps.setTextDocument(textDocumentCaps);
+    clientCapabilitiesHolder.setCapabilities(caps);
+    completionProvider.handleInitializeEvent();
+  }
+
   @Test
   void dotCompletionOnValueTableColumnsPropertyInCombinedScenario() {
     // Trailing-dot после `ТЗ1.Колонки.` плюс следующий statement в той же процедуре.
@@ -1203,6 +1216,90 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .as("без поддержки markdown документация отдаётся голой строкой (plaintext)")
       .isTrue();
     assertThat(doc.getLeft()).contains("Добавляет значение");
+  }
+
+  @Test
+  void methodSignatureGoesToLabelDetailsWhenClientSupportsLabelDetails() {
+    // given
+    // Клиент заявил completionItem.labelDetailsSupport: сигнатуру и тип возврата
+    // кладём в labelDetails (detail/description) и не дублируем в плоский detail.
+    enableLabelDetailsSupport(true);
+    languageServerConfiguration.setLanguage(Language.RU);
+    var documentContext = TestUtils.getDocumentContext("М = Новый Массив;\nМ.");
+
+    // when
+    CompletionItem count;
+    try {
+      count = dotCompletionItem(documentContext, new Position(1, 2), "Количество");
+    } finally {
+      languageServerConfiguration.setLanguage(Language.DEFAULT_LANGUAGE);
+    }
+
+    // then
+    var labelDetails = count.getLabelDetails();
+    assertThat(labelDetails)
+      .as("при поддержке labelDetailsSupport сигнатура кладётся в labelDetails")
+      .isNotNull();
+    assertThat(labelDetails.getDetail())
+      .as("labelDetails.detail — сигнатура «()»")
+      .isEqualTo("()");
+    assertThat(labelDetails.getDescription())
+      .as("labelDetails.description — возвращаемый тип")
+      .isEqualTo("Число");
+    assertThat(count.getDetail())
+      .as("плоский detail не дублирует сигнатуру, когда она ушла в labelDetails")
+      .isNull();
+  }
+
+  @Test
+  void propertyTypeGoesToLabelDetailsDescriptionWhenClientSupportsLabelDetails() {
+    // given
+    enableLabelDetailsSupport(true);
+    initServerContext("./src/test/resources/providers", false);
+    var documentContext = TestUtils.getDocumentContextFromFile(
+      "./src/test/resources/providers/completion-properties.os", context);
+
+    // when
+    var columns = dotCompletionItem(documentContext, new Position(1, 3), "Колонки");
+
+    // then
+    var labelDetails = columns.getLabelDetails();
+    assertThat(labelDetails)
+      .as("у свойства тип уходит в labelDetails.description")
+      .isNotNull();
+    assertThat(labelDetails.getDescription()).isNotBlank();
+    assertThat(labelDetails.getDetail())
+      .as("у свойства нет сигнатуры, поэтому labelDetails.detail не заполняется")
+      .isNull();
+    assertThat(columns.getDetail())
+      .as("плоский detail не дублирует тип, когда он ушёл в labelDetails")
+      .isNull();
+  }
+
+  @Test
+  void methodSignatureStaysInFlatDetailWhenClientLacksLabelDetails() {
+    // given
+    // Клиент без labelDetailsSupport — прежнее поведение: сигнатура в плоском detail,
+    // labelDetails не заполняется.
+    enableLabelDetailsSupport(false);
+    languageServerConfiguration.setLanguage(Language.RU);
+    var documentContext = TestUtils.getDocumentContext("М = Новый Массив;\nМ.");
+
+    // when
+    CompletionItem count;
+    try {
+      count = dotCompletionItem(documentContext, new Position(1, 2), "Количество");
+    } finally {
+      languageServerConfiguration.setLanguage(Language.DEFAULT_LANGUAGE);
+    }
+
+    // then
+    assertThat(count.getLabelDetails())
+      .as("без labelDetailsSupport labelDetails не заполняется")
+      .isNull();
+    assertThat(count.getDetail())
+      .as("без labelDetailsSupport сигнатура остаётся в плоском detail, как раньше")
+      .isEqualTo("(): Число");
   }
 
   @Test


### PR DESCRIPTION
## Проблема

В автодополнении сигнатура метода и возвращаемый тип кладутся в плоский `CompletionItem.detail` (строка вида `(Пар1, Пар2?): Тип`). LSP 3.17 ввёл `CompletionItemLabelDetails` — серое описание прямо рядом с именем в списке (`detail` + `description`). Серверная опция `completionItem.labelDetailsSupport` не заявлялась, поэтому клиенты (VS Code и др.) не получали этих деталей в нативном виде.

## Решение

- `BSLLanguageServer.getCompletionProvider`: заявляем `CompletionItemOptions.labelDetailsSupport = true` в `CompletionOptions`.
- `CompletionProvider`: кэшируем клиентскую capability `completionItem.labelDetailsSupport` на `handleInitializeEvent` единообразно с `snippetSupport`/`markdownDocumentationSupport`.
- Сборка деталей члена вынесена в `applyMethodDetail` / `applyPropertyDetail` → `applyDetail`:
  - при поддержке клиентом — сигнатура `(Пар1, Пар2?)` в `labelDetails.detail`, возвращаемый тип / тип свойства в `labelDetails.description`; плоский `detail` не заполняется (нет дублирования);
  - без поддержки — прежнее поведение: всё в `setDetail` строкой `(...): Тип`.
- Несколько перегрузок передаются строкой-счётчиком вариантов синтаксиса в `labelDetails.detail`.

## Тесты

`CompletionProviderTest` (76 тестов, 0 падений), новые:
- `methodSignatureGoesToLabelDetailsWhenClientSupportsLabelDetails` — `Массив.Количество` → `labelDetails.detail="()"`, `.description="Число"`, плоский `detail=null`;
- `propertyTypeGoesToLabelDetailsDescriptionWhenClientSupportsLabelDetails` — у свойства тип в `labelDetails.description`, плоский `detail=null`;
- `methodSignatureStaysInFlatDetailWhenClientLacksLabelDetails` — без поддержки `labelDetails=null`, плоский `detail="(): Число"` (прежнее поведение).

Сначала красный (2 теста падали `labelDetails == null`), затем реализация, финальный прогон зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)