### PR TITLE
feat(SymbolProvider): отмена запроса workspace/symbol через CancelChecker

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
@@ -43,6 +43,7 @@ import org.eclipse.lsp4j.SymbolInformation;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.jsonrpc.CompletableFutures;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import org.jspecify.annotations.Nullable;
@@ -80,9 +81,9 @@ public class BSLWorkspaceService implements WorkspaceService {
 
   @Override
   public CompletableFuture<Either<List<? extends SymbolInformation>,List<? extends WorkspaceSymbol>>> symbol(WorkspaceSymbolParams params) {
-    return CompletableFuture.supplyAsync(
-      () -> Either.forRight(symbolProvider.getSymbols(params)),
-      executor
+    return CompletableFutures.computeAsync(
+      executor,
+      cancelChecker -> Either.forRight(symbolProvider.getSymbols(params, cancelChecker))
     );
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
@@ -38,6 +38,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.Location;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.springframework.stereotype.Component;
 
@@ -70,7 +71,18 @@ public class SymbolProvider {
     VariableKind.GLOBAL
   );
 
-  public List<? extends WorkspaceSymbol> getSymbols(WorkspaceSymbolParams params) {
+  /**
+   * Выполняет поиск символов рабочей области по запросу {@code workspace/symbol} с поддержкой отмены.
+   * <p>
+   * Отмена проверяется на границе каждого документа: если клиент отменил запрос
+   * (например, прислав новый запрос при следующем нажатии клавиши), обход прерывается
+   * исключением {@link java.util.concurrent.CancellationException}.
+   *
+   * @param params        Параметры запроса {@code workspace/symbol}, в т.ч. строка запроса
+   * @param cancelChecker Проверяющий отмену запроса; вызывается на границе каждого документа
+   * @return Список найденных символов рабочей области
+   */
+  public List<? extends WorkspaceSymbol> getSymbols(WorkspaceSymbolParams params, CancelChecker cancelChecker) {
     var queryString = Optional.ofNullable(params.getQuery())
       .orElse("");
 
@@ -79,6 +91,7 @@ public class SymbolProvider {
     // Search for symbols in all workspace contexts
     return serverContextProvider.getAllContexts().values().stream()
       .flatMap(serverContext -> serverContext.getDocuments().values().stream())
+      .peek(documentContext -> cancelChecker.checkCanceled())
       .flatMap(SymbolProvider::getSymbolEntries)
       .filter(symbolEntry -> queryString.isEmpty() || pattern.matcher(symbolEntry.symbol().getName()).find())
       .map(SymbolProvider::createWorkspaceSymbol)

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderOScriptConstructorTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderOScriptConstructorTest.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAn
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
@@ -34,7 +35,7 @@ import java.nio.file.Path;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
- * Регресс на {@link SymbolProvider#getSymbols(WorkspaceSymbolParams)} и
+ * Регресс на {@link SymbolProvider#getSymbols(WorkspaceSymbolParams, CancelChecker)} и
  * {@link DocumentSymbolProvider#getDocumentSymbols}: до выделения
  * {@code ConstructorSymbol} в отдельный {@link SymbolKind#Constructor} фильтр
  * workspace symbol search поддерживал только {@link SymbolKind#Method}/{@link
@@ -60,7 +61,9 @@ class SymbolProviderOScriptConstructorTest extends AbstractServerContextAwareTes
     initServerContext(Path.of(FIXTURE_DIR).toAbsolutePath(), true);
 
     // when
-    var symbols = symbolProvider.getSymbols(new WorkspaceSymbolParams("ПриСозданииОбъекта"));
+    var symbols = symbolProvider.getSymbols(new WorkspaceSymbolParams("ПриСозданииОбъекта"), () -> {
+      // no-op: проверка отмены не требуется в тесте поиска
+    });
 
     // then
     assertThat(symbols)

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
@@ -93,7 +93,9 @@ class SymbolProviderScriptVariantTest {
     var params = new WorkspaceSymbolParams("НеУстаревшаяПроцедура");
 
     // when
-    var symbols = symbolProvider.getSymbols(params);
+    var symbols = symbolProvider.getSymbols(params, () -> {
+      // no-op: проверка отмены не требуется в тесте поиска
+    });
 
     // then
     assertThat(symbols)

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
@@ -35,6 +35,7 @@ import org.eclipse.lsp4j.SymbolTag;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -46,14 +47,20 @@ import java.nio.file.Path;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.concurrent.CancellationException;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class SymbolProviderTest {
+
+  private static final CancelChecker NO_CANCEL = () -> {
+    // no-op: проверка отмены не требуется в тестах поиска
+  };
 
   @Autowired
   private ServerContext context;
@@ -78,7 +85,7 @@ class SymbolProviderTest {
     var params = new WorkspaceSymbolParams();
 
     // when
-    var symbols = symbolProvider.getSymbols(params);
+    var symbols = symbolProvider.getSymbols(params, NO_CANCEL);
 
     // then
     assertThat(symbols)
@@ -119,7 +126,7 @@ class SymbolProviderTest {
     var params = new WorkspaceSymbolParams("НеУстаревшаяПроцедура");
 
     // when
-    var symbols = symbolProvider.getSymbols(params);
+    var symbols = symbolProvider.getSymbols(params, NO_CANCEL);
 
     // then
     assertThat(symbols)
@@ -142,7 +149,7 @@ class SymbolProviderTest {
     var params = new WorkspaceSymbolParams("НеУстар");
 
     // when
-    var symbols = symbolProvider.getSymbols(params);
+    var symbols = symbolProvider.getSymbols(params, NO_CANCEL);
 
     // then
     assertThat(symbols)
@@ -161,7 +168,7 @@ class SymbolProviderTest {
     var params = new WorkspaceSymbolParams(".*");
 
     // when
-    var symbols = symbolProvider.getSymbols(params);
+    var symbols = symbolProvider.getSymbols(params, NO_CANCEL);
 
     // then
     assertThat(symbols)
@@ -180,7 +187,7 @@ class SymbolProviderTest {
     var params = new WorkspaceSymbolParams("Метод(");
 
     // when
-    var symbols = symbolProvider.getSymbols(params);
+    var symbols = symbolProvider.getSymbols(params, NO_CANCEL);
 
     // then
     assertThat(symbols).isEmpty();
@@ -215,12 +222,45 @@ class SymbolProviderTest {
     var params = new WorkspaceSymbolParams("Метод(");
 
     // when
-    var symbols = provider.getSymbols(params);
+    var symbols = provider.getSymbols(params, NO_CANCEL);
 
     // then
     assertThat(symbols)
       .hasSize(1)
       .anyMatch(symbolInformation -> symbolInformation.getName().equals(symbolName));
+  }
+
+  @Test
+  void getSymbolsCancelledCheckerInterruptsSearch() {
+
+    // given
+    // Отменённый CancelChecker должен прервать обход документов исключением CancellationException.
+    var params = new WorkspaceSymbolParams();
+    CancelChecker cancelChecker = () -> {
+      throw new CancellationException();
+    };
+
+    // when / then
+    assertThatThrownBy(() -> symbolProvider.getSymbols(params, cancelChecker))
+      .isInstanceOf(CancellationException.class);
+  }
+
+  @Test
+  void getSymbolsNonCancelledCheckerReturnsFullResult() {
+
+    // given
+    // Не-отменённый CancelChecker не должен влиять на результат: возвращается полная выдача.
+    var params = new WorkspaceSymbolParams();
+    CancelChecker cancelChecker = () -> {
+      // not cancelled
+    };
+
+    // when
+    var symbols = symbolProvider.getSymbols(params, cancelChecker);
+
+    // then
+    assertThat(symbols)
+      .hasSizeGreaterThan(0);
   }
 
   /**


### PR DESCRIPTION
## Проблема

Клиент LSP шлёт `workspace/symbol` на каждое нажатие клавиши, но сервер выполнял каждый запрос целиком: ранее `BSLWorkspaceService.symbol` использовал `CompletableFuture.supplyAsync`, у которого нет механизма отмены. Устаревшие запросы продолжали обходить все документы рабочей области, нагружая сервер впустую.

## Решение

- `BSLWorkspaceService.symbol` переведён с `CompletableFuture.supplyAsync` на `CompletableFutures.computeAsync`, который передаёт `CancelChecker` в задачу.
- `SymbolProvider.getSymbols` теперь принимает `CancelChecker` и проверяет отмену на границе каждого документа через `.peek(documentContext -> cancelChecker.checkCanceled())`. При отмене обход прерывается `CancellationException`.
- Перегрузка `getSymbols(WorkspaceSymbolParams)` без checker-а убрана; все вызовы (в т.ч. в тестах) переведены на новую сигнатуру.

Сопоставление имён остаётся прежним (regex с откатом на литерал при невалидном выражении) — это PR только про отмену.

## Тесты

- `getSymbolsCancelledCheckerInterruptsSearch` — отменённый checker прерывает обход `CancellationException`.
- `getSymbolsNonCancelledCheckerReturnsFullResult` — не-отменённый checker не влияет на результат.
- Существующие тесты `SymbolProviderTest`, `SymbolProviderOScriptConstructorTest`, `SymbolProviderScriptVariantTest` переведены на новую сигнатуру.

`./gradlew test --tests "*SymbolProviderTest"` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Improvements**
  * Symbol search now supports request cancellation, enabling users to interrupt long-running workspace searches mid-operation for better responsiveness during document traversal.

* **Tests**
  * Added comprehensive test coverage for cancellation behavior in symbol search operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->