### PR TITLE
feat(foldingRange): соблюдать клиентский rangeLimit

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FoldingRangeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FoldingRangeProvider.java
@@ -32,9 +32,11 @@ import org.eclipse.lsp4j.FoldingRangeCapabilities;
 import org.eclipse.lsp4j.FoldingRangeSupportCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.springframework.context.event.EventListener;
+import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;
+import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 
@@ -57,20 +59,36 @@ public final class FoldingRangeProvider {
   // поддержку, текст сбрасывается в null, чтобы клиент подставил собственную заглушку.
   private boolean collapsedTextSupported;
 
+  // Кэшируется на initialize. rangeLimit — максимальное число сворачиваемых областей, которое
+  // готов принять клиент (textDocument.foldingRange.rangeLimit). null означает отсутствие лимита.
+  @Nullable
+  private Integer rangeLimit;
+
   /**
    * Обработчик события {@link LanguageServerInitializeRequestReceivedEvent}.
    * <p>
-   * Кэширует клиентскую возможность {@code textDocument.foldingRange.foldingRange.collapsedText}
-   * (LSP 3.17), определяющую, отдавать ли клиенту текст-заглушку свёрнутого блока.
+   * Кэширует клиентские возможности секции {@code textDocument.foldingRange}:
+   * <ul>
+   *   <li>{@code foldingRange.collapsedText} (LSP 3.17) — определяет, отдавать ли клиенту
+   *   текст-заглушку свёрнутого блока;</li>
+   *   <li>{@code rangeLimit} — максимальное число сворачиваемых областей, которое готов принять
+   *   клиент. Отсутствие значения трактуется как отсутствие лимита.</li>
+   * </ul>
    */
   @EventListener(LanguageServerInitializeRequestReceivedEvent.class)
   public void handleInitializeEvent() {
-    collapsedTextSupported = clientCapabilitiesHolder.getCapabilities()
+    var foldingRangeCapabilities = clientCapabilitiesHolder.getCapabilities()
       .map(ClientCapabilities::getTextDocument)
-      .map(TextDocumentClientCapabilities::getFoldingRange)
+      .map(TextDocumentClientCapabilities::getFoldingRange);
+
+    collapsedTextSupported = foldingRangeCapabilities
       .map(FoldingRangeCapabilities::getFoldingRange)
       .map(FoldingRangeSupportCapabilities::getCollapsedText)
       .orElse(Boolean.FALSE);
+
+    rangeLimit = foldingRangeCapabilities
+      .map(FoldingRangeCapabilities::getRangeLimit)
+      .orElse(null);
   }
 
   /**
@@ -80,6 +98,11 @@ public final class FoldingRangeProvider {
    * ({@link FoldingRange#setCollapsedText(String)}). Если клиент не заявил поддержку возможности
    * {@code textDocument.foldingRange.foldingRange.collapsedText} (LSP 3.17), провайдер сбрасывает
    * этот текст в {@code null}, чтобы клиент подставил собственную заглушку.
+   * <p>
+   * Если клиент заявил лимит на число областей ({@code textDocument.foldingRange.rangeLimit})
+   * и вычисленный список его превышает, список усекается до лимита с приоритизацией наиболее
+   * полезных областей (см. {@link #applyRangeLimit(List)}). Если лимит не заявлен, возвращаются
+   * все области без изменений.
    *
    * @param documentContext Контекст документа
    * @return Список областей, которые можно свернуть
@@ -94,7 +117,38 @@ public final class FoldingRangeProvider {
       foldingRanges.forEach(foldingRange -> foldingRange.setCollapsedText(null));
     }
 
-    return foldingRanges;
+    return applyRangeLimit(foldingRanges);
+  }
+
+  /**
+   * Усечь список сворачиваемых областей до заявленного клиентом лимита
+   * ({@code textDocument.foldingRange.rangeLimit}).
+   * <p>
+   * Если лимит не заявлен ({@code rangeLimit == null}) или список не превышает лимит, список
+   * возвращается без изменений.
+   * <p>
+   * Правило приоритизации при усечении: сохраняются наиболее полезные внешние/верхнеуровневые
+   * области, поскольку клиент при превышении лимита усекает список произвольно и может скрыть
+   * именно крупные блоки (области {@code #Область}, тела методов), оставив мелкие вложенные.
+   * Области сортируются по убыванию размаха (число охватываемых строк, {@code endLine - startLine}):
+   * чем крупнее область, тем выше её приоритет. Тем самым в выдачу попадают верхнеуровневые области,
+   * а глубоко вложенные мелкие диапазоны отбрасываются первыми. При равном размахе сохраняется
+   * относительный порядок (стабильная сортировка), что обеспечивает детерминированный результат.
+   *
+   * @param foldingRanges Полный список вычисленных сворачиваемых областей
+   * @return Список, усечённый до лимита по приоритету, либо исходный список, если усечение не нужно
+   */
+  private List<FoldingRange> applyRangeLimit(List<FoldingRange> foldingRanges) {
+    if (rangeLimit == null || foldingRanges.size() <= rangeLimit) {
+      return foldingRanges;
+    }
+
+    return foldingRanges.stream()
+      .sorted(Comparator.comparingInt(
+        (FoldingRange foldingRange) -> foldingRange.getEndLine() - foldingRange.getStartLine())
+        .reversed())
+      .limit(rangeLimit)
+      .collect(Collectors.toList());
   }
 
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FoldingRangeProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FoldingRangeProviderTest.java
@@ -34,6 +34,7 @@ import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.lang.Nullable;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.util.List;
@@ -53,12 +54,12 @@ class FoldingRangeProviderTest {
 
   @BeforeEach
   void beforeEach() {
-    setCollapsedTextSupport(false);
+    setCapabilities(false, null);
   }
 
   @AfterEach
   void afterEach() {
-    setCollapsedTextSupport(false);
+    setCapabilities(false, null);
   }
 
   @Test
@@ -116,7 +117,7 @@ class FoldingRangeProviderTest {
   void testCollapsedTextForRegionWhenSupported() {
 
     // given
-    setCollapsedTextSupport(true);
+    setCapabilities(true, null);
     var documentContext = TestUtils.getDocumentContextFromFile("./src/test/resources/providers/foldingRange.bsl");
 
     // when
@@ -133,7 +134,7 @@ class FoldingRangeProviderTest {
   void testCollapsedTextForRegionSplitsNameIntoWords() {
 
     // given
-    setCollapsedTextSupport(true);
+    setCapabilities(true, null);
     var documentContext = TestUtils.getDocumentContextFromFile(
       "./src/test/resources/providers/foldingRangeRegionName.bsl");
 
@@ -151,7 +152,7 @@ class FoldingRangeProviderTest {
   void testCollapsedTextForMethodWhenSupported() {
 
     // given
-    setCollapsedTextSupport(true);
+    setCapabilities(true, null);
     var documentContext = TestUtils.getDocumentContextFromFile("./src/test/resources/providers/foldingRange.bsl");
 
     // when
@@ -168,7 +169,7 @@ class FoldingRangeProviderTest {
   void testCollapsedTextNotSetWhenNotSupported() {
 
     // given
-    setCollapsedTextSupport(false);
+    setCapabilities(false, null);
     var documentContext = TestUtils.getDocumentContextFromFile("./src/test/resources/providers/foldingRange.bsl");
 
     // when
@@ -180,14 +181,69 @@ class FoldingRangeProviderTest {
       .allMatch(foldingRange -> foldingRange.getCollapsedText() == null);
   }
 
+  @Test
+  void testRangeLimitTruncatesToPrioritizedRanges() {
+
+    // given: клиент ограничивает число областей значением меньше, чем их вычислено (13)
+    setCapabilities(false, 3);
+    var documentContext = TestUtils.getDocumentContextFromFile("./src/test/resources/providers/foldingRange.bsl");
+
+    // when
+    List<FoldingRange> foldingRanges = foldingRangeProvider.getFoldingRange(documentContext);
+
+    // then: возвращено ровно rangeLimit областей, и это самые крупные (внешние/верхнеуровневые)
+    assertThat(foldingRanges).hasSize(3);
+    assertThat(foldingRanges)
+      .anyMatch(foldingRange -> foldingRange.getStartLine() == 3 && foldingRange.getEndLine() == 26)
+      .anyMatch(foldingRange -> foldingRange.getStartLine() == 5 && foldingRange.getEndLine() == 19)
+      .anyMatch(foldingRange -> foldingRange.getStartLine() == 7 && foldingRange.getEndLine() == 17);
+
+    // and: мелкие вложенные области отброшены первыми
+    assertThat(foldingRanges)
+      .noneMatch(foldingRange -> foldingRange.getStartLine() == 12 && foldingRange.getEndLine() == 14);
+  }
+
+  @Test
+  void testRangeLimitNotAppliedWhenAbsent() {
+
+    // given: клиент не заявил лимит
+    setCapabilities(false, null);
+    var documentContext = TestUtils.getDocumentContextFromFile("./src/test/resources/providers/foldingRange.bsl");
+
+    // when
+    List<FoldingRange> foldingRanges = foldingRangeProvider.getFoldingRange(documentContext);
+
+    // then: возвращены все области без изменений
+    assertThat(foldingRanges).hasSize(13);
+  }
+
+  @Test
+  void testRangeLimitNotAppliedWhenListWithinLimit() {
+
+    // given: лимит больше числа вычисленных областей
+    setCapabilities(false, 100);
+    var documentContext = TestUtils.getDocumentContextFromFile("./src/test/resources/providers/foldingRange.bsl");
+
+    // when
+    List<FoldingRange> foldingRanges = foldingRangeProvider.getFoldingRange(documentContext);
+
+    // then: возвращены все области без изменений
+    assertThat(foldingRanges).hasSize(13);
+  }
+
   /**
-   * Подменяет заявленную клиентом поддержку {@code collapsedText} в {@link ClientCapabilitiesHolder}
-   * и пересчитывает её кэш в провайдере через {@code handleInitializeEvent}.
+   * Подменяет заявленные клиентом возможности секции {@code textDocument.foldingRange}
+   * в {@link ClientCapabilitiesHolder} и пересчитывает их кэш в провайдере
+   * через {@code handleInitializeEvent}.
+   *
+   * @param collapsedTextSupported поддержка возможности {@code foldingRange.collapsedText}
+   * @param rangeLimit             значение {@code rangeLimit} ({@code null} — лимит не заявлен)
    */
-  private void setCollapsedTextSupport(boolean supported) {
-    var foldingRangeSupportCapabilities = new FoldingRangeSupportCapabilities(supported);
+  private void setCapabilities(boolean collapsedTextSupported, @Nullable Integer rangeLimit) {
+    var foldingRangeSupportCapabilities = new FoldingRangeSupportCapabilities(collapsedTextSupported);
     var foldingRangeCapabilities = new FoldingRangeCapabilities();
     foldingRangeCapabilities.setFoldingRange(foldingRangeSupportCapabilities);
+    foldingRangeCapabilities.setRangeLimit(rangeLimit);
     var textDocumentClientCapabilities = new TextDocumentClientCapabilities();
     textDocumentClientCapabilities.setFoldingRange(foldingRangeCapabilities);
     var clientCapabilities = new ClientCapabilities();


### PR DESCRIPTION
## Что и зачем

Клиентская возможность `textDocument.foldingRange.rangeLimit` (максимальное число сворачиваемых областей, которое готов принять клиент) ранее **игнорировалась**. На крупных модулях сервер отдавал полный список, а клиент мог молча усечь его произвольно — в том числе скрыв крупные верхнеуровневые блоки.

## Что сделано

- **Чтение и кэширование лимита.** `rangeLimit` (`Integer`, может отсутствовать → лимита нет) читается из `ClientCapabilities` и кэшируется на `initialize` через `@EventListener(LanguageServerInitializeRequestReceivedEvent)` — по той же схеме, что и `collapsedText`, без чтения возможностей на каждый запрос.
- **Усечение с приоритизацией.** Если вычисленный список областей превышает лимит, он усекается до `rangeLimit`. Правило приоритизации: области сортируются по убыванию размаха (`endLine - startLine`), поэтому в выдаче остаются наиболее полезные внешние/верхнеуровневые блоки (`#Область`, тела методов), а глубоко вложенные мелкие диапазоны отбрасываются первыми. Сортировка стабильна — результат детерминирован. Правило задокументировано в javadoc метода.
- **Лимит не заявлен** → возвращаются все области без изменений (поведение не меняется).

## Тесты

- `testRangeLimitTruncatesToPrioritizedRanges` — при `rangeLimit < N` возвращается ровно `rangeLimit` областей, и это самые крупные (внешние); мелкие вложенные отброшены.
- `testRangeLimitNotAppliedWhenAbsent` — без лимита возвращаются все области.
- `testRangeLimitNotAppliedWhenListWithinLimit` — лимит больше числа областей: всё без изменений.
- Существующие тесты folding range зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)