### PR TITLE
feat(documenthighlight): kind=Text для подсветки парных лексем

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/AbstractASTDocumentHighlightSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/AbstractASTDocumentHighlightSupplier.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.documenthighlight;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.jspecify.annotations.Nullable;
 
 import java.util.List;
@@ -50,6 +51,6 @@ public abstract class AbstractASTDocumentHighlightSupplier implements DocumentHi
 
     var token = terminalNode.getSymbol();
     var range = Ranges.create(token);
-    highlights.add(new DocumentHighlight(range));
+    highlights.add(new DocumentHighlight(range, DocumentHighlightKind.Text));
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/AbstractSDBLDocumentHighlightSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/AbstractSDBLDocumentHighlightSupplier.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.parser.SDBLTokenizer;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.Position;
 import org.jspecify.annotations.Nullable;
 
@@ -88,7 +89,7 @@ public abstract class AbstractSDBLDocumentHighlightSupplier implements DocumentH
       return;
     }
     var range = Ranges.create(token);
-    highlights.add(new DocumentHighlight(range));
+    highlights.add(new DocumentHighlight(range, DocumentHighlightKind.Text));
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/BracketDocumentHighlightSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/BracketDocumentHighlightSupplier.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.parser.BSLParser;
 import org.antlr.v4.runtime.Token;
 import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.jspecify.annotations.Nullable;
 import java.util.Optional;
@@ -101,12 +102,12 @@ public class BracketDocumentHighlightSupplier implements DocumentHighlightSuppli
     }
 
     // Добавляем текущую скобку
-    highlights.add(new DocumentHighlight(Ranges.create(token)));
+    highlights.add(new DocumentHighlight(Ranges.create(token), DocumentHighlightKind.Text));
 
     // Ищем парную скобку
     var matchingToken = findMatchingBracket(token, allTokens, openType, closeType, isOpening);
     if (matchingToken != null) {
-      highlights.add(new DocumentHighlight(Ranges.create(matchingToken)));
+      highlights.add(new DocumentHighlight(Ranges.create(matchingToken), DocumentHighlightKind.Text));
     }
 
     return highlights;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/RegionDocumentHighlightSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/RegionDocumentHighlightSupplier.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.DocumentHighlightParams;
 import java.util.Optional;
 import org.springframework.stereotype.Component;
@@ -74,10 +75,10 @@ public class RegionDocumentHighlightSupplier implements DocumentHighlightSupplie
     List<DocumentHighlight> highlights = new ArrayList<>();
     
     // Подсвечиваем начало региона
-    highlights.add(new DocumentHighlight(region.getStartRange()));
-    
+    highlights.add(new DocumentHighlight(region.getStartRange(), DocumentHighlightKind.Text));
+
     // Подсвечиваем конец региона
-    highlights.add(new DocumentHighlight(region.getEndRange()));
+    highlights.add(new DocumentHighlight(region.getEndRange(), DocumentHighlightKind.Text));
     
     return highlights;
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/BracketDocumentHighlightSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/BracketDocumentHighlightSupplierTest.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.documenthighlight;
 
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -150,6 +151,28 @@ class BracketDocumentHighlightSupplierTest {
 
     // then
     assertThat(highlights).isEmpty();
+  }
+
+  @Test
+  void testHighlightKindIsText() {
+    // given
+    // Подсветка парных скобок — это подсветка парных лексем, а не чтение/запись переменной,
+    // поэтому kind должен быть Text.
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+    var params = new DocumentHighlightParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var position = new Position(4, 20);
+    params.setPosition(position);
+    var terminalNodeInfo = DocumentHighlightTestUtils.findTerminalNode(position, documentContext);
+
+    // when
+    var highlights = supplier.getDocumentHighlight(params, documentContext, terminalNodeInfo);
+
+    // then
+    assertThat(highlights).isNotEmpty();
+    assertThat(highlights)
+      .extracting(DocumentHighlight::getKind)
+      .containsOnly(DocumentHighlightKind.Text);
   }
 
   private void assertHighlightRange(List<DocumentHighlight> highlights,

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/IfStatementDocumentHighlightSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/IfStatementDocumentHighlightSupplierTest.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.documenthighlight;
 
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -311,6 +312,28 @@ class IfStatementDocumentHighlightSupplierTest {
 
     assertHighlightRange(highlights, 3, 4, 3, 8);      // Если
     assertHighlightRange(highlights, 3, 16, 3, 21);    // Тогда
+  }
+
+  @Test
+  void testHighlightKindIsText() {
+    // given
+    // Подсветка парных ключевых слов конструкции Если/КонецЕсли — это не чтение/запись переменной,
+    // а подсветка парных лексем, поэтому kind должен быть Text.
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+    var params = new DocumentHighlightParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    var position = new Position(3, 5);
+    params.setPosition(position);
+    var terminalNodeInfo = DocumentHighlightTestUtils.findTerminalNode(position, documentContext); // На "Если"
+
+    // when
+    var highlights = supplier.getDocumentHighlight(params, documentContext, terminalNodeInfo);
+
+    // then
+    assertThat(highlights).isNotEmpty();
+    assertThat(highlights)
+      .extracting(DocumentHighlight::getKind)
+      .containsOnly(DocumentHighlightKind.Text);
   }
 
   private void assertHighlightRange(List<DocumentHighlight> highlights,

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/RegionDocumentHighlightSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/RegionDocumentHighlightSupplierTest.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.documenthighlight;
 
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -130,6 +131,26 @@ class RegionDocumentHighlightSupplierTest {
 
     // then
     assertThat(highlights).isEmpty();
+  }
+
+  @Test
+  void testHighlightKindIsText() {
+    // given
+    // Подсветка парной конструкции #Область/#КонецОбласти — это подсветка парных лексем,
+    // а не чтение/запись переменной, поэтому kind должен быть Text.
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+    var params = new DocumentHighlightParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(2, 3)); // На "#Область"
+
+    // when
+    var highlights = supplier.getDocumentHighlight(params, documentContext, Optional.empty());
+
+    // then
+    assertThat(highlights).isNotEmpty();
+    assertThat(highlights)
+      .extracting(DocumentHighlight::getKind)
+      .containsOnly(DocumentHighlightKind.Text);
   }
 
   private void assertHighlightRange(List<DocumentHighlight> highlights,

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/SDBLCaseDocumentHighlightSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/documenthighlight/SDBLCaseDocumentHighlightSupplierTest.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.documenthighlight;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.DocumentHighlight;
+import org.eclipse.lsp4j.DocumentHighlightKind;
 import org.eclipse.lsp4j.DocumentHighlightParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -125,6 +126,24 @@ class SDBLCaseDocumentHighlightSupplierTest {
     var highlights = supplier.getDocumentHighlight(params, documentContext, Optional.empty());
     // then
     assertThat(highlights).isEmpty();
+  }
+  @Test
+  void testHighlightKindIsText() {
+    // given
+    // Подсветка парных ключевых слов конструкции ВЫБОР/КОНЕЦ — это подсветка парных лексем,
+    // а не чтение/запись переменной, поэтому kind должен быть Text.
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+    var params = new DocumentHighlightParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    // Курсор на "ВЫБОР" (строка 7, позиция 9 - внутри слова)
+    params.setPosition(new Position(7, 9));
+    // when
+    var highlights = supplier.getDocumentHighlight(params, documentContext, Optional.empty());
+    // then
+    assertThat(highlights).isNotEmpty();
+    assertThat(highlights)
+      .extracting(DocumentHighlight::getKind)
+      .containsOnly(DocumentHighlightKind.Text);
   }
   private void assertHighlightRange(List<DocumentHighlight> highlights,
                                      int startLine, int startChar,


### PR DESCRIPTION
## Проблема

Сапплаеры подсветки парных конструкций (`AbstractASTDocumentHighlightSupplier`, `AbstractSDBLDocumentHighlightSupplier`, а также `BracketDocumentHighlightSupplier` и `RegionDocumentHighlightSupplier`) создавали `DocumentHighlight` без указания `kind`. В отличие от `IdentifierDocumentHighlightSupplier` (Read/Write через ReferenceIndex), для парных ключевых слов BSL и SDBL (`Если`/`КонецЕсли`, `Цикл`/`КонецЦикла`, скобки, `ВЫБОР`/`КОГДА`/`КОНЕЦ`, `#Область`/`#КонецОбласти` и т.п.) `kind` не выставлялся вообще.

## Решение

Для подсветки парных лексем семантически корректен `DocumentHighlightKind.Text` (это не чтение/запись переменной, а подсветка парных лексем). `kind=Text` проставлен единообразно во всех местах формирования `DocumentHighlight` для парных конструкций:

- `AbstractASTDocumentHighlightSupplier.addTokenHighlight` (покрывает If/Loop/Try/Subroutine);
- `AbstractSDBLDocumentHighlightSupplier.addTokenHighlight` (покрывает SDBL Case/Join/Bracket);
- `BracketDocumentHighlightSupplier` (BSL-скобки, прямое создание `DocumentHighlight`);
- `RegionDocumentHighlightSupplier` (`#Область`/`#КонецОбласти`, прямое создание).

`IdentifierDocumentHighlightSupplier` не затрагивался — он уже корректно проставляет Read/Write.

## Тесты

Добавлены проверки `kind == Text` (`testHighlightKindIsText`) в тесты `IfStatementDocumentHighlightSupplierTest` (AST), `SDBLCaseDocumentHighlightSupplierTest` (SDBL), `BracketDocumentHighlightSupplierTest` и `RegionDocumentHighlightSupplierTest`. Сначала тесты были красными (kind = null), после реализации — зелёные; существующие тесты сапплаеров остались зелёными.

🤖 Generated with [Claude Code](https://claude.com/claude-code)