### PR TITLE
fix(completion): не дублировать скобку — убрать commit character "(" у вызываемых

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -846,11 +846,14 @@ public final class CompletionProvider {
    * {@link CompletionItemKind}, если клиент объявил поддержку
    * {@code completionItem.commitCharactersSupport}. Commit character —
    * символ, ввод которого фиксирует пункт и сразу вставляет его вместе с
-   * этим символом. Набор подбирается по смыслу пункта: вызываемые
-   * (метод/функция/конструктор) фиксируются открывающей скобкой
-   * {@code "("}, члены-объекты и переменные/модули — точкой {@code "."}
-   * (после фиксации осмысленно дальнейшее обращение к члену). Ключевым
-   * словам и прочим пунктам commit characters не задаются.
+   * этим символом. Набор подбирается по смыслу пункта: члены-объекты и
+   * переменные/модули фиксируются точкой {@code "."} (после фиксации осмысленно
+   * дальнейшее обращение к члену). Вызываемым (метод/функция/конструктор)
+   * commit characters НЕ задаются: их {@code insertText} уже вставляет открывающую
+   * скобку (см. {@link #applyCallableInsertText}), а commit character по спецификации
+   * LSP добавляется после текста пункта — символ {@code "("} продублировал бы скобку
+   * ({@code Имя((}) и сломал signatureHelp. Ключевым словам и прочим пунктам commit
+   * characters также не задаются.
    *
    * @param item пункт автодополнения, которому проставляются commit characters.
    */
@@ -863,10 +866,14 @@ public final class CompletionProvider {
       return;
     }
     switch (kind) {
-      case Method, Function, Constructor -> item.setCommitCharacters(List.of("("));
+      // Вызываемым (метод/функция/конструктор) commit character "(" НЕ задаётся: их
+      // insertText уже вставляет открывающую скобку (`Имя($0)` / `Имя(` / `Имя()`, см.
+      // applyCallableInsertText), а commit character по спецификации LSP добавляется ПОСЛЕ
+      // текста пункта. Получилась бы дублирующая скобка `Имя((` со сломанным signatureHelp.
       case Field, Property, Variable, Module -> item.setCommitCharacters(List.of("."));
       default -> {
-        // ключевые слова, классы и прочие пункты commit characters не получают
+        // методы/функции/конструкторы (скобку даёт insertText), ключевые слова, классы
+        // и прочие пункты commit characters не получают
       }
     }
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -2017,7 +2017,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
-  void methodMemberGetsOpenParenCommitCharacter() {
+  void methodMemberGetsNoCommitCharacterBecauseInsertTextAddsParen() {
     // given — клиент поддерживает commitCharactersSupport
     enableCommitCharactersSupport(true);
     var documentContext = TestUtils.getDocumentContext("М = Новый Массив;\nМ.");
@@ -2025,9 +2025,13 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
     // when
     var add = dotCompletionItem(documentContext, new Position(1, 2), "Добавить");
 
-    // then — метод фиксируется вставкой открывающей скобки
+    // then — методу commit character "(" НЕ задаётся: его insertText уже вставляет
+    // открывающую скобку (`Добавить(` без snippetSupport либо `Добавить($0)` с ним),
+    // а commit character добавился бы после текста и продублировал её (`Добавить((`),
+    // сломав signatureHelp.
     assertThat(add.getKind()).isEqualTo(CompletionItemKind.Method);
-    assertThat(add.getCommitCharacters()).containsExactly("(");
+    assertThat(add.getInsertText()).startsWith("Добавить(");
+    assertThat(add.getCommitCharacters()).isNull();
   }
 
   @Test


### PR DESCRIPTION
## Проблема

При обычном наборе вызова метода (`Список.Добавить(`, `Сложить(` и т.п.) в редакторе появлялась **двойная открывающая скобка** (`Добавить(()`), а подсказка по параметрам (`signatureHelp`) не всплывала.

## Причина

Пункту автодополнения метода/функции/конструктора одновременно проставлялись:
- `insertText`, который **сам вставляет открывающую скобку** — `Имя($0)` (со `snippetSupport`) либо `Имя(` (без него), см. `applyCallableInsertText`;
- `commitCharacters = ["("]` (фича из #4091).

По спецификации LSP commit character вставляется **после** текста выбранного пункта. Поскольку автокомплит открыт во время набора, ввод `(` фиксировал пункт (вставив его текст со скобкой) и затем добавлял ещё одну `(` → `Имя((`. Курсор оказывался в рассогласованных скобках, и `signatureHelp` не поднимался.

Конфликт двух свежих фич: commit-символ `(` × авто-вставка скобки в `insertText`.

## Исправление

Вызываемым (`Method`/`Function`/`Constructor`) commit character `"("` больше **не задаётся** — открывающую скобку и подъём подсказки уже обеспечивает `insertText` (+ `triggerParameterHints`). Это совпадает с поведением эталонных LSP-серверов (TypeScript LS, gopls, rust-analyzer), которые не объявляют `(` commit-символом при авто-вставке скобок.

Commit character `"."` для свойств, переменных и модулей сохранён (их `insertText` — голое имя, дублирования нет).

## Тест

`methodMemberGetsNoCommitCharacterBecauseInsertTextAddsParen` (бывш. `methodMemberGetsOpenParenCommitCharacter`) теперь проверяет, что метод **не** получает commit character, а его `insertText` уже несёт скобку.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed code completion for methods and functions to prevent duplicate opening parentheses when completing callable items.
  * Improved signature help functionality by preventing conflicting character insertion during method completion.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->