### PR TITLE
feat(SymbolProvider): fuzzy-сопоставление workspace/symbol по подпоследовательности + лимит выдачи

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Component;
 import java.net.URI;
 import java.util.EnumSet;
 import java.util.List;
+import java.util.Locale;
 import java.util.Optional;
 import java.util.Set;
 import java.util.regex.Pattern;
@@ -87,15 +88,57 @@ public class SymbolProvider {
       .orElse("");
 
     var pattern = compilePattern(queryString);
+    var lowerCasedQuery = queryString.toLowerCase(Locale.ROOT);
 
     // Search for symbols in all workspace contexts
     return serverContextProvider.getAllContexts().values().stream()
       .flatMap(serverContext -> serverContext.getDocuments().values().stream())
       .peek(documentContext -> cancelChecker.checkCanceled())
       .flatMap(SymbolProvider::getSymbolEntries)
-      .filter(symbolEntry -> queryString.isEmpty() || pattern.matcher(symbolEntry.symbol().getName()).find())
+      .filter(symbolEntry -> matches(queryString, lowerCasedQuery, pattern, symbolEntry.symbol().getName()))
       .map(SymbolProvider::createWorkspaceSymbol)
       .collect(Collectors.toList());
+  }
+
+  /**
+   * Проверяет, соответствует ли имя символа запросу {@code workspace/symbol}.
+   * <p>
+   * Пустой запрос соответствует любому символу. В остальных случаях имя считается совпавшим,
+   * если оно совпадает с запросом как с регулярным выражением (поведение по умолчанию) ЛИБО
+   * содержит символы запроса как подпоследовательность. Спецификация LSP рекомендует
+   * "расслабленное" сопоставление, оставляя клиенту дофильтрацию и ранжирование результатов.
+   *
+   * @param queryString      Исходная строка запроса пользователя
+   * @param lowerCasedQuery  Строка запроса, приведённая к нижнему регистру для сопоставления по подпоследовательности
+   * @param pattern          Скомпилированный шаблон регулярного выражения для запроса
+   * @param symbolName       Имя проверяемого символа
+   * @return {@code true}, если имя символа соответствует запросу хотя бы одним из способов
+   */
+  private static boolean matches(String queryString, String lowerCasedQuery, Pattern pattern, String symbolName) {
+    return queryString.isEmpty()
+      || pattern.matcher(symbolName).find()
+      || isSubsequence(lowerCasedQuery, symbolName.toLowerCase(Locale.ROOT));
+  }
+
+  /**
+   * Определяет, является ли строка запроса подпоследовательностью имени символа.
+   * <p>
+   * Каждый символ запроса должен встречаться в имени в том же порядке, но не обязательно подряд.
+   * Обе строки ожидаются уже приведёнными к нижнему регистру для регистронезависимого сопоставления.
+   *
+   * @param query Строка запроса в нижнем регистре
+   * @param name  Имя символа в нижнем регистре
+   * @return {@code true}, если все символы запроса встречаются в имени в исходном порядке
+   */
+  private static boolean isSubsequence(String query, String name) {
+    var queryIndex = 0;
+    var queryLength = query.length();
+    for (var nameIndex = 0; queryIndex < queryLength && nameIndex < name.length(); nameIndex++) {
+      if (query.charAt(queryIndex) == name.charAt(nameIndex)) {
+        queryIndex++;
+      }
+    }
+    return queryIndex == queryLength;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
@@ -73,6 +73,20 @@ public class SymbolProvider {
   );
 
   /**
+   * Максимальное число символов, возвращаемых в ответе на запрос {@code workspace/symbol}.
+   * <p>
+   * Сопоставление по подпоследовательности на коротком запросе (1-2 символа) совпадает почти
+   * с каждым методом проекта, поэтому на больших конфигурациях без ограничения собрались бы
+   * сотни тысяч элементов, чем захлебнулись бы и сервер, и клиент. Лимит применяется через
+   * {@code .limit(...)} в стриме до сборки результата: благодаря short-circuit обход документов
+   * прекращается сразу после набора лимита и не зависит от общего размера проекта.
+   * <p>
+   * Усечение допустимо: спецификация LSP считает {@code workspace/symbol} "расслабленным" поиском,
+   * клиент сам дофильтровывает и ранжирует выдачу, сужая запрос по мере набора текста.
+   */
+  private static final int MAX_RESULTS = 1000;
+
+  /**
    * Выполняет поиск символов рабочей области по запросу {@code workspace/symbol} с поддержкой отмены.
    * <p>
    * Отмена проверяется на границе каждого документа: если клиент отменил запрос
@@ -97,6 +111,7 @@ public class SymbolProvider {
       .flatMap(SymbolProvider::getSymbolEntries)
       .filter(symbolEntry -> matches(queryString, lowerCasedQuery, pattern, symbolEntry.symbol().getName()))
       .map(SymbolProvider::createWorkspaceSymbol)
+      .limit(MAX_RESULTS)
       .collect(Collectors.toList());
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
@@ -34,6 +34,7 @@ import com.github._1c_syntax.bsl.types.MdoReference;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
@@ -48,6 +48,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.CancellationException;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -61,6 +63,11 @@ class SymbolProviderTest {
   private static final CancelChecker NO_CANCEL = () -> {
     // no-op: проверка отмены не требуется в тестах поиска
   };
+
+  /**
+   * Ожидаемый лимит выдачи {@code workspace/symbol}; зеркалит {@code SymbolProvider.MAX_RESULTS}.
+   */
+  private static final int MAX_RESULTS = 1000;
 
   @Autowired
   private ServerContext context;
@@ -301,6 +308,45 @@ class SymbolProviderTest {
         symbolInformation.getName().equals("ГлобальнаяСервернаяПроцедура")
           && symbolInformation.getKind() == SymbolKind.Method
       );
+  }
+
+  @Test
+  void getSymbolsLimitsResultSizeForShortQuery() {
+
+    // given
+    // Запрос из одной буквы «a» по подпоследовательности совпадает с каждым символом, чьё имя
+    // содержит «a». Подаём заведомо больше символов, чем лимит выдачи, и ожидаем, что результат
+    // усечён ровно до лимита (короткое замыкание стрима до сборки).
+    var matchingSymbolsCount = MAX_RESULTS + 100;
+    var symbolUri = Absolute.uri("file:///module.bsl");
+
+    var symbols = IntStream.range(0, matchingSymbolsCount)
+      .mapToObj(index -> mockMethodSymbol("aMethod" + index))
+      .collect(Collectors.toList());
+
+    var symbolTree = mock(SymbolTree.class);
+    when(symbolTree.getChildrenFlat()).thenReturn(symbols);
+
+    var documentContext = mock(DocumentContext.class);
+    when(documentContext.getUri()).thenReturn(symbolUri);
+    when(documentContext.getSymbolTree()).thenReturn(symbolTree);
+    when(documentContext.getMdObject()).thenReturn(Optional.empty());
+    symbols.forEach(symbol -> when(symbol.getOwner()).thenReturn(documentContext));
+
+    var serverContext = mock(ServerContext.class);
+    when(serverContext.getDocuments()).thenReturn(Map.of(symbolUri, documentContext));
+
+    var serverContextProvider = mock(ServerContextProvider.class);
+    when(serverContextProvider.getAllContexts()).thenReturn(Map.of(symbolUri, serverContext));
+
+    var provider = new SymbolProvider(serverContextProvider);
+    var params = new WorkspaceSymbolParams("a");
+
+    // when
+    var result = provider.getSymbols(params, NO_CANCEL);
+
+    // then
+    assertThat(result).hasSize(MAX_RESULTS);
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
@@ -263,6 +263,46 @@ class SymbolProviderTest {
       .hasSizeGreaterThan(0);
   }
 
+  @Test
+  void getSymbolsFuzzySubsequenceMatch() {
+
+    // given
+    // Запрос «ГСП» не является непрерывной подстрокой имени «ГлобальнаяСервернаяПроцедура»,
+    // поэтому regex-сопоставление его не находит. Однако символы Г, С, П встречаются
+    // в имени в том же порядке, поэтому fuzzy-сопоставление по подпоследовательности
+    // должно вернуть символ.
+    var params = new WorkspaceSymbolParams("ГСП");
+
+    // when
+    var symbols = symbolProvider.getSymbols(params, NO_CANCEL);
+
+    // then
+    assertThat(symbols)
+      .anyMatch(symbolInformation ->
+        symbolInformation.getName().equals("ГлобальнаяСервернаяПроцедура")
+          && symbolInformation.getKind() == SymbolKind.Method
+      );
+  }
+
+  @Test
+  void getSymbolsFuzzySubsequenceCaseInsensitive() {
+
+    // given
+    // Регистр символов запроса не должен влиять на сопоставление по подпоследовательности
+    // (кириллица приводится к нижнему регистру).
+    var params = new WorkspaceSymbolParams("гсп");
+
+    // when
+    var symbols = symbolProvider.getSymbols(params, NO_CANCEL);
+
+    // then
+    assertThat(symbols)
+      .anyMatch(symbolInformation ->
+        symbolInformation.getName().equals("ГлобальнаяСервернаяПроцедура")
+          && symbolInformation.getKind() == SymbolKind.Method
+      );
+  }
+
   /**
    * Создаёт mock символа-метода с заданным именем для проверки сопоставления имён.
    *


### PR DESCRIPTION
## Проблема

`workspace/symbol` сопоставлял имена только как regex (с откатом на литеральную подстроку). Из-за этого «расслабленный» поиск, который рекомендует спецификация LSP, не работал: запрос вроде `ГСП` не находил `ГлобальнаяСервернаяПроцедура`, хотя пользователь явно имел в виду именно его.

## Решение

- Символ попадает в выдачу, если имя совпадает с запросом как regex ЛИБО содержит символы запроса как подпоследовательность (регистронезависимо; кириллица через `toLowerCase(Locale.ROOT)`). Поведение literal-fallback при невалидном regex сохранено.
- Выделены приватные методы `matches` и `isSubsequence` с javadoc.
- Размер выдачи ограничен `MAX_RESULTS` через `.limit()` в стриме: на коротком запросе подпоследовательность совпадает почти с каждым методом проекта, поэтому без ограничения на больших конфигурациях собрались бы сотни тысяч элементов. Благодаря short-circuit обход документов прекращается сразу после набора лимита.

## Тесты

- `getSymbolsFuzzySubsequenceMatch` — `ГСП` находит `ГлобальнаяСервернаяПроцедура`.
- `getSymbolsFuzzySubsequenceCaseInsensitive` — регистр запроса не влияет.
- `getSymbolsLimitsResultSizeForShortQuery` — результат усечён ровно до `MAX_RESULTS`.

`./gradlew test --tests "*SymbolProviderTest"` — BUILD SUCCESSFUL.

## Открытая дискуссия по лимиту

Дизайн лимита **обсуждается** и этот PR не следует мержить вслепую. В обсуждении исходного #4080 (в т.ч. комментарий про то, «как работают другие серверы») рассматриваются альтернативы:

- **rank-then-limit** — сначала ранжировать совпадения (по качеству fuzzy-сопоставления), затем усекать, чтобы в выдачу попадали наиболее релевантные, а не первые попавшиеся по порядку обхода;
- убрать лимит вовсе и положиться на клиентскую дофильтрацию;
- завести индекс символов для эффективного поиска вместо полного обхода.

Текущая реализация — простой `.limit()` по порядку стрима; вероятен переход на rank-then-limit. Прошу ревьюеров высказаться по выбору стратегии.

🤖 Generated with [Claude Code](https://claude.com/claude-code)