### PR TITLE
fix(ColorProvider): не показывать ложный чёрный цвет для нелитеральных аргументов конструктора Цвет

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/color/ConstructorColorInformationSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/color/ConstructorColorInformationSupplier.java
@@ -60,10 +60,11 @@ public class ConstructorColorInformationSupplier implements ColorInformationSupp
       .map(BSLParser.NewExpressionContext.class::cast)
       .filter(newExpression -> Constructors.typeName(newExpression).filter(name -> COLOR_PATTERN.matcher(name).matches()).isPresent())
       .map(ConstructorColorInformationSupplier::toColorInformation)
+      .flatMap(Optional::stream)
       .collect(Collectors.toList());
   }
 
-  private static ColorInformation toColorInformation(BSLParser.NewExpressionContext ctx) {
+  private static Optional<ColorInformation> toColorInformation(BSLParser.NewExpressionContext ctx) {
     byte redPosition;
     byte greenPosition;
     byte bluePosition;
@@ -82,32 +83,39 @@ public class ConstructorColorInformationSupplier implements ColorInformationSupp
       .map(BSLParser.DoCallContext::callParamList)
       .orElseGet(() -> new BSLParser.CallParamListContext(null, 0));
 
-    double red = getColorValue(callParams, redPosition);
-    double green = getColorValue(callParams, greenPosition);
-    double blue = getColorValue(callParams, bluePosition);
+    Optional<Double> red = getColorValue(callParams, redPosition);
+    Optional<Double> green = getColorValue(callParams, greenPosition);
+    Optional<Double> blue = getColorValue(callParams, bluePosition);
+
+    if (red.isEmpty() || green.isEmpty() || blue.isEmpty()) {
+      return Optional.empty();
+    }
 
     var range = Ranges.create(ctx);
-    var color = new Color(red, green, blue, DEFAULT_ALPHA_CHANNEL);
+    var color = new Color(red.get(), green.get(), blue.get(), DEFAULT_ALPHA_CHANNEL);
 
-    return new ColorInformation(range, color);
+    return Optional.of(new ColorInformation(range, color));
   }
 
-  private static Double getColorValue(BSLParser.CallParamListContext callParams, byte colorPosition) {
-    return Optional.ofNullable(callParams.callParam(colorPosition))
-      .map(BSLParser.CallParamContext::expression)
+  private static Optional<Double> getColorValue(BSLParser.CallParamListContext callParams, byte colorPosition) {
+    var callParam = callParams.callParam(colorPosition);
+    if (callParam == null || callParam.expression() == null) {
+      return Optional.of(0.0);
+    }
+
+    return Optional.of(callParam.expression())
       .filter(expression -> expression.getTokens().size() == 1)
       .map(expression -> expression.getTokens().getFirst())
       .map(Token::getText)
-      .map(ConstructorColorInformationSupplier::tryParseInteger)
-      .map(colorValue -> (double) colorValue / MAX_COLOR_COMPONENT_VALUE)
-      .orElse(0.0);
+      .flatMap(ConstructorColorInformationSupplier::tryParseInteger)
+      .map(colorValue -> (double) colorValue / MAX_COLOR_COMPONENT_VALUE);
   }
 
-  private static Integer tryParseInteger(String value) {
+  private static Optional<Integer> tryParseInteger(String value) {
     try {
-      return Integer.parseInt(value);
+      return Optional.of(Integer.parseInt(value));
     } catch (NumberFormatException e) {
-      return 0;
+      return Optional.empty();
     }
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/color/ConstructorColorInformationSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/color/ConstructorColorInformationSupplierTest.java
@@ -50,10 +50,9 @@ class ConstructorColorInformationSupplierTest {
 
     // then
     assertThatColorInformations(colorInformation)
-      .hasSize(5)
+      .hasSize(4)
       .hasColorAndRange(new Color(0, 0, 0, 1), Ranges.create(0, 4, 14))
       .hasColorAndRange(new Color(0.00392156862745098, 0.00784313725490196, 0.011764705882352941, 1), Ranges.create(1, 4, 23))
-      .hasColorAndRange(new Color(0, 0, 0, 1), Ranges.create(2, 4, 35))
       .hasColorAndRange(new Color(0.00392156862745098, 0.00784313725490196, 0.011764705882352941, 1), Ranges.create(3, 4, 26))
       .hasColorAndRange(new Color(0, 0, 0, 1), Ranges.create(4, 4, 17))
     ;


### PR DESCRIPTION
## Проблема

`ConstructorColorInformationSupplier.getColorValue` трактовал любой аргумент конструктора `Новый Цвет(...)`, не являющийся однотокенным целочисленным литералом, как `0`. В результате для выражений вида `Новый Цвет(Перем1, Перем2, Перем3)` клиенту отдавался `ColorInformation` с чёрным цветом (`0,0,0`), хотя реальный цвет в момент анализа неизвестен. Это дезинформировало пользователя ложным чёрным квадратиком. Поведение было даже закреплено тестом.

## Решение

Если хотя бы один из аргументов R/G/B **присутствует, но не является целочисленным литералом**, `ColorInformation` для этого `Новый Цвет(...)` не возвращается вовсе (вместо подстановки `0`).

`getColorValue` теперь возвращает `Optional<Double>`:
- аргумент отсутствует (`callParam == null`) → `Optional.of(0.0)` (платформенное значение по умолчанию, чёрный для `Новый Цвет` без аргументов сохраняется);
- присутствует целочисленный литерал → распарсенное значение;
- присутствует, но не целочисленный литерал → `Optional.empty()` (дисквалифицирует всё выражение).

`toColorInformation` возвращает `Optional<ColorInformation>` и пустые значения отфильтровываются.

## Изменение существующего теста

В `ConstructorColorInformationSupplierTest.getColorInformation` была строка, закреплявшая ложный чёрный для `Новый Цвет(Число, Число, Число)` (нелитеральные аргументы). Она удалена осознанно: теперь для нелитеральных аргументов цвет не предлагается. Ожидаемый размер списка уменьшен с 5 до 4. Случаи без аргументов (`Новый Цвет`, `Новый("Цвет")` → чёрный) и с литералами (`Новый Цвет(1,2,3)`, `Новый("Цвет",1,2,3)`) остались без изменений.

## Тесты

`./gradlew test --tests ConstructorColorInformationSupplierTest --tests ColorProviderTest -Dversioning.disable=true -Pversion=0.0.0-DEV` → BUILD SUCCESSFUL. Перед фиксом обновлённый тест корректно падал (красный по правильной причине — размер 5 вместо 4).

🤖 Generated with [Claude Code](https://claude.com/claude-code)