### PR TITLE
feat(SymbolProvider): поддержка workspaceSymbol/resolve (LSP 3.17)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -470,6 +470,7 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
   private static WorkspaceSymbolOptions getWorkspaceProvider() {
     var workspaceSymbolOptions = new WorkspaceSymbolOptions();
     workspaceSymbolOptions.setWorkDoneProgress(Boolean.FALSE);
+    workspaceSymbolOptions.setResolveProvider(Boolean.TRUE);
     return workspaceSymbolOptions;
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
@@ -88,6 +88,14 @@ public class BSLWorkspaceService implements WorkspaceService {
   }
 
   @Override
+  public CompletableFuture<WorkspaceSymbol> resolveWorkspaceSymbol(WorkspaceSymbol workspaceSymbol) {
+    return CompletableFuture.supplyAsync(
+      () -> symbolProvider.resolveSymbol(workspaceSymbol),
+      executor
+    );
+  }
+
+  @Override
   public void didChangeConfiguration(DidChangeConfigurationParams params) {
     // no-op: configuration is managed through .bsl-language-server.json files
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/ClientCapabilitiesHolder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/ClientCapabilitiesHolder.java
@@ -28,6 +28,9 @@ import lombok.ToString;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.ClientInfo;
 import org.eclipse.lsp4j.InitializeParams;
+import org.eclipse.lsp4j.SymbolCapabilities;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+import org.eclipse.lsp4j.WorkspaceSymbolResolveSupportCapabilities;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
@@ -57,6 +60,13 @@ public class ClientCapabilitiesHolder {
     "Antigravity",
     "code-server"
   );
+
+  /**
+   * Имя свойства {@code workspace.symbol.resolveSupport.properties}, которым клиент по LSP 3.17
+   * заявляет готовность дорезолвливать точный диапазон символа рабочей области через
+   * запрос {@code workspaceSymbol/resolve}.
+   */
+  private static final String WORKSPACE_SYMBOL_LOCATION_RANGE_PROPERTY = "location.range";
 
   /**
    * Возможности клиента.
@@ -100,6 +110,27 @@ public class ClientCapabilitiesHolder {
     return getClientInfo()
       .map(ClientInfo::getName)
       .map(VS_CODE_LIKE_CLIENT_NAMES::contains)
+      .orElse(false);
+  }
+
+  /**
+   * Поддерживает ли подключённый (по данным {@code initialize}) клиент дорезолвливание
+   * символов рабочей области запросом {@code workspaceSymbol/resolve} (LSP 3.17).
+   * <p>
+   * Признак определяется по {@code workspace.symbol.resolveSupport}: клиент должен явно
+   * перечислить свойство {@code location.range}, означающее, что он готов получить символ
+   * с облегчённым местоположением (только {@code uri}) и дозапросить точный диапазон.
+   *
+   * @return {@code true}, если клиент заявил поддержку дорезолвливания диапазона символа;
+   *   {@code false}, если поддержка не заявлена или клиент о себе не сообщил.
+   */
+  public boolean isWorkspaceSymbolResolveSupported() {
+    return getCapabilities()
+      .map(ClientCapabilities::getWorkspace)
+      .map(WorkspaceClientCapabilities::getSymbol)
+      .map(SymbolCapabilities::getResolveSupport)
+      .map(WorkspaceSymbolResolveSupportCapabilities::getProperties)
+      .map(properties -> properties.contains(WORKSPACE_SYMBOL_LOCATION_RANGE_PROPERTY))
       .orElse(false);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProvider.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
@@ -29,18 +30,28 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.variable.VariableKind;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
+import com.github._1c_syntax.bsl.languageserver.databind.URITypeAdapter;
+import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
 import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.types.MdoReference;
 import com.github._1c_syntax.bsl.types.ScriptVariant;
+import com.github._1c_syntax.utils.Absolute;
 import com.github._1c_syntax.utils.CaseInsensitivePattern;
+import com.google.gson.annotations.JsonAdapter;
 import lombok.RequiredArgsConstructor;
+import lombok.SneakyThrows;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.WorkspaceSymbol;
+import org.eclipse.lsp4j.WorkspaceSymbolLocation;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
+import org.jspecify.annotations.Nullable;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.net.URI;
 import java.util.EnumSet;
@@ -65,11 +76,34 @@ import java.util.stream.Stream;
 public class SymbolProvider {
 
   private final ServerContextProvider serverContextProvider;
+  private final ClientCapabilitiesHolder clientCapabilitiesHolder;
+  private final JsonMapper jsonMapper;
 
   private static final Set<VariableKind> SUPPORTED_VARIABLE_KINDS = EnumSet.of(
     VariableKind.MODULE,
     VariableKind.GLOBAL
   );
+
+  /**
+   * Закэшированный признак поддержки клиентом дорезолвливания символов рабочей области
+   * ({@code workspaceSymbol/resolve}). Вычисляется один раз при получении
+   * {@link LanguageServerInitializeRequestReceivedEvent}, чтобы не читать
+   * {@link ClientCapabilitiesHolder} на каждый запрос {@code workspace/symbol}.
+   */
+  private boolean resolveSupported;
+
+  /**
+   * Обработчик события {@link LanguageServerInitializeRequestReceivedEvent}.
+   * <p>
+   * Один раз определяет и кэширует признак поддержки клиентом дорезолвливания диапазона
+   * символа: в момент события {@link ClientCapabilitiesHolder} уже содержит возможности клиента.
+   *
+   * @param event Событие получения запроса инициализации.
+   */
+  @EventListener
+  public void handleInitializeEvent(LanguageServerInitializeRequestReceivedEvent event) {
+    resolveSupported = clientCapabilitiesHolder.isWorkspaceSymbolResolveSupported();
+  }
 
   /**
    * Выполняет поиск символов рабочей области по запросу {@code workspace/symbol} с поддержкой отмены.
@@ -94,8 +128,35 @@ public class SymbolProvider {
       .peek(documentContext -> cancelChecker.checkCanceled())
       .flatMap(SymbolProvider::getSymbolEntries)
       .filter(symbolEntry -> queryString.isEmpty() || pattern.matcher(symbolEntry.symbol().getName()).find())
-      .map(SymbolProvider::createWorkspaceSymbol)
+      .map(this::createWorkspaceSymbol)
       .collect(Collectors.toList());
+  }
+
+  /**
+   * Дорезолвливает символ рабочей области, достраивая точное местоположение
+   * ({@link Location} с диапазоном) по запросу {@code workspaceSymbol/resolve} (LSP 3.17).
+   * <p>
+   * Облегчённый символ, отданный в {@link #getSymbols}, несёт местоположение в виде
+   * {@link WorkspaceSymbolLocation} (только {@code uri}, без диапазона) и поле
+   * {@link WorkspaceSymbol#getData()} с данными для восстановления. По этим данным
+   * символ повторно отыскивается в дереве символов документа и его диапазон
+   * подставляется в местоположение. Если символ уже несёт полное местоположение
+   * или данные восстановить не удалось, символ возвращается без изменений.
+   *
+   * @param workspaceSymbol Символ рабочей области, подлежащий дорезолвливанию.
+   * @return Символ с полным местоположением, либо исходный символ, если дорезолвить нечем.
+   */
+  public WorkspaceSymbol resolveSymbol(WorkspaceSymbol workspaceSymbol) {
+    var data = extractData(workspaceSymbol.getData());
+    if (data == null) {
+      return workspaceSymbol;
+    }
+
+    findSymbolRange(data)
+      .ifPresent(range -> workspaceSymbol.setLocation(Either.forLeft(new Location(data.uri().toString(), range))));
+    workspaceSymbol.setData(null);
+
+    return workspaceSymbol;
   }
 
   /**
@@ -133,19 +194,69 @@ public class SymbolProvider {
     };
   }
 
-  private static WorkspaceSymbol createWorkspaceSymbol(SymbolEntry symbolEntry) {
+  private WorkspaceSymbol createWorkspaceSymbol(SymbolEntry symbolEntry) {
     var uri = symbolEntry.uri();
     var symbol = symbolEntry.symbol();
-    var location = new Location(uri.toString(), symbol.getRange());
+    var containerName = getContainerName(symbol, symbolEntry.scriptVariant());
 
     var workspaceSymbol = new WorkspaceSymbol();
     workspaceSymbol.setName(symbol.getName());
     workspaceSymbol.setKind(symbol.getSymbolKind());
-    workspaceSymbol.setLocation(Either.forLeft(location));
     workspaceSymbol.setTags(symbol.getTags());
-    getContainerName(symbol, symbolEntry.scriptVariant()).ifPresent(workspaceSymbol::setContainerName);
+    containerName.ifPresent(workspaceSymbol::setContainerName);
+
+    if (resolveSupported) {
+      // Облегчённый символ: только uri без точного диапазона. Диапазон будет достроен
+      // в workspaceSymbol/resolve, чтобы не вычислять его для всех символов сразу.
+      workspaceSymbol.setLocation(Either.forRight(new WorkspaceSymbolLocation(uri.toString())));
+      workspaceSymbol.setData(new WorkspaceSymbolData(uri, symbol.getName(), containerName.orElse(null)));
+    } else {
+      workspaceSymbol.setLocation(Either.forLeft(new Location(uri.toString(), symbol.getRange())));
+    }
 
     return workspaceSymbol;
+  }
+
+  /**
+   * Извлекает данные облегчённого символа из поля {@link WorkspaceSymbol#getData()}.
+   * <p>
+   * При получении запроса {@code workspaceSymbol/resolve} клиент возвращает поле {@code data}
+   * сериализованным (JSON-объект), поэтому при необходимости выполняется его десериализация
+   * в {@link WorkspaceSymbolData}.
+   *
+   * @param rawData Сырое значение поля {@code data} символа.
+   * @return Данные облегчённого символа, либо {@code null}, если поле отсутствует.
+   */
+  @SneakyThrows
+  private @Nullable WorkspaceSymbolData extractData(@Nullable Object rawData) {
+    if (rawData == null) {
+      return null;
+    }
+    if (rawData instanceof WorkspaceSymbolData data) {
+      return data;
+    }
+    return jsonMapper.readValue(rawData.toString(), WorkspaceSymbolData.class);
+  }
+
+  /**
+   * Отыскивает точный диапазон символа в дереве символов документа-источника по данным
+   * облегчённого символа.
+   *
+   * @param data Данные облегчённого символа (uri, имя, имя контейнера).
+   * @return Диапазон символа, либо {@link Optional#empty()}, если документ или символ не найдены.
+   */
+  private Optional<Range> findSymbolRange(WorkspaceSymbolData data) {
+    var uri = Absolute.uri(data.uri());
+    var expectedContainerName = Optional.ofNullable(data.containerName());
+    return serverContextProvider.getServerContext(uri)
+      .map(serverContext -> serverContext.getDocument(uri))
+      .map(SymbolProvider::getSymbolEntries)
+      .orElseGet(Stream::empty)
+      .filter(symbolEntry -> symbolEntry.symbol().getName().equals(data.name()))
+      .filter(symbolEntry -> getContainerName(symbolEntry.symbol(), symbolEntry.scriptVariant())
+        .equals(expectedContainerName))
+      .map(symbolEntry -> symbolEntry.symbol().getRange())
+      .findFirst();
   }
 
   /**
@@ -186,5 +297,23 @@ public class SymbolProvider {
    * @param scriptVariant Вариант встроенного языка проекта документа-источника
    */
   private record SymbolEntry(URI uri, SourceDefinedSymbol symbol, ScriptVariant scriptVariant) {
+  }
+
+  /**
+   * Данные облегчённого символа рабочей области для восстановления точного диапазона
+   * в запросе {@code workspaceSymbol/resolve}.
+   * <p>
+   * Передаётся клиенту в поле {@link WorkspaceSymbol#getData()} и возвращается сервером
+   * без изменений при дорезолвливании.
+   *
+   * @param uri           Идентификатор документа, в котором определён символ.
+   * @param name          Имя символа.
+   * @param containerName Имя контейнера символа, либо {@code null}, если контейнера нет.
+   */
+  record WorkspaceSymbolData(
+    @JsonAdapter(URITypeAdapter.class) URI uri,
+    String name,
+    @Nullable String containerName
+  ) {
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/ClientCapabilitiesHolderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/ClientCapabilitiesHolderTest.java
@@ -23,9 +23,14 @@ package com.github._1c_syntax.bsl.languageserver;
 
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.ClientInfo;
+import org.eclipse.lsp4j.SymbolCapabilities;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
+import org.eclipse.lsp4j.WorkspaceSymbolResolveSupportCapabilities;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.ValueSource;
+
+import java.util.List;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -121,5 +126,61 @@ class ClientCapabilitiesHolderTest {
 
     // then
     assertThat(result).isFalse();
+  }
+
+  @Test
+  void isWorkspaceSymbolResolveSupportedIsTrueWhenLocationRangeDeclared() {
+    // given
+    var holder = new ClientCapabilitiesHolder();
+    holder.setCapabilities(capabilitiesWithResolveProperties(List.of("location.range")));
+
+    // when
+    var result = holder.isWorkspaceSymbolResolveSupported();
+
+    // then
+    assertThat(result).isTrue();
+  }
+
+  @Test
+  void isWorkspaceSymbolResolveSupportedIsFalseWhenLocationRangeNotDeclared() {
+    // given
+    var holder = new ClientCapabilitiesHolder();
+    holder.setCapabilities(capabilitiesWithResolveProperties(List.of("tags")));
+
+    // when
+    var result = holder.isWorkspaceSymbolResolveSupported();
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  @Test
+  void isWorkspaceSymbolResolveSupportedIsFalseWhenCapabilitiesAbsent() {
+    // given
+    var holder = new ClientCapabilitiesHolder();
+
+    // when
+    var result = holder.isWorkspaceSymbolResolveSupported();
+
+    // then
+    assertThat(result).isFalse();
+  }
+
+  /**
+   * Собирает {@link ClientCapabilities} с заявленными свойствами
+   * {@code workspace.symbol.resolveSupport.properties}.
+   *
+   * @param properties перечень свойств, которые клиент готов дорезолвливать
+   * @return возможности клиента с заполненной секцией resolveSupport
+   */
+  private static ClientCapabilities capabilitiesWithResolveProperties(List<String> properties) {
+    var resolveSupport = new WorkspaceSymbolResolveSupportCapabilities(properties);
+    var symbolCapabilities = new SymbolCapabilities();
+    symbolCapabilities.setResolveSupport(resolveSupport);
+    var workspaceCapabilities = new WorkspaceClientCapabilities();
+    workspaceCapabilities.setSymbol(symbolCapabilities);
+    var capabilities = new ClientCapabilities();
+    capabilities.setWorkspace(workspaceCapabilities);
+    return capabilities;
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
@@ -37,6 +38,7 @@ import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.Arguments;
 import org.junit.jupiter.params.provider.MethodSource;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.net.URI;
 import java.util.List;
@@ -89,7 +91,7 @@ class SymbolProviderScriptVariantTest {
     when(serverContextProvider.getAllContexts())
       .thenReturn(Map.of(URI.create("file:///workspace"), serverContext));
 
-    var symbolProvider = new SymbolProvider(serverContextProvider);
+    var symbolProvider = new SymbolProvider(serverContextProvider, mock(ClientCapabilitiesHolder.class), new JsonMapper());
     var params = new WorkspaceSymbolParams("НеУстаревшаяПроцедура");
 
     // when

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
@@ -21,25 +21,34 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
+import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
 import com.github._1c_syntax.utils.Absolute;
+import com.google.gson.Gson;
 import lombok.SneakyThrows;
+import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.SymbolCapabilities;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
+import org.eclipse.lsp4j.WorkspaceClientCapabilities;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceSymbol;
 import org.eclipse.lsp4j.WorkspaceSymbolParams;
+import org.eclipse.lsp4j.WorkspaceSymbolResolveSupportCapabilities;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import tools.jackson.databind.json.JsonMapper;
 
 import java.io.File;
 import java.net.URI;
@@ -68,6 +77,8 @@ class SymbolProviderTest {
   private ServerContextProvider serverContextProvider;
   @Autowired
   private SymbolProvider symbolProvider;
+  @Autowired
+  private ClientCapabilitiesHolder clientCapabilitiesHolder;
 
   @BeforeEach
   void before() {
@@ -76,6 +87,34 @@ class SymbolProviderTest {
     var workspaceFolder = new WorkspaceFolder(metadataPath.toURI().toString(), "test-workspace");
     var workspaceContext = serverContextProvider.addWorkspace(workspaceFolder);
     workspaceContext.populateContext();
+  }
+
+  @AfterEach
+  void after() {
+    // сбрасываем разделяемый holder и закэшированный признак между тестами
+    clientCapabilitiesHolder.setCapabilities(null);
+    symbolProvider.handleInitializeEvent(initializeEvent());
+  }
+
+  /**
+   * Включает поддержку дорезолвливания на разделяемом {@link ClientCapabilitiesHolder}
+   * и обновляет закэшированный в провайдере признак, как при получении initialize.
+   */
+  private void enableResolveSupport() {
+    var resolveSupport = new WorkspaceSymbolResolveSupportCapabilities(List.of("location.range"));
+    var symbolCapabilities = new SymbolCapabilities();
+    symbolCapabilities.setResolveSupport(resolveSupport);
+    var workspaceCapabilities = new WorkspaceClientCapabilities();
+    workspaceCapabilities.setSymbol(symbolCapabilities);
+    var capabilities = new ClientCapabilities();
+    capabilities.setWorkspace(workspaceCapabilities);
+
+    clientCapabilitiesHolder.setCapabilities(capabilities);
+    symbolProvider.handleInitializeEvent(initializeEvent());
+  }
+
+  private static LanguageServerInitializeRequestReceivedEvent initializeEvent() {
+    return new LanguageServerInitializeRequestReceivedEvent(mock(), null);
   }
 
   @Test
@@ -218,7 +257,7 @@ class SymbolProviderTest {
     var serverContextProvider = mock(ServerContextProvider.class);
     when(serverContextProvider.getAllContexts()).thenReturn(Map.of(symbolUri, serverContext));
 
-    var provider = new SymbolProvider(serverContextProvider);
+    var provider = new SymbolProvider(serverContextProvider, mock(ClientCapabilitiesHolder.class), new JsonMapper());
     var params = new WorkspaceSymbolParams("Метод(");
 
     // when
@@ -261,6 +300,93 @@ class SymbolProviderTest {
     // then
     assertThat(symbols)
       .hasSizeGreaterThan(0);
+  }
+
+  @Test
+  void getSymbolsWithoutResolveSupportReturnsFullLocation() {
+
+    // given
+    // клиент не заявил поддержку workspaceSymbol/resolve
+    var params = new WorkspaceSymbolParams("НеУстаревшаяПроцедура");
+
+    // when
+    var symbols = symbolProvider.getSymbols(params, NO_CANCEL);
+
+    // then
+    assertThat(symbols)
+      .isNotEmpty()
+      .allMatch(workspaceSymbol -> workspaceSymbol.getLocation().isLeft())
+      .allMatch(workspaceSymbol -> workspaceSymbol.getLocation().getLeft().getRange() != null)
+      .allMatch(workspaceSymbol -> workspaceSymbol.getData() == null);
+  }
+
+  @Test
+  void getSymbolsWithResolveSupportReturnsLightweightLocation() {
+
+    // given
+    enableResolveSupport();
+    var params = new WorkspaceSymbolParams("НеУстаревшаяПроцедура");
+
+    // when
+    var symbols = symbolProvider.getSymbols(params, NO_CANCEL);
+
+    // then
+    assertThat(symbols)
+      .isNotEmpty()
+      .allMatch(workspaceSymbol -> workspaceSymbol.getLocation().isRight())
+      .allMatch(workspaceSymbol -> workspaceSymbol.getLocation().getRight().getUri() != null)
+      .allMatch(workspaceSymbol -> workspaceSymbol.getData() != null);
+  }
+
+  @Test
+  void resolveSymbolRestoresFullRange() {
+
+    // given
+    // при поддержке resolve символ отдаётся облегчённым, точный диапазон достраивается отдельно
+    enableResolveSupport();
+    var params = new WorkspaceSymbolParams("НеУстаревшаяПроцедура");
+    var lightweightSymbol = symbolProvider.getSymbols(params, NO_CANCEL).stream()
+      .filter(workspaceSymbol -> uriContainsRight(workspaceSymbol, "ПервыйОбщийМодуль"))
+      .findFirst()
+      .orElseThrow();
+    var uri = lightweightSymbol.getLocation().getRight().getUri();
+
+    // when
+    var resolvedSymbol = symbolProvider.resolveSymbol(lightweightSymbol);
+
+    // then
+    assertThat(resolvedSymbol.getLocation().isLeft()).isTrue();
+    var location = resolvedSymbol.getLocation().getLeft();
+    assertThat(location.getUri()).isEqualTo(uri);
+    assertThat(location.getRange()).isNotNull();
+    assertThat(resolvedSymbol.getData()).isNull();
+  }
+
+  @Test
+  void resolveSymbolRestoresFullRangeFromSerializedData() {
+
+    // given
+    // клиент возвращает поле data сериализованным (JSON), как это происходит по протоколу
+    enableResolveSupport();
+    var params = new WorkspaceSymbolParams("НеУстаревшаяПроцедура");
+    var lightweightSymbol = symbolProvider.getSymbols(params, NO_CANCEL).stream()
+      .filter(workspaceSymbol -> uriContainsRight(workspaceSymbol, "ПервыйОбщийМодуль"))
+      .findFirst()
+      .orElseThrow();
+    lightweightSymbol.setData(new Gson().toJsonTree(lightweightSymbol.getData()));
+
+    // when
+    var resolvedSymbol = symbolProvider.resolveSymbol(lightweightSymbol);
+
+    // then
+    assertThat(resolvedSymbol.getLocation().isLeft()).isTrue();
+    assertThat(resolvedSymbol.getLocation().getLeft().getRange()).isNotNull();
+    assertThat(resolvedSymbol.getData()).isNull();
+  }
+
+  @SneakyThrows
+  private boolean uriContainsRight(WorkspaceSymbol workspaceSymbol, String name) {
+    return Path.of(new URI(workspaceSymbol.getLocation().getRight().getUri())).toString().contains(name);
   }
 
   /**


### PR DESCRIPTION
## Проблема

`workspace/symbol` всегда строит для каждого найденного символа полную `Location` с точным `range`. На больших конфигурациях это означает вычисление точных диапазонов сразу для всех символов, даже если пользователь откроет лишь один. По LSP 3.17 это решается через `workspaceSymbol/resolve`: сервер отдаёт символы с облегчённым местоположением, а точный диапазон достраивается лениво по запросу клиента. Ранее `resolveProvider` не заявлялся и обработчика resolve не было.

## Решение

- `BSLLanguageServer.getWorkspaceProvider`: `WorkspaceSymbolOptions.resolveProvider = true`.
- `ClientCapabilitiesHolder.isWorkspaceSymbolResolveSupported()`: читает `workspace.symbol.resolveSupport.properties` и проверяет наличие `location.range`.
- `SymbolProvider`:
  - кэширует клиентский флаг через `@EventListener(LanguageServerInitializeRequestReceivedEvent)` (не читает holder на каждый запрос);
  - при поддержке resolve `symbol()` отдаёт облегчённый `WorkspaceSymbol`: `location` как `WorkspaceSymbolLocation` (только `uri`, без `range`) + `data` (`uri`, `name`, `containerName`) для восстановления; иначе — полная `Location` как прежде;
  - `resolveSymbol(WorkspaceSymbol)` по `data` повторно находит символ в дереве символов документа (по имени + имени контейнера) и подставляет точный `range`.
- `BSLWorkspaceService.resolveWorkspaceSymbol` делегирует в `SymbolProvider` (метод ранее не переопределялся).

Правки локальны и независимы от доработок fuzzy/лимита в `getSymbols` (#4095): resolve использует существующий `getSymbolEntries`/фильтрацию и не завязан на лимит.

## Тесты

- `SymbolProviderTest`: без resolveSupport — полная `Location` с `range` и без `data`; с resolveSupport — облегчённый `WorkspaceSymbolLocation` (uri, без range) + `data`; `resolveSymbol` восстанавливает полный `range` (как для in-memory `data`, так и для сериализованного JSON-варианта клиента).
- `ClientCapabilitiesHolderTest`: `isWorkspaceSymbolResolveSupported` — true при `location.range`, false при ином свойстве и при отсутствии capabilities.
- Все затронутые сьюты зелёные: SymbolProviderTest (12), ClientCapabilitiesHolderTest (14), BSLWorkspaceServiceTest (25), SymbolProviderScriptVariantTest (2), SymbolProviderOScriptConstructorTest (2) — 0 failures / 0 errors.

🤖 Generated with [Claude Code](https://claude.com/claude-code)