### PR TITLE
feat(workspace): RelativePattern для наблюдателей за файлами

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -67,6 +67,7 @@ import org.eclipse.lsp4j.InlayHintRegistrationOptions;
 import org.eclipse.lsp4j.ReferenceOptions;
 import org.eclipse.lsp4j.Registration;
 import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.RelativePattern;
 import org.eclipse.lsp4j.RenameCapabilities;
 import org.eclipse.lsp4j.RenameOptions;
 import org.eclipse.lsp4j.SaveOptions;
@@ -117,6 +118,13 @@ import java.util.concurrent.ExecutorService;
 @Component
 @RequiredArgsConstructor
 public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
+
+  /**
+   * Glob-шаблоны файлов рабочей области, за изменениями которых наблюдает клиент.
+   * Относительны корню workspace folder (используются как с глобальным glob,
+   * так и в составе {@link RelativePattern}).
+   */
+  private static final List<String> WATCHED_FILE_PATTERNS = List.of("**/*.bsl", "**/*.os");
 
   private final BSLTextDocumentService textDocumentService;
   private final BSLWorkspaceService workspaceService;
@@ -246,6 +254,13 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
    * {@code **&#47;*.bsl} и {@code **&#47;*.os}; за конфигурационным файлом следит сам сервер
    * (см. {@code ConfigurationFileSystemWatcher}), поэтому клиентский наблюдатель за ним не нужен.
    * <p>
+   * Если клиент заявил поддержку
+   * {@code workspace.didChangeWatchedFiles.relativePatternSupport}, наблюдатели регистрируются
+   * через {@link RelativePattern} с привязкой к корню каждой workspace folder — это сужает
+   * область наблюдения до конкретных папок и исключает лишние срабатывания между корнями.
+   * Иначе используется один глобальный glob-шаблон (поведение по умолчанию), что сохраняет
+   * совместимость с клиентами без поддержки относительных шаблонов.
+   * <p>
    * Если клиент не заявил динамическую регистрацию или не подключён, метод ничего не делает.
    */
   private void registerFileWatchers() {
@@ -255,10 +270,7 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
 
     languageClientHolder.execIfConnected(client -> {
       var watchKind = WatchKind.Create | WatchKind.Change | WatchKind.Delete;
-      var watchers = List.of(
-        new FileSystemWatcher(Either.forLeft("**/*.bsl"), watchKind),
-        new FileSystemWatcher(Either.forLeft("**/*.os"), watchKind)
-      );
+      var watchers = buildFileSystemWatchers(watchKind);
 
       var registrationOptions = new DidChangeWatchedFilesRegistrationOptions(watchers);
       var registration = new Registration(
@@ -271,11 +283,49 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
     });
   }
 
+  /**
+   * Строит список наблюдателей за файлами рабочей области.
+   * <p>
+   * Если клиент поддерживает относительные шаблоны и серверу известны корни workspace folder,
+   * для каждой пары «корень × шаблон» создаётся отдельный наблюдатель с {@link RelativePattern}.
+   * Иначе для каждого шаблона создаётся один наблюдатель с глобальным glob-шаблоном.
+   *
+   * @param watchKind битовая маска отслеживаемых событий
+   *                  ({@link WatchKind#Create}, {@link WatchKind#Change}, {@link WatchKind#Delete})
+   * @return список наблюдателей за файлами для регистрации у клиента
+   */
+  private List<FileSystemWatcher> buildFileSystemWatchers(int watchKind) {
+    var workspaceRoots = serverContextProvider.getAllContexts().keySet();
+
+    if (!hasDidChangeWatchedFilesRelativePatternSupport() || workspaceRoots.isEmpty()) {
+      return WATCHED_FILE_PATTERNS.stream()
+        .map(pattern -> new FileSystemWatcher(Either.<String, RelativePattern>forLeft(pattern), watchKind))
+        .toList();
+    }
+
+    return workspaceRoots.stream()
+      .flatMap(root -> WATCHED_FILE_PATTERNS.stream()
+        .map(pattern -> {
+          var baseUri = Either.<WorkspaceFolder, String>forRight(root.toString());
+          var relativePattern = new RelativePattern(baseUri, pattern);
+          return new FileSystemWatcher(Either.<String, RelativePattern>forRight(relativePattern), watchKind);
+        }))
+      .toList();
+  }
+
   private boolean hasDidChangeWatchedFilesDynamicRegistration() {
     return clientCapabilitiesHolder.getCapabilities()
       .map(ClientCapabilities::getWorkspace)
       .map(WorkspaceClientCapabilities::getDidChangeWatchedFiles)
       .map(DidChangeWatchedFilesCapabilities::getDynamicRegistration)
+      .orElse(false);
+  }
+
+  private boolean hasDidChangeWatchedFilesRelativePatternSupport() {
+    return clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getWorkspace)
+      .map(WorkspaceClientCapabilities::getDidChangeWatchedFiles)
+      .map(DidChangeWatchedFilesCapabilities::getRelativePatternSupport)
       .orElse(false);
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver;
 import com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.DiagnosticParams;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.Diagnostics;
@@ -94,6 +95,7 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
@@ -139,6 +141,37 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
   private final ExecutorService populateContextExecutor;
 
   private boolean shutdownWasCalled;
+
+  // Кэшируются на initialize. Гейтят регистрацию клиентских наблюдателей за файлами в initialized():
+  // dynamicRegistration — без неё динамическая регистрация workspace/didChangeWatchedFiles запрещена;
+  // relativePatternSupport — выбор между RelativePattern и глобальным glob-шаблоном.
+  private boolean didChangeWatchedFilesDynamicRegistration;
+  private boolean didChangeWatchedFilesRelativePatternSupport;
+
+  /**
+   * Обработчик события {@link LanguageServerInitializeRequestReceivedEvent}.
+   * <p>
+   * Кэширует клиентские возможности {@code workspace.didChangeWatchedFiles.dynamicRegistration} и
+   * {@code workspace.didChangeWatchedFiles.relativePatternSupport}, чтобы при последующей регистрации
+   * наблюдателей за файлами в {@link #initialized(InitializedParams)} не перечитывать
+   * {@link ClientCapabilities} на каждый вызов. Событие приходит после обработки {@code initialize}
+   * (когда возможности уже сохранены в {@link ClientCapabilitiesHolder}) и до {@code initialized},
+   * поэтому к моменту регистрации флаги уже актуальны.
+   */
+  @EventListener(LanguageServerInitializeRequestReceivedEvent.class)
+  public void handleInitializeEvent() {
+    var didChangeWatchedFiles = clientCapabilitiesHolder.getCapabilities()
+      .map(ClientCapabilities::getWorkspace)
+      .map(WorkspaceClientCapabilities::getDidChangeWatchedFiles);
+
+    didChangeWatchedFilesDynamicRegistration = didChangeWatchedFiles
+      .map(DidChangeWatchedFilesCapabilities::getDynamicRegistration)
+      .orElse(Boolean.FALSE);
+
+    didChangeWatchedFilesRelativePatternSupport = didChangeWatchedFiles
+      .map(DidChangeWatchedFilesCapabilities::getRelativePatternSupport)
+      .orElse(Boolean.FALSE);
+  }
 
   @Override
   public CompletableFuture<InitializeResult> initialize(InitializeParams params) {
@@ -314,19 +347,11 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
   }
 
   private boolean hasDidChangeWatchedFilesDynamicRegistration() {
-    return clientCapabilitiesHolder.getCapabilities()
-      .map(ClientCapabilities::getWorkspace)
-      .map(WorkspaceClientCapabilities::getDidChangeWatchedFiles)
-      .map(DidChangeWatchedFilesCapabilities::getDynamicRegistration)
-      .orElse(false);
+    return didChangeWatchedFilesDynamicRegistration;
   }
 
   private boolean hasDidChangeWatchedFilesRelativePatternSupport() {
-    return clientCapabilitiesHolder.getCapabilities()
-      .map(ClientCapabilities::getWorkspace)
-      .map(WorkspaceClientCapabilities::getDidChangeWatchedFiles)
-      .map(DidChangeWatchedFilesCapabilities::getRelativePatternSupport)
-      .orElse(false);
+    return didChangeWatchedFilesRelativePatternSupport;
   }
 
   @Override

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
@@ -34,6 +34,7 @@ import org.eclipse.lsp4j.InitializeParams;
 import org.eclipse.lsp4j.InitializeResult;
 import org.eclipse.lsp4j.InitializedParams;
 import org.eclipse.lsp4j.RegistrationParams;
+import org.eclipse.lsp4j.RelativePattern;
 import org.eclipse.lsp4j.RenameCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.eclipse.lsp4j.TextDocumentSyncKind;
@@ -60,6 +61,7 @@ import java.util.concurrent.ExecutionException;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.tuple;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatThrownBy;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.mock;
@@ -221,6 +223,96 @@ class BSLLanguageServerTest {
 
     var options = (DidChangeWatchedFilesRegistrationOptions) registration.getRegisterOptions();
     assertThat(options.getWatchers())
+      .extracting(FileSystemWatcher::getGlobPattern)
+      .extracting(globPattern -> globPattern.getLeft())
+      .containsExactlyInAnyOrder("**/*.bsl", "**/*.os");
+  }
+
+  @Test
+  void initializedRegistersRelativePatternWatchersPerWorkspaceFolder(@TempDir Path firstRoot, @TempDir Path secondRoot) {
+    // given
+    var client = mock(LanguageClient.class);
+    when(client.registerCapability(any()))
+      .thenReturn(CompletableFuture.completedFuture(null));
+    languageClientHolder.connect(client);
+
+    var firstFolderUri = Absolute.uri(firstRoot.toUri()).toString();
+    var secondFolderUri = Absolute.uri(secondRoot.toUri()).toString();
+
+    var initParams = new InitializeParams();
+    initParams.setWorkspaceFolders(List.of(
+      new WorkspaceFolder(firstFolderUri, "first"),
+      new WorkspaceFolder(secondFolderUri, "second")
+    ));
+
+    var capabilities = new ClientCapabilities();
+    var workspace = new WorkspaceClientCapabilities();
+    var watchedFiles = new DidChangeWatchedFilesCapabilities(true);
+    watchedFiles.setRelativePatternSupport(true);
+    workspace.setDidChangeWatchedFiles(watchedFiles);
+    capabilities.setWorkspace(workspace);
+    initParams.setCapabilities(capabilities);
+
+    server.initialize(initParams);
+
+    // when
+    server.initialized(new InitializedParams());
+
+    // then
+    var captor = ArgumentCaptor.forClass(RegistrationParams.class);
+    verify(client).registerCapability(captor.capture());
+
+    var registrations = captor.getValue().getRegistrations();
+    assertThat(registrations).hasSize(1);
+
+    var options = (DidChangeWatchedFilesRegistrationOptions) registrations.get(0).getRegisterOptions();
+    assertThat(options.getWatchers())
+      .allSatisfy(watcher -> assertThat(watcher.getGlobPattern().isRight()).isTrue())
+      .extracting(FileSystemWatcher::getGlobPattern)
+      .extracting(globPattern -> {
+        RelativePattern relativePattern = globPattern.getRight();
+        return tuple(relativePattern.getBaseUri().getRight(), relativePattern.getPattern());
+      })
+      .containsExactlyInAnyOrder(
+        tuple(firstFolderUri, "**/*.bsl"),
+        tuple(firstFolderUri, "**/*.os"),
+        tuple(secondFolderUri, "**/*.bsl"),
+        tuple(secondFolderUri, "**/*.os")
+      );
+  }
+
+  @Test
+  void initializedFallsBackToGlobalGlobWithoutRelativePatternSupport() {
+    // given
+    var client = mock(LanguageClient.class);
+    when(client.registerCapability(any()))
+      .thenReturn(CompletableFuture.completedFuture(null));
+    languageClientHolder.connect(client);
+
+    var initParams = new InitializeParams();
+    var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "test");
+    initParams.setWorkspaceFolders(List.of(workspaceFolder));
+
+    var capabilities = new ClientCapabilities();
+    var workspace = new WorkspaceClientCapabilities();
+    // dynamicRegistration declared, but relativePatternSupport is absent
+    workspace.setDidChangeWatchedFiles(new DidChangeWatchedFilesCapabilities(true));
+    capabilities.setWorkspace(workspace);
+    initParams.setCapabilities(capabilities);
+
+    server.initialize(initParams);
+
+    // when
+    server.initialized(new InitializedParams());
+
+    // then
+    var captor = ArgumentCaptor.forClass(RegistrationParams.class);
+    verify(client).registerCapability(captor.capture());
+
+    var options = (DidChangeWatchedFilesRegistrationOptions)
+      captor.getValue().getRegistrations().get(0).getRegisterOptions();
+    assertThat(options.getWatchers())
+      .allSatisfy(watcher -> assertThat(watcher.getGlobPattern().isLeft()).isTrue())
       .extracting(FileSystemWatcher::getGlobPattern)
       .extracting(globPattern -> globPattern.getLeft())
       .containsExactlyInAnyOrder("**/*.bsl", "**/*.os");


### PR DESCRIPTION
## Что

Регистрация наблюдателей за файлами (`workspace/didChangeWatchedFiles`, добавлена в #4073) теперь использует `RelativePattern` вместо единого глобального glob.

## Зачем

Раньше наблюдатели регистрировались одним глобальным шаблоном (`**/*.bsl`, `**/*.os`) без привязки к корням рабочей области. При нескольких workspace folder это приводило к избыточному охвату между корнями.

## Как

- **Per-folder scoping**: для каждой workspace folder (корни берутся из `ServerContextProvider.getAllContexts()`) и каждого шаблона создаётся отдельный `FileSystemWatcher` с `RelativePattern(baseUri = корень папки, pattern = относительный glob)`.
- **Capability gating**: относительные шаблоны включаются только если клиент заявил `workspace.didChangeWatchedFiles.relativePatternSupport`. Возможность читается из `ClientCapabilitiesHolder` в момент регистрации (однократно, в `initialized`).
- **Fallback**: если относительные шаблоны не поддерживаются (или серверу неизвестны корни) — используется прежний единый глобальный glob, без регрессии.
- Набор отслеживаемых шаблонов и видов событий не изменился.

## Тесты

- `initializedRegistersRelativePatternWatchersPerWorkspaceFolder` — при `relativePatternSupport=true` и N папках наблюдатели регистрируются с `RelativePattern` на каждую папку (корректные baseUri + pattern).
- `initializedFallsBackToGlobalGlobWithoutRelativePatternSupport` — без `relativePatternSupport` регистрируются прежние глобальные glob-наблюдатели.
- Существующие тесты наблюдателей/`didChangeWatchedFiles` остаются зелёными.

`BSLLanguageServerTest`: 14 tests, 0 failures. `compileJava` — BUILD SUCCESSFUL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced file watching capabilities with support for workspace-relative glob patterns, enabling more precise monitoring of `.bsl` and `.os` files across multiple workspace roots.

* **Tests**
  * Added comprehensive test coverage for file system watcher registration behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->