### PR TITLE
fix(sentry): распознавать pre-release версии с точкой в rc.N

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/sentry/SentryScopeConfigurer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/sentry/SentryScopeConfigurer.java
@@ -105,12 +105,23 @@ public class SentryScopeConfigurer {
   }
 
   private String getEnvironment() {
-    String version = serverInfo.getVersion();
+    return resolveEnvironment(serverInfo.getVersion());
+  }
+
+  /**
+   * Сопоставляет строку версии сервера со значением environment для Sentry.
+   *
+   * @param version Строка версии сервера, например {@code 1.0.0}, {@code 1.0.0-rc.2} или
+   *                {@code develop-1234}
+   * @return Имя окружения Sentry: {@code production}, {@code pre-release}, {@code develop} или
+   *         {@code feature}
+   */
+  static String resolveEnvironment(String version) {
     String environment;
 
     if (version.matches("\\d+\\.\\d+\\.\\d+")) {
       environment = "production";
-    } else if (version.matches("\\d+\\.\\d+\\.\\d+-r[ca]\\d+")) {
+    } else if (version.matches("\\d+\\.\\d+\\.\\d+-r[ca]\\.?\\d+")) {
       environment = "pre-release";
     } else if (version.startsWith("develop-") && !version.contains("-DIRTY-")) {
       environment = "develop";

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/aop/sentry/SentryScopeConfigurerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/aop/sentry/SentryScopeConfigurerTest.java
@@ -33,6 +33,8 @@ import org.eclipse.lsp4j.services.LanguageServer;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.context.ApplicationEventPublisher;
@@ -144,5 +146,26 @@ class SentryScopeConfigurerTest {
     assertThat(capturedEvent.get()).isNotNull();
     assertThat(capturedEvent.get().getTags()).containsEntry("client.name", "UNKNOWN");
     assertThat(capturedEvent.get().getTags()).containsEntry("client.version", "UNKNOWN");
+  }
+
+  @ParameterizedTest
+  @CsvSource({
+    "1.0.0,        production",
+    "1.2.34,       production",
+    "1.0.0-rc.2,   pre-release",
+    "1.0.0-rc2,    pre-release",
+    "1.0.0-ra.1,   pre-release",
+    "1.0.0-ra1,    pre-release",
+    "develop-1234, develop",
+    "develop-1234-DIRTY-abcdef, feature",
+    "1.0.0-alpha,  feature",
+    "feature-foo,  feature"
+  })
+  void testResolveEnvironment(String version, String expectedEnvironment) {
+    // when
+    var environment = SentryScopeConfigurer.resolveEnvironment(version);
+
+    // then
+    assertThat(environment).isEqualTo(expectedEnvironment);
   }
 }


### PR DESCRIPTION
## Проблема

В Sentry-issue [BSL-LANGUAGE-SERVER-W7](https://1c-syntax.sentry.io/issues/7552251217/) событие релиза `bsl-language-server@1.0.0-rc.2` помечено окружением `feature`, хотя должно быть `pre-release`.

Причина: `SentryScopeConfigurer.getEnvironment()` вычисляет environment регуляркой по строке версии. Регулярка для pre-release — `\d+\.\d+\.\d+-r[ca]\d+` — ожидала формат `1.0.0-rc2` (без точки между `rc` и номером). Реальная semver-версия `1.0.0-rc.2` содержит точку, поэтому не матчилась, проваливалась до `else` и получала `feature`.

GitHub-маркировка тега как pre-release на это вычисление не влияет — environment зависит только от строки версии.

## Изменения

- Разрешена необязательная точка в регулярке: `-r[ca]\.?\d+` (покрывает оба формата — `rc2` и `rc.2`).
- Логика маппинга версия→environment вынесена в package-private `resolveEnvironment(String)`, чтобы тестировать без поднятия Spring-контекста.
- Добавлен параметризованный тест на все ветки маппинга (production / pre-release / develop / feature), включая регрессию `1.0.0-rc.2`.

Fixes BSL-LANGUAGE-SERVER-W7

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced pre-release version pattern recognition for release and candidate versions to accommodate optional dot formatting before version numbers.

* **Tests**
  * Added parameterized test suite to validate version-to-environment resolution across various version string formats.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->