### PR TITLE
fix(symbol): сделать WorkspaceSymbolIndex синглтоном (#4123)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
@@ -29,7 +29,6 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymb
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.variable.VariableKind;
-import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.types.ScriptVariant;
 import org.apache.commons.collections4.trie.PatriciaTrie;
@@ -105,14 +104,21 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * Индекс наследует {@link AbstractDocumentLifecycleClearableIndex}: его {@code @EventListener}'ы
  * сбрасывают записи документа на изменение содержимого, освобождение данных, закрытие и удаление.
  * <p>
+ * Бин — обычный синглтон (НЕ {@code @WorkspaceScope}): {@code workspace/symbol} по протоколу LSP —
+ * кросс-воркспейсный запрос, поэтому единый индекс хранит символы документов всех рабочих областей
+ * и отдаёт их одним ранжированным списком. Записи ключуются по URI документа ({@link Entry#uri()}),
+ * а жизненный цикл держится на per-document событиях (в т.ч. {@code ServerContextDocumentRemovedEvent},
+ * который рассылается и при удалении рабочей области), так что закрытие/удаление области штатно
+ * вычищает её документы из индекса без отдельного per-workspace teardown'а. Индекс самодостаточен:
+ * не обращается ни к одному {@code @WorkspaceScope}-бину, поэтому workspace-контекст потока ему не нужен.
+ * <p>
  * Потокобезопасность: {@link PatriciaTrie} не потокобезопасен, поэтому доступ к нему защищён
  * {@link ReadWriteLock}. Запросы ({@link #search(String, CancelChecker)}) держат read-lock,
  * переиндексация и сброс ({@link #index(DocumentContext)}, {@link #clear(URI)}) — write-lock,
- * так что чтение и запись не гоняются. Записи {@link Entry} неизменяемы и безопасно покидают
- * блокировку в составе результата.
+ * так что чтение и запись не гоняются (в т.ч. при конкурентной индексации из populate-пулов разных
+ * рабочих областей). Записи {@link Entry} неизменяемы и безопасно покидают блокировку в составе результата.
  */
 @Component
-@WorkspaceScope
 public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableIndex {
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceServiceTest.java
@@ -41,6 +41,7 @@ import org.eclipse.lsp4j.FileRename;
 import org.eclipse.lsp4j.RenameFilesParams;
 import org.eclipse.lsp4j.WorkspaceFolder;
 import org.eclipse.lsp4j.WorkspaceFoldersChangeEvent;
+import org.eclipse.lsp4j.WorkspaceSymbolParams;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.TempDir;
@@ -576,6 +577,47 @@ class BSLWorkspaceServiceTest {
     } finally {
       applicationContext.removeApplicationListener(listener);
     }
+  }
+
+  /**
+   * Регрессия на ScopeNotActiveException из issue #4123: запрос {@code workspace/symbol}
+   * выполняется на потоке {@code workspaceServiceExecutor}, а JSON-RPC диспетчер не устанавливает
+   * workspace-контекст вызывающего потока. Раньше {@code workspaceSymbolIndex} был {@code @WorkspaceScope}
+   * и без контекста не резолвился ({@code ScopeNotActiveException: Scope 'workspace' is not active}).
+   * После де-скопинга индекс — обычный синглтон, поэтому запрос обслуживается с любого потока без
+   * установленного workspace-контекста.
+   */
+  @Test
+  void symbol_worksFromThreadWithoutWorkspaceContext() throws Exception {
+    // given
+    var workspaceUri = Absolute.uri(tempDir.toUri());
+    var testFile = tempDir.resolve("symbol_index_module.bsl").toFile();
+    FileUtils.writeStringToFile(
+      testFile,
+      "Процедура ТестоваяПроцедураПоискаСимволов() КонецПроцедуры",
+      StandardCharsets.UTF_8
+    );
+    var uri = Absolute.uri(testFile.toURI());
+
+    // Наполняем индекс: rebuildDocument синхронно публикует DocumentContextContentChangedEvent.
+    WorkspaceContextHolder.run(workspaceUri, () -> {
+      var ctx = workspaceServerContext();
+      var documentContext = ctx.addDocument(uri);
+      ctx.rebuildDocument(documentContext);
+    });
+
+    // Воспроизводим прод-условие: вызывающий поток (JSON-RPC диспетчер) без workspace-контекста.
+    WorkspaceContextHolder.clear();
+
+    var params = new WorkspaceSymbolParams("ТестоваяПроцедураПоискаСимволов");
+
+    // when
+    var symbols = workspaceService.symbol(params).get().getRight();
+
+    // then
+    assertThat(symbols)
+      .as("workspace/symbol должен обслуживаться с потока без workspace-контекста (индекс — синглтон)")
+      .anyMatch(symbol -> symbol.getName().equals("ТестоваяПроцедураПоискаСимволов"));
   }
 
   @Test


### PR DESCRIPTION
## Проблема

`workspace/symbol` стабильно падает с `-32603 Internal error` (issue #4123):

```
ScopeNotActiveException: ... 'scopedTarget.workspaceSymbolIndex':
Scope 'workspace' is not active for the current thread
```

Запрос выполняется на потоке `workspaceServiceExecutor`, которому JSON-RPC диспетчер не устанавливает workspace-контекст, а `WorkspaceSymbolIndex` был `@WorkspaceScope` → scoped proxy не резолвится.

**Регресс rc.1 → rc.2:** в rc.1 индекса ещё не было — `workspace/symbol` шёл обходом документов и работал кросс-воркспейсно. Индекс появился в rc.2 уже `@WorkspaceScope`, что и сломало запрос.

## Решение

Снят `@WorkspaceScope` — индекс стал обычным синглтоном.

Обоснование, почему scope здесь лишний:
- `workspace/symbol` по протоколу LSP — **кросс-воркспейсный** запрос: единый индекс по всем рабочим областям это и есть желаемое поведение (как в rc.1), изолировать области в выдаче не нужно;
- индекс **самодостаточен**: `index()`/`search()` не обращаются ни к одному `@WorkspaceScope`-бину, workspace-контекст потока ему не нужен;
- жизненный цикл держится на **per-document событиях** (`Changed`/`Cleared`/`Closed`/`Removed`); `removeWorkspace` штатно рассылает `ServerContextDocumentRemovedEvent` по каждому документу → закрытие/удаление области вычищает её документы без per-workspace teardown'а;
- индекс уже потокобезопасен (`ReadWriteLock` + `ConcurrentMap`), конкурентная индексация из populate-пулов разных областей корректна.

`SymbolProvider` и `BSLWorkspaceService` остаются **без изменений** относительно develop — провайдер просто дёргает один индекс.

## Тесты

- Регрессионный тест `BSLWorkspaceServiceTest#symbol_worksFromThreadWithoutWorkspaceContext`: воспроизводит прод-условие (вызывающий поток без workspace-контекста). До фикса падал с `ScopeNotActiveException`, после — зелёный.
- `WorkspaceSymbolIndexTest`, `SymbolProvider*Test`, `BSLWorkspaceServiceTest` проходят (тестовый `liteCleanup` чистит синглтон-индекс через те же document-события).

Closes #4123

🤖 Generated with [Claude Code](https://claude.com/claude-code)