### PR TITLE
feat(documentLink): кликабельные http(s)-ссылки из комментариев кода

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/documentlink/CommentUrlDocumentLinkSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/documentlink/CommentUrlDocumentLinkSupplier.java
@@ -1,0 +1,70 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.documentlink;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import org.antlr.v4.runtime.Token;
+import org.eclipse.lsp4j.DocumentLink;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Сапплаер для формирования кликабельных ссылок из http(s)-адресов,
+ * встречающихся в комментариях кода (ссылки на ИТС, задачи, стандарты и т.п.).
+ */
+@Component
+public class CommentUrlDocumentLinkSupplier implements DocumentLinkSupplier {
+
+  private static final Pattern URL_PATTERN = Pattern.compile("https?://[^\\s\"'<>)\\]}]+");
+
+  @Override
+  public List<DocumentLink> getDocumentLinks(DocumentContext documentContext) {
+    var documentLinks = new ArrayList<DocumentLink>();
+
+    for (Token comment : documentContext.getComments()) {
+      addLinksFromComment(comment, documentLinks);
+    }
+
+    return documentLinks;
+  }
+
+  private static void addLinksFromComment(Token comment, List<DocumentLink> documentLinks) {
+    var text = comment.getText();
+    var matcher = URL_PATTERN.matcher(text);
+
+    var line = comment.getLine() - 1;
+    var commentStartChar = comment.getCharPositionInLine();
+
+    while (matcher.find()) {
+      var url = matcher.group();
+      var startChar = commentStartChar + matcher.start();
+      var endChar = commentStartChar + matcher.end();
+      var range = Ranges.create(line, startChar, endChar);
+
+      documentLinks.add(new DocumentLink(range, url));
+    }
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/documentlink/CommentUrlDocumentLinkSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/documentlink/CommentUrlDocumentLinkSupplierTest.java
@@ -1,0 +1,108 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.documentlink;
+
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import org.eclipse.lsp4j.DocumentLink;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+@SpringBootTest
+@CleanupContextBeforeClassAndAfterClass
+class CommentUrlDocumentLinkSupplierTest {
+
+  @Autowired
+  private CommentUrlDocumentLinkSupplier supplier;
+
+  @Test
+  void testCommentWithUrlProducesLink() {
+    // given
+    var content = """
+      // См. https://its.1c.ru/db/v8std
+      Процедура Тест()
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(content);
+
+    // when
+    var documentLinks = supplier.getDocumentLinks(documentContext);
+
+    // then
+    assertThat(documentLinks)
+      .hasSize(1)
+      .first()
+      .satisfies(documentLink -> {
+        assertThat(documentLink.getTarget()).isEqualTo("https://its.1c.ru/db/v8std");
+        assertThat(documentLink.getRange()).isEqualTo(Ranges.create(0, 7, 33));
+      });
+  }
+
+  @Test
+  void testMultipleUrlsInSingleComment() {
+    // given
+    var content = "// http://example.com и https://example.org";
+    var documentContext = TestUtils.getDocumentContext(content);
+
+    // when
+    var documentLinks = supplier.getDocumentLinks(documentContext);
+
+    // then
+    assertThat(documentLinks)
+      .extracting(DocumentLink::getTarget)
+      .containsExactly("http://example.com", "https://example.org");
+  }
+
+  @Test
+  void testCommentWithoutUrlProducesNothing() {
+    // given
+    var content = "// Просто комментарий без ссылок";
+    var documentContext = TestUtils.getDocumentContext(content);
+
+    // when
+    var documentLinks = supplier.getDocumentLinks(documentContext);
+
+    // then
+    assertThat(documentLinks).isEmpty();
+  }
+
+  @Test
+  void testUrlOutsideCommentIsIgnored() {
+    // given
+    var content = """
+      Процедура Тест()
+        Адрес = "https://example.com";
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(content);
+
+    // when
+    var documentLinks = supplier.getDocumentLinks(documentContext);
+
+    // then
+    assertThat(documentLinks).isEmpty();
+  }
+}


### PR DESCRIPTION
## Проблема

`textDocument/documentLink` наполнялся единственным сапплаером — ссылками по рассчитанным диагностикам. http(s)-URL, которые разработчики оставляют в комментариях кода (ссылки на ИТС, задачи, стандарты), кликабельными не были.

## Решение

Добавлен второй `DocumentLinkSupplier` — `CommentUrlDocumentLinkSupplier`. Он берёт токены комментариев из `DocumentContext.getComments()` (тип `BSLLexer.LINE_COMMENT`), находит в их тексте http/https-URL регуляркой `https?://[^\s"'<>)\]}]+` и для каждого URL отдаёт `DocumentLink` с `target` = URL и точным `range` именно URL внутри комментария (через `Ranges.create(line, startChar, endChar)`, смещение считается от позиции URL в токене).

Существующий `DiagnosticDescriptionDocumentLinkSupplier` не затронут — провайдер просто агрегирует обоих сапплаеров.

## Тесты

`CommentUrlDocumentLinkSupplierTest`:
- комментарий с https-URL → один `DocumentLink` с корректным target и range;
- несколько URL в одном комментарии → несколько ссылок в порядке вхождения;
- комментарий без URL → пусто;
- URL в строковом литерале вне комментария → не сканируется.

Финальный прогон затронутых классов (`CommentUrlDocumentLinkSupplierTest`, `DiagnosticDescriptionDocumentLinkSupplierTest`, `DocumentLinkProviderTest`) — `BUILD SUCCESSFUL`, все тесты PASSED.

🤖 Generated with [Claude Code](https://claude.com/claude-code)