### PR TITLE
fix(completion): установить workspace-контекст при completionItem/resolve

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -235,7 +235,23 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
   @Override
   public CompletableFuture<CompletionItem> resolveCompletionItem(CompletionItem unresolved) {
-    return CompletableFuture.completedFuture(completionProvider.resolveCompletionItem(unresolved));
+    var data = completionProvider.extractData(unresolved);
+    if (data == null) {
+      // item без data — резолвить нечем, возвращаем как есть.
+      return CompletableFuture.completedFuture(unresolved);
+    }
+    var maybeDocument = serverContextProvider.getDocumentUnsafe(data.getUri().toString());
+    if (maybeDocument.isEmpty()) {
+      return CompletableFuture.completedFuture(unresolved);
+    }
+    var documentContext = maybeDocument.get();
+
+    // resolveCompletionItem обращается к workspace-scoped typeService/globalScopeProvider,
+    // поэтому резолв должен выполняться в workspace-контексте документа.
+    return withFreshDocumentContext(
+      documentContext,
+      () -> completionProvider.resolveCompletionItem(unresolved, data)
+    );
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
@@ -29,6 +29,8 @@ import lombok.Data;
 import lombok.NoArgsConstructor;
 import org.jspecify.annotations.Nullable;
 
+import java.net.URI;
+
 /**
  * DTO для хранения промежуточных данных completion item между его созданием
  * ({@code textDocument/completion}) и отложенным разрешением документации
@@ -97,6 +99,16 @@ public class CompletionData {
   private String functionName;
 
   /**
+   * URI документа, в контексте которого item был построен.
+   * <p>
+   * Нужен для {@code completionItem/resolve}: запрос приходит без позиции и без
+   * текстового документа, а {@code typeService}/{@code globalScopeProvider} —
+   * workspace-scoped бины. По этому URI восстанавливается документ и его
+   * workspace, чтобы установить workspace-контекст перед резолвом documentation.
+   */
+  private URI uri;
+
+  /**
    * Создаёт ключ восстановления документации члена типа (dot-completion).
    *
    * @param typeKind          вид типа-владельца члена.
@@ -104,11 +116,12 @@ public class CompletionData {
    * @param memberName        имя члена (метода/свойства).
    * @param fileType          тип файла-потребителя (BSL/OS).
    * @param scriptVariant     локаль скрипта (ru/en).
+   * @param uri               URI документа, в контексте которого построен item.
    * @return ключ восстановления члена типа.
    */
   public static CompletionData forMember(TypeKind typeKind, String typeQualifiedName, String memberName,
-                                         FileType fileType, Language scriptVariant) {
-    return new CompletionData(typeKind, typeQualifiedName, memberName, fileType, scriptVariant, null);
+                                         FileType fileType, Language scriptVariant, URI uri) {
+    return new CompletionData(typeKind, typeQualifiedName, memberName, fileType, scriptVariant, null, uri);
   }
 
   /**
@@ -117,9 +130,10 @@ public class CompletionData {
    * @param functionName  имя глобальной функции.
    * @param fileType      тип файла-потребителя (BSL/OS).
    * @param scriptVariant локаль скрипта (ru/en).
+   * @param uri           URI документа, в контексте которого построен item.
    * @return ключ восстановления глобальной функции.
    */
-  public static CompletionData forFunction(String functionName, FileType fileType, Language scriptVariant) {
-    return new CompletionData(null, null, null, fileType, scriptVariant, functionName);
+  public static CompletionData forFunction(String functionName, FileType fileType, Language scriptVariant, URI uri) {
+    return new CompletionData(null, null, null, fileType, scriptVariant, functionName, uri);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
@@ -60,6 +60,16 @@ import java.net.URI;
 public class CompletionData {
 
   /**
+   * URI документа, в контексте которого item был построен.
+   * <p>
+   * Нужен для {@code completionItem/resolve}: запрос приходит без позиции и без
+   * текстового документа, а {@code typeService}/{@code globalScopeProvider} —
+   * workspace-scoped бины. По этому URI восстанавливается документ и его
+   * workspace, чтобы установить workspace-контекст перед резолвом documentation.
+   */
+  private URI uri;
+
+  /**
    * Вид типа-владельца члена (часть идентичности {@link com.github._1c_syntax.bsl.languageserver.types.model.TypeRef}).
    * {@code null} для варианта глобальной функции.
    */
@@ -99,41 +109,31 @@ public class CompletionData {
   private String functionName;
 
   /**
-   * URI документа, в контексте которого item был построен.
-   * <p>
-   * Нужен для {@code completionItem/resolve}: запрос приходит без позиции и без
-   * текстового документа, а {@code typeService}/{@code globalScopeProvider} —
-   * workspace-scoped бины. По этому URI восстанавливается документ и его
-   * workspace, чтобы установить workspace-контекст перед резолвом documentation.
-   */
-  private URI uri;
-
-  /**
    * Создаёт ключ восстановления документации члена типа (dot-completion).
    *
+   * @param uri               URI документа, в контексте которого построен item.
    * @param typeKind          вид типа-владельца члена.
    * @param typeQualifiedName каноническое полное имя типа-владельца.
    * @param memberName        имя члена (метода/свойства).
    * @param fileType          тип файла-потребителя (BSL/OS).
    * @param scriptVariant     локаль скрипта (ru/en).
-   * @param uri               URI документа, в контексте которого построен item.
    * @return ключ восстановления члена типа.
    */
-  public static CompletionData forMember(TypeKind typeKind, String typeQualifiedName, String memberName,
-                                         FileType fileType, Language scriptVariant, URI uri) {
-    return new CompletionData(typeKind, typeQualifiedName, memberName, fileType, scriptVariant, null, uri);
+  public static CompletionData forMember(URI uri, TypeKind typeKind, String typeQualifiedName, String memberName,
+                                         FileType fileType, Language scriptVariant) {
+    return new CompletionData(uri, typeKind, typeQualifiedName, memberName, fileType, scriptVariant, null);
   }
 
   /**
    * Создаёт ключ восстановления документации глобальной функции (no-dot completion).
    *
+   * @param uri           URI документа, в контексте которого построен item.
    * @param functionName  имя глобальной функции.
    * @param fileType      тип файла-потребителя (BSL/OS).
    * @param scriptVariant локаль скрипта (ru/en).
-   * @param uri           URI документа, в контексте которого построен item.
    * @return ключ восстановления глобальной функции.
    */
-  public static CompletionData forFunction(String functionName, FileType fileType, Language scriptVariant, URI uri) {
-    return new CompletionData(null, null, null, fileType, scriptVariant, functionName, uri);
+  public static CompletionData forFunction(URI uri, String functionName, FileType fileType, Language scriptVariant) {
+    return new CompletionData(uri, null, null, null, fileType, scriptVariant, functionName);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -65,6 +65,7 @@ import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
 import tools.jackson.databind.json.JsonMapper;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -339,22 +340,21 @@ public final class CompletionProvider {
   /**
    * Разрешает отложенную документацию completion item ({@code completionItem/resolve}).
    * <p>
-   * Если item пришёл без {@link CompletionItem#getData()} — резолвить нечем, item
-   * возвращается как есть. Иначе по data-ключу восстанавливается источник описания:
-   * для глобальной функции — она сама по имени в глобальной области видимости, для
-   * члена типа — тип-владелец и член. После чего {@code documentation} собирается тем
-   * же способом, что был бы при жадной сборке. Поле {@code data} очищается для
-   * экономии трафика.
+   * По data-ключу восстанавливается источник описания: для глобальной функции — она
+   * сама по имени в глобальной области видимости, для члена типа — тип-владелец и член.
+   * После чего {@code documentation} собирается тем же способом, что был бы при жадной
+   * сборке. Поле {@code data} очищается для экономии трафика.
+   * <p>
+   * И {@code globalScopeProvider}, и {@code typeService} — workspace-scoped бины, поэтому
+   * вызывающий обязан установить workspace-контекст текущего документа перед вызовом
+   * (см. {@link #extractData(CompletionItem)} для получения {@code uri} документа).
    *
    * @param unresolved completion item, пришедший от клиента на разрешение.
-   * @return тот же item с проставленной {@code documentation} и очищенным {@code data};
-   *         либо неизменённый item, если данных для резолва нет.
+   * @param data       ключ восстановления документации, извлечённый из item
+   *                   через {@link #extractData(CompletionItem)}.
+   * @return тот же item с проставленной {@code documentation} и очищенным {@code data}.
    */
-  public CompletionItem resolveCompletionItem(CompletionItem unresolved) {
-    var data = extractData(unresolved);
-    if (data == null) {
-      return unresolved;
-    }
+  public CompletionItem resolveCompletionItem(CompletionItem unresolved, CompletionData data) {
     var functionName = data.getFunctionName();
     if (functionName != null) {
       globalScopeProvider.findFunction(functionName, data.getFileType())
@@ -398,7 +398,7 @@ public final class CompletionProvider {
    * @return извлечённые данные либо {@code null}, если data отсутствует.
    */
   @Nullable
-  private CompletionData extractData(CompletionItem item) {
+  public CompletionData extractData(CompletionItem item) {
     var rawData = item.getData();
     if (rawData == null) {
       return null;
@@ -464,7 +464,7 @@ public final class CompletionProvider {
       // зачёркнутыми).
       .filter(m -> !PlatformMemberVersions.firesUnavailable(m.metadata().sinceVersion(), target))
       .toList();
-    var items = toCompletionItems(filtered, owners, fileType, scriptVariant, target);
+    var items = toCompletionItems(filtered, owners, fileType, scriptVariant, target, documentContext.getUri());
     for (int i = 0; i < filtered.size(); i++) {
       var member = filtered.get(i);
       var bucket = localFieldNames.contains(member.name()) ? BUCKET_MEMBER_FIELD : BUCKET_MEMBER_DEFAULT;
@@ -614,7 +614,7 @@ public final class CompletionProvider {
       }
       var displayName = fn.displayName(scriptVariant);
       if (matches(displayName, prefix)) {
-        var item = toCompletionItem(fn, fileType, scriptVariant, target);
+        var item = toCompletionItem(fn, fileType, scriptVariant, target, documentContext.getUri());
         applySortText(item, BUCKET_GLOBAL, isMemberDeprecated(fn, target));
         items.add(item);
       }
@@ -737,11 +737,11 @@ public final class CompletionProvider {
    * функции по имени (см. {@link CompletionData}). Клиент без resolveSupport получает её сразу.
    */
   private CompletionItem toCompletionItem(MemberDescriptor member, FileType fileType,
-                                          Language scriptVariant, CompatibilityMode target) {
+                                          Language scriptVariant, CompatibilityMode target, URI uri) {
     var item = buildMemberItem(member, documentationResolveSupport,
       CompletionItemKind.Function, CompletionItemKind.Variable, scriptVariant, target);
     if (documentationResolveSupport) {
-      item.setData(CompletionData.forFunction(member.name(), fileType, scriptVariant));
+      item.setData(CompletionData.forFunction(member.name(), fileType, scriptVariant, uri));
     }
     return item;
   }
@@ -750,7 +750,8 @@ public final class CompletionProvider {
                                                  Map<String, TypeRef> owners,
                                                  FileType fileType,
                                                  Language scriptVariant,
-                                                 CompatibilityMode target) {
+                                                 CompatibilityMode target,
+                                                 URI uri) {
     var items = new ArrayList<CompletionItem>(members.size());
     for (var member : members) {
       var owner = owners.get(member.name());
@@ -761,7 +762,7 @@ public final class CompletionProvider {
         CompletionItemKind.Method, CompletionItemKind.Property, scriptVariant, target);
       if (deferDocumentation) {
         item.setData(CompletionData.forMember(
-          owner.kind(), owner.qualifiedName(), member.name(), fileType, scriptVariant));
+          owner.kind(), owner.qualifiedName(), member.name(), fileType, scriptVariant, uri));
       }
       items.add(item);
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -741,7 +741,7 @@ public final class CompletionProvider {
     var item = buildMemberItem(member, documentationResolveSupport,
       CompletionItemKind.Function, CompletionItemKind.Variable, scriptVariant, target);
     if (documentationResolveSupport) {
-      item.setData(CompletionData.forFunction(member.name(), fileType, scriptVariant, uri));
+      item.setData(CompletionData.forFunction(uri, member.name(), fileType, scriptVariant));
     }
     return item;
   }
@@ -762,7 +762,7 @@ public final class CompletionProvider {
         CompletionItemKind.Method, CompletionItemKind.Property, scriptVariant, target);
       if (deferDocumentation) {
         item.setData(CompletionData.forMember(
-          owner.kind(), owner.qualifiedName(), member.name(), fileType, scriptVariant, uri));
+          uri, owner.kind(), owner.qualifiedName(), member.name(), fileType, scriptVariant));
       }
       items.add(item);
     }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
@@ -869,6 +869,34 @@ class BSLTextDocumentServiceTest {
     }
   }
 
+  @Test
+  void resolveCompletionItem_returnsItemAsIsWhenNoData() throws Exception {
+    // given — item без data (резолвить нечем)
+    var item = new CompletionItem("Сообщить");
+
+    // when
+    var result = textDocumentService.resolveCompletionItem(item).get();
+
+    // then — item возвращается как есть, провайдер не вызывается
+    assertThat(result).isSameAs(item);
+    verify(completionProvider, never()).resolveCompletionItem(any(), any());
+  }
+
+  @Test
+  void resolveCompletionItem_returnsItemAsIsForUnknownDocument() throws Exception {
+    // given — data ссылается на документ, которого нет в индексе
+    var unknownUri = Absolute.uri(new File("./src/test/resources/__no_such_document__.bsl"));
+    var item = new CompletionItem("Сообщить");
+    item.setData(CompletionData.forFunction(unknownUri, "Сообщить", FileType.BSL, Language.RU));
+
+    // when
+    var result = textDocumentService.resolveCompletionItem(item).get();
+
+    // then — без документа резолвить негде, item возвращается как есть
+    assertThat(result).isSameAs(item);
+    verify(completionProvider, never()).resolveCompletionItem(any(), any());
+  }
+
   // Tests for unknown file handling (dryRun - no didOpen before call)
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
@@ -21,11 +21,15 @@
  */
 package com.github._1c_syntax.bsl.languageserver;
 
+import com.github._1c_syntax.bsl.languageserver.completion.CompletionData;
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
 import com.github._1c_syntax.bsl.languageserver.jsonrpc.DiagnosticParams;
+import com.github._1c_syntax.bsl.languageserver.providers.CompletionProvider;
 import com.github._1c_syntax.bsl.languageserver.providers.DefinitionProvider;
 import com.github._1c_syntax.bsl.languageserver.providers.DiagnosticProvider;
 import com.github._1c_syntax.bsl.languageserver.providers.HoverProvider;
@@ -43,6 +47,7 @@ import org.eclipse.lsp4j.CodeActionContext;
 import org.eclipse.lsp4j.CodeActionParams;
 import org.eclipse.lsp4j.CodeLensParams;
 import org.eclipse.lsp4j.ColorPresentationParams;
+import org.eclipse.lsp4j.CompletionItem;
 import org.eclipse.lsp4j.CompletionParams;
 import org.eclipse.lsp4j.DefinitionParams;
 import org.eclipse.lsp4j.DiagnosticCapabilities;
@@ -142,6 +147,8 @@ class BSLTextDocumentServiceTest {
   private DefinitionProvider definitionProvider;
   @MockitoSpyBean
   private LinkedEditingRangeProvider linkedEditingRangeProvider;
+  @MockitoSpyBean
+  private CompletionProvider completionProvider;
 
   @BeforeEach
   void setUp() {
@@ -814,6 +821,47 @@ class BSLTextDocumentServiceTest {
       assertThat(capturedUri.get())
         .as("WorkspaceContextHolder must be set on text-document-service worker thread")
         .isNotNull();
+    } finally {
+      if (savedContext != null) {
+        WorkspaceContextHolder.set(savedContext);
+      }
+    }
+  }
+
+  /**
+   * Регрессионный тест ScopeNotActiveException из Sentry: {@code completionItem/resolve}
+   * приходит без позиции и текстового документа, а {@code resolveCompletionItem} обращается
+   * к workspace-scoped {@code typeService}/{@code globalScopeProvider}. Без установки
+   * workspace-контекста по {@code data.uri} резолв падал с
+   * {@code ScopeNotActiveException: Scope 'workspace' is not active for the current thread}.
+   */
+  @Test
+  void resolveCompletionItem_setsWorkspaceContextForWorkspaceScopedBeans() throws Exception {
+    // given — открытый документ и ленивый completion item с data-ключом, указывающим на него
+    doOpen();
+    var item = new CompletionItem("Сообщить");
+    item.setData(CompletionData.forFunction(
+      "Сообщить", FileType.BSL, Language.RU, Absolute.uri(getTestFile())));
+
+    var capturedUri = new AtomicReference<URI>();
+    doAnswer(invocation -> {
+      capturedUri.set(WorkspaceContextHolder.get());
+      return invocation.getArgument(0);
+    }).when(completionProvider).resolveCompletionItem(any(), any());
+
+    // simulate LSP4J handler thread: no workspace context on calling thread
+    var savedContext = WorkspaceContextHolder.get();
+    WorkspaceContextHolder.clear();
+    try {
+      // when
+      textDocumentService.resolveCompletionItem(item).get();
+
+      // then — workspace-контекст установлен на воркере перед обращением к scoped-бинам
+      var expectedWorkspaceUri = Absolute.uri(new File("./src/test/resources").getAbsoluteFile().toURI());
+      assertThat(capturedUri.get())
+        .as("WorkspaceContextHolder must be set before resolveCompletionItem touches workspace-scoped beans")
+        .isNotNull()
+        .isEqualTo(expectedWorkspaceUri);
     } finally {
       if (savedContext != null) {
         WorkspaceContextHolder.set(savedContext);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentServiceTest.java
@@ -841,7 +841,7 @@ class BSLTextDocumentServiceTest {
     doOpen();
     var item = new CompletionItem("Сообщить");
     item.setData(CompletionData.forFunction(
-      "Сообщить", FileType.BSL, Language.RU, Absolute.uri(getTestFile())));
+      Absolute.uri(getTestFile()), "Сообщить", FileType.BSL, Language.RU));
 
     var capturedUri = new AtomicReference<URI>();
     doAnswer(invocation -> {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -44,6 +44,7 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 
 import java.util.List;
+import java.util.Objects;
 import java.util.Set;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
@@ -1908,7 +1909,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
     var lazy = dotCompletionItem(documentContext, new Position(1, 2), "Добавить");
 
     // when — клиент запрашивает resolve этого item
-    var resolved = completionProvider.resolveCompletionItem(lazy);
+    var resolved = resolve(lazy);
 
     // then — documentation восстановлена тем же контентом, что был бы жадным
     assertThat(resolved.getDocumentation())
@@ -1919,6 +1920,11 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
     assertThat(resolved.getData())
       .as("после resolve data очищается для экономии трафика")
       .isNull();
+  }
+
+  private CompletionItem resolve(CompletionItem item) {
+    var data = completionProvider.extractData(item);
+    return completionProvider.resolveCompletionItem(item, Objects.requireNonNull(data));
   }
 
   private CompletionItem noDotCompletionItem(
@@ -1968,7 +1974,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
     var lazy = noDotCompletionItem(lazyContext, new Position(0, 4), "Сообщить");
 
     // when — клиент запрашивает resolve этого item
-    var resolved = completionProvider.resolveCompletionItem(lazy);
+    var resolved = resolve(lazy);
 
     // then — documentation восстановлена тем же контентом, что был бы жадным
     assertThat(resolved.getDocumentation())


### PR DESCRIPTION
## Проблема

`completionItem/resolve` падал с ошибкой из Sentry:

```
ScopeNotActiveException: Scope 'workspace' is not active for the current thread
  at CompletionProvider.resolveMemberDocumentation(CompletionProvider.java:384)
  at CompletionProvider.resolveCompletionItem(CompletionProvider.java:363)
  at BSLTextDocumentService.resolveCompletionItem(BSLTextDocumentService.java:238)
```

`resolveCompletionItem` обращается к workspace-scoped бинам `typeService` и `globalScopeProvider`, но обработчик в `BSLTextDocumentService` вызывал провайдер напрямую — без установки workspace-контекста потока (в отличие от `completion()`, обёрнутого в `withFreshDocumentContext`).

## Причина

Запрос `completionItem/resolve` по LSP приходит без позиции и текстового документа — только сам `CompletionItem`. Определить workspace было неоткуда: `CompletionData` не содержала URI документа.

## Решение

Зеркалит уже существующий паттерн `resolveCodeLens`/`resolveInlayHint`:

- в `CompletionData` добавлен `uri` документа (как в `CodeLensData`/`InlayHintData`), проставляется при сборке item;
- `BSLTextDocumentService.resolveCompletionItem` по этому URI восстанавливает документ и выполняет резолв в его workspace-контексте через `withFreshDocumentContext`;
- `CompletionProvider.extractData` стал публичным, `resolveCompletionItem` принимает уже извлечённую `CompletionData`.

## Тесты

- Новый регрессионный тест `BSLTextDocumentServiceTest.resolveCompletionItem_setsWorkspaceContextForWorkspaceScopedBeans` воспроизводит сценарий из Sentry (вызов resolve на потоке без workspace-контекста). Проверено: красный без фикса, зелёный с фиксом.
- Существующие тесты resolve в `CompletionProviderTest` обновлены под новую сигнатуру.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced code completion item resolution to properly preserve document context when generating lazy documentation. The completion engine now maintains accurate workspace context throughout the resolution process, preventing context loss and ensuring documentation is generated with correct workspace information for improved code intelligence accuracy.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->