### PR TITLE
fix(inlayhints): показывать значения по умолчанию пропущенных аргументов

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplier.java
@@ -284,12 +284,16 @@ public class PlatformMethodCallInlayHintSupplier extends AbstractMethodCallInlay
     }
     var lang = currentLanguage();
     var variadicIndex = variadicIndex(parameters);
+    // Единственный пустой callParam — это запись вида `Метод()` / `Новый Тип()`,
+    // т.е. ноль фактических аргументов. Пропуск аргумента (`Метод(а,,б)`) даёт
+    // несколько callParam'ов, в которых пустой обозначает именно опущенный довод.
+    var hasSkippedArguments = args.size() > 1;
     for (var i = 0; i < args.size(); i++) {
       var unit = paramAt(parameters, variadicIndex, i, lang);
       if (unit == null) {
         break;
       }
-      appendHint(sink, member, unit, args.get(i));
+      appendHint(sink, member, unit, args.get(i), hasSkippedArguments);
     }
   }
 
@@ -317,15 +321,20 @@ public class PlatformMethodCallInlayHintSupplier extends AbstractMethodCallInlay
   }
 
   private void appendHint(List<InlayHint> sink, MemberDescriptor member, NamedParam unit,
-                          BSLParser.CallParamContext callParam) {
+                          BSLParser.CallParamContext callParam, boolean argumentSkipAllowed) {
     var passedValue = callParam.getText();
-    // `Новый Тип();` парсится как один пустой callParam — не показываем хинт для
-    // пустого аргумента, иначе получим бессмысленное `Новый Массив(Массив:);`.
+    // Пустой довод — либо `Метод()`/`Новый Тип()` (ноль аргументов, хинт не нужен),
+    // либо пропущенный аргумент `Метод(а,,б)`. Для пропущенного при включённом
+    // showDefaultValues показываем значение по умолчанию из сигнатуры.
     if (passedValue.isBlank()) {
+      if (!argumentSkipAllowed || !showDefaultValues() || unit.descriptor().defaultValue().isBlank()) {
+        return;
+      }
+    } else if (!showParametersWithTheSameName()
+      && shadowsName(passedValue, unit.name(), unit.descriptor())) {
       return;
-    }
-    if (!showParametersWithTheSameName() && shadowsName(passedValue, unit.name(), unit.descriptor())) {
-      return;
+    } else {
+      // непустой довод, не дублирующий имя параметра — показываем обычный хинт ниже
     }
     var hint = new InlayHint();
     hint.setKind(InlayHintKind.Parameter);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierUnitTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierUnitTest.java
@@ -21,13 +21,23 @@
  */
 package com.github._1c_syntax.bsl.languageserver.inlayhints;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
+import com.github._1c_syntax.bsl.languageserver.configuration.inlayhints.InlayHintOptions;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Resources;
+import com.github._1c_syntax.bsl.parser.BSLTokenizer;
+import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintParams;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -36,7 +46,11 @@ import org.mockito.junit.jupiter.MockitoExtension;
 import org.mockito.junit.jupiter.MockitoSettings;
 import org.mockito.quality.Strictness;
 
+import java.util.List;
+import java.util.Optional;
+
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.when;
 
 /**
@@ -73,7 +87,66 @@ class PlatformMethodCallInlayHintSupplierUnitTest {
     // when
     var hints = supplier.getInlayHints(documentContext, params);
 
-    // then — L96 return List.of().
+    // then — при отсутствии AST подсказок нет.
+    assertThat(hints).isEmpty();
+  }
+
+  @Test
+  void skippedArgumentShowsDefaultValueHint() {
+    // given — реальный AST вызова СтрНайти с пропущенным средним аргументом;
+    // сигнатура содержит средний параметр со значением по умолчанию.
+    when(documentContext.getAst()).thenReturn(new BSLTokenizer("СтрНайти(\"a\",,\"b\");\n").getAst());
+
+    var signature = SignatureDescriptor.of(List.of(
+      ParameterDescriptor.of("СтрокаПоиска"),
+      new ParameterDescriptor("НачальнаяПозиция", TypeSet.EMPTY, true, "", "1"),
+      ParameterDescriptor.of("Подстрока")
+    ));
+    var member = MemberDescriptor.method("СтрНайти", List.of(signature));
+    var typedMember = new TypeService.TypedMember(null, member, Ranges.create(0, 0, 8), 3);
+
+    when(configuration.getLanguage()).thenReturn(Language.RU);
+    when(configuration.getInlayHintOptions()).thenReturn(new InlayHintOptions());
+    when(typeService.memberAt(any(), any())).thenReturn(Optional.of(typedMember));
+    when(typeService.expressionTypesAt(any(), any())).thenReturn(TypeSet.EMPTY);
+
+    var params = new InlayHintParams();
+    params.setRange(new Range(new Position(0, 0), new Position(1, 0)));
+
+    // when
+    var hints = supplier.getInlayHints(documentContext, params);
+
+    // then — для пропущенного среднего аргумента показан хинт со значением по умолчанию.
+    assertThat(hints)
+      .extracting(InlayHint::getLabel)
+      .extracting(Either::getLeft)
+      .contains("НачальнаяПозиция (1)");
+  }
+
+  @Test
+  void emptySingleArgumentDoesNotProduceHint() {
+    // given — `Сообщить()` парсится как один пустой callParam; это ноль фактических
+    // аргументов, а не пропущенный — хинт показывать нельзя.
+    when(documentContext.getAst()).thenReturn(new BSLTokenizer("Сообщить();\n").getAst());
+
+    var signature = SignatureDescriptor.of(List.of(
+      new ParameterDescriptor("ТекстСообщения", TypeSet.EMPTY, true, "", "Пустая строка")
+    ));
+    var member = MemberDescriptor.method("Сообщить", List.of(signature));
+    var typedMember = new TypeService.TypedMember(null, member, Ranges.create(0, 0, 8), 0);
+
+    when(configuration.getLanguage()).thenReturn(Language.RU);
+    when(configuration.getInlayHintOptions()).thenReturn(new InlayHintOptions());
+    when(typeService.memberAt(any(), any())).thenReturn(Optional.of(typedMember));
+    when(typeService.expressionTypesAt(any(), any())).thenReturn(TypeSet.EMPTY);
+
+    var params = new InlayHintParams();
+    params.setRange(new Range(new Position(0, 0), new Position(1, 0)));
+
+    // when
+    var hints = supplier.getInlayHints(documentContext, params);
+
+    // then — ноль аргументов: хинтов нет.
     assertThat(hints).isEmpty();
   }
 }


### PR DESCRIPTION
## Что

Подсказки inlay-hint для платформенных методов теперь показывают значение по умолчанию для **пропущенных** аргументов.

## Поведение

- `Метод(а,,б)` — для пропущенного (пустого) второго аргумента теперь отображается подсказка со значением по умолчанию.
- `Метод()` и `Новый Тип()` (единственный пустой аргумент / вызов без аргументов) по-прежнему подсказок не дают.

Выделено из #4077 (часть 1 из 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Inlay hints for method calls with skipped arguments now conditionally display parameter default values when the feature is enabled.

* **Tests**
  * Expanded test coverage for inlay hint behavior with skipped arguments and empty call arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->