### PR TITLE
fix(CommandProvider): возвращать JSON-RPC InvalidParams вместо RuntimeException в executeCommand

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CommandProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CommandProvider.java
@@ -23,9 +23,13 @@ package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.commands.CommandArguments;
 import com.github._1c_syntax.bsl.languageserver.commands.CommandSupplier;
+import com.github._1c_syntax.bsl.languageserver.utils.Resources;
 import lombok.RequiredArgsConstructor;
 import lombok.SneakyThrows;
 import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseError;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.json.JsonMapper;
@@ -45,6 +49,7 @@ public class CommandProvider {
 
   private final Map<String, CommandSupplier<CommandArguments>> commandSuppliersById;
   private final JsonMapper jsonMapper;
+  private final Resources resources;
 
   private final CodeLensProvider codeLensProvider;
   private final InlayHintProvider inlayHintProvider;
@@ -61,7 +66,8 @@ public class CommandProvider {
 
     var commandSupplier = commandSuppliersById.get(commandId);
     if (commandSupplier == null) {
-      throw new RuntimeException("Unknown command id: " + commandId);
+      var message = resources.getResourceString(getClass(), "unknownCommandId", commandId);
+      throw new ResponseErrorException(new ResponseError(ResponseErrorCode.MethodNotFound, message, null));
     }
 
     var result = commandSupplier
@@ -95,15 +101,16 @@ public class CommandProvider {
    * @param executeCommandParams Параметры запроса workspace/executeCommand.
    * @return Аргументы команды.
    *
-   * @throws RuntimeException Выбрасывает исключение, если параметры входящего запроса не содержат
-   * данных для вычисления аргументов команды.
+   * @throws ResponseErrorException Выбрасывает исключение с кодом {@link ResponseErrorCode#InvalidParams},
+   * если параметры входящего запроса не содержат данных для вычисления аргументов команды.
    */
   @SneakyThrows
   public CommandArguments extractArguments(ExecuteCommandParams executeCommandParams) {
     var rawArguments = executeCommandParams.getArguments();
 
     if (rawArguments.isEmpty()) {
-      throw new RuntimeException("Command arguments is empty");
+      var message = resources.getResourceString(getClass(), "emptyCommandArguments");
+      throw new ResponseErrorException(new ResponseError(ResponseErrorCode.InvalidParams, message, null));
     }
 
     var rawArgument = rawArguments.getFirst();

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/providers/CommandProvider_en.properties
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/providers/CommandProvider_en.properties
@@ -1,0 +1,2 @@
+unknownCommandId=Unknown command id: "%s".
+emptyCommandArguments=Command arguments are empty.

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/providers/CommandProvider_ru.properties
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/providers/CommandProvider_ru.properties
@@ -1,0 +1,2 @@
+unknownCommandId=Неизвестный идентификатор команды: "%s".
+emptyCommandArguments=Аргументы команды отсутствуют.

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CommandProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CommandProviderTest.java
@@ -23,7 +23,10 @@ package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.commands.CommandSupplier;
 import com.github._1c_syntax.bsl.languageserver.commands.DefaultCommandArguments;
+import com.github._1c_syntax.utils.Absolute;
 import org.eclipse.lsp4j.ExecuteCommandParams;
+import org.eclipse.lsp4j.jsonrpc.ResponseErrorException;
+import org.eclipse.lsp4j.jsonrpc.messages.ResponseErrorCode;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -35,6 +38,7 @@ import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 class CommandProviderTest {
@@ -80,6 +84,36 @@ class CommandProviderTest {
     // then
     assertThat(result)
       .isEqualTo(1);
+  }
+
+  @Test
+  void executeCommandWithUnknownIdThrowsMethodNotFound() {
+    // given
+    var commandArguments = new DefaultCommandArguments(Absolute.uri("file:///fake-uri"), "unknownCommandId");
+
+    // when
+    var thrown = assertThatThrownBy(() -> commandProvider.executeCommand(commandArguments));
+
+    // then
+    thrown
+      .isInstanceOf(ResponseErrorException.class)
+      .extracting(error -> ((ResponseErrorException) error).getResponseError().getCode())
+      .isEqualTo(ResponseErrorCode.MethodNotFound.getValue());
+  }
+
+  @Test
+  void extractArgumentsWithEmptyArgumentsThrowsInvalidParams() {
+    // given
+    var params = new ExecuteCommandParams("Some command", List.of());
+
+    // when
+    var thrown = assertThatThrownBy(() -> commandProvider.extractArguments(params));
+
+    // then
+    thrown
+      .isInstanceOf(ResponseErrorException.class)
+      .extracting(error -> ((ResponseErrorException) error).getResponseError().getCode())
+      .isEqualTo(ResponseErrorCode.InvalidParams.getValue());
   }
 
   @TestConfiguration


### PR DESCRIPTION
## Проблема

`CommandProvider.executeCommand` и `extractArguments` при неизвестном идентификаторе команды и при пустых аргументах бросали голый `RuntimeException` с захардкоженным англоязычным текстом. Клиент по JSON-RPC получал generic-ошибку (`InternalError`) без осмысленного кода и без локализуемого сообщения.

## Решение

- Неизвестный идентификатор команды → `ResponseErrorException` с кодом `MethodNotFound`: семантически это обращение к несуществующему "методу"-команде.
- Пустые аргументы запроса → `ResponseErrorException` с кодом `InvalidParams`: запрос синтаксически валиден, но переданные параметры недостаточны.
- Сообщения вынесены в ресурсы `CommandProvider_ru.properties` / `CommandProvider_en.properties` и читаются через `Resources.getResourceString(...)` — по образцу `RenameProvider`.
- Javadoc `extractArguments` обновлён: теперь `@throws ResponseErrorException` со ссылкой на `InvalidParams`.

## Тесты

Добавлены два теста (структура given/when/then):
- `executeCommandWithUnknownIdThrowsMethodNotFound` — проверяет тип исключения и код `MethodNotFound`.
- `extractArgumentsWithEmptyArgumentsThrowsInvalidParams` — проверяет тип исключения и код `InvalidParams`.

Прогон `./gradlew test --tests "*CommandProviderTest"` — 5 тестов, BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)