### PR TITLE
fix(TypeHierarchyProvider): SymbolKind.Interface для интерфейсов OneScript

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/TypeHierarchyProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/TypeHierarchyProvider.java
@@ -154,9 +154,10 @@ public class TypeHierarchyProvider {
     // classNames здесь непустой.
     var primaryName = oScriptLibraryIndex.classNames(documentContext).getFirst();
 
+    var kind = typeRelations.isInterface(documentContext) ? SymbolKind.Interface : SymbolKind.Class;
     var item = new TypeHierarchyItem(
       primaryName,
-      SymbolKind.Class,
+      kind,
       documentContext.getUri().toString(),
       module.getRange(),
       typeRelations.classSelectionRange(documentContext)

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/TypeHierarchyProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/TypeHierarchyProviderTest.java
@@ -201,6 +201,55 @@ class TypeHierarchyProviderTest extends AbstractServerContextAwareTest {
     assertThat(subtypes).isEmpty();
   }
 
+  @Test
+  void prepareReturnsInterfaceKindForInterface() {
+    // given — Плавающее объявлен через &Интерфейс.
+    var document = document("Плавающее.os");
+
+    // when
+    var items = provider.prepareTypeHierarchy(document, prepareParams(document));
+
+    // then — элемент иерархии помечен как интерфейс.
+    assertThat(items)
+      .hasSize(1)
+      .allMatch(item -> item.getName().equals("Плавающее"))
+      .allMatch(item -> item.getKind() == SymbolKind.Interface);
+  }
+
+  @Test
+  void supertypesMarkImplementedInterfaceWithInterfaceKind() {
+    // given — Собака реализует интерфейс Плавающее (&Реализует).
+    var document = document("Собака.os");
+
+    // when
+    var supertypes = provider.supertypes(document, new TypeHierarchySupertypesParams(item(document)));
+
+    // then — интерфейс помечен как Interface, родитель-класс — как Class.
+    assertThat(supertypes)
+      .filteredOn(item -> item.getName().equals("Плавающее"))
+      .singleElement()
+      .matches(item -> item.getKind() == SymbolKind.Interface);
+    assertThat(supertypes)
+      .filteredOn(item -> item.getName().equals("Млекопитающее"))
+      .singleElement()
+      .matches(item -> item.getKind() == SymbolKind.Class);
+  }
+
+  @Test
+  void subtypesMarkImplementorWithClassKind() {
+    // given — интерфейс Плавающее реализован классом Собака.
+    var document = document("Плавающее.os");
+
+    // when
+    var subtypes = provider.subtypes(document, new TypeHierarchySubtypesParams(item(document)));
+
+    // then — реализатор остаётся классом.
+    assertThat(subtypes)
+      .singleElement()
+      .matches(item -> item.getName().equals("Собака"))
+      .matches(item -> item.getKind() == SymbolKind.Class);
+  }
+
   private DocumentContext document(String fileName) {
     var uri = uri(fileName);
     var documentContext = context.getDocument(uri);


### PR DESCRIPTION
## Проблема

`TypeHierarchyProvider.toItem` всегда выставлял `SymbolKind.Class` при формировании `TypeHierarchyItem`, даже когда `.os`-документ объявлен как интерфейс (`&Интерфейс`). В результате клиент показывал интерфейсы (например `Плавающее`, `Летающее`) с иконкой класса — и в корневом элементе `prepareTypeHierarchy`, и в супертипах (реализуемые через `&Реализует` интерфейсы), и в подтипах.

## Решение

В `toItem` вычисляем вид элемента через уже существующую точку истины об интерфейсах — `TypeRelations.isInterface(documentContext)` (та же проверка, что используется в фиче `&Реализует`): для интерфейса `SymbolKind.Interface`, иначе `SymbolKind.Class`. Правка локальна: затронуто только формирование `TypeHierarchyItem`, логика супертипов/подтипов (`&Реализует`) и упрощённый `return` не тронуты.

## Тесты

Добавлены в `TypeHierarchyProviderTest`:
- `prepareReturnsInterfaceKindForInterface` — корневой элемент интерфейса `Плавающее` имеет `kind == Interface`;
- `supertypesMarkImplementedInterfaceWithInterfaceKind` — у `Собака` супертип `Плавающее` помечен `Interface`, а родитель `Млекопитающее` — `Class`;
- `subtypesMarkImplementorWithClassKind` — реализатор `Собака` интерфейса `Плавающее` остаётся `Class`.

Сначала тесты были красными (2 падали по правильной причине — выдавался `Class` вместо `Interface`), после правки все 16 тестов класса зелёные.

`./gradlew test --tests "...TypeHierarchyProviderTest" -Dversioning.disable=true -Pversion=0.0.0-DEV` → `tests="16" skipped="0" failures="0" errors="0"`, BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Type Hierarchy now correctly identifies and displays interface and class types with their proper symbol kinds. Previously, all types in the hierarchy were incorrectly classified as classes regardless of their actual kind. This improvement ensures accurate type representation and provides clearer visual distinction in hierarchy views.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->