### PR TITLE
feat(completion): паритет completion item — пользовательские методы и конструкторы как платформенные

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.completion.CompletionData;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
@@ -40,6 +41,8 @@ import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryInde
 import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
 import com.github._1c_syntax.bsl.languageserver.types.scope.UseDirectiveScanner;
 import com.github._1c_syntax.bsl.languageserver.types.symbol.SyntheticKind;
+import com.github._1c_syntax.bsl.parser.description.MethodDescription;
+import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import com.github._1c_syntax.bsl.support.CompatibilityMode;
 import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;
@@ -67,6 +70,7 @@ import tools.jackson.databind.json.JsonMapper;
 
 import java.net.URI;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
@@ -628,6 +632,8 @@ public final class CompletionProvider {
         var item = new CompletionItem(method.getName());
         item.setKind(method.isFunction() ? CompletionItemKind.Function : CompletionItemKind.Method);
         applyCallableInsertText(item, method.getName(), !method.getParameters().isEmpty());
+        applySourceMethodDetail(item, method);
+        applySourceMethodDocumentation(item, method);
         if (method.isDeprecated()) {
           markDeprecatedItem(item);
         }
@@ -1078,6 +1084,96 @@ public final class CompletionProvider {
     }
     sb.append(')');
     return sb.toString();
+  }
+
+  /**
+   * Заполняет детали пункта автодополнения для локального (source-defined) метода: сигнатуру
+   * «{@code (Пар1, Пар2?)}» и — для функций с задокументированным типом возврата — имя типа,
+   * уложенные тем же {@link #applyDetail(CompletionItem, String, String)}, что и для платформенных
+   * методов ({@link #applyMethodDetail}). Благодаря этому пользовательские и платформенные методы
+   * выглядят в автодополнении одинаково.
+   *
+   * @param item   пункт автодополнения локального метода.
+   * @param method символ локального метода (процедуры/функции) текущего документа.
+   */
+  private void applySourceMethodDetail(CompletionItem item, MethodSymbol method) {
+    var paramList = formatSourceParameterList(method);
+    var returnTypeName = method.isFunction() ? sourceReturnTypeName(method) : "";
+    applyDetail(item, paramList, returnTypeName);
+  }
+
+  /**
+   * Сигнатура «{@code (Пар1, Пар2?)}» по параметрам локального метода: имя параметра, необязательные
+   * (с значением по умолчанию) помечаются «{@code ?}». Зеркалит {@link #formatParameterList} для
+   * платформенных методов, отличаясь лишь источником данных
+   * ({@link com.github._1c_syntax.bsl.languageserver.context.symbol.ParameterDefinition}).
+   *
+   * @param method символ локального метода.
+   * @return строка сигнатуры в круглых скобках.
+   */
+  private static String formatSourceParameterList(MethodSymbol method) {
+    var sb = new StringBuilder();
+    sb.append('(');
+    var params = method.getParameters();
+    for (int i = 0; i < params.size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      var parameter = params.get(i);
+      sb.append(parameter.getName());
+      if (parameter.isOptional()) {
+        // Необязательный параметр помечаем «?» после имени: ИмяПараметра?.
+        sb.append('?');
+      }
+    }
+    sb.append(')');
+    return sb.toString();
+  }
+
+  /**
+   * Имя типа возвращаемого значения локальной функции из её doc-comment'а
+   * ({@code Возвращаемое значение:}). Несколько типов объединяются через «{@code  | }» (как в hover);
+   * если тип не задокументирован — пустая строка (BSL не типизирован, иного источника нет).
+   *
+   * @param method символ локальной функции.
+   * @return имя типа возврата либо пустая строка.
+   */
+  private static String sourceReturnTypeName(MethodSymbol method) {
+    return method.getDescription()
+      .map(MethodDescription::getReturnedValue)
+      .map(types -> types.stream()
+        .map(TypeDescription::name)
+        .flatMap(name -> Arrays.stream(name.split(",")))
+        .map(String::trim)
+        .filter(name -> !name.isEmpty())
+        .collect(Collectors.joining(" | ")))
+      .orElse("");
+  }
+
+  /**
+   * Документация пункта автодополнения для локального метода из его doc-comment'а: назначение и,
+   * если метод устарел, причина устаревания (сам факт устаревания клиенту передаёт LSP-тег, см.
+   * {@link #markDeprecatedItem}). Зеркалит {@link #applyDocumentation} для source-символов.
+   *
+   * @param item   пункт автодополнения локального метода.
+   * @param method символ локального метода.
+   */
+  private void applySourceMethodDocumentation(CompletionItem item, MethodSymbol method) {
+    method.getDescription().ifPresent(description -> {
+      var sb = new StringBuilder();
+      if (description.isDeprecated() && !description.getDeprecationInfo().isBlank()) {
+        sb.append(description.getDeprecationInfo());
+        if (!description.getPurposeDescription().isBlank()) {
+          sb.append("\n\n");
+        }
+      }
+      if (!description.getPurposeDescription().isBlank()) {
+        sb.append(description.getPurposeDescription());
+      }
+      if (sb.length() > 0) {
+        setDocumentation(item, sb.toString());
+      }
+    });
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -940,10 +940,7 @@ public final class CompletionProvider {
         // первый вариант может быть беспараметровым, а следующий — принимать аргументы
         // (например, Новый HTTPЗапрос() и (Адрес, Заголовки)).
         ctorHasParameters = ctors.size() > 1 || !ctors.get(0).parameters().isEmpty();
-        var paramList = ctors.get(0).parameters().stream()
-          .map(p -> p.displayName(scriptVariant))
-          .collect(java.util.stream.Collectors.joining(", "));
-        item.setDetail("(" + paramList + ")");
+        applyConstructorDetail(item, ctors, scriptVariant);
       }
       var desc = typeService.getDescription(ref, scriptVariant, fileType);
       if (!desc.isEmpty()) {
@@ -952,6 +949,27 @@ public final class CompletionProvider {
     }
     applyCallableInsertText(item, className, ctorHasParameters);
     return item;
+  }
+
+  /**
+   * Детали конструктора в позиции после {@code Новый}: сигнатура «{@code (Пар1, Пар2?)}» единственной
+   * перегрузки либо счётчик вариантов при нескольких перегрузках — теми же
+   * {@link #applyDetail(CompletionItem, String, String)} / {@link #formatParameterList} /
+   * {@link #formatSignaturesCount}, что и {@link #applyMethodDetail} для методов, чтобы конструкторы
+   * и платформенные методы выглядели одинаково (в т.ч. {@code labelDetails} при поддержке клиентом).
+   * Тип возврата не показываем: результат конструктора — сам класс, дублирующий label.
+   *
+   * @param item          пункт автодополнения класса.
+   * @param constructors  сигнатуры конструкторов класса (одна или несколько перегрузок).
+   * @param scriptVariant язык отображаемых имён параметров.
+   */
+  private void applyConstructorDetail(CompletionItem item, List<SignatureDescriptor> constructors,
+                                      Language scriptVariant) {
+    if (constructors.size() > 1) {
+      applyDetail(item, formatSignaturesCount(constructors.size(), scriptVariant), "");
+      return;
+    }
+    applyDetail(item, formatParameterList(constructors.get(0), scriptVariant), "");
   }
 
   private void applyCallableInsertText(CompletionItem item, String name, boolean hasParameters) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -249,6 +249,86 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void newCompletionConstructorSignatureMatchesPlatformMethodFormat() {
+    // given: конструктор после `Новый` должен форматировать сигнатуру так же, как метод:
+    // необязательный параметр со знаком «?». У Массив один конструктор с необязательным
+    // КоличествоЭлементов.
+    var documentContext = TestUtils.getDocumentContext("А = Новый Масс");
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(0, "А = Новый Масс".length()));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    var item = items.stream()
+      .filter(it -> "Массив".equals(it.getLabel()))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Массив должен попасть в completion после `Новый`"));
+
+    assertThat(item.getKind()).isEqualTo(CompletionItemKind.Class);
+    assertThat(item.getDetail())
+      .as("необязательный параметр конструктора помечается «?», как у методов")
+      .isEqualTo("(КоличествоЭлементов?)");
+  }
+
+  @Test
+  void newCompletionConstructorOverloadsShownAsCountLikePlatformMethod() {
+    // given: несколько перегрузок конструктора показываются счётчиком вариантов,
+    // как у платформенных методов с несколькими сигнатурами. У Структура — 2 конструктора.
+    var documentContext = TestUtils.getDocumentContext("С = Новый Структ");
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(0, "С = Новый Структ".length()));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    var item = items.stream()
+      .filter(it -> "Структура".equals(it.getLabel()))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Структура должна попасть в completion после `Новый`"));
+
+    assertThat(item.getDetail())
+      .as("несколько перегрузок конструктора — счётчиком вариантов, а не параметрами первой")
+      .contains("2")
+      .doesNotContain("ФиксированнаяСтруктура");
+  }
+
+  @Test
+  void newCompletionConstructorUsesLabelDetailsWhenClientSupportsThem() {
+    // given: при поддержке клиентом labelDetails (LSP 3.17) сигнатура конструктора уходит
+    // в labelDetails.detail (а не в плоский detail), как у платформенных методов.
+    enableLabelDetailsSupport(true);
+    var documentContext = TestUtils.getDocumentContext("А = Новый Масс");
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(0, "А = Новый Масс".length()));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    var item = items.stream()
+      .filter(it -> "Массив".equals(it.getLabel()))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Массив должен попасть в completion после `Новый`"));
+
+    assertThat(item.getLabelDetails())
+      .as("сигнатура конструктора кладётся в labelDetails при поддержке клиентом")
+      .isNotNull();
+    assertThat(item.getLabelDetails().getDetail()).isEqualTo("(КоличествоЭлементов?)");
+    assertThat(item.getDetail())
+      .as("плоский detail не дублируется при labelDetails")
+      .isNull();
+  }
+
+  @Test
   void dotCompletionCommonModuleMethodHasSignatureAndDocumentationLikePlatform() {
     // given: метод общего модуля (source-defined) в dot-completion должен иметь
     // сигнатуру, тип возврата и документацию так же, как платформенные методы.

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -249,6 +249,38 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void dotCompletionCommonModuleMethodHasSignatureAndDocumentationLikePlatform() {
+    // given: метод общего модуля (source-defined) в dot-completion должен иметь
+    // сигнатуру, тип возврата и документацию так же, как платформенные методы.
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    var documentContext = TestUtils.getDocumentContextFromFile(
+      "./src/test/resources/types/CommonModuleMidCallCompletion.bsl");
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    // строка `\tОбщегоНазначения.ОбщийМодуль("Имя");` — позиция сразу после первой точки
+    params.setPosition(new Position(1, 18));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    var item = items.stream()
+      .filter(it -> "ЗначениеВМассиве".equals(it.getLabel()))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("метод общего модуля должен попасть в dot-completion"));
+
+    assertThat(item.getKind()).isEqualTo(CompletionItemKind.Method);
+    assertThat(item.getDetail())
+      .as("сигнатура и тип возврата метода общего модуля — как у платформенного")
+      .isEqualTo("(Значение): Массив");
+    assertThat(documentationText(item))
+      .as("документация метода общего модуля берётся из doc-comment")
+      .contains("Создает массив");
+  }
+
+  @Test
   void noDotCompletionLocalMethodHasSignatureAndDocumentationLikePlatform() {
     // given: локальная функция с обязательным и необязательным параметрами и doc-comment'ом
     // (назначение + тип возврата). Её completion-item должен выглядеть как платформенный метод:

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -249,6 +249,50 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void noDotCompletionLocalMethodHasSignatureAndDocumentationLikePlatform() {
+    // given: локальная функция с обязательным и необязательным параметрами и doc-comment'ом
+    // (назначение + тип возврата). Её completion-item должен выглядеть как платформенный метод:
+    // сигнатура «(Имя, Приветствие?)» + тип возврата в detail и документация из doc-comment.
+    var content = """
+      // Возвращает приветствие.
+      //
+      // Возвращаемое значение:
+      //   - Строка - текст приветствия.
+      //
+      Функция СформироватьПриветствие(Имя, Приветствие = "Привет") Экспорт
+      Возврат Приветствие;
+      КонецФункции
+
+      Процедура Тест()
+      Сформи
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(content);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    // строка `Сформи` (line 10, 0-based), позиция сразу после префикса
+    params.setPosition(new Position(10, 6));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    var item = items.stream()
+      .filter(it -> "СформироватьПриветствие".equals(it.getLabel()))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("локальная функция должна попасть в no-dot completion"));
+
+    assertThat(item.getKind()).isEqualTo(CompletionItemKind.Function);
+    assertThat(item.getDetail())
+      .as("сигнатура и тип возврата локального метода — как у платформенного")
+      .isEqualTo("(Имя, Приветствие?): Строка");
+    assertThat(documentationText(item))
+      .as("документация локального метода берётся из doc-comment")
+      .contains("Возвращает приветствие");
+  }
+
+  @Test
   void testNoDotCompletionReturnsGlobals() {
     var content = "Сооб";
     var documentContext = TestUtils.getDocumentContext(content);


### PR DESCRIPTION
## Цель

Сделать completion item'ы пользовательских/source-defined символов визуально идентичными платформенным (сигнатура, тип возврата, документация, раскладка labelDetails).

## Что сделано

**1. Локальные методы текущего модуля (no-dot completion).**
Раньше показывали только имя. Теперь — сигнатура `(Пар1, Пар2?)` из `MethodSymbol.getParameters()`, тип возврата из doc-comment'а (`Возвращаемое значение:`) и документация (назначение + причина устаревания), через те же `applyDetail`/`setDocumentation`, что и платформенные методы.

**2. Конструкторы после `Новый`.**
Сигнатура форматировалась вручную: без `?` у необязательных параметров, только параметры первой перегрузки, `detail` напрямую (минуя labelDetails). Теперь — теми же `applyDetail`/`formatParameterList`/`formatSignaturesCount`, что и методы: `(Пар?)`, `N вариантов` при нескольких перегрузках, labelDetails при поддержке клиентом. Тип возврата не показываем (результат конструктора — сам класс, дублирует label).

## Аудит остальных веток

Перебрал все места создания `CompletionItem`. Ветки, порождающие **методы**, теперь все богатые:
- платформенные глобальные функции (no-dot) — были;
- локальные методы (no-dot) — этот PR;
- члены типа в dot-completion, включая **source-методы общих/OScript-модулей** (`MemberDescriptor`/`buildMemberItem`) — были богатыми, добавлен тест-страж.

Бедными осознанно остаются не-методы: локальные **переменные** (в BSL не типизированы — нужен вывод типов, отдельная задача), ключевые слова, имена типов/неймспейсов.

## Тесты

- `noDotCompletionLocalMethodHasSignatureAndDocumentationLikePlatform` — локальный метод: `(Имя, Приветствие?): Строка` + документация (red→green).
- `dotCompletionCommonModuleMethodHasSignatureAndDocumentationLikePlatform` — метод общего модуля: `(Значение): Массив` + документация (страж паритета).
- `newCompletionConstructorSignatureMatchesPlatformMethodFormat` — `(КоличествоЭлементов?)` (red→green).
- `newCompletionConstructorOverloadsShownAsCountLikePlatformMethod` — несколько перегрузок → счётчик вариантов (red→green).
- `newCompletionConstructorUsesLabelDetailsWhenClientSupportsThem` — labelDetails при поддержке клиентом (red→green).

Весь `CompletionProviderTest` зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)