### PR TITLE
feat(CompletionProvider): отложенный resolve documentation для глобальных функций

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
+import org.jspecify.annotations.Nullable;
 
 /**
  * DTO для хранения промежуточных данных completion item между его созданием
@@ -41,6 +42,15 @@ import lombok.NoArgsConstructor;
  * <p>
  * Сериализуется клиентом в JSON и приходит обратно как {@code JsonObject}/Map —
  * поля сделаны bean-style (Lombok {@code @Data}) для round-trip через Jackson.
+ * <p>
+ * Поддерживаются два вида ключа восстановления:
+ * <ul>
+ *   <li>член типа (dot-completion): заполнены {@code typeKind}/{@code typeQualifiedName}
+ *       и {@code memberName}, по ним восстанавливается член типа-владельца;</li>
+ *   <li>глобальная функция (no-dot completion): заполнено {@code functionName},
+ *       по нему функция ищется в глобальной области видимости. Поля типа-владельца
+ *       при этом не используются.</li>
+ * </ul>
  */
 @Data
 @NoArgsConstructor
@@ -49,21 +59,28 @@ public class CompletionData {
 
   /**
    * Вид типа-владельца члена (часть идентичности {@link com.github._1c_syntax.bsl.languageserver.types.model.TypeRef}).
+   * {@code null} для варианта глобальной функции.
    */
+  @Nullable
   private TypeKind typeKind;
 
   /**
    * Каноническое полное имя типа-владельца члена (часть идентичности TypeRef).
+   * {@code null} для варианта глобальной функции.
    */
+  @Nullable
   private String typeQualifiedName;
 
   /**
    * Имя члена (метода/свойства), для которого нужно восстановить документацию.
+   * {@code null} для варианта глобальной функции.
    */
+  @Nullable
   private String memberName;
 
   /**
-   * Тип файла-потребителя (BSL/OS) — влияет на набор членов типа.
+   * Тип файла-потребителя (BSL/OS) — влияет на набор членов типа и набор
+   * глобальных функций.
    */
   private FileType fileType;
 
@@ -71,4 +88,38 @@ public class CompletionData {
    * Локаль скрипта (ru/en) для отбора написаний и языка описания.
    */
   private Language scriptVariant;
+
+  /**
+   * Имя глобальной функции, для которой нужно восстановить документацию.
+   * Заполнено только для варианта глобальной функции; для члена типа — {@code null}.
+   */
+  @Nullable
+  private String functionName;
+
+  /**
+   * Создаёт ключ восстановления документации члена типа (dot-completion).
+   *
+   * @param typeKind          вид типа-владельца члена.
+   * @param typeQualifiedName каноническое полное имя типа-владельца.
+   * @param memberName        имя члена (метода/свойства).
+   * @param fileType          тип файла-потребителя (BSL/OS).
+   * @param scriptVariant     локаль скрипта (ru/en).
+   * @return ключ восстановления члена типа.
+   */
+  public static CompletionData forMember(TypeKind typeKind, String typeQualifiedName, String memberName,
+                                         FileType fileType, Language scriptVariant) {
+    return new CompletionData(typeKind, typeQualifiedName, memberName, fileType, scriptVariant, null);
+  }
+
+  /**
+   * Создаёт ключ восстановления документации глобальной функции (no-dot completion).
+   *
+   * @param functionName  имя глобальной функции.
+   * @param fileType      тип файла-потребителя (BSL/OS).
+   * @param scriptVariant локаль скрипта (ru/en).
+   * @return ключ восстановления глобальной функции.
+   */
+  public static CompletionData forFunction(String functionName, FileType fileType, Language scriptVariant) {
+    return new CompletionData(null, null, null, fileType, scriptVariant, functionName);
+  }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -340,9 +340,11 @@ public final class CompletionProvider {
    * Разрешает отложенную документацию completion item ({@code completionItem/resolve}).
    * <p>
    * Если item пришёл без {@link CompletionItem#getData()} — резолвить нечем, item
-   * возвращается как есть. Иначе по data-ключу восстанавливается тип-владелец и член,
-   * после чего {@code documentation} собирается тем же способом, что был бы при жадной
-   * сборке. Поле {@code data} очищается для экономии трафика.
+   * возвращается как есть. Иначе по data-ключу восстанавливается источник описания:
+   * для глобальной функции — она сама по имени в глобальной области видимости, для
+   * члена типа — тип-владелец и член. После чего {@code documentation} собирается тем
+   * же способом, что был бы при жадной сборке. Поле {@code data} очищается для
+   * экономии трафика.
    *
    * @param unresolved completion item, пришедший от клиента на разрешение.
    * @return тот же item с проставленной {@code documentation} и очищенным {@code data};
@@ -353,13 +355,36 @@ public final class CompletionProvider {
     if (data == null) {
       return unresolved;
     }
-    var ref = new TypeRef(data.getTypeKind(), data.getTypeQualifiedName());
-    typeService.getMembers(ref, data.getFileType(), data.getScriptVariant()).stream()
-      .filter(member -> member.name().equals(data.getMemberName()))
-      .findFirst()
-      .ifPresent(member -> applyDocumentation(unresolved, member, data.getScriptVariant()));
+    var functionName = data.getFunctionName();
+    if (functionName != null) {
+      globalScopeProvider.findFunction(functionName, data.getFileType())
+        .ifPresent(function -> applyDocumentation(unresolved, function, data.getScriptVariant()));
+    } else {
+      resolveMemberDocumentation(unresolved, data);
+    }
     unresolved.setData(null);
     return unresolved;
+  }
+
+  /**
+   * Восстанавливает {@code documentation} члена типа по ключу {@link CompletionData}
+   * dot-варианта (тип-владелец + имя члена). Если ключ типа неполон — ничего не делает.
+   *
+   * @param unresolved completion item, которому проставляется документация.
+   * @param data       ключ восстановления члена типа.
+   */
+  private void resolveMemberDocumentation(CompletionItem unresolved, CompletionData data) {
+    var typeKind = data.getTypeKind();
+    var typeQualifiedName = data.getTypeQualifiedName();
+    var memberName = data.getMemberName();
+    if (typeKind == null || typeQualifiedName == null || memberName == null) {
+      return;
+    }
+    var ref = new TypeRef(typeKind, typeQualifiedName);
+    typeService.getMembers(ref, data.getFileType(), data.getScriptVariant()).stream()
+      .filter(member -> member.name().equals(memberName))
+      .findFirst()
+      .ifPresent(member -> applyDocumentation(unresolved, member, data.getScriptVariant()));
   }
 
   /**
@@ -586,7 +611,7 @@ public final class CompletionProvider {
       }
       var displayName = fn.displayName(scriptVariant);
       if (matches(displayName, prefix)) {
-        var item = toCompletionItem(fn, scriptVariant, target);
+        var item = toCompletionItem(fn, fileType, scriptVariant, target);
         applySortText(item, BUCKET_GLOBAL, isMemberDeprecated(fn, target));
         items.add(item);
       }
@@ -701,9 +726,22 @@ public final class CompletionProvider {
     }
   }
 
-  private CompletionItem toCompletionItem(MemberDescriptor member, Language scriptVariant, CompatibilityMode target) {
-    return buildMemberItem(member, null, FileType.BSL,
+  /**
+   * Сборка completion item глобальной функции (no-dot). Метки/виды/детали/вставка строятся
+   * жадно. {@code documentation} тяжела для глобального контекста, поэтому при поддержке
+   * клиентом lazy-resolve откладывается в {@code completionItem/resolve}: вместо текста в
+   * {@code data} кладётся ключ восстановления функции по имени (см. {@link CompletionData}),
+   * а жадно собранная documentation снимается. Клиент без resolveSupport получает её сразу.
+   */
+  private CompletionItem toCompletionItem(MemberDescriptor member, FileType fileType,
+                                          Language scriptVariant, CompatibilityMode target) {
+    var item = buildMemberItem(member, null, fileType,
       CompletionItemKind.Function, CompletionItemKind.Variable, scriptVariant, target);
+    if (documentationResolveSupport) {
+      item.setDocumentation((MarkupContent) null);
+      item.setData(CompletionData.forFunction(member.name(), fileType, scriptVariant));
+    }
+    return item;
   }
 
   private List<CompletionItem> toCompletionItems(Collection<MemberDescriptor> members,
@@ -757,7 +795,7 @@ public final class CompletionProvider {
     // откладываем её в completionItem/resolve, оставляя в ответе лишь data-ключ.
     // Иначе строим жадно (прежнее поведение).
     if (documentationResolveSupport && owner != null) {
-      item.setData(new CompletionData(
+      item.setData(CompletionData.forMember(
         owner.kind(), owner.qualifiedName(), member.name(), fileType, scriptVariant));
     } else {
       applyDocumentation(item, member, scriptVariant);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -729,16 +729,15 @@ public final class CompletionProvider {
   /**
    * Сборка completion item глобальной функции (no-dot). Метки/виды/детали/вставка строятся
    * жадно. {@code documentation} тяжела для глобального контекста, поэтому при поддержке
-   * клиентом lazy-resolve откладывается в {@code completionItem/resolve}: вместо текста в
-   * {@code data} кладётся ключ восстановления функции по имени (см. {@link CompletionData}),
-   * а жадно собранная documentation снимается. Клиент без resolveSupport получает её сразу.
+   * клиентом lazy-resolve она вовсе не строится изначально, а откладывается в
+   * {@code completionItem/resolve}: вместо текста в {@code data} кладётся ключ восстановления
+   * функции по имени (см. {@link CompletionData}). Клиент без resolveSupport получает её сразу.
    */
   private CompletionItem toCompletionItem(MemberDescriptor member, FileType fileType,
                                           Language scriptVariant, CompatibilityMode target) {
-    var item = buildMemberItem(member, null, fileType,
+    var item = buildMemberItem(member, documentationResolveSupport,
       CompletionItemKind.Function, CompletionItemKind.Variable, scriptVariant, target);
     if (documentationResolveSupport) {
-      item.setDocumentation((MarkupContent) null);
       item.setData(CompletionData.forFunction(member.name(), fileType, scriptVariant));
     }
     return item;
@@ -752,8 +751,16 @@ public final class CompletionProvider {
     var items = new ArrayList<CompletionItem>(members.size());
     for (var member : members) {
       var owner = owners.get(member.name());
-      items.add(buildMemberItem(member, owner, fileType,
-        CompletionItemKind.Method, CompletionItemKind.Property, scriptVariant, target));
+      // documentation откладывается в resolve только когда член резолвим обратно по
+      // owner-типу. Локальные поля (owner == null) резолвить нечем — documentation строится сразу.
+      var deferDocumentation = documentationResolveSupport && owner != null;
+      var item = buildMemberItem(member, deferDocumentation,
+        CompletionItemKind.Method, CompletionItemKind.Property, scriptVariant, target);
+      if (deferDocumentation) {
+        item.setData(CompletionData.forMember(
+          owner.kind(), owner.qualifiedName(), member.name(), fileType, scriptVariant));
+      }
+      items.add(item);
     }
     return items;
   }
@@ -772,10 +779,14 @@ public final class CompletionProvider {
    * </ul>
    * Раньше {@code purposeDescription} писалось одновременно в {@code detail} и в
    * {@code documentation} — VS Code показывал его дважды в подсказке.
+   *
+   * @param deferDocumentation если {@code true}, {@code documentation} вовсе не строится:
+   *                           она будет дотянута лениво в {@code completionItem/resolve}
+   *                           (ключ восстановления в {@code data} проставляет вызывающий).
+   *                           Если {@code false} — собирается жадно (прежнее поведение).
    */
   private CompletionItem buildMemberItem(MemberDescriptor member,
-                                         @Nullable TypeRef owner,
-                                         FileType fileType,
+                                         boolean deferDocumentation,
                                          CompletionItemKind methodKind,
                                          CompletionItemKind propertyKind,
                                          Language scriptVariant,
@@ -791,13 +802,9 @@ public final class CompletionProvider {
       applyPropertyDetail(item, member, scriptVariant);
     }
     // documentation тяжела для широких типов (Глобальный контекст, union типов):
-    // если клиент умеет lazy-resolve и член резолвим обратно по owner-типу —
-    // откладываем её в completionItem/resolve, оставляя в ответе лишь data-ключ.
-    // Иначе строим жадно (прежнее поведение).
-    if (documentationResolveSupport && owner != null) {
-      item.setData(CompletionData.forMember(
-        owner.kind(), owner.qualifiedName(), member.name(), fileType, scriptVariant));
-    } else {
+    // если её откладывают в completionItem/resolve, изначально не строим вовсе
+    // (data-ключ проставит вызывающий). Иначе строим жадно (прежнее поведение).
+    if (!deferDocumentation) {
       applyDocumentation(item, member, scriptVariant);
     }
     markDeprecated(item, member, target);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -1921,6 +1921,82 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .isNull();
   }
 
+  private CompletionItem noDotCompletionItem(
+    com.github._1c_syntax.bsl.languageserver.context.DocumentContext documentContext,
+    Position position,
+    String label
+  ) {
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(position);
+    return completionProvider.getCompletion(documentContext, params).getItems().stream()
+      .filter(it -> label.equals(it.getLabel()))
+      .findFirst()
+      .orElseThrow();
+  }
+
+  @Test
+  void globalFunctionItemArrivesWithoutDocumentationButWithDataWhenResolveSupported() {
+    // given — клиент умеет лениво разрешать documentation
+    enableDocumentationResolveSupport(true);
+    var documentContext = TestUtils.getDocumentContext("Сооб");
+
+    // when
+    var message = noDotCompletionItem(documentContext, new Position(0, 4), "Сообщить");
+
+    // then — documentation отложена, но data приложена для resolve;
+    // жадно построенные поля (insertText) остаются
+    assertThat(message.getDocumentation())
+      .as("при поддержке resolveSupport documentation глобальной функции отдаётся лениво")
+      .isNull();
+    assertThat(message.getData())
+      .as("для отложенного resolve в item глобальной функции кладётся data-ключ")
+      .isNotNull();
+    assertThat(message.getInsertText()).isEqualTo("Сообщить(");
+  }
+
+  @Test
+  void resolveCompletionItemRestoresSameGlobalFunctionDocumentationAsEager() {
+    // given — то же описание, что было бы при жадной сборке (клиент без resolveSupport)
+    enableMarkdownDocumentation(true);
+    var eagerContext = TestUtils.getDocumentContext("Сооб");
+    var eager = noDotCompletionItem(eagerContext, new Position(0, 4), "Сообщить");
+    var expectedDoc = documentationText(eager);
+
+    enableDocumentationResolveSupport(true);
+    var lazyContext = TestUtils.getDocumentContext("Сооб");
+    var lazy = noDotCompletionItem(lazyContext, new Position(0, 4), "Сообщить");
+
+    // when — клиент запрашивает resolve этого item
+    var resolved = completionProvider.resolveCompletionItem(lazy);
+
+    // then — documentation восстановлена тем же контентом, что был бы жадным
+    assertThat(resolved.getDocumentation())
+      .as("resolve восстанавливает documentation глобальной функции")
+      .isNotNull();
+    assertThat(resolved.getDocumentation().getRight().getKind()).isEqualTo(MarkupKind.MARKDOWN);
+    assertThat(resolved.getDocumentation().getRight().getValue()).isEqualTo(expectedDoc);
+    assertThat(resolved.getData())
+      .as("после resolve data очищается для экономии трафика")
+      .isNull();
+  }
+
+  @Test
+  void globalFunctionKeepsEagerDocumentationWhenClientLacksResolveSupport() {
+    // given — клиент без resolveSupport (только markdown documentation)
+    enableMarkdownDocumentation(true);
+    var documentContext = TestUtils.getDocumentContext("Сооб");
+
+    // when
+    var message = noDotCompletionItem(documentContext, new Position(0, 4), "Сообщить");
+
+    // then — прежнее поведение: documentation приходит сразу, data не нужна
+    assertThat(message.getDocumentation())
+      .as("без resolveSupport documentation глобальной функции остаётся жадной")
+      .isNotNull();
+    assertThat(message.getData()).isNull();
+  }
+
   private void enableCommitCharactersSupport(boolean enabled) {
     var itemCaps = new CompletionItemCapabilities();
     itemCaps.setCommitCharactersSupport(enabled);


### PR DESCRIPTION
## Проблема

Отложенная `documentation` через `completionItem/resolve` была реализована только для членов типов (dot-completion, ключ в `item.data` через `CompletionData`). Глобальные функции платформы и глобального контекста (no-dot completion) строили тяжёлую `documentation` жадно в каждом ответе `textDocument/completion` — даже если клиент объявил `completionItem.resolveSupport` со свойством `documentation`.

## Решение

Распространил отложенный resolve на глобальные функции:

- `CompletionData` получил второй вариант-ключ восстановления — по имени функции. Добавлены фабрики `forMember(...)` (член типа, прежний путь) и `forFunction(...)` (глобальная функция); поля типа-владельца помечены `@Nullable`.
- `CompletionProvider.toCompletionItem` для глобальной функции при `documentationResolveSupport` кладёт в `data` ключ `forFunction(name, fileType, scriptVariant)` и снимает жадно собранную `documentation`.
- `resolveCompletionItem` ветвится: при наличии `functionName` дорезолвливает описание через `globalScopeProvider.findFunction(...)` тем же `applyDocumentation`; иначе — прежний путь члена типа (выделен в `resolveMemberDocumentation`).
- `label`/`kind`/`detail`/`insertText`/`sortText` остаются жадными. Клиент без `resolveSupport` получает `documentation` сразу (прежнее поведение).

`BSLTextDocumentService.resolveCompletionItem` уже делегирует в `CompletionProvider` — правок не потребовал.

## Тесты

Добавлены в `CompletionProviderTest` (структура given/when/then):
- `globalFunctionItemArrivesWithoutDocumentationButWithDataWhenResolveSupported` — при `resolveSupport` глобальная функция приходит без `documentation`, но с `data`-ключом; жадные поля (`insertText`) на месте;
- `resolveCompletionItemRestoresSameGlobalFunctionDocumentationAsEager` — resolve восстанавливает ровно тот же контент, что был бы при жадной сборке;
- `globalFunctionKeepsEagerDocumentationWhenClientLacksResolveSupport` — без `resolveSupport` documentation отдаётся сразу, `data` отсутствует.

Существующие resolve-тесты членов типов не сломаны.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added lazy documentation loading support for code completion items when the client advertises resolution capabilities.
  * Enhanced code completion for global functions with optimized documentation resolution.

* **Bug Fixes**
  * Improved completion item resolution handling to properly manage documentation state across different completion contexts.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->