### PR TITLE
test(SignatureHelpProvider): офсетные label у ParameterInformation

### DIFF
--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProviderTest.java
@@ -529,6 +529,56 @@ class SignatureHelpProviderTest {
   }
 
   @Test
+  void parameterInformationUsesOffsetLabelsPointingToOwnSubstring() {
+    // given — метод с параметрами одинакового типа (Строка), при котором подсветка
+    // по подстроке имени/типа была бы неоднозначной; офсеты должны указывать строго
+    // на собственную подстроку каждого параметра в label сигнатуры.
+    var content = """
+      // Описание.
+      //
+      // Параметры:
+      //  Строка - Строка
+      //  ИмяСтроки - Строка
+      //
+      Процедура М(Строка, ИмяСтроки) Экспорт
+      КонецПроцедуры
+
+      М(А, Б);
+      """;
+    var documentContext = TestUtils.getDocumentContext(content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var col = content.split("\n")[9].indexOf("М(") + "М(".length();
+    params.setPosition(new Position(9, col));
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — у каждого параметра label задан офсетами (right), а не строкой (left),
+    // и подстрока label по этим офсетам совпадает с ожидаемым рендерингом параметра.
+    assertThat(help.getSignatures()).hasSize(1);
+    var sig = help.getSignatures().get(0);
+    var sigLabel = sig.getLabel();
+    assertThat(sig.getParameters()).hasSize(2);
+
+    var firstLabel = sig.getParameters().get(0).getLabel();
+    assertThat(firstLabel.isRight()).isTrue();
+    var firstRange = firstLabel.getRight();
+    assertThat(sigLabel.substring(firstRange.getFirst(), firstRange.getSecond()))
+      .isEqualTo("Строка: Строка");
+
+    var secondLabel = sig.getParameters().get(1).getLabel();
+    assertThat(secondLabel.isRight()).isTrue();
+    var secondRange = secondLabel.getRight();
+    assertThat(sigLabel.substring(secondRange.getFirst(), secondRange.getSecond()))
+      .isEqualTo("ИмяСтроки: Строка");
+
+    // офсеты непересекающиеся и идут по возрастанию — повторяющийся тип не сбивает подсветку.
+    assertThat(secondRange.getFirst()).isGreaterThanOrEqualTo(firstRange.getSecond());
+    assertThat(help.getActiveParameter()).isZero();
+  }
+
+  @Test
   void retriggerKeepsUserSelectedSignatureWhenStillValid() {
     // given — у метода Разделить две перегрузки: одна с разделителем и одна
     // с разделителем и кодировкой; курсор на первом параметре (после открывающей


### PR DESCRIPTION
## Проблема

По заданию требовалось перевести `ParameterInformation.label` со строкового представления (имя параметра) на пару офсетов `[start, end)` в строке-метке сигнатуры (`SignatureInformation.label`) — чтобы клиент подсвечивал активный параметр по диапазону, а не по подстроке (что неточно при повторяющихся именах/типах).

При чтении кода выяснилось, что эта реализация **уже присутствует** на `develop`: `SignatureHelpProvider.appendParameter` запоминает `start = label.length()` до дописывания параметра и `end = label.length()` после, и задаёт `info.setLabel(Either.forRight(new Tuple.Two<>(start, end)))`. Строковых (`forLeft`) label у параметров в провайдере нет. Следуя правилу «диагностика до правок прода» и «сначала красный тест», прод не трогался: написанный по сценарию задания тест оказался зелёным — баг отсутствует.

## Решение

Production-код не менялся (изменение было бы спекулятивным и сломало бы рабочую логику). Добавлено регрессионное тестовое покрытие, фиксирующее офсетное поведение — гарантия против отката к подстроковым label в будущем.

## Тесты

Новый `parameterInformationUsesOffsetLabelsPointingToOwnSubstring` (given/when/then):
- метод `М(Строка, ИмяСтроки)` с JsDoc-типами, где оба параметра имеют тип `Строка` — намеренно неоднозначный для подстроковой подсветки случай;
- проверяется `label.isRight()` у каждого параметра (офсеты, не строка);
- `sigLabel.substring(start, end)` совпадает с ожидаемым рендерингом параметра (`"Строка: Строка"`, `"ИмяСтроки: Строка"`);
- офсеты непересекающиеся и возрастающие — повторяющийся тип не сбивает подсветку;
- `activeParameter` прежний.

Весь класс `SignatureHelpProviderTest` зелёный (`./gradlew test --tests "...SignatureHelpProviderTest" -Dversioning.disable=true -Pversion=0.0.0-DEV` → BUILD SUCCESSFUL).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Improved test coverage for signature parameter label rendering to ensure accurate offset-based range handling.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->