### PR TITLE
feat(ImplementationProvider): LocationLink/linkSupport для textDocument/implementation

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -291,7 +291,7 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
     return withFreshDocumentContext(
       documentContext,
-      () -> Either.forLeft(implementationProvider.getImplementations(documentContext, params))
+      () -> implementationProvider.getImplementations(documentContext, params)
     );
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/ImplementationProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/ImplementationProvider.java
@@ -21,15 +21,24 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
+import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
 import com.github._1c_syntax.bsl.languageserver.types.oscript.extends_.TypeRelations;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import lombok.RequiredArgsConstructor;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.ImplementationCapabilities;
 import org.eclipse.lsp4j.ImplementationParams;
 import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Range;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jspecify.annotations.Nullable;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
@@ -60,57 +69,139 @@ import java.util.List;
 public class ImplementationProvider {
 
   private final TypeRelations typeRelations;
+  private final ClientCapabilitiesHolder clientCapabilitiesHolder;
 
-  // Результаты — по одной локации на класс/метод-реализатор, поэтому URI
+  // Результаты — по одной связи на класс/метод-реализатор, поэтому targetUri
   // уникален: сортировки по нему достаточно для детерминированного порядка.
-  private final Comparator<Location> locationComparator = Comparator.comparing(Location::getUri);
+  private final Comparator<LocationLink> linkComparator = Comparator.comparing(LocationLink::getTargetUri);
+
+  // Кэшируется на initialize. linkSupport — gate для ответа LocationLink[] на запрос
+  // textDocument/implementation. Если клиент не заявил поддержку, ответ понижается до Location[].
+  private boolean linkSupport;
 
   /**
-   * Найти реализации интерфейса, представленного текущим документом.
+   * Обработчик события {@link LanguageServerInitializeRequestReceivedEvent}.
+   * <p>
+   * Кэширует клиентскую возможность {@code textDocument.implementation.linkSupport},
+   * влияющую на формат ответа навигации: при её отсутствии ответ {@link LocationLink}
+   * понижается до {@link Location}.
+   */
+  @EventListener(LanguageServerInitializeRequestReceivedEvent.class)
+  public void handleInitializeEvent() {
+    linkSupport = clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getTextDocument)
+      .map(TextDocumentClientCapabilities::getImplementation)
+      .map(ImplementationCapabilities::getLinkSupport)
+      .orElse(Boolean.FALSE);
+  }
+
+  /**
+   * Найти реализации интерфейса, представленного текущим документом, в формате,
+   * согласованном с клиентскими возможностями.
+   * <p>
+   * По спецификации LSP 3.14+ ответ типа {@link LocationLink} допустим, только если
+   * клиент заявил {@code textDocument.implementation.linkSupport}. При наличии поддержки
+   * возвращается правая сторона ({@link LocationLink}) с диапазоном-источником под
+   * курсором ({@code originSelectionRange}) и диапазонами цели; иначе результат
+   * понижается до левой стороны ({@link Location}) с {@code targetUri} и
+   * {@code targetSelectionRange} каждой связи.
    *
    * @param documentContext контекст документа (ожидается файл-интерфейс)
    * @param params          параметры запроса (позиция курсора)
-   * @return локации реализующих методов/классов; пустой список, если документ
+   * @return {@link Either} со списком {@link LocationLink} при поддержке связей либо
+   *         со списком {@link Location} при её отсутствии; пустой список, если документ
    *         не является интерфейсом
    */
-  public List<Location> getImplementations(DocumentContext documentContext, ImplementationParams params) {
+  public Either<List<? extends Location>, List<? extends LocationLink>> getImplementations(
+    DocumentContext documentContext,
+    ImplementationParams params
+  ) {
+    var links = findLocationLinks(documentContext, params);
+
+    if (linkSupport) {
+      return Either.forRight(links);
+    }
+
+    List<Location> locations = links.stream()
+      .map(link -> new Location(link.getTargetUri(), link.getTargetSelectionRange()))
+      .toList();
+    return Either.forLeft(locations);
+  }
+
+  private List<LocationLink> findLocationLinks(DocumentContext documentContext, ImplementationParams params) {
     if (documentContext.getFileType() != FileType.OS
       || !typeRelations.isInterface(documentContext)) {
       return Collections.emptyList();
     }
 
-    var methodName = methodNameAt(documentContext, params);
+    var interfaceMethod = exportMethodAt(documentContext, params);
 
-    var result = new ArrayList<Location>();
+    var result = new ArrayList<LocationLink>();
     for (var implementor : typeRelations.implementors(documentContext)) {
-      if (methodName != null) {
-        implementor.getSymbolTree().getMethodSymbol(methodName)
+      if (interfaceMethod != null) {
+        // originSelectionRange — диапазон идентификатора метода интерфейса под курсором.
+        var originSelectionRange = interfaceMethod.getSelectionRange();
+        implementor.getSymbolTree().getMethodSymbol(interfaceMethod.getName())
           .filter(MethodSymbol::isExport)
-          .ifPresent(method -> result.add(location(implementor, method.getSelectionRange())));
+          .ifPresent(method -> result.add(
+            link(implementor, method.getRange(), method.getSelectionRange(), originSelectionRange)));
       } else {
-        result.add(location(implementor, typeRelations.classSelectionRange(implementor)));
+        var classSelectionRange = typeRelations.classSelectionRange(implementor);
+        result.add(classLink(implementor, classRange(implementor), classSelectionRange));
       }
     }
-    result.sort(locationComparator);
+    result.sort(linkComparator);
     return result;
   }
 
   /**
-   * Имя экспортного метода интерфейса под курсором (для перехода к одноимённым
+   * Экспортный метод интерфейса под курсором (для перехода к одноимённым
    * реализациям), либо {@code null}, если курсор не на экспортном методе (тогда
    * переход — к самим реализующим классам). Конструктор {@code ПриСозданииОбъекта}
    * по соглашению не экспортный, поэтому отсекается фильтром экспортности
    * (а у реализаций — фильтром {@code isExport} при поиске одноимённого метода).
    */
-  private static @Nullable String methodNameAt(DocumentContext documentContext, ImplementationParams params) {
+  private static @Nullable MethodSymbol exportMethodAt(DocumentContext documentContext, ImplementationParams params) {
     var symbol = documentContext.getSymbolTree().getSymbolAtPosition(params.getPosition());
     if (symbol instanceof MethodSymbol method && method.isExport()) {
-      return method.getName();
+      return method;
     }
     return null;
   }
 
-  private static Location location(DocumentContext documentContext, Range range) {
-    return new Location(documentContext.getUri().toString(), range);
+  private static Range classRange(DocumentContext documentContext) {
+    var moduleRange = documentContext.getSymbolTree().getModule().getRange();
+    return moduleRange != null ? moduleRange : Ranges.create(0, 0, 0, 0);
+  }
+
+  private static LocationLink link(
+    DocumentContext documentContext,
+    Range targetRange,
+    Range targetSelectionRange,
+    Range originSelectionRange
+  ) {
+    return new LocationLink(
+      documentContext.getUri().toString(),
+      targetRange,
+      targetSelectionRange,
+      originSelectionRange
+    );
+  }
+
+  /**
+   * Связь на класс-реализатор без диапазона-источника: при переходе из тела
+   * интерфейса (а не с конкретного метода) под курсором нет идентификатора,
+   * поэтому {@code originSelectionRange} не задаётся.
+   */
+  private static LocationLink classLink(
+    DocumentContext documentContext,
+    Range targetRange,
+    Range targetSelectionRange
+  ) {
+    var locationLink = new LocationLink();
+    locationLink.setTargetUri(documentContext.getUri().toString());
+    locationLink.setTargetRange(targetRange);
+    locationLink.setTargetSelectionRange(targetSelectionRange);
+    return locationLink;
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/ImplementationAbstractClassTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/ImplementationAbstractClassTest.java
@@ -63,7 +63,8 @@ class ImplementationAbstractClassTest extends AbstractServerContextAwareTest {
     var interfaceDoc = document("ИнтерфейсХранилища.os");
     var params = params(interfaceDoc, new Position(0, 0));
 
-    var implementations = provider.getImplementations(interfaceDoc, params);
+    // По умолчанию клиент не заявил linkSupport → провайдер отдаёт Location[].
+    var implementations = provider.getImplementations(interfaceDoc, params).getLeft();
 
     // Прямой реализатор (абстрактный родитель) и транзитивный (конкретный наследник).
     assertThat(implementations)
@@ -76,7 +77,8 @@ class ImplementationAbstractClassTest extends AbstractServerContextAwareTest {
     var interfaceDoc = document("ИнтерфейсХранилища.os");
     var params = params(interfaceDoc, methodPosition(interfaceDoc, "Сохранить"));
 
-    var implementations = provider.getImplementations(interfaceDoc, params);
+    // По умолчанию клиент не заявил linkSupport → провайдер отдаёт Location[].
+    var implementations = provider.getImplementations(interfaceDoc, params).getLeft();
 
     // Метод фактически реализован только в конкретном наследнике; абстрактный
     // родитель метод не определяет, поэтому в результат не попадает.

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/ImplementationInterfaceHierarchyTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/ImplementationInterfaceHierarchyTest.java
@@ -63,7 +63,8 @@ class ImplementationInterfaceHierarchyTest extends AbstractServerContextAwareTes
     var interfaceDoc = document("БазовыйИнтерфейс.os");
     var params = params(interfaceDoc, new Position(0, 0));
 
-    var implementations = provider.getImplementations(interfaceDoc, params);
+    // По умолчанию клиент не заявил linkSupport → провайдер отдаёт Location[].
+    var implementations = provider.getImplementations(interfaceDoc, params).getLeft();
 
     // Прямая реализация базового интерфейса и реализация производного интерфейса
     // (производный &Расширяет базовый — значит его реализатор реализует и базовый).
@@ -77,7 +78,8 @@ class ImplementationInterfaceHierarchyTest extends AbstractServerContextAwareTes
     var interfaceDoc = document("ПроизводныйИнтерфейс.os");
     var params = params(interfaceDoc, new Position(0, 0));
 
-    var implementations = provider.getImplementations(interfaceDoc, params);
+    // По умолчанию клиент не заявил linkSupport → провайдер отдаёт Location[].
+    var implementations = provider.getImplementations(interfaceDoc, params).getLeft();
 
     // Реализатор только базового интерфейса не является реализатором производного.
     assertThat(implementations)
@@ -90,7 +92,8 @@ class ImplementationInterfaceHierarchyTest extends AbstractServerContextAwareTes
     var interfaceDoc = document("БазовыйИнтерфейс.os");
     var params = params(interfaceDoc, methodPosition(interfaceDoc, "БазовыйМетод"));
 
-    var implementations = provider.getImplementations(interfaceDoc, params);
+    // По умолчанию клиент не заявил linkSupport → провайдер отдаёт Location[].
+    var implementations = provider.getImplementations(interfaceDoc, params).getLeft();
 
     // Метод БазовыйМетод реализован в обоих классах.
     assertThat(implementations)

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/ImplementationProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/ImplementationProviderTest.java
@@ -21,22 +21,30 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.utils.Absolute;
+import org.eclipse.lsp4j.ClientCapabilities;
+import org.eclipse.lsp4j.ImplementationCapabilities;
 import org.eclipse.lsp4j.ImplementationParams;
 import org.eclipse.lsp4j.Location;
+import org.eclipse.lsp4j.LocationLink;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentIdentifier;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.net.URI;
 import java.nio.file.Path;
+import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
 
 @CleanupContextBeforeClassAndAfterClass
 class ImplementationProviderTest extends AbstractServerContextAwareTest {
@@ -44,22 +52,48 @@ class ImplementationProviderTest extends AbstractServerContextAwareTest {
   @Autowired
   private ImplementationProvider provider;
 
+  @MockitoSpyBean
+  private ClientCapabilitiesHolder clientCapabilitiesHolder;
+
   private static final Path FIXTURE_ROOT =
     Path.of("src/test/resources/oscript-libraries/interface-lib").toAbsolutePath();
 
   @BeforeEach
   void init() {
     initServerContext(FIXTURE_ROOT, false);
+    // По умолчанию клиент не заявляет linkSupport: унаследованные тесты навигации
+    // получают Location[]; отдельные тесты проверяют ответ LocationLink[].
+    setClientLinkSupport(false);
+  }
+
+  /**
+   * Настраивает заявленную клиентом возможность {@code textDocument.implementation.linkSupport}
+   * и пересчитывает её кэш в провайдере через {@code handleInitializeEvent}.
+   *
+   * @param linkSupport {@code true}, если клиент поддерживает {@link LocationLink}
+   */
+  private void setClientLinkSupport(boolean linkSupport) {
+    var capabilities = new ClientCapabilities();
+    var textDocumentCapabilities = new TextDocumentClientCapabilities();
+    var implementationCapabilities = new ImplementationCapabilities();
+    implementationCapabilities.setLinkSupport(linkSupport);
+    textDocumentCapabilities.setImplementation(implementationCapabilities);
+    capabilities.setTextDocument(textDocumentCapabilities);
+    when(clientCapabilitiesHolder.getCapabilities()).thenReturn(Optional.of(capabilities));
+    provider.handleInitializeEvent();
   }
 
   @Test
   void implementationOnInterfaceMethodReturnsImplementingMethods() {
+    // given
     var interfaceDoc = document("МойИнтерфейс.os");
     // Позиция на объявлении метода МойМетод в интерфейсе.
     var params = params(interfaceDoc, methodPosition(interfaceDoc, "МойМетод"));
 
-    var implementations = provider.getImplementations(interfaceDoc, params);
+    // when
+    var implementations = provider.getImplementations(interfaceDoc, params).getLeft();
 
+    // then
     assertThat(implementations)
       .hasSize(2)
       .allMatch(location -> location.getUri().endsWith(".os"));
@@ -70,12 +104,15 @@ class ImplementationProviderTest extends AbstractServerContextAwareTest {
 
   @Test
   void implementationOnInterfaceBodyReturnsImplementingClasses() {
+    // given
     var interfaceDoc = document("МойИнтерфейс.os");
     // Позиция вне метода (на конструкторе) — переход к самим классам.
     var params = params(interfaceDoc, new Position(0, 0));
 
-    var implementations = provider.getImplementations(interfaceDoc, params);
+    // when
+    var implementations = provider.getImplementations(interfaceDoc, params).getLeft();
 
+    // then
     assertThat(implementations)
       .extracting(location -> uriBaseName(location))
       .containsExactlyInAnyOrder("Реализация1", "Реализация2");
@@ -83,10 +120,100 @@ class ImplementationProviderTest extends AbstractServerContextAwareTest {
 
   @Test
   void implementationOnNonInterfaceIsEmpty() {
+    // given
     var implementorDoc = document("Реализация1.os");
     var params = params(implementorDoc, new Position(0, 0));
 
-    assertThat(provider.getImplementations(implementorDoc, params)).isEmpty();
+    // when
+    var implementations = provider.getImplementations(implementorDoc, params).getLeft();
+
+    // then
+    assertThat(implementations).isEmpty();
+  }
+
+  @Test
+  void implementationReturnsLocationLinksWhenClientSupportsLinkSupport() {
+    // given - клиент, заявивший textDocument.implementation.linkSupport, и курсор
+    // на экспортном методе интерфейса.
+    setClientLinkSupport(true);
+    var interfaceDoc = document("МойИнтерфейс.os");
+    var interfaceMethod = interfaceDoc.getSymbolTree().getMethodSymbol("МойМетод").orElseThrow();
+    var params = params(interfaceDoc, interfaceMethod.getSelectionRange().getStart());
+
+    // when
+    var implementations = provider.getImplementations(interfaceDoc, params).getRight();
+
+    // then - клиент с поддержкой связей получает LocationLink[] с диапазоном-источником
+    // под курсором и корректными диапазонами цели.
+    assertThat(implementations)
+      .hasSize(2)
+      .allSatisfy(link -> {
+        assertThat(link).isInstanceOf(LocationLink.class);
+        assertThat(link.getTargetUri()).endsWith(".os");
+        assertThat(link.getOriginSelectionRange()).isEqualTo(interfaceMethod.getSelectionRange());
+        assertThat(link.getTargetRange()).isNotNull();
+        assertThat(link.getTargetSelectionRange()).isNotNull();
+      });
+    assertThat(implementations)
+      .extracting(ImplementationProviderTest::linkBaseName)
+      .containsExactlyInAnyOrder("Реализация1", "Реализация2");
+
+    // Диапазон цели метода-реализатора совпадает с его символом.
+    var implementor1 = document("Реализация1.os");
+    var implementorMethod = implementor1.getSymbolTree().getMethodSymbol("МойМетод").orElseThrow();
+    assertThat(implementations)
+      .filteredOn(link -> "Реализация1".equals(linkBaseName(link)))
+      .singleElement()
+      .satisfies(link -> {
+        assertThat(link.getTargetUri()).isEqualTo(implementor1.getUri().toString());
+        assertThat(link.getTargetRange()).isEqualTo(implementorMethod.getRange());
+        assertThat(link.getTargetSelectionRange()).isEqualTo(implementorMethod.getSelectionRange());
+      });
+  }
+
+  @Test
+  void implementationDowngradesToLocationsWhenClientLacksLinkSupport() {
+    // given - клиент без textDocument.implementation.linkSupport
+    setClientLinkSupport(false);
+    var interfaceDoc = document("МойИнтерфейс.os");
+    var params = params(interfaceDoc, methodPosition(interfaceDoc, "МойМетод"));
+
+    // when
+    var implementations = provider.getImplementations(interfaceDoc, params);
+
+    // then - результат понижается до Location[] с targetUri и targetSelectionRange
+    assertThat(implementations.isLeft()).isTrue();
+    assertThat(implementations.getLeft())
+      .hasSize(2)
+      .extracting(location -> uriBaseName(location))
+      .containsExactlyInAnyOrder("Реализация1", "Реализация2");
+
+    var implementor1 = document("Реализация1.os");
+    var implementorMethod = implementor1.getSymbolTree().getMethodSymbol("МойМетод").orElseThrow();
+    assertThat(implementations.getLeft())
+      .filteredOn(location -> "Реализация1".equals(uriBaseName(location)))
+      .singleElement()
+      .isEqualTo(new Location(implementor1.getUri().toString(), implementorMethod.getSelectionRange()));
+  }
+
+  @Test
+  void implementationLocationLinkOnInterfaceBodyHasNoOriginSelectionRange() {
+    // given - клиент с linkSupport и курсор в теле интерфейса (не на методе):
+    // под курсором нет идентификатора, переход — к самим классам.
+    setClientLinkSupport(true);
+    var interfaceDoc = document("МойИнтерфейс.os");
+    var params = params(interfaceDoc, new Position(0, 0));
+
+    // when
+    var implementations = provider.getImplementations(interfaceDoc, params).getRight();
+
+    // then - связи на классы без originSelectionRange
+    assertThat(implementations)
+      .hasSize(2)
+      .allSatisfy(link -> assertThat(link.getOriginSelectionRange()).isNull());
+    assertThat(implementations)
+      .extracting(ImplementationProviderTest::linkBaseName)
+      .containsExactlyInAnyOrder("Реализация1", "Реализация2");
   }
 
   private DocumentContext document(String fileName) {
@@ -109,7 +236,15 @@ class ImplementationProviderTest extends AbstractServerContextAwareTest {
   }
 
   private static String uriBaseName(Location location) {
-    var path = URI.create(location.getUri()).getPath();
+    return baseName(location.getUri());
+  }
+
+  private static String linkBaseName(LocationLink link) {
+    return baseName(link.getTargetUri());
+  }
+
+  private static String baseName(String uri) {
+    var path = URI.create(uri).getPath();
     var name = path.substring(path.lastIndexOf('/') + 1);
     return name.endsWith(".os") ? name.substring(0, name.length() - ".os".length()) : name;
   }


### PR DESCRIPTION
## Что сделано

`textDocument/implementation` теперь возвращает `LocationLink[]` (вместо `Location[]`), когда клиент заявил возможность `textDocument.implementation.linkSupport`. Это зеркалит подход, уже применённый для `textDocument/definition` в PR #4058.

Каждая связь несёт:
- `targetUri`, `targetRange` (полный диапазон символа-реализатора), `targetSelectionRange` (диапазон идентификатора);
- `originSelectionRange` — диапазон идентификатора-источника под курсором (метод интерфейса), что даёт редактору более точный peek-UX.

При переходе из тела интерфейса (курсор не на методе) под курсором нет идентификатора, поэтому `originSelectionRange` у связей на классы-реализаторы не задаётся.

## Совместимость

Если клиент не заявил `linkSupport`, ответ прозрачно понижается до прежнего `Location[]` (`Either.forLeft`) — без регрессии.

## Кэширование возможности

Возможность `textDocument.implementation.linkSupport` кэшируется один раз на `initialize` через `@EventListener(LanguageServerInitializeRequestReceivedEvent)` — точно как в `DefinitionProvider`. `ClientCapabilities` не читаются на каждый запрос.

## Тесты

- клиент с `linkSupport = true` → `LocationLink[]` с заданным `originSelectionRange` и корректными диапазонами цели;
- курсор в теле интерфейса с `linkSupport = true` → связи на классы без `originSelectionRange`;
- клиент без `linkSupport` → прежний `Location[]`;
- унаследованные тесты `Implementation*` остаются зелёными.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for enhanced implementation navigation with location links, providing richer navigation information for compatible clients.

* **Bug Fixes**
  * Fixed Javadoc generation failures caused by resolution issues with unstable artifact links.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->