### PR TITLE
feat(formatting): textDocument/rangesFormatting (LSP 3.18)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -385,8 +385,6 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
   private static DocumentRangeFormattingOptions getDocumentRangeFormattingProvider() {
     var documentRangeFormattingOptions = new DocumentRangeFormattingOptions();
     documentRangeFormattingOptions.setWorkDoneProgress(Boolean.FALSE);
-    // LSP 3.18: сообщаем клиенту о поддержке textDocument/rangesFormatting
-    // (форматирование нескольких диапазонов за один запрос).
     documentRangeFormattingOptions.setRangesSupport(Boolean.TRUE);
     return documentRangeFormattingOptions;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServer.java
@@ -385,6 +385,9 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
   private static DocumentRangeFormattingOptions getDocumentRangeFormattingProvider() {
     var documentRangeFormattingOptions = new DocumentRangeFormattingOptions();
     documentRangeFormattingOptions.setWorkDoneProgress(Boolean.FALSE);
+    // LSP 3.18: сообщаем клиенту о поддержке textDocument/rangesFormatting
+    // (форматирование нескольких диапазонов за один запрос).
+    documentRangeFormattingOptions.setRangesSupport(Boolean.TRUE);
     return documentRangeFormattingOptions;
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -88,6 +88,7 @@ import org.eclipse.lsp4j.DocumentLink;
 import org.eclipse.lsp4j.DocumentLinkParams;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
+import org.eclipse.lsp4j.DocumentRangesFormattingParams;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.DocumentSymbolParams;
 import org.eclipse.lsp4j.FoldingRange;
@@ -398,6 +399,20 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
     return withFreshDocumentContext(
       documentContext,
       () -> formatProvider.getRangeFormatting(params, documentContext)
+    );
+  }
+
+  @Override
+  public CompletableFuture<List<? extends TextEdit>> rangesFormatting(DocumentRangesFormattingParams params) {
+    var maybeDocument = serverContextProvider.getDocumentUnsafe(params.getTextDocument().getUri());
+    if (maybeDocument.isEmpty()) {
+      return CompletableFuture.completedFuture(null);
+    }
+    var documentContext = maybeDocument.get();
+
+    return withFreshDocumentContext(
+      documentContext,
+      () -> formatProvider.getRangesFormatting(params, documentContext)
     );
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProvider.java
@@ -35,6 +35,7 @@ import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
+import org.eclipse.lsp4j.DocumentRangesFormattingParams;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -57,10 +58,12 @@ import java.util.stream.Collectors;
 /**
  * Провайдер для форматирования исходного кода.
  * <p>
- * Обрабатывает запросы {@code textDocument/formatting} и {@code textDocument/rangeFormatting}.
+ * Обрабатывает запросы {@code textDocument/formatting}, {@code textDocument/rangeFormatting} и
+ * {@code textDocument/rangesFormatting}.
  *
  * @see <a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_formatting">Document Formatting Request specification</a>
  * @see <a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangeFormatting">Document Range Formatting Request specification</a>
+ * @see <a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_rangesFormatting">Document Ranges Formatting Request specification</a>
  * @see <a href="https://microsoft.github.io/language-server-protocol/specifications/specification-current/#textDocument_onTypeFormatting">Document On Type Formatting Request specification</a>
  */
 @Component
@@ -339,8 +342,40 @@ public final class FormatProvider {
     DocumentRangeFormattingParams params,
     DocumentContext documentContext
   ) {
-    Position start = params.getRange().getStart();
-    Position end = params.getRange().getEnd();
+    return getRangeFormatting(params.getRange(), params.getOptions(), documentContext);
+  }
+
+  /**
+   * Возвращает правки форматирования сразу для нескольких диапазонов документа.
+   * <p>
+   * Обрабатывает запрос {@code textDocument/rangesFormatting} (LSP 3.18): каждый диапазон из
+   * {@link DocumentRangesFormattingParams#getRanges()} форматируется независимо тем же алгоритмом,
+   * что и одиночный {@code textDocument/rangeFormatting}, с одними и теми же протокольными
+   * {@link FormattingOptions}. Правки от всех диапазонов объединяются в общий список.
+   *
+   * @param params          параметры запроса rangesFormatting с набором диапазонов и опциями
+   * @param documentContext контекст текущего документа
+   * @return объединённый список правок по всем переданным диапазонам; пустой, если форматировать
+   * нечего
+   */
+  public List<TextEdit> getRangesFormatting(
+    DocumentRangesFormattingParams params,
+    DocumentContext documentContext
+  ) {
+    var options = params.getOptions();
+    return params.getRanges().stream()
+      .map(range -> getRangeFormatting(range, options, documentContext))
+      .flatMap(List::stream)
+      .collect(Collectors.toList());
+  }
+
+  private List<TextEdit> getRangeFormatting(
+    Range range,
+    FormattingOptions options,
+    DocumentContext documentContext
+  ) {
+    Position start = range.getStart();
+    Position end = range.getEnd();
     int startLine = start.getLine() + 1;
     int startCharacter = start.getCharacter();
     int endLine = end.getLine() + 1;
@@ -356,7 +391,7 @@ public final class FormatProvider {
       .collect(Collectors.toList());
 
     return getTextEdits(
-      tokens, documentContext.getScriptVariantLocale(), params.getRange(), startCharacter, params.getOptions());
+      tokens, documentContext.getScriptVariantLocale(), range, startCharacter, options);
   }
 
   @EventListener

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FormatProviderTest.java
@@ -31,6 +31,7 @@ import org.apache.commons.io.FileUtils;
 import org.eclipse.lsp4j.DocumentFormattingParams;
 import org.eclipse.lsp4j.DocumentOnTypeFormattingParams;
 import org.eclipse.lsp4j.DocumentRangeFormattingParams;
+import org.eclipse.lsp4j.DocumentRangesFormattingParams;
 import org.eclipse.lsp4j.FormattingOptions;
 import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
@@ -95,6 +96,51 @@ class FormatProviderTest {
 
     TextEdit textEdit = textEdits.getFirst();
     assertThat(textEdit.getNewText()).isEqualTo(formattedFileContent);
+  }
+
+  @Test
+  void testRangesFormat() throws IOException {
+    // given: два независимых диапазона в одном запросе rangesFormatting (LSP 3.18).
+    // Эталоном для каждого диапазона служит результат одиночного rangeFormatting того же
+    // диапазона: rangesFormatting обязан форматировать каждый диапазон независимо и теми же
+    // протокольными опциями.
+    var options = new FormattingOptions(4, true);
+    Range firstRange = Ranges.create(4, 0, 10, 0);
+    Range secondRange = Ranges.create(12, 0, 23, 0);
+
+    String fileContent = FileUtils.readFileToString(getTestFile(), StandardCharsets.UTF_8);
+
+    var documentContext = TestUtils.getDocumentContext(
+      Absolute.uri(getTextDocumentIdentifier().getUri()),
+      fileContent
+    );
+
+    var firstSingle = new DocumentRangeFormattingParams();
+    firstSingle.setTextDocument(getTextDocumentIdentifier());
+    firstSingle.setRange(firstRange);
+    firstSingle.setOptions(options);
+    String expectedFirstRange = formatProvider.getRangeFormatting(firstSingle, documentContext)
+      .getFirst().getNewText();
+
+    var secondSingle = new DocumentRangeFormattingParams();
+    secondSingle.setTextDocument(getTextDocumentIdentifier());
+    secondSingle.setRange(secondRange);
+    secondSingle.setOptions(options);
+    String expectedSecondRange = formatProvider.getRangeFormatting(secondSingle, documentContext)
+      .getFirst().getNewText();
+
+    var params = new DocumentRangesFormattingParams();
+    params.setTextDocument(getTextDocumentIdentifier());
+    params.setRanges(List.of(firstRange, secondRange));
+    params.setOptions(options);
+
+    // when
+    List<TextEdit> textEdits = formatProvider.getRangesFormatting(params, documentContext);
+
+    // then: по одной правке на каждый диапазон, и каждый отформатирован независимо
+    assertThat(textEdits).hasSize(2);
+    assertThat(textEdits.get(0).getNewText()).isEqualTo(expectedFirstRange);
+    assertThat(textEdits.get(1).getNewText()).isEqualTo(expectedSecondRange);
   }
 
   @Test


### PR DESCRIPTION
## Что сделано

Реализована поддержка запроса `textDocument/rangesFormatting` (LSP 3.18) — форматирование нескольких диапазонов документа за один запрос.

- `FormatProvider#getRangesFormatting` форматирует каждый диапазон из запроса независимо, переиспользуя существующую логику одиночного `textDocument/rangeFormatting` и те же протокольные `FormattingOptions` (включая trim-опции из #4069).
- Добавлен override `rangesFormatting(...)` в `BSLTextDocumentService`.
- Серверная capability объявлена через `documentRangeFormattingProvider.rangesSupport = true` (модель capability для rangesFormatting в LSP 3.18 / lsp4j 1.0.0).
- Тест `testRangesFormat`: проверяет, что каждый из нескольких диапазонов форматируется независимо (эталон — результат одиночного `rangeFormatting` тех же диапазонов).

## Проверка

`FormatProviderTest` (включая новый тест) и `compileJava` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)