### PR TITLE
fix(SignatureHelpProvider): учёт клиентских capability signatureHelp (labelOffset, documentationFormat)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
@@ -21,9 +21,11 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
@@ -40,14 +42,22 @@ import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
 import org.antlr.v4.runtime.tree.TerminalNode;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.MarkupContent;
+import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.ParameterInformation;
+import org.eclipse.lsp4j.ParameterInformationCapabilities;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpCapabilities;
 import org.eclipse.lsp4j.SignatureHelpContext;
 import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SignatureInformation;
+import org.eclipse.lsp4j.SignatureInformationCapabilities;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.jsonrpc.messages.Tuple;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -77,6 +87,34 @@ public final class SignatureHelpProvider {
   private final TypeService typeService;
   private final GlobalScopeProvider globalScopeProvider;
   private final LanguageServerConfiguration configuration;
+  private final ClientCapabilitiesHolder clientCapabilitiesHolder;
+
+  // Кэшируется на initialize. Поддерживает ли клиент labelOffsetSupport
+  // (textDocument.signatureHelp.signatureInformation.parameterInformation.labelOffsetSupport).
+  // Если да — ParameterInformation.label задаётся офсетами [start, end) в строке label сигнатуры.
+  // Если нет — label задаётся строкой-подстрокой параметра (LSP-офсеты — опциональная фича клиента).
+  private boolean labelOffsetSupport;
+
+  // Кэшируется на initialize. Поддерживает ли клиент markdown в documentation сигнатуры
+  // (textDocument.signatureHelp.signatureInformation.documentationFormat). Если да —
+  // documentation сигнатуры отдаётся как MarkupContent(MARKDOWN), иначе голой строкой (plaintext).
+  private boolean markdownDocumentationSupport;
+
+  @EventListener(LanguageServerInitializeRequestReceivedEvent.class)
+  public void handleInitializeEvent() {
+    var signatureInformation = clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getTextDocument)
+      .map(TextDocumentClientCapabilities::getSignatureHelp)
+      .map(SignatureHelpCapabilities::getSignatureInformation);
+    labelOffsetSupport = signatureInformation
+      .map(SignatureInformationCapabilities::getParameterInformation)
+      .map(ParameterInformationCapabilities::getLabelOffsetSupport)
+      .orElse(Boolean.FALSE);
+    markdownDocumentationSupport = signatureInformation
+      .map(SignatureInformationCapabilities::getDocumentationFormat)
+      .map(formats -> formats.contains(MarkupKind.MARKDOWN))
+      .orElse(Boolean.FALSE);
+  }
 
   /**
    * @return signature help для указанной позиции, либо пустой {@link SignatureHelp} если контекст
@@ -473,14 +511,34 @@ public final class SignatureHelpProvider {
     info.setParameters(paramInfos);
     var sigDesc = sig.displayDescription(lang);
     if (!sigDesc.isBlank()) {
-      info.setDocumentation(sigDesc);
+      setSignatureDocumentation(info, sigDesc);
     }
     return info;
   }
 
   /**
+   * Проставляет documentation сигнатуры с учётом клиентских capabilities. Если клиент
+   * объявил поддержку markdown в {@code signatureInformation.documentationFormat} —
+   * текст отдаётся как {@link MarkupContent} с {@link MarkupKind#MARKDOWN}, иначе голой
+   * строкой (plaintext). Сам текст описания не содержит markdown-разметки, поэтому
+   * дополнительной очистки для plaintext-клиента не требуется.
+   *
+   * @param info          сигнатура, которой проставляется документация.
+   * @param documentation текст описания сигнатуры.
+   */
+  private void setSignatureDocumentation(SignatureInformation info, String documentation) {
+    if (markdownDocumentationSupport) {
+      info.setDocumentation(new MarkupContent(MarkupKind.MARKDOWN, documentation));
+    } else {
+      info.setDocumentation(documentation);
+    }
+  }
+
+  /**
    * Дописать в {@code label} один параметр ({@code Имя: Тип? = Значение}) и вернуть
-   * соответствующий {@link ParameterInformation} с диапазоном подсветки.
+   * соответствующий {@link ParameterInformation}. Метка параметра задаётся офсетами
+   * {@code [start, end)} в строке label сигнатуры, если клиент объявил labelOffsetSupport;
+   * иначе — строкой-подстрокой того же диапазона (LSP-офсеты — опциональная фича клиента).
    * Необязательный параметр помечается «?»: знак приклеивается к типу
    * ({@code Имя: Тип?}), а при отсутствии типа — к имени ({@code Имя?}).
    */
@@ -501,7 +559,12 @@ public final class SignatureHelpProvider {
     }
     var end = label.length();
     var info = new ParameterInformation();
-    info.setLabel(Either.forRight(new Tuple.Two<>(start, end)));
+    if (labelOffsetSupport) {
+      info.setLabel(Either.forRight(new Tuple.Two<>(start, end)));
+    } else {
+      // Клиент без labelOffsetSupport: label — строка-подстрока соответствующего параметра.
+      info.setLabel(Either.forLeft(label.substring(start, end)));
+    }
     var pDesc = p.displayDescription(lang);
     if (!pDesc.isBlank()) {
       info.setDocumentation(pDesc);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProviderTest.java
@@ -21,19 +21,29 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.MarkupKind;
+import org.eclipse.lsp4j.ParameterInformationCapabilities;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.SignatureHelp;
+import org.eclipse.lsp4j.SignatureHelpCapabilities;
 import org.eclipse.lsp4j.SignatureHelpContext;
 import org.eclipse.lsp4j.SignatureHelpParams;
 import org.eclipse.lsp4j.SignatureHelpTriggerKind;
 import org.eclipse.lsp4j.SignatureInformation;
+import org.eclipse.lsp4j.SignatureInformationCapabilities;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -45,6 +55,35 @@ class SignatureHelpProviderTest {
 
   @Autowired
   private LanguageServerConfiguration languageServerConfiguration;
+
+  @Autowired
+  private ClientCapabilitiesHolder clientCapabilitiesHolder;
+
+  @AfterEach
+  void resetClientCapabilities() {
+    clientCapabilitiesHolder.setCapabilities(null);
+    signatureHelpProvider.handleInitializeEvent();
+  }
+
+  private void initSignatureHelpCapabilities(boolean labelOffsetSupport, boolean markdownDocumentation) {
+    var parameterInformation = new ParameterInformationCapabilities();
+    parameterInformation.setLabelOffsetSupport(labelOffsetSupport);
+    var signatureInformation = new SignatureInformationCapabilities();
+    signatureInformation.setParameterInformation(parameterInformation);
+    if (markdownDocumentation) {
+      signatureInformation.setDocumentationFormat(List.of(MarkupKind.MARKDOWN, MarkupKind.PLAINTEXT));
+    } else {
+      signatureInformation.setDocumentationFormat(List.of(MarkupKind.PLAINTEXT));
+    }
+    var signatureHelp = new SignatureHelpCapabilities();
+    signatureHelp.setSignatureInformation(signatureInformation);
+    var textDocumentCaps = new TextDocumentClientCapabilities();
+    textDocumentCaps.setSignatureHelp(signatureHelp);
+    var caps = new ClientCapabilities();
+    caps.setTextDocument(textDocumentCaps);
+    clientCapabilitiesHolder.setCapabilities(caps);
+    signatureHelpProvider.handleInitializeEvent();
+  }
 
   @Test
   void testNoSignatureWithoutCall() {
@@ -716,6 +755,111 @@ class SignatureHelpProviderTest {
 
     // then — метка не совпадает, используется серверная логика (0).
     assertThat(help.getActiveSignature()).isZero();
+  }
+
+  @Test
+  void parameterLabelUsesOffsetsWhenClientSupportsLabelOffset() {
+    // given — клиент заявил labelOffsetSupport.
+    initSignatureHelpCapabilities(true, false);
+    var content =
+      "Процедура МояПроцедура(А, Б) Экспорт\n"
+        + "КонецПроцедуры\n"
+        + "\n"
+        + "МояПроцедура(1, 2);\n";
+    var documentContext = TestUtils.getDocumentContext(content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(3, "МояПроцедура(".length()));
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — ParameterInformation.label задан офсетами [start, end), которые
+    // указывают на подстроку параметра внутри label сигнатуры.
+    assertThat(help.getSignatures()).hasSize(1);
+    var sig = help.getSignatures().get(0);
+    var paramLabel = sig.getParameters().get(0).getLabel();
+    assertThat(paramLabel.isRight()).isTrue();
+    var offsets = paramLabel.getRight();
+    assertThat(sig.getLabel().substring(offsets.getFirst(), offsets.getSecond())).isEqualTo("А");
+  }
+
+  @Test
+  void parameterLabelUsesStringWhenClientDoesNotSupportLabelOffset() {
+    // given — клиент НЕ заявил labelOffsetSupport.
+    initSignatureHelpCapabilities(false, false);
+    var content =
+      "Процедура МояПроцедура(А, Б) Экспорт\n"
+        + "КонецПроцедуры\n"
+        + "\n"
+        + "МояПроцедура(1, 2);\n";
+    var documentContext = TestUtils.getDocumentContext(content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(3, "МояПроцедура(".length()));
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — ParameterInformation.label задан строкой-подстрокой параметра.
+    assertThat(help.getSignatures()).hasSize(1);
+    var sig = help.getSignatures().get(0);
+    var paramLabel = sig.getParameters().get(0).getLabel();
+    assertThat(paramLabel.isLeft()).isTrue();
+    assertThat(paramLabel.getLeft()).isEqualTo("А");
+  }
+
+  @Test
+  void signatureDocumentationUsesMarkdownWhenClientSupportsIt() {
+    // given — клиент поддерживает markdown в documentation сигнатуры.
+    initSignatureHelpCapabilities(true, true);
+    var content =
+      "// Описание метода.\n"
+        + "Процедура МояПроцедура(А) Экспорт\n"
+        + "КонецПроцедуры\n"
+        + "\n"
+        + "МояПроцедура(1);\n";
+    var documentContext = TestUtils.getDocumentContext(content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(4, "МояПроцедура(".length()));
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — documentation сигнатуры — MarkupContent(MARKDOWN).
+    assertThat(help.getSignatures()).hasSize(1);
+    var documentation = help.getSignatures().get(0).getDocumentation();
+    assertThat(documentation).isNotNull();
+    assertThat(documentation.isRight()).isTrue();
+    assertThat(documentation.getRight().getKind()).isEqualTo(MarkupKind.MARKDOWN);
+    assertThat(documentation.getRight().getValue()).contains("Описание метода");
+  }
+
+  @Test
+  void signatureDocumentationUsesPlaintextWhenClientDoesNotSupportMarkdown() {
+    // given — клиент не поддерживает markdown в documentation сигнатуры.
+    initSignatureHelpCapabilities(true, false);
+    var content =
+      "// Описание метода.\n"
+        + "Процедура МояПроцедура(А) Экспорт\n"
+        + "КонецПроцедуры\n"
+        + "\n"
+        + "МояПроцедура(1);\n";
+    var documentContext = TestUtils.getDocumentContext(content);
+    var params = new SignatureHelpParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(4, "МояПроцедура(".length()));
+
+    // when
+    var help = signatureHelpProvider.getSignatureHelp(documentContext, params);
+
+    // then — documentation сигнатуры — обычная строка (plaintext).
+    assertThat(help.getSignatures()).hasSize(1);
+    var documentation = help.getSignatures().get(0).getDocumentation();
+    assertThat(documentation).isNotNull();
+    assertThat(documentation.isLeft()).isTrue();
+    assertThat(documentation.getLeft()).contains("Описание метода");
   }
 
   private static SignatureHelpContext userPickedContext(SignatureHelp previous, int activeSignature) {


### PR DESCRIPTION
## Проблема

`SignatureHelpProvider` формировал ответ без оглядки на заявленные клиентом возможности `textDocument.signatureHelp`:

- `ParameterInformation.label` ВСЕГДА задавался офсетами `[start, end)` (`Either.forRight(Tuple.Two)`), хотя `labelOffsetSupport` — опциональная фича клиента (LSP 3.14+). Клиент без неё офсеты не понимает.
- documentation сигнатуры отдавалась голой строкой без учёта `documentationFormat`.

## Решение

Добавлен `@EventListener(LanguageServerInitializeRequestReceivedEvent)` `handleInitializeEvent()`, кэширующий два флага в полях (по образцу `CompletionProvider`/`DefinitionProvider`):

- `labelOffsetSupport` ← `signatureInformation.parameterInformation.labelOffsetSupport`;
- `markdownDocumentationSupport` ← `signatureInformation.documentationFormat` содержит `markdown`.

Формирование ответа:

- **labelOffset**: при поддержке — офсеты как раньше; иначе `ParameterInformation.label` задаётся строкой-подстрокой того же диапазона (`label.substring(start, end)`), что валидно по спецификации (строка должна быть подстрокой label сигнатуры).
- **documentationFormat**: documentation сигнатуры — `MarkupContent(MARKDOWN)` при поддержке markdown, иначе plaintext-строка. Текст описания сигнатуры markdown-разметки не содержит, поэтому дополнительной очистки (как `stripMarkdownEmphasis` в `CompletionProvider`) не требуется — гейтинг лишь оборачивает в нужный тип. documentation параметров оставлена строкой (контент уже plaintext).

Дефолт обоих флагов — `false` (фичи opt-in), как и в `CompletionProvider`. Retrigger-логика, label-офсеты и Sonar-фиксы не затронуты — правки локальны.

## Тесты

`SignatureHelpProviderTest` (33 теста, 0 падений), 4 новых:

- `parameterLabelUsesOffsetsWhenClientSupportsLabelOffset` — `label.isRight()`, офсеты указывают на корректную подстроку;
- `parameterLabelUsesStringWhenClientDoesNotSupportLabelOffset` — `label.isLeft()`, строка = имя параметра;
- `signatureDocumentationUsesMarkdownWhenClientSupportsIt` — documentation = `MarkupContent(MARKDOWN)`;
- `signatureDocumentationUsesPlaintextWhenClientDoesNotSupportMarkdown` — documentation = строка.

Сначала красный (нет `handleInitializeEvent` → compile fail), затем зелёный после реализации.

```
BUILD SUCCESSFUL in 6s
11 actionable tasks: 1 executed, 10 up-to-date
```
tests="33" skipped="0" failures="0" errors="0"

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Improvements**
  * Enhanced signature help to intelligently adapt parameter label formatting and documentation rendering based on detected client capabilities.
  * Improved documentation display with conditional markdown formatting support for compatible clients.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->