### PR TITLE
feat(capabilities): явно декларировать positionEncoding=utf-16

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -64,6 +64,7 @@ import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.InlayHintRegistrationOptions;
+import org.eclipse.lsp4j.PositionEncodingKind;
 import org.eclipse.lsp4j.ReferenceOptions;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
@@ -141,6 +142,11 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
     setConfigurationRoot(params);
 
     var capabilities = new ServerCapabilities();
+    // Сервер работает только с UTF-16 (кодировка позиций по умолчанию в LSP).
+    // Явно объявляем её в ответе на initialize: по спецификации LSP 3.17 сервер выбирает
+    // одну из поддерживаемых клиентом кодировок (general.positionEncodings) и эхоит её здесь.
+    // Поддерживается только UTF-16, поэтому всегда декларируем именно её.
+    capabilities.setPositionEncoding(PositionEncodingKind.UTF16);
     capabilities.setTextDocumentSync(getTextDocumentSyncOptions());
     capabilities.setDocumentRangeFormattingProvider(getDocumentRangeFormattingProvider());
     capabilities.setDocumentFormattingProvider(getDocumentFormattingProvider());

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
@@ -30,9 +30,11 @@ import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.DidChangeWatchedFilesCapabilities;
 import org.eclipse.lsp4j.DidChangeWatchedFilesRegistrationOptions;
 import org.eclipse.lsp4j.FileSystemWatcher;
+import org.eclipse.lsp4j.GeneralClientCapabilities;
 import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
+import org.eclipse.lsp4j.PositionEncodingKind;
 import org.eclipse.lsp4j.RegistrationParams;
 import org.eclipse.lsp4j.RenameCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
@@ -145,6 +147,45 @@ class BSLLanguageServerTest {
     } finally {
       globalConfiguration.reset();
     }
+  }
+
+  @Test
+  void initializeDeclaresUtf16PositionEncoding() throws ExecutionException, InterruptedException {
+    // given
+    InitializeParams params = new InitializeParams();
+
+    WorkspaceFolder workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "test");
+    params.setWorkspaceFolders(List.of(workspaceFolder));
+
+    // when
+    InitializeResult initialize = server.initialize(params).get();
+
+    // then
+    assertThat(initialize.getCapabilities().getPositionEncoding())
+      .isEqualTo(PositionEncodingKind.UTF16);
+  }
+
+  @Test
+  void initializeDeclaresUtf16PositionEncodingWhenClientNegotiatesIt()
+    throws ExecutionException, InterruptedException {
+    // given
+    InitializeParams params = new InitializeParams();
+
+    WorkspaceFolder workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "test");
+    params.setWorkspaceFolders(List.of(workspaceFolder));
+
+    var clientCapabilities = new ClientCapabilities();
+    var general = new GeneralClientCapabilities();
+    general.setPositionEncodings(List.of(PositionEncodingKind.UTF16));
+    clientCapabilities.setGeneral(general);
+    params.setCapabilities(clientCapabilities);
+
+    // when
+    InitializeResult initialize = server.initialize(params).get();
+
+    // then
+    assertThat(initialize.getCapabilities().getPositionEncoding())
+      .isEqualTo(PositionEncodingKind.UTF16);
   }
 
   @Test


### PR DESCRIPTION
## Что и зачем

Сервер использует UTF-16 для смещений позиций (кодировка по умолчанию в LSP), но никогда не объявлял это явно.

LSP 3.17 добавил согласование кодировки позиций:
- клиент присылает `general.positionEncodings` (список, например `["utf-16"]`);
- сервер выбирает одну из поддерживаемых им кодировок и эхоит её в `ServerCapabilities.positionEncoding`.

Теперь на `initialize` сервер всегда выставляет `PositionEncodingKind.UTF16` (константа `"utf-16"`). Поскольку поддерживается только UTF-16, она и декларируется всегда — это всегда допустимо по спецификации (UTF-16 — кодировка по умолчанию). Явное объявление протокольно корректно и страхует от рассинхрона смещений.

Реальные вычисления смещений не менялись — они и так в UTF-16.

## API lsp4j

- `org.eclipse.lsp4j.ServerCapabilities#setPositionEncoding(String)`
- `org.eclipse.lsp4j.PositionEncodingKind.UTF16`

## Тесты

- `initializeDeclaresUtf16PositionEncoding` — результат initialize содержит `positionEncoding == "utf-16"`.
- `initializeDeclaresUtf16PositionEncodingWhenClientNegotiatesIt` — клиент прислал `general.positionEncodings = ["utf-16"]` → сервер по-прежнему отвечает `utf-16`.
- Существующие тесты initialize остаются зелёными.

🤖 Generated with [Claude Code](https://claude.com/claude-code)