### PR TITLE
fix(mcp): нормализовать root-uri через Absolute.uri

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumer.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.mcp;
 
+import com.github._1c_syntax.utils.Absolute;
 import io.modelcontextprotocol.server.McpSyncServerExchange;
 import io.modelcontextprotocol.spec.McpSchema.Root;
 import lombok.RequiredArgsConstructor;
@@ -29,7 +30,6 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-import java.net.URI;
 import java.nio.file.Path;
 import java.util.List;
 import java.util.Objects;
@@ -100,7 +100,7 @@ public class McpRootsChangeConsumer implements BiConsumer<McpSyncServerExchange,
 
   private static @Nullable Path toPath(Root root) {
     try {
-      return Path.of(URI.create(root.uri()));
+      return Absolute.path(Absolute.uri(root.uri()));
     } catch (RuntimeException e) {
       LOGGER.warn("Skipping unsupported MCP root uri `{}`", root.uri(), e);
       return null;


### PR DESCRIPTION
`McpRootsChangeConsumer.toPath` строил `Path` из `URI.create(root.uri())`. По соглашению проекта URI всегда нормализуем через `Absolute.uri(...)` (а не `URI.create`), чтобы пути из разных источников совпадали. Заменил на `Path.of(Absolute.uri(root.uri()))`, убрал неиспользуемый импорт `java.net.URI`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Refactor**
  * Updated MCP root URI-to-filesystem path conversion to use a dedicated absolute-path utility, improving correctness and reducing edge-case failures when translating root locations. This results in more consistent path handling across environments and avoids less reliable URI-to-Path conversions. Workspace add/remove behavior stays the same, and no configuration changes are required for users.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->