### PR TITLE
feat(CompletionProvider): commitCharacters для членов и вызываемых

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -141,6 +141,13 @@ public final class CompletionProvider {
   // с записью сигнатуры в плоский detail.
   private boolean labelDetailsSupport;
 
+  // Кэшируется на initialize. Поддерживает ли клиент completionItem.commitCharactersSupport —
+  // фиксацию пункта вводом «commit character». Если да — методам/функциям проставляем
+  // commitCharacters ["("] (вставка открывающей скобки фиксирует вызываемый),
+  // членам-объектам и переменным/модулям — ["."] (осмысленно дальнейшее обращение).
+  // Если клиент не поддерживает — commitCharacters не задаём вовсе.
+  private boolean commitCharactersSupport;
+
   @EventListener(LanguageServerInitializeRequestReceivedEvent.class)
   public void handleInitializeEvent() {
     var completionItem = clientCapabilitiesHolder.getCapabilities()
@@ -166,6 +173,9 @@ public final class CompletionProvider {
       .orElse(Boolean.FALSE);
     labelDetailsSupport = completionItem
       .map(CompletionItemCapabilities::getLabelDetailsSupport)
+      .orElse(Boolean.FALSE);
+    commitCharactersSupport = completionItem
+      .map(CompletionItemCapabilities::getCommitCharactersSupport)
       .orElse(Boolean.FALSE);
   }
 
@@ -537,6 +547,7 @@ public final class CompletionProvider {
           var item = new CompletionItem(qualified);
           item.setKind(CompletionItemKind.Module);
           applySortText(item, BUCKET_TYPE, false);
+          applyCommitCharacters(item);
           items.add(item);
         }
       }
@@ -560,6 +571,7 @@ public final class CompletionProvider {
       var item = new CompletionItem(name);
       item.setKind(completionKindForSynthetic(ctx.getSyntheticKind()));
       applySortText(item, BUCKET_GLOBAL, false);
+      applyCommitCharacters(item);
       items.add(item);
     }
 
@@ -590,6 +602,7 @@ public final class CompletionProvider {
           markDeprecatedItem(item);
         }
         applySortText(item, BUCKET_LOCAL, method.isDeprecated());
+        applyCommitCharacters(item);
         items.add(item);
       }
     }
@@ -600,6 +613,7 @@ public final class CompletionProvider {
         var item = new CompletionItem(variable.getName());
         item.setKind(CompletionItemKind.Variable);
         applySortText(item, BUCKET_LOCAL, false);
+        applyCommitCharacters(item);
         items.add(item);
       }
     }
@@ -749,6 +763,7 @@ public final class CompletionProvider {
       applyDocumentation(item, member, scriptVariant);
     }
     markDeprecated(item, member, target);
+    applyCommitCharacters(item);
     return item;
   }
 
@@ -773,6 +788,36 @@ public final class CompletionProvider {
    */
   private static void applySortText(CompletionItem item, String bucket, boolean deprecated) {
     item.setSortText(bucket + (deprecated ? "1" : "0") + "_" + item.getLabel());
+  }
+
+  /**
+   * Проставляет {@code commitCharacters} пункту автодополнения по его
+   * {@link CompletionItemKind}, если клиент объявил поддержку
+   * {@code completionItem.commitCharactersSupport}. Commit character —
+   * символ, ввод которого фиксирует пункт и сразу вставляет его вместе с
+   * этим символом. Набор подбирается по смыслу пункта: вызываемые
+   * (метод/функция/конструктор) фиксируются открывающей скобкой
+   * {@code "("}, члены-объекты и переменные/модули — точкой {@code "."}
+   * (после фиксации осмысленно дальнейшее обращение к члену). Ключевым
+   * словам и прочим пунктам commit characters не задаются.
+   *
+   * @param item пункт автодополнения, которому проставляются commit characters.
+   */
+  private void applyCommitCharacters(CompletionItem item) {
+    if (!commitCharactersSupport) {
+      return;
+    }
+    var kind = item.getKind();
+    if (kind == null) {
+      return;
+    }
+    switch (kind) {
+      case Method, Function, Constructor -> item.setCommitCharacters(List.of("("));
+      case Field, Property, Variable, Module -> item.setCommitCharacters(List.of("."));
+      default -> {
+        // ключевые слова, классы и прочие пункты commit characters не получают
+      }
+    }
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -1921,6 +1921,105 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .isNull();
   }
 
+  private void enableCommitCharactersSupport(boolean enabled) {
+    var itemCaps = new CompletionItemCapabilities();
+    itemCaps.setCommitCharactersSupport(enabled);
+    var completionCaps = new CompletionCapabilities();
+    completionCaps.setCompletionItem(itemCaps);
+    var textDocumentCaps = new TextDocumentClientCapabilities();
+    textDocumentCaps.setCompletion(completionCaps);
+    var caps = new ClientCapabilities();
+    caps.setTextDocument(textDocumentCaps);
+    clientCapabilitiesHolder.setCapabilities(caps);
+    completionProvider.handleInitializeEvent();
+  }
+
+  @Test
+  void methodMemberGetsOpenParenCommitCharacter() {
+    // given — клиент поддерживает commitCharactersSupport
+    enableCommitCharactersSupport(true);
+    var documentContext = TestUtils.getDocumentContext("М = Новый Массив;\nМ.");
+
+    // when
+    var add = dotCompletionItem(documentContext, new Position(1, 2), "Добавить");
+
+    // then — метод фиксируется вставкой открывающей скобки
+    assertThat(add.getKind()).isEqualTo(CompletionItemKind.Method);
+    assertThat(add.getCommitCharacters()).containsExactly("(");
+  }
+
+  @Test
+  void propertyMemberGetsDotCommitCharacter() {
+    // given — клиент поддерживает commitCharactersSupport; ТЗ.Колонки — свойство
+    enableCommitCharactersSupport(true);
+    initServerContext("./src/test/resources/providers", false);
+    var documentContext = TestUtils.getDocumentContextFromFile(
+      "./src/test/resources/providers/completion-properties.os", context);
+
+    // when
+    var columns = dotCompletionItem(documentContext, new Position(1, 3), "Колонки");
+
+    // then — у свойства осмысленно дальнейшее обращение через точку
+    assertThat(columns.getKind()).isEqualTo(CompletionItemKind.Property);
+    assertThat(columns.getCommitCharacters()).containsExactly(".");
+  }
+
+  @Test
+  void localVariableGetsDotCommitCharacter() {
+    // given — клиент поддерживает commitCharactersSupport; локальная переменная
+    enableCommitCharactersSupport(true);
+    var content = """
+      Перем МояПеременная;
+
+      МояПерем""";
+    var documentContext = TestUtils.getDocumentContext(content);
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(2, 8));
+
+    // when
+    var variable = completionProvider.getCompletion(documentContext, params).getItems().stream()
+      .filter(it -> "МояПеременная".equals(it.getLabel()))
+      .findFirst()
+      .orElseThrow();
+
+    // then
+    assertThat(variable.getKind()).isEqualTo(CompletionItemKind.Variable);
+    assertThat(variable.getCommitCharacters()).containsExactly(".");
+  }
+
+  @Test
+  void keywordHasNoCommitCharacters() {
+    // given — клиент поддерживает commitCharactersSupport
+    enableCommitCharactersSupport(true);
+    var documentContext = TestUtils.getDocumentContext("Если");
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(0, 4));
+
+    // when
+    var keyword = completionProvider.getCompletion(documentContext, params).getItems().stream()
+      .filter(it -> it.getKind() == CompletionItemKind.Keyword)
+      .findFirst()
+      .orElseThrow();
+
+    // then — ключевым словам commitCharacters не задаются
+    assertThat(keyword.getCommitCharacters()).isNull();
+  }
+
+  @Test
+  void methodMemberHasNoCommitCharactersWhenClientLacksSupport() {
+    // given — клиент не поддерживает commitCharactersSupport
+    enableCommitCharactersSupport(false);
+    var documentContext = TestUtils.getDocumentContext("М = Новый Массив;\nМ.");
+
+    // when
+    var add = dotCompletionItem(documentContext, new Position(1, 2), "Добавить");
+
+    // then — без клиентской capability commitCharacters не задаются
+    assertThat(add.getCommitCharacters()).isNull();
+  }
+
   @Test
   void dotCompletionKeepsEagerDocumentationWhenClientLacksResolveSupport() {
     // given — клиент без resolveSupport (только markdown documentation)


### PR DESCRIPTION
## Проблема
В `textDocument/completion` пункты не задавали `commitCharacters`. Из-за этого клиент не мог фиксировать вызываемый вводом `(` или член-объект вводом `.` — нажатие такого символа не выбирало подсвеченный пункт и не вставляло его вместе с символом.

## Решение
Добавлен helper `applyCommitCharacters(CompletionItem)`, проставляющий набор по `CompletionItemKind`:
- `Method` / `Function` / `Constructor` → `["("]` — фиксация вставкой открывающей скобки;
- `Field` / `Property` / `Variable` / `Module` → `["."]` — осмысленно дальнейшее обращение к члену;
- ключевые слова, классы и прочее — не задаются.

Гейтинг по клиентской capability `completionItem.commitCharactersSupport`: флаг кэшируется в `handleInitializeEvent` рядом со `snippetSupport` / `labelDetailsSupport` / `resolveSupport`. Если клиент не объявил поддержку — `commitCharacters` не задаются вовсе. Серверный `triggerCharacters` (точка как триггер completion) не затрагивается — это отдельный механизм.

Helper вызывается строго локально в местах выдачи item-ов: `buildMemberItem` (члены dot-completion и глобальные функции), локальные методы/переменные документа, глобальные контексты и квалифицированные имена MD-объектов. Чужие правки (sortText, resolve, MarkupContent, labelDetails) не переформатированы.

## Тесты
Новые тесты в `CompletionProviderTest` (red-first, затем реализация):
- `methodMemberGetsOpenParenCommitCharacter` — метод получает `["("]`;
- `propertyMemberGetsDotCommitCharacter` — свойство получает `["."]`;
- `localVariableGetsDotCommitCharacter` — локальная переменная получает `["."]`;
- `keywordHasNoCommitCharacters` — ключевое слово без `commitCharacters`;
- `methodMemberHasNoCommitCharactersWhenClientLacksSupport` — при клиенте без `commitCharactersSupport` не задаются.

Прогон: `./gradlew test --tests "...CompletionProviderTest"` — 78 tests, 0 failures.

🤖 Generated with [Claude Code](https://claude.com/claude-code)