### PR TITLE
perf(inlayhints): убрать квадратичный обход AST в SourceDefinedMethodCallInlayHintSupplier

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/DoCallRangeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/DoCallRangeIndex.java
@@ -1,0 +1,131 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.inlayhints;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.languageserver.utils.Trees;
+import com.github._1c_syntax.bsl.parser.BSLParser;
+import org.antlr.v4.runtime.ParserRuleContext;
+import org.eclipse.lsp4j.Range;
+
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Optional;
+
+/**
+ * Индекс {@code doCall}-узлов документа по диапазону имени вызываемого метода.
+ * <p>
+ * Строится одним обходом AST документа и позволяет резолвить вызов по ссылке
+ * на метод за {@code O(1)} вместо повторного обхода AST на каждую ссылку.
+ * Ключом служит {@link Reference#selectionRange()} ссылки, совпадающий с
+ * диапазоном имени вызываемого метода (для конструктора — с диапазоном имени типа).
+ */
+final class DoCallRangeIndex {
+
+  private final Map<String, BSLParser.DoCallContext> doCallsByMethodNameRange;
+
+  private DoCallRangeIndex(Map<String, BSLParser.DoCallContext> doCallsByMethodNameRange) {
+    this.doCallsByMethodNameRange = doCallsByMethodNameRange;
+  }
+
+  /**
+   * Строит индекс по AST документа.
+   * <p>
+   * Все {@code doCall}-узлы документа собираются в карту по диапазону имени
+   * вызываемого метода (для конструктора — по диапазону имени типа). Этот диапазон
+   * совпадает с {@link Reference#selectionRange()} соответствующей ссылки.
+   *
+   * @param documentContext контекст документа, AST которого обходится
+   * @return индекс вызовов документа; пустой, если вызовов нет
+   */
+  static DoCallRangeIndex of(DocumentContext documentContext) {
+    var ast = documentContext.getAst();
+    var doCalls = Trees.findAllRuleNodes(ast, BSLParser.RULE_doCall);
+    Map<String, BSLParser.DoCallContext> result = HashMap.newHashMap(doCalls.size());
+    for (var node : doCalls) {
+      var doCall = (BSLParser.DoCallContext) node;
+      var doCallParent = doCall.getParent();
+      if (doCallParent == null) {
+        continue;
+      }
+      methodNameRange(doCallParent)
+        .ifPresent(methodNameRange -> result.putIfAbsent(rangeKey(methodNameRange), doCall));
+    }
+    return new DoCallRangeIndex(result);
+  }
+
+  /**
+   * Возвращает {@code doCall}-узел, соответствующий ссылке на метод.
+   *
+   * @param reference ссылка на вызываемый метод; используется её {@link Reference#selectionRange()}
+   * @return узел вызова либо {@link Optional#empty()}, если в документе нет вызова с таким диапазоном
+   */
+  Optional<BSLParser.DoCallContext> doCallFor(Reference reference) {
+    return Optional.ofNullable(doCallsByMethodNameRange.get(rangeKey(reference.selectionRange())));
+  }
+
+  /**
+   * Строковый ключ карты вызовов по диапазону имени метода.
+   * <p>
+   * Используется вместо {@link Range} из lsp4j, который не реализует
+   * {@link Comparable}: {@link String} реализует {@link Comparable} и не зависит
+   * от деталей {@link Range#hashCode()}, что устраняет риск деградации хэш-карты
+   * при коллизиях ключей.
+   *
+   * @param range диапазон имени метода/типа
+   * @return ключ вида {@code "startLine:startChar:endLine:endChar"}
+   */
+  private static String rangeKey(Range range) {
+    var start = range.getStart();
+    var end = range.getEnd();
+    return start.getLine() + ":" + start.getCharacter() + ":" + end.getLine() + ":" + end.getCharacter();
+  }
+
+  /**
+   * Диапазон имени вызываемого метода для родителя {@code doCall}-узла —
+   * именно его {@link com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex}
+   * хранит в {@link Reference#selectionRange()}.
+   *
+   * @param doCallParent родительский узел вызова (methodCall, globalMethodCall или newExpression)
+   * @return диапазон имени метода/типа либо {@link Optional#empty()},
+   *   если узел не является вызовом метода
+   */
+  private static Optional<Range> methodNameRange(ParserRuleContext doCallParent) {
+    if (doCallParent instanceof BSLParser.MethodCallContext methodCallContext) {
+      var methodName = methodCallContext.methodName();
+      return methodName == null ? Optional.empty() : Optional.of(Ranges.create(methodName));
+    } else if (doCallParent instanceof BSLParser.GlobalMethodCallContext globalMethodCallContext) {
+      var methodName = globalMethodCallContext.methodName();
+      return methodName == null ? Optional.empty() : Optional.of(Ranges.create(methodName));
+    } else if (doCallParent instanceof BSLParser.NewExpressionContext newExpressionContext) {
+      var typeName = newExpressionContext.typeName();
+      if (typeName != null && typeName.IDENTIFIER() != null) {
+        return Optional.of(Ranges.create(typeName.IDENTIFIER()));
+      }
+      return Optional.empty();
+    } else {
+      return Optional.empty();
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplier.java
@@ -29,9 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.hover.DescriptionFormatter;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
-import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
-import org.antlr.v4.runtime.ParserRuleContext;
 import org.apache.commons.lang3.Strings;
 import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintKind;
@@ -43,7 +41,6 @@ import org.eclipse.lsp4j.SymbolKind;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
-import java.util.Collection;
 import java.util.List;
 
 /**
@@ -72,60 +69,66 @@ public class SourceDefinedMethodCallInlayHintSupplier extends AbstractMethodCall
   @Override
   public List<InlayHint> getInlayHints(DocumentContext documentContext, InlayHintParams params) {
     var range = params.getRange();
-    return referenceIndex.getReferencesFrom(documentContext.getUri(), SymbolKind.Method).stream()
+    var references = referenceIndex.getReferencesFrom(documentContext.getUri(), SymbolKind.Method).stream()
       .filter(reference -> Ranges.containsPosition(range, reference.selectionRange().getStart()))
       .filter(Reference::isSourceDefinedSymbolReference)
-      .map(this::toInlayHints)
-      .flatMap(Collection::stream)
       .toList();
+    if (references.isEmpty()) {
+      return List.of();
+    }
+
+    // Один обход AST документа на все ссылки: индекс сопоставляет каждый вызов с
+    // диапазоном имени метода (тем же, что хранится в reference.selectionRange()),
+    // чтобы дальше резолвить вызов по ссылке за O(1) вместо обхода AST на каждую ссылку.
+    var doCallRangeIndex = DoCallRangeIndex.of(documentContext);
+
+    var result = new ArrayList<InlayHint>();
+    for (var reference : references) {
+      doCallRangeIndex.doCallFor(reference)
+        .ifPresent(doCall -> result.addAll(toInlayHints(reference, doCall)));
+    }
+    return result;
   }
 
-  private List<InlayHint> toInlayHints(Reference reference) {
+  private List<InlayHint> toInlayHints(Reference reference, BSLParser.DoCallContext doCall) {
+
+    var callParamList = doCall.callParamList();
+    if (callParamList == null) {
+      return List.of();
+    }
+    var callParams = callParamList.callParam();
 
     var methodSymbol = (MethodSymbol) reference.symbol();
     var parameters = methodSymbol.getParameters();
 
-    var ast = reference.from().getOwner().getAst();
-    var doCalls = Trees.findAllRuleNodes(ast, BSLParser.RULE_doCall);
+    var hints = new ArrayList<InlayHint>();
+    for (var i = 0; i < parameters.size(); i++) {
 
-    return doCalls.stream()
-      .map(BSLParser.DoCallContext.class::cast)
-      .filter(doCall -> isRightMethod(doCall.getParent(), reference))
-      .map(BSLParser.DoCallContext::callParamList)
-      .map(BSLParser.CallParamListContext::callParam)
-      .map((List<? extends BSLParser.CallParamContext> callParams) -> {
-        var hints = new ArrayList<InlayHint>();
-        for (var i = 0; i < parameters.size(); i++) {
+      // todo: show all parameters (in config)?
+      if (callParams.size() < i + 1) {
+        break;
+      }
 
-          // todo: show all parameters (in config)?
-          if (callParams.size() < i + 1) {
-            break;
-          }
+      var parameter = parameters.get(i);
+      var callParam = callParams.get(i);
 
-          var parameter = parameters.get(i);
-          var callParam = callParams.get(i);
+      var passedValue = callParam.getText();
 
-          var passedValue = callParam.getText();
+      if (!showParametersWithTheSameName() && Strings.CI.contains(passedValue, parameter.getName())) {
+        continue;
+      }
 
-          if (!showParametersWithTheSameName() && Strings.CI.contains(passedValue, parameter.getName())) {
-            continue;
-          }
+      var inlayHint = new InlayHint();
+      inlayHint.setKind(InlayHintKind.Parameter);
 
-          var inlayHint = new InlayHint();
-          inlayHint.setKind(InlayHintKind.Parameter);
+      setLabelAndPadding(inlayHint, parameter, passedValue, reference);
+      setPosition(inlayHint, callParam);
+      setTooltip(inlayHint, parameter);
 
-          setLabelAndPadding(inlayHint, parameter, passedValue, reference);
-          setPosition(inlayHint, callParam);
-          setTooltip(inlayHint, parameter);
+      hints.add(inlayHint);
+    }
 
-          hints.add(inlayHint);
-        }
-
-        return hints;
-      })
-      .flatMap(Collection::stream)
-      .toList();
-
+    return hints;
   }
 
   private void setLabelAndPadding(
@@ -164,23 +167,5 @@ public class SourceDefinedMethodCallInlayHintSupplier extends AbstractMethodCall
     var markdown = descriptionFormatter.parameterToString(parameter);
     var tooltip = new MarkupContent(MarkupKind.MARKDOWN, markdown);
     inlayHint.setTooltip(tooltip);
-  }
-
-
-  private static boolean isRightMethod(ParserRuleContext doCallParent, Reference reference) {
-    var selectionRange = reference.selectionRange();
-
-    if (doCallParent instanceof BSLParser.MethodCallContext methodCallContext) {
-      return selectionRange.equals(Ranges.create(methodCallContext.methodName()));
-    } else if (doCallParent instanceof BSLParser.GlobalMethodCallContext globalMethodCallContext) {
-      return selectionRange.equals(Ranges.create(globalMethodCallContext.methodName()));
-    } else if (doCallParent instanceof BSLParser.NewExpressionContext newExpressionContext) {
-      var typeName = newExpressionContext.typeName();
-      return typeName != null
-        && typeName.IDENTIFIER() != null
-        && selectionRange.equals(Ranges.create(typeName.IDENTIFIER()));
-    } else {
-      return false;
-    }
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/SourceDefinedMethodCallInlayHintSupplierTest.java
@@ -27,10 +27,12 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.eclipse.lsp4j.InlayHint;
 import org.eclipse.lsp4j.InlayHintKind;
 import org.eclipse.lsp4j.InlayHintParams;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -143,6 +145,146 @@ class SourceDefinedMethodCallInlayHintSupplierTest extends AbstractServerContext
       })
     ;
   }
+  @Test
+  void testHintsAreEmittedForEveryCallSiteOfSameMethod() {
+
+    // given — ChangeHealth(...) вызывается в нескольких процедурах файла; диапазон
+    // охватывает весь документ, поэтому в выборку попадают все вызовы метода.
+    var documentContext = TestUtils.getDocumentContextFromFile(FILE_PATH);
+    var lines = documentContext.getContentList();
+    var lastLine = Math.max(0, lines.length - 1);
+    var fullRange = new Range(
+      new Position(0, 0),
+      Ranges.create(lastLine, 0, lines[lastLine].length()).getEnd()
+    );
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var params = new InlayHintParams(textDocumentIdentifier, fullRange);
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then — каждый из восьми вызовов ChangeHealth(...) даёт по две подсказки
+    // (PlayersHealth и Amount), а позиции подсказок уникальны (вызовы не схлопнулись).
+    var changeHealthHints = inlayHints.stream()
+      .filter(hint -> hint.getLabel().isLeft())
+      .filter(hint -> {
+        var label = hint.getLabel().getLeft();
+        return "PlayersHealth:".equals(label) || "Amount:".equals(label);
+      })
+      .toList();
+    assertThat(changeHealthHints).hasSize(16);
+    assertThat(changeHealthHints)
+      .extracting(InlayHint::getPosition)
+      .doesNotHaveDuplicates();
+  }
+
+  @Test
+  void testEmptyArgumentShowsDefaultValueHint() {
+
+    // given — вызов метода с единственным пустым доводом: парсер формирует один
+    // пустой callParam, и при включённом показе значений по умолчанию подсказка
+    // содержит имя параметра и его значение по умолчанию.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Внешняя()
+          Внутренняя();
+      КонецПроцедуры
+
+      Процедура Внутренняя(Знач Параметр = 1)
+      КонецПроцедуры
+      """);
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var range = documentContext.getSymbolTree().getMethods().getFirst().getRange();
+    var params = new InlayHintParams(textDocumentIdentifier, range);
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then
+    assertThat(inlayHints)
+      .extracting(InlayHint::getLabel)
+      .extracting(Either::getLeft)
+      .containsExactly("Параметр (1)");
+  }
+
+  @Test
+  void testFewerArgumentsThanParametersStopAtLastPassedArgument() {
+
+    // given — аргументов меньше, чем параметров: обход прерывается на последнем
+    // переданном доводе, для отсутствующих доводов подсказки не формируются.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Внешняя()
+          Внутренняя(5);
+      КонецПроцедуры
+
+      Процедура Внутренняя(Знач Первый, Знач Второй, Знач Третий)
+      КонецПроцедуры
+      """);
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var range = documentContext.getSymbolTree().getMethods().getFirst().getRange();
+    var params = new InlayHintParams(textDocumentIdentifier, range);
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then — подсказка только для переданного первого довода.
+    assertThat(inlayHints)
+      .extracting(InlayHint::getLabel)
+      .extracting(Either::getLeft)
+      .containsExactly("Первый:");
+  }
+
+  @Test
+  void testRangeWithoutMethodCallsProducesNoHints() {
+
+    // given — диапазон не охватывает ни одного вызова метода: ссылок нет,
+    // поэтому возвращается пустой список.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Внешняя()
+          Перем ЛокальнаяПеременная;
+      КонецПроцедуры
+      """);
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var params = new InlayHintParams(textDocumentIdentifier, new Range(new Position(0, 0), new Position(0, 0)));
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then
+    assertThat(inlayHints).isEmpty();
+  }
+
+  @Test
+  void testSkippedArgumentShowsDefaultValueHint() {
+
+    // given — пропущенный первый аргумент при включённом показе значений по умолчанию:
+    // подсказка содержит имя параметра и его значение по умолчанию.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Внешняя()
+          Внутренняя(, 5);
+      КонецПроцедуры
+
+      Процедура Внутренняя(Знач Первый = 42, Знач Второй = 0)
+      КонецПроцедуры
+      """);
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var range = documentContext.getSymbolTree().getMethods().getFirst().getRange();
+    var params = new InlayHintParams(textDocumentIdentifier, range);
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then
+    assertThat(inlayHints)
+      .extracting(InlayHint::getLabel)
+      .extracting(Either::getLeft)
+      .contains("Первый (42)");
+  }
+
   @Test
   void testConstructorCallInlayHints() {
 


### PR DESCRIPTION
## Что

Устранён квадратичный обход AST в `SourceDefinedMethodCallInlayHintSupplier`.

## Как

- Раньше для **каждой** ссылки выполнялся `Trees.findAllRuleNodes` по всему AST.
- Теперь — один проход, результат складывается в новый класс `DoCallRangeIndex`, ключом служит `Range` вызова / имени типа, совпадающий с `Reference#selectionRange()`.
- Поиск по индексу — O(1).

Поведение не изменилось; добавлен новый класс `DoCallRangeIndex`.

Выделено из #4077 (часть 2 из 2).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Enhanced parameter inlay hints for method calls, with improved handling of default values and skipped arguments in call parameters.

* **Refactoring**
  * Optimized performance of inlay hint generation by reducing unnecessary full AST traversals when processing method references.

* **Tests**
  * Added comprehensive test coverage for method call inlay hints, including edge cases with empty and skipped arguments.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->