### PR TITLE
feat(mcp): proactive roots/list bootstrap + расширенный type_info + новый global_member_info

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsBootstrapper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsBootstrapper.java
@@ -1,0 +1,92 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp;
+
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+
+/**
+ * Проактивно запрашивает MCP-roots у клиента после первого tool-вызова.
+ * <p>
+ * Согласно MCP-спецификации сервер сам должен один раз дёрнуть {@code roots/list}
+ * после {@code notifications/initialized}, если клиент объявил roots-capability.
+ * Уведомление {@code notifications/roots/list_changed} — только для последующих
+ * изменений. Если клиент (например, Claude Code 2.1.178 на Windows) объявляет
+ * пустой набор и не шлёт list_changed, без проактивного запроса сервер не узнает
+ * об открытых workspace-folder'ах и все workspace-зависимые tools падают
+ * с «No registered workspace».
+ * <p>
+ * Spring AI 2.0 не предоставляет post-initialize hook, поэтому запрашиваем roots
+ * лениво: при первом получении {@link McpSyncServerExchange} в любом tool-вызове.
+ * Бутстрап однократный — попытка фиксируется флагом, повторных запросов не идёт.
+ * Уведомления {@code roots/list_changed} (если клиент их шлёт) продолжают обрабатываться
+ * штатно через {@link McpRootsChangeConsumer}.
+ */
+@Slf4j
+@Component
+@Profile("mcp")
+@RequiredArgsConstructor
+public class McpRootsBootstrapper {
+
+  private final McpRootsChangeConsumer rootsConsumer;
+
+  private final AtomicBoolean attempted = new AtomicBoolean(false);
+
+  /**
+   * При первом вызове запрашивает у клиента {@code roots/list}, если он объявил
+   * roots-capability, и передаёт ответ в {@link McpRootsChangeConsumer}. Повторные
+   * вызовы — no-op (включая случаи когда клиент не поддерживает roots или запрос
+   * упал с ошибкой).
+   *
+   * @param exchange exchange tool-вызова, через который выполняется запрос.
+   */
+  public void bootstrapIfNeeded(@Nullable McpSyncServerExchange exchange) {
+    if (exchange == null) {
+      return;
+    }
+    if (!attempted.compareAndSet(false, true)) {
+      return;
+    }
+    var capabilities = exchange.getClientCapabilities();
+    if (capabilities == null || capabilities.roots() == null) {
+      LOGGER.debug("Skipping proactive roots/list — client does not declare roots capability");
+      return;
+    }
+    try {
+      var result = exchange.listRoots();
+      if (result == null || result.roots() == null || result.roots().isEmpty()) {
+        LOGGER.debug("Client returned no roots on proactive roots/list");
+        return;
+      }
+      LOGGER.info("Proactive roots/list returned {} root(s); registering workspaces", result.roots().size());
+      rootsConsumer.accept(exchange, result.roots());
+    } catch (RuntimeException e) {
+      LOGGER.warn("Proactive roots/list failed; workspaces will be registered only on roots/list_changed", e);
+    }
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumer.java
@@ -59,6 +59,8 @@ public class McpRootsChangeConsumer implements BiConsumer<McpSyncServerExchange,
    */
   private final Set<Path> registeredRoots = ConcurrentHashMap.newKeySet();
 
+  private static final String FILE_SCHEME_PREFIX = "file://";
+
   @Override
   public synchronized void accept(McpSyncServerExchange exchange, List<Root> roots) {
     var desired = roots.stream()
@@ -119,13 +121,14 @@ public class McpRootsChangeConsumer implements BiConsumer<McpSyncServerExchange,
    * @param raw исходное значение {@code uri} из MCP-Root.
    * @return нормализованный URI, либо исходный, если нормализация не требуется.
    */
-  static String normalizeWindowsFileUri(@Nullable String raw) {
+  static @Nullable String normalizeWindowsFileUri(@Nullable String raw) {
     if (raw == null || raw.isEmpty()) {
       return raw;
     }
     var result = raw;
-    if (startsWithIgnoreCase(result, "file://") && hasDriveLetterAfterPrefix(result, "file://".length())) {
-      result = "file:///" + result.substring("file://".length());
+    if (startsWithIgnoreCase(result, FILE_SCHEME_PREFIX)
+      && hasDriveLetterAfterPrefix(result, FILE_SCHEME_PREFIX.length())) {
+      result = "file:///" + result.substring(FILE_SCHEME_PREFIX.length());
     }
     var schemeDelimiter = result.indexOf("://");
     if (schemeDelimiter >= 0 && result.indexOf('\\', schemeDelimiter) >= 0) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumer.java
@@ -99,11 +99,50 @@ public class McpRootsChangeConsumer implements BiConsumer<McpSyncServerExchange,
   }
 
   private static @Nullable Path toPath(Root root) {
+    var raw = root.uri();
+    var normalized = normalizeWindowsFileUri(raw);
     try {
-      return Absolute.path(Absolute.uri(root.uri()));
+      return Absolute.path(Absolute.uri(normalized));
     } catch (RuntimeException e) {
-      LOGGER.warn("Skipping unsupported MCP root uri `{}`", root.uri(), e);
+      LOGGER.warn("Skipping unsupported MCP root uri `{}`", raw, e);
       return null;
     }
+  }
+
+  /**
+   * Чинит {@code file://}-URI в windows-патологии, которую шлют некоторые MCP-клиенты:
+   * {@code file://D:\path\with\backslashes} вместо RFC 8089 {@code file:///D:/path}.
+   * <p>
+   * Конкретно покрытые случаи: {@code file://<letter>:<path>} (буква диска как «host») и
+   * любые backslash'и в path-части — приводятся к {@code file:///<letter>:/<path-with-forward-slashes>}.
+   *
+   * @param raw исходное значение {@code uri} из MCP-Root.
+   * @return нормализованный URI, либо исходный, если нормализация не требуется.
+   */
+  static String normalizeWindowsFileUri(@Nullable String raw) {
+    if (raw == null || raw.isEmpty()) {
+      return raw;
+    }
+    var result = raw;
+    if (startsWithIgnoreCase(result, "file://") && hasDriveLetterAfterPrefix(result, "file://".length())) {
+      result = "file:///" + result.substring("file://".length());
+    }
+    var schemeDelimiter = result.indexOf("://");
+    if (schemeDelimiter >= 0 && result.indexOf('\\', schemeDelimiter) >= 0) {
+      var head = result.substring(0, schemeDelimiter + "://".length());
+      var tail = result.substring(schemeDelimiter + "://".length()).replace('\\', '/');
+      result = head + tail;
+    }
+    return result;
+  }
+
+  private static boolean startsWithIgnoreCase(String value, String prefix) {
+    return value.regionMatches(true, 0, prefix, 0, prefix.length());
+  }
+
+  private static boolean hasDriveLetterAfterPrefix(String value, int offset) {
+    return value.length() > offset + 1
+      && Character.isLetter(value.charAt(offset))
+      && value.charAt(offset + 1) == ':';
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapper.java
@@ -77,7 +77,7 @@ public class McpToolSpecificationsBootstrapWrapper implements BeanPostProcessor 
   private BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> wrapHandler(
     BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> original
   ) {
-    return (exchange, request) -> {
+    return (McpSyncServerExchange exchange, CallToolRequest request) -> {
       try {
         rootsBootstrapper.getObject().bootstrapIfNeeded(exchange);
       } catch (RuntimeException e) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapper.java
@@ -1,0 +1,91 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.ObjectProvider;
+import org.springframework.beans.factory.config.BeanPostProcessor;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.function.BiFunction;
+
+/**
+ * Оборачивает каждый {@link SyncToolSpecification}, собранный Spring AI MCP по
+ * {@code @McpTool}-методам, в обёртку, которая перед делегированием в исходный
+ * handler вызывает {@link McpRootsBootstrapper}. Это даёт проактивный
+ * {@code roots/list} (как требует MCP-спека) без какого-либо знания о
+ * bootstrap-логике в самих tool-методах.
+ * <p>
+ * Spring AI autoconfig публикует список как {@code @Bean public List<SyncToolSpecification> toolSpecs(...)}
+ * в {@code McpServerSpecificationFactoryAutoConfiguration}; имя bean'а — {@code "toolSpecs"}.
+ * Мы перехватываем post-init этого bean'а и подменяем его на список обёрток.
+ * <p>
+ * Зависимость на {@link McpRootsBootstrapper} ленивая через {@link ObjectProvider},
+ * чтобы не вынуждать создание workspace-scoped бина в момент инициализации
+ * {@code BeanPostProcessor}'а.
+ */
+@Slf4j
+@Component
+@Profile("mcp")
+@RequiredArgsConstructor
+public class McpToolSpecificationsBootstrapWrapper implements BeanPostProcessor {
+
+  private static final String SPRING_AI_TOOL_SPECS_BEAN_NAME = "toolSpecs";
+
+  private final ObjectProvider<McpRootsBootstrapper> rootsBootstrapper;
+
+  @Override
+  public Object postProcessAfterInitialization(Object bean, String beanName) {
+    if (!SPRING_AI_TOOL_SPECS_BEAN_NAME.equals(beanName) || !(bean instanceof List<?> list)) {
+      return bean;
+    }
+    return list.stream()
+      .map(item -> item instanceof SyncToolSpecification spec ? wrap(spec) : item)
+      .toList();
+  }
+
+  private SyncToolSpecification wrap(SyncToolSpecification original) {
+    return new SyncToolSpecification(original.tool(), wrapHandler(original.callHandler()));
+  }
+
+  private BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> wrapHandler(
+    BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> original
+  ) {
+    return (exchange, request) -> {
+      try {
+        rootsBootstrapper.getObject().bootstrapIfNeeded(exchange);
+      } catch (RuntimeException e) {
+        // Никогда не валим tool-вызов из-за проблем bootstrap'а — tools без зарегистрированных
+        // workspace'ов сами кинут понятное «No registered workspace».
+        LOGGER.warn("Failed to bootstrap MCP roots before tool call", e);
+      }
+      return original.apply(exchange, request);
+    };
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpWorkspaceResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpWorkspaceResolver.java
@@ -21,7 +21,6 @@
  */
 package com.github._1c_syntax.bsl.languageserver.mcp;
 
-import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;
@@ -33,15 +32,14 @@ import java.net.URI;
 
 /**
  * Выбор workspace для MCP-инструментов, у которых нет явной привязки к конкретному
- * файлу (например, {@code type_info}, {@code global_member_info}).
+ * файлу (например, {@code type_info}, {@code global_member_info}). Клиент обязан явно
+ * указать {@code root} (одно из значений объявленных им MCP-roots), потому что ответ
+ * может различаться между несколькими открытыми пространствами (конфигурации, OneScript-
+ * проекты, библиотеки).
  * <p>
- * Если клиент явно указал {@code root} (одно из значений объявленных им MCP-roots),
- * резолвится конкретно этот workspace; в противном случае берётся любой
- * зарегистрированный. Если зарегистрированных нет — бросается осмысленное исключение.
- * <p>
- * Сравнение URI ведётся через {@link Absolute#uri(String)} — чтобы клиентское
- * представление ({@code file://D:/repo} / {@code file:///D:/repo/} / разный
- * regex-эскейпинг) сходилось с тем URI, под которым workspace зарегистрирован.
+ * Сравнение URI ведётся через {@link Absolute#uri(String)} — чтобы клиентское представление
+ * ({@code file://D:/repo} / {@code file:///D:/repo/} / разный regex-эскейпинг) сходилось с
+ * тем URI, под которым workspace зарегистрирован.
  */
 @Component
 @Profile("mcp")
@@ -53,26 +51,21 @@ public class McpWorkspaceResolver {
   /**
    * Выбрать workspace для tool-запроса.
    *
-   * @param requestedRoot URI workspace-root'а, на который ссылается запрос, либо {@code null}.
+   * @param requestedRoot URI workspace-root'а, на который ссылается запрос.
    * @return URI зарегистрированного workspace.
-   * @throws IllegalArgumentException если {@code requestedRoot} задан, но не совпадает ни с одним
-   *   зарегистрированным workspace; либо если {@code requestedRoot} не задан и нет
-   *   ни одного зарегистрированного workspace.
+   * @throws IllegalArgumentException если {@code requestedRoot} пуст/отсутствует, либо не
+   *   совпадает ни с одним зарегистрированным workspace.
    */
   public URI resolveWorkspaceUri(@Nullable String requestedRoot) {
-    var contexts = serverContextProvider.getAllContexts();
-    if (requestedRoot != null && !requestedRoot.isBlank()) {
-      var normalized = Absolute.uri(requestedRoot);
-      return contexts.keySet().stream()
-        .filter(uri -> uri.equals(normalized))
-        .findFirst()
-        .orElseThrow(() -> new IllegalArgumentException(
-          "No registered workspace matches root: " + requestedRoot));
+    if (requestedRoot == null || requestedRoot.isBlank()) {
+      throw new IllegalArgumentException(
+        "Workspace root is required. Pass one of the roots the client declared via MCP roots.");
     }
-    return contexts.values().stream()
+    var normalized = Absolute.uri(requestedRoot);
+    return serverContextProvider.getAllContexts().keySet().stream()
+      .filter(uri -> uri.equals(normalized))
       .findFirst()
-      .map(ServerContext::getWorkspaceUri)
       .orElseThrow(() -> new IllegalArgumentException(
-        "No registered workspace. Open a workspace via MCP roots first."));
+        "No registered workspace matches root: " + requestedRoot));
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpWorkspaceResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpWorkspaceResolver.java
@@ -1,0 +1,78 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp;
+
+import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
+import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.utils.Absolute;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+
+/**
+ * Выбор workspace для MCP-инструментов, у которых нет явной привязки к конкретному
+ * файлу (например, {@code type_info}, {@code global_member_info}).
+ * <p>
+ * Если клиент явно указал {@code root} (одно из значений объявленных им MCP-roots),
+ * резолвится конкретно этот workspace; в противном случае берётся любой
+ * зарегистрированный. Если зарегистрированных нет — бросается осмысленное исключение.
+ * <p>
+ * Сравнение URI ведётся через {@link Absolute#uri(String)} — чтобы клиентское
+ * представление ({@code file://D:/repo} / {@code file:///D:/repo/} / разный
+ * regex-эскейпинг) сходилось с тем URI, под которым workspace зарегистрирован.
+ */
+@Component
+@Profile("mcp")
+@RequiredArgsConstructor
+public class McpWorkspaceResolver {
+
+  private final ServerContextProvider serverContextProvider;
+
+  /**
+   * Выбрать workspace для tool-запроса.
+   *
+   * @param requestedRoot URI workspace-root'а, на который ссылается запрос, либо {@code null}.
+   * @return URI зарегистрированного workspace.
+   * @throws IllegalArgumentException если {@code requestedRoot} задан, но не совпадает ни с одним
+   *   зарегистрированным workspace; либо если {@code requestedRoot} не задан и нет
+   *   ни одного зарегистрированного workspace.
+   */
+  public URI resolveWorkspaceUri(@Nullable String requestedRoot) {
+    var contexts = serverContextProvider.getAllContexts();
+    if (requestedRoot != null && !requestedRoot.isBlank()) {
+      var normalized = Absolute.uri(requestedRoot);
+      return contexts.keySet().stream()
+        .filter(uri -> uri.equals(normalized))
+        .findFirst()
+        .orElseThrow(() -> new IllegalArgumentException(
+          "No registered workspace matches root: " + requestedRoot));
+    }
+    return contexts.values().stream()
+      .findFirst()
+      .map(ServerContext::getWorkspaceUri)
+      .orElseThrow(() -> new IllegalArgumentException(
+        "No registered workspace. Open a workspace via MCP roots first."));
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberDto.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberDto.java
@@ -30,33 +30,41 @@ import org.jspecify.annotations.Nullable;
 import java.util.List;
 
 /**
- * Член типа — метод или свойство.
+ * Член типа — метод, свойство или событие.
  *
  * @param name Имя члена.
- * @param kind Вид члена: {@code METHOD} или {@code PROPERTY}.
+ * @param kind Вид члена: {@code METHOD}, {@code PROPERTY} или {@code EVENT}.
  * @param types Типы значения свойства или возвращаемого значения метода (полные имена).
  * @param description Описание; {@code null}, если отсутствует.
- * @param signatures Сигнатуры (для метода); для свойства — пустой список.
+ * @param signatures Сигнатуры (для метода/события); для свойства — пустой список.
+ * @param async Признак асинхронного метода ({@code Асинх}/{@code Async}); для свойств всегда {@code false}.
+ * @param metadata Платформенная метаинформация (версии, контексты, примеры и т.п.);
+ *   {@code null}, если метаинформация отсутствует.
  */
 public record TypeMemberDto(
   String name,
   String kind,
   List<String> types,
   @Nullable String description,
-  List<TypeSignatureDto> signatures
+  List<TypeSignatureDto> signatures,
+  boolean async,
+  @Nullable TypeMemberMetadataDto metadata
 ) {
 
   public static TypeMemberDto from(MemberDescriptor member, Language language) {
-    var signatures = member.kind() == MemberKind.METHOD
-      ? member.signatures().stream().map(signature -> TypeSignatureDto.from(signature, language)).toList()
-      : List.<TypeSignatureDto>of();
+    var signatures = member.kind() == MemberKind.PROPERTY
+      ? List.<TypeSignatureDto>of()
+      : member.signatures().stream().map(signature -> TypeSignatureDto.from(signature, language)).toList();
     var description = member.displayDescription(language);
+    var metadata = TypeMemberMetadataDto.from(member.metadata(), language);
     return new TypeMemberDto(
       member.displayName(language),
       member.kind().name(),
       member.returnTypes().refs().stream().map(TypeRef::qualifiedName).sorted().toList(),
       description == null || description.isBlank() ? null : description,
-      signatures
+      signatures,
+      member.async(),
+      metadata.isEmpty() ? null : metadata
     );
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberMetadataDto.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberMetadataDto.java
@@ -1,0 +1,105 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp.dto;
+
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
+import com.github._1c_syntax.bsl.languageserver.types.model.Availability;
+import com.github._1c_syntax.bsl.languageserver.types.model.BilingualString;
+import com.github._1c_syntax.bsl.languageserver.types.model.PlatformMetadata;
+import org.jspecify.annotations.Nullable;
+
+import java.util.Comparator;
+import java.util.List;
+
+/**
+ * Платформенная метаинформация члена типа: контексты исполнения, версионная
+ * совместимость, тексты разделов «Возвращаемое значение», «Замечание», «Примеры»,
+ * «См. также» из HBK.
+ *
+ * @param sinceVersion Версия платформы, начиная с которой член доступен; {@code null}, если не задано.
+ * @param deprecatedSinceVersion Версия, начиная с которой устарел; {@code null}, если не задано.
+ * @param recommendedReplacements Рекомендуемые замены устаревшего члена.
+ * @param availabilities Контексты исполнения, в которых член доступен.
+ * @param accessMode Режим доступа для свойства ({@code READ} / {@code READ_WRITE}); {@code null} для методов.
+ * @param returnValueDescription Текст раздела «Возвращаемое значение»; {@code null}, если отсутствует.
+ * @param notes Текст раздела «Замечание»; {@code null}, если отсутствует.
+ * @param examples Примеры использования.
+ * @param seeAlso «См. также» — связанные сущности.
+ */
+public record TypeMemberMetadataDto(
+  @Nullable String sinceVersion,
+  @Nullable String deprecatedSinceVersion,
+  List<String> recommendedReplacements,
+  List<String> availabilities,
+  @Nullable String accessMode,
+  @Nullable String returnValueDescription,
+  @Nullable String notes,
+  List<String> examples,
+  List<String> seeAlso
+) {
+
+  /** Пустая метаинформация — все поля {@code null} или пустые списки. */
+  public static final TypeMemberMetadataDto EMPTY = new TypeMemberMetadataDto(
+    null, null, List.of(), List.of(), null, null, null, List.of(), List.of()
+  );
+
+  public static TypeMemberMetadataDto from(PlatformMetadata metadata, Language language) {
+    return new TypeMemberMetadataDto(
+      nullIfBlank(metadata.sinceVersion()),
+      nullIfBlank(metadata.deprecatedSinceVersion()),
+      List.copyOf(metadata.recommendedReplacements()),
+      metadata.availabilities().stream()
+        .map(Availability::name)
+        .sorted()
+        .toList(),
+      metadata.accessMode() == null ? null : metadata.accessMode().name(),
+      nullIfBlank(metadata.returnValueDescription().forLanguage(language)),
+      nullIfBlank(metadata.notes().forLanguage(language)),
+      bilingualList(metadata.examples(), language),
+      bilingualList(metadata.seeAlso(), language)
+    );
+  }
+
+  public boolean isEmpty() {
+    return sinceVersion == null
+      && deprecatedSinceVersion == null
+      && recommendedReplacements.isEmpty()
+      && availabilities.isEmpty()
+      && accessMode == null
+      && returnValueDescription == null
+      && notes == null
+      && examples.isEmpty()
+      && seeAlso.isEmpty();
+  }
+
+  private static @Nullable String nullIfBlank(@Nullable String value) {
+    return value == null || value.isBlank() ? null : value;
+  }
+
+  private static List<String> bilingualList(List<BilingualString> source, Language language) {
+    return source.stream()
+      .map(item -> item.forLanguage(language))
+      .filter(text -> !text.isBlank())
+      .sorted(Comparator.naturalOrder())
+      .toList();
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberMetadataDto.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberMetadataDto.java
@@ -80,13 +80,20 @@ public record TypeMemberMetadataDto(
   }
 
   public boolean isEmpty() {
-    return sinceVersion == null
-      && deprecatedSinceVersion == null
-      && recommendedReplacements.isEmpty()
+    return allVersionFieldsEmpty() && allTextFieldsEmpty() && allCollectionFieldsEmpty();
+  }
+
+  private boolean allVersionFieldsEmpty() {
+    return sinceVersion == null && deprecatedSinceVersion == null && accessMode == null;
+  }
+
+  private boolean allTextFieldsEmpty() {
+    return returnValueDescription == null && notes == null;
+  }
+
+  private boolean allCollectionFieldsEmpty() {
+    return recommendedReplacements.isEmpty()
       && availabilities.isEmpty()
-      && accessMode == null
-      && returnValueDescription == null
-      && notes == null
       && examples.isEmpty()
       && seeAlso.isEmpty();
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeParameterDto.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeParameterDto.java
@@ -34,22 +34,29 @@ import java.util.List;
  * @param name Имя параметра.
  * @param types Допустимые типы значения параметра (полные имена).
  * @param optional Признак необязательного параметра.
+ * @param variadic Признак variadic-параметра (произвольное число значений в хвосте сигнатуры).
  * @param defaultValue Значение по умолчанию; {@code null}, если не задано.
+ * @param description Описание параметра; {@code null}, если отсутствует.
  */
 public record TypeParameterDto(
   String name,
   List<String> types,
   boolean optional,
-  @Nullable String defaultValue
+  boolean variadic,
+  @Nullable String defaultValue,
+  @Nullable String description
 ) {
 
   public static TypeParameterDto from(ParameterDescriptor parameter, Language language) {
     var defaultValue = parameter.defaultValue();
+    var description = parameter.displayDescription(language);
     return new TypeParameterDto(
       parameter.displayName(language),
       parameter.types().refs().stream().map(TypeRef::qualifiedName).sorted().toList(),
       parameter.optional(),
-      defaultValue == null || defaultValue.isBlank() ? null : defaultValue
+      parameter.variadic(),
+      defaultValue == null || defaultValue.isBlank() ? null : defaultValue,
+      description == null || description.isBlank() ? null : description
     );
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeParameterDto.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeParameterDto.java
@@ -55,8 +55,8 @@ public record TypeParameterDto(
       parameter.types().refs().stream().map(TypeRef::qualifiedName).sorted().toList(),
       parameter.optional(),
       parameter.variadic(),
-      defaultValue == null || defaultValue.isBlank() ? null : defaultValue,
-      description == null || description.isBlank() ? null : description
+      defaultValue.isBlank() ? null : defaultValue,
+      description.isBlank() ? null : description
     );
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
@@ -1,0 +1,154 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp.tools;
+
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
+import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
+import com.github._1c_syntax.bsl.languageserver.mcp.dto.TypeMemberDto;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
+import com.github._1c_syntax.bsl.languageserver.types.scope.GlobalSymbolScope;
+import com.github._1c_syntax.bsl.languageserver.types.symbol.SyntheticSymbol;
+import lombok.RequiredArgsConstructor;
+import org.jspecify.annotations.Nullable;
+import org.springframework.ai.mcp.annotation.McpTool;
+import org.springframework.ai.mcp.annotation.McpToolParam;
+import org.springframework.context.annotation.Profile;
+import org.springframework.stereotype.Component;
+
+import java.net.URI;
+import java.util.List;
+import java.util.Optional;
+
+/**
+ * MCP-инструмент {@code global_member_info}: по имени глобального члена 1С/BSL
+ * (например, {@code Сообщить}/{@code Message}, {@code Метаданные}/{@code Metadata})
+ * возвращает его описание — функцию, свойство либо системное перечисление.
+ * <p>
+ * Резолв проходит в порядке: глобальная функция → глобальное свойство → системное
+ * перечисление. Для функций отдаётся полный {@link TypeMemberDto} с сигнатурами и
+ * платформенной метаинформацией; для свойств/перечислений — упрощённый дескриптор
+ * с типом значения и описанием.
+ */
+@Component
+@Profile("mcp")
+@RequiredArgsConstructor
+public class GlobalMemberInfoTool {
+
+  private final ServerContextProvider serverContextProvider;
+  private final GlobalScopeProvider globalScopeProvider;
+
+  /**
+   * Описание глобального члена.
+   *
+   * @param name Имя члена в запрошенной локали.
+   * @param kind Вид члена: {@code FUNCTION}, {@code PROPERTY} или {@code ENUM}.
+   * @param member Описание члена (сигнатуры/типы/метаинформация).
+   */
+  public record Result(
+    String name,
+    String kind,
+    TypeMemberDto member
+  ) {
+  }
+
+  @McpTool(
+    name = "global_member_info",
+    description = "Look up a 1C/BSL global member by name (function, property or system enum) and "
+      + "return its signatures, return types and platform metadata. Resolves global functions like "
+      + "`Сообщить`/`Message`, global properties like `Метаданные`/`Metadata`, and system enums.",
+    // Output schema disabled: Spring AI generates a non-nullable schema that rejects null DTO fields.
+    // Known upstream bug, open as of 2.0.0-M6.
+    generateOutputSchema = false)
+  public Result globalMemberInfo(
+    @McpToolParam(required = true, description = McpToolParams.GLOBAL_MEMBER_NAME)
+    String name,
+    @McpToolParam(required = true, description = McpToolParams.FILE_TYPE)
+    FileType fileType,
+    @McpToolParam(required = false, description = McpToolParams.LANGUAGE)
+    @Nullable Language language
+  ) {
+    var effectiveLanguage = language == null ? Language.RU : language;
+    try (var ignored = WorkspaceContextHolder.forUri(anyWorkspaceUri())) {
+      var function = globalScopeProvider.findFunction(name, fileType);
+      if (function.isPresent()) {
+        return functionResult(function.get(), effectiveLanguage);
+      }
+
+      var propertyType = globalScopeProvider.findGlobalProperty(name, fileType);
+      if (propertyType.isPresent()) {
+        return globalValueResult(name, fileType, propertyType.get(), "PROPERTY", effectiveLanguage);
+      }
+
+      var enumType = globalScopeProvider.findGlobalEnum(name, fileType);
+      if (enumType.isPresent()) {
+        return globalValueResult(name, fileType, enumType.get(), "ENUM", effectiveLanguage);
+      }
+
+      throw new IllegalArgumentException("Global member is not found: " + name);
+    }
+  }
+
+  private Result functionResult(MemberDescriptor descriptor, Language language) {
+    return new Result(
+      descriptor.displayName(language),
+      "FUNCTION",
+      TypeMemberDto.from(descriptor, language)
+    );
+  }
+
+  private Result globalValueResult(String requestedName, FileType fileType,
+                                   TypeRef valueType, String kind, Language language) {
+    var entry = globalScopeProvider.findGlobalEntry(requestedName, fileType);
+    var canonicalName = entry.map(GlobalSymbolScope.Entry::symbol)
+      .map(symbol -> symbol.getName())
+      .orElse(requestedName);
+    var description = entry.map(GlobalSymbolScope.Entry::symbol)
+      .filter(SyntheticSymbol.class::isInstance)
+      .map(SyntheticSymbol.class::cast)
+      .map(symbol -> symbol.getSymbolDescription().getPurposeDescription())
+      .filter(text -> !text.isBlank())
+      .orElse(null);
+    var member = new TypeMemberDto(
+      canonicalName,
+      "PROPERTY",
+      List.of(valueType.qualifiedName()),
+      description,
+      List.of(),
+      false,
+      null
+    );
+    return new Result(canonicalName, kind, member);
+  }
+
+  private URI anyWorkspaceUri() {
+    return serverContextProvider.getAllContexts().values().stream()
+      .findFirst()
+      .map(ServerContext::getWorkspaceUri)
+      .orElseThrow(() -> new IllegalArgumentException(
+        "No registered workspace. Open a workspace via MCP roots first."));
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
@@ -29,6 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.mcp.dto.TypeMemberDto;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.types.scope.GlobalSymbolScope;
 import com.github._1c_syntax.bsl.languageserver.types.symbol.SyntheticSymbol;
 import lombok.RequiredArgsConstructor;
@@ -102,19 +103,19 @@ public class GlobalMemberInfoTool {
 
       var propertyType = globalScopeProvider.findGlobalProperty(name, fileType);
       if (propertyType.isPresent()) {
-        return globalValueResult(name, fileType, propertyType.get(), "PROPERTY", effectiveLanguage);
+        return globalValueResult(name, fileType, propertyType.get(), "PROPERTY");
       }
 
       var enumType = globalScopeProvider.findGlobalEnum(name, fileType);
       if (enumType.isPresent()) {
-        return globalValueResult(name, fileType, enumType.get(), "ENUM", effectiveLanguage);
+        return globalValueResult(name, fileType, enumType.get(), "ENUM");
       }
 
       throw new IllegalArgumentException("Global member is not found: " + name);
     }
   }
 
-  private Result functionResult(MemberDescriptor descriptor, Language language) {
+  private static Result functionResult(MemberDescriptor descriptor, Language language) {
     return new Result(
       descriptor.displayName(language),
       "FUNCTION",
@@ -123,10 +124,10 @@ public class GlobalMemberInfoTool {
   }
 
   private Result globalValueResult(String requestedName, FileType fileType,
-                                   TypeRef valueType, String kind, Language language) {
+                                   TypeRef valueType, String kind) {
     var entry = globalScopeProvider.findGlobalEntry(requestedName, fileType);
     var canonicalName = entry.map(GlobalSymbolScope.Entry::symbol)
-      .map(symbol -> symbol.getName())
+      .map(Symbol::getName)
       .orElse(requestedName);
     var description = entry.map(GlobalSymbolScope.Entry::symbol)
       .filter(SyntheticSymbol.class::isInstance)

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
@@ -23,9 +23,8 @@ package com.github._1c_syntax.bsl.languageserver.mcp.tools;
 
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
-import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
-import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
+import com.github._1c_syntax.bsl.languageserver.mcp.McpWorkspaceResolver;
 import com.github._1c_syntax.bsl.languageserver.mcp.dto.TypeMemberDto;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
@@ -39,9 +38,7 @@ import org.springframework.ai.mcp.annotation.McpToolParam;
 import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
-import java.net.URI;
 import java.util.List;
-import java.util.Optional;
 
 /**
  * MCP-инструмент {@code global_member_info}: по имени глобального члена 1С/BSL
@@ -52,13 +49,18 @@ import java.util.Optional;
  * перечисление. Для функций отдаётся полный {@link TypeMemberDto} с сигнатурами и
  * платформенной метаинформацией; для свойств/перечислений — упрощённый дескриптор
  * с типом значения и описанием.
+ * <p>
+ * Резолв выполняется в workspace'е, указанном клиентом через параметр {@code root}; если
+ * параметр не задан — в любом зарегистрированном (это нормально для платформенных имён,
+ * но для конфигурационных и OneScript-проектов результат может зависеть от выбора
+ * workspace, поэтому при нескольких roots лучше адресовать явно).
  */
 @Component
 @Profile("mcp")
 @RequiredArgsConstructor
 public class GlobalMemberInfoTool {
 
-  private final ServerContextProvider serverContextProvider;
+  private final McpWorkspaceResolver workspaceResolver;
   private final GlobalScopeProvider globalScopeProvider;
 
   /**
@@ -89,10 +91,12 @@ public class GlobalMemberInfoTool {
     @McpToolParam(required = true, description = McpToolParams.FILE_TYPE)
     FileType fileType,
     @McpToolParam(required = false, description = McpToolParams.LANGUAGE)
-    @Nullable Language language
+    @Nullable Language language,
+    @McpToolParam(required = false, description = McpToolParams.ROOT)
+    @Nullable String root
   ) {
     var effectiveLanguage = language == null ? Language.RU : language;
-    try (var ignored = WorkspaceContextHolder.forUri(anyWorkspaceUri())) {
+    try (var ignored = WorkspaceContextHolder.forUri(workspaceResolver.resolveWorkspaceUri(root))) {
       var function = globalScopeProvider.findFunction(name, fileType);
       if (function.isPresent()) {
         return functionResult(function.get(), effectiveLanguage);
@@ -142,13 +146,5 @@ public class GlobalMemberInfoTool {
       null
     );
     return new Result(canonicalName, kind, member);
-  }
-
-  private URI anyWorkspaceUri() {
-    return serverContextProvider.getAllContexts().values().stream()
-      .findFirst()
-      .map(ServerContext::getWorkspaceUri)
-      .orElseThrow(() -> new IllegalArgumentException(
-        "No registered workspace. Open a workspace via MCP roots first."));
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
@@ -50,10 +50,8 @@ import java.util.List;
  * платформенной метаинформацией; для свойств/перечислений — упрощённый дескриптор
  * с типом значения и описанием.
  * <p>
- * Резолв выполняется в workspace'е, указанном клиентом через параметр {@code root}; если
- * параметр не задан — в любом зарегистрированном (это нормально для платформенных имён,
- * но для конфигурационных и OneScript-проектов результат может зависеть от выбора
- * workspace, поэтому при нескольких roots лучше адресовать явно).
+ * Резолв выполняется в workspace'е, указанном клиентом через обязательный параметр
+ * {@code root}.
  */
 @Component
 @Profile("mcp")
@@ -90,10 +88,10 @@ public class GlobalMemberInfoTool {
     String name,
     @McpToolParam(required = true, description = McpToolParams.FILE_TYPE)
     FileType fileType,
+    @McpToolParam(required = true, description = McpToolParams.ROOT)
+    String root,
     @McpToolParam(required = false, description = McpToolParams.LANGUAGE)
-    @Nullable Language language,
-    @McpToolParam(required = false, description = McpToolParams.ROOT)
-    @Nullable String root
+    @Nullable Language language
   ) {
     var effectiveLanguage = language == null ? Language.RU : language;
     try (var ignored = WorkspaceContextHolder.forUri(workspaceResolver.resolveWorkspaceUri(root))) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/McpToolParams.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/McpToolParams.java
@@ -34,9 +34,9 @@ final class McpToolParams {
   static final String LANGUAGE = "Language for names and descriptions: `RU` (default) or `EN`.";
   static final String GLOBAL_MEMBER_NAME = "Global function, property or enum name in Russian or English "
     + "(e.g. `Сообщить` / `Message`, `Метаданные` / `Metadata`).";
-  static final String ROOT = "Optional URI of a workspace root (one of the roots the client declared) to scope "
-    + "the lookup to. When omitted, any registered workspace is used — fine for purely platform names, "
-    + "but pick a root explicitly when the answer may differ between configuration and OneScript projects.";
+  static final String ROOT = "URI of the workspace root (one of the roots the client declared) to scope the "
+    + "lookup to. Required because the answer can differ between roots — configuration vs OneScript "
+    + "projects, different configurations, etc. For purely platform names pick any registered root.";
 
   private McpToolParams() {
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/McpToolParams.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/McpToolParams.java
@@ -31,6 +31,9 @@ final class McpToolParams {
   static final String LINE = "Zero-based line number of the symbol.";
   static final String CHARACTER = "Zero-based character offset within the line.";
   static final String TYPE_NAME = "1C/BSL type name in Russian or English (e.g. `Массив` / `Array`).";
+  static final String LANGUAGE = "Language for names and descriptions: `RU` (default) or `EN`.";
+  static final String GLOBAL_MEMBER_NAME = "Global function, property or enum name in Russian or English "
+    + "(e.g. `Сообщить` / `Message`, `Метаданные` / `Metadata`).";
 
   private McpToolParams() {
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/McpToolParams.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/McpToolParams.java
@@ -34,6 +34,9 @@ final class McpToolParams {
   static final String LANGUAGE = "Language for names and descriptions: `RU` (default) or `EN`.";
   static final String GLOBAL_MEMBER_NAME = "Global function, property or enum name in Russian or English "
     + "(e.g. `Сообщить` / `Message`, `Метаданные` / `Metadata`).";
+  static final String ROOT = "Optional URI of a workspace root (one of the roots the client declared) to scope "
+    + "the lookup to. When omitted, any registered workspace is used — fine for purely platform names, "
+    + "but pick a root explicitly when the answer may differ between configuration and OneScript projects.";
 
   private McpToolParams() {
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
 import com.github._1c_syntax.bsl.languageserver.mcp.dto.TypeMemberDto;
+import com.github._1c_syntax.bsl.languageserver.mcp.dto.TypeSignatureDto;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
@@ -44,10 +45,10 @@ import java.util.List;
 
 /**
  * MCP-инструмент {@code type_info}: по имени типа 1С/BSL (например, {@code Массив}) возвращает его
- * методы и свойства с сигнатурами и типами — из системы типов {@link TypeService}.
+ * методы, свойства, события, конструкторы — из системы типов {@link TypeService}.
  * <p>
  * Тип ищется в реестре первого зарегистрированного рабочего пространства (платформенные типы общие
- * для всех пространств). Имена и описания — на русском, как в платформе 1С.
+ * для всех пространств). Имена и описания — по запрошенной локали (по умолчанию русский).
  */
 @Component
 @Profile("mcp")
@@ -68,20 +69,28 @@ public class TypeInfoTool {
    * @param description Описание типа; {@code null}, если отсутствует.
    * @param properties Свойства типа.
    * @param methods Методы типа.
+   * @param events События типа (для платформенных типов с событиями).
+   * @param constructors Сигнатуры конструкторов ({@code Новый ...}); пустой список, если конструкторов нет.
+   * @param definedAt URI исходного файла-объявления (для конфигурационных и пользовательских типов);
+   *   {@code null} для платформенных/примитивных типов.
    */
   public record Result(
     String name,
     String kind,
     @Nullable String description,
     List<TypeMemberDto> properties,
-    List<TypeMemberDto> methods
+    List<TypeMemberDto> methods,
+    List<TypeMemberDto> events,
+    List<TypeSignatureDto> constructors,
+    @Nullable String definedAt
   ) {
   }
 
   @McpTool(
     name = "type_info",
-    description = "Look up a 1C/BSL type by name (e.g. `Массив`/`Array`) and return its properties and "
-      + "methods with signatures, parameters and return types.",
+    description = "Look up a 1C/BSL type by name (e.g. `Массив`/`Array`) and return its properties, "
+      + "methods, events and constructors with signatures, parameters, return types and platform "
+      + "metadata (since/deprecated versions, execution contexts, examples, see-also).",
     // Output schema disabled: Spring AI generates a non-nullable schema that rejects null DTO fields
     // (here — nullable description/defaultValue). Known upstream bug, open as of 2.0.0-M6.
     generateOutputSchema = false)
@@ -89,31 +98,45 @@ public class TypeInfoTool {
     @McpToolParam(required = true, description = McpToolParams.TYPE_NAME)
     String typeName,
     @McpToolParam(required = true, description = McpToolParams.FILE_TYPE)
-    FileType fileType
+    FileType fileType,
+    @McpToolParam(required = false, description = McpToolParams.LANGUAGE)
+    @Nullable Language language
   ) {
+    var effectiveLanguage = language == null ? Language.RU : language;
     try (var ignored = WorkspaceContextHolder.forUri(anyWorkspaceUri())) {
       var typeRef = typeService.resolve(typeName, fileType)
         .orElseThrow(() -> new IllegalArgumentException("Type is not found: " + typeName));
 
-      var members = typeService.getMembers(typeRef, fileType);
-      var properties = membersOfKind(members, MemberKind.PROPERTY);
-      var methods = membersOfKind(members, MemberKind.METHOD);
+      var members = typeService.getMembers(typeRef, fileType, effectiveLanguage);
+      var properties = membersOfKind(members, MemberKind.PROPERTY, effectiveLanguage);
+      var methods = membersOfKind(members, MemberKind.METHOD, effectiveLanguage);
+      var events = membersOfKind(members, MemberKind.EVENT, effectiveLanguage);
 
-      var description = typeService.getDescription(typeRef, Language.RU, fileType);
+      var constructors = typeService.getConstructors(typeRef, fileType).stream()
+        .map(signature -> TypeSignatureDto.from(signature, effectiveLanguage))
+        .toList();
+
+      var description = typeService.getDescription(typeRef, effectiveLanguage, fileType);
+      var definedAt = typeService.definingUri(typeRef).map(URI::toString).orElse(null);
       return new Result(
         typeRef.qualifiedName(),
         typeRef.kind().name(),
         description == null || description.isBlank() ? null : description,
         properties,
-        methods
+        methods,
+        events,
+        constructors,
+        definedAt
       );
     }
   }
 
-  private static List<TypeMemberDto> membersOfKind(Collection<MemberDescriptor> members, MemberKind kind) {
+  private static List<TypeMemberDto> membersOfKind(
+    Collection<MemberDescriptor> members, MemberKind kind, Language language
+  ) {
     return members.stream()
       .filter(member -> !member.generic() && member.kind() == kind)
-      .map(member -> TypeMemberDto.from(member, Language.RU))
+      .map(member -> TypeMemberDto.from(member, language))
       .sorted(BY_NAME)
       .toList();
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
@@ -46,11 +46,8 @@ import java.util.List;
  * MCP-инструмент {@code type_info}: по имени типа 1С/BSL (например, {@code Массив}) возвращает его
  * методы, свойства, события, конструкторы — из системы типов {@link TypeService}.
  * <p>
- * Тип ищется в реестре workspace'а, указанного клиентом через параметр {@code root}; если параметр
- * не задан — в любом зарегистрированном (это нормально для платформенных имён, но для
- * конфигурационных и OneScript-проектов результат может зависеть от выбора workspace, поэтому при
- * нескольких roots лучше адресовать явно). Имена и описания — по запрошенной локали (по умолчанию
- * русский).
+ * Тип ищется в реестре workspace'а, указанного клиентом через обязательный параметр {@code root}.
+ * Имена и описания — по запрошенной локали (по умолчанию русский).
  */
 @Component
 @Profile("mcp")
@@ -101,10 +98,10 @@ public class TypeInfoTool {
     String typeName,
     @McpToolParam(required = true, description = McpToolParams.FILE_TYPE)
     FileType fileType,
+    @McpToolParam(required = true, description = McpToolParams.ROOT)
+    String root,
     @McpToolParam(required = false, description = McpToolParams.LANGUAGE)
-    @Nullable Language language,
-    @McpToolParam(required = false, description = McpToolParams.ROOT)
-    @Nullable String root
+    @Nullable Language language
   ) {
     var effectiveLanguage = language == null ? Language.RU : language;
     try (var ignored = WorkspaceContextHolder.forUri(workspaceResolver.resolveWorkspaceUri(root))) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
@@ -23,9 +23,8 @@ package com.github._1c_syntax.bsl.languageserver.mcp.tools;
 
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
-import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
-import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceContextHolder;
+import com.github._1c_syntax.bsl.languageserver.mcp.McpWorkspaceResolver;
 import com.github._1c_syntax.bsl.languageserver.mcp.dto.TypeMemberDto;
 import com.github._1c_syntax.bsl.languageserver.mcp.dto.TypeSignatureDto;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
@@ -47,8 +46,11 @@ import java.util.List;
  * MCP-инструмент {@code type_info}: по имени типа 1С/BSL (например, {@code Массив}) возвращает его
  * методы, свойства, события, конструкторы — из системы типов {@link TypeService}.
  * <p>
- * Тип ищется в реестре первого зарегистрированного рабочего пространства (платформенные типы общие
- * для всех пространств). Имена и описания — по запрошенной локали (по умолчанию русский).
+ * Тип ищется в реестре workspace'а, указанного клиентом через параметр {@code root}; если параметр
+ * не задан — в любом зарегистрированном (это нормально для платформенных имён, но для
+ * конфигурационных и OneScript-проектов результат может зависеть от выбора workspace, поэтому при
+ * нескольких roots лучше адресовать явно). Имена и описания — по запрошенной локали (по умолчанию
+ * русский).
  */
 @Component
 @Profile("mcp")
@@ -58,7 +60,7 @@ public class TypeInfoTool {
   private static final Comparator<TypeMemberDto> BY_NAME =
     Comparator.comparing(TypeMemberDto::name, String.CASE_INSENSITIVE_ORDER);
 
-  private final ServerContextProvider serverContextProvider;
+  private final McpWorkspaceResolver workspaceResolver;
   private final TypeService typeService;
 
   /**
@@ -100,10 +102,12 @@ public class TypeInfoTool {
     @McpToolParam(required = true, description = McpToolParams.FILE_TYPE)
     FileType fileType,
     @McpToolParam(required = false, description = McpToolParams.LANGUAGE)
-    @Nullable Language language
+    @Nullable Language language,
+    @McpToolParam(required = false, description = McpToolParams.ROOT)
+    @Nullable String root
   ) {
     var effectiveLanguage = language == null ? Language.RU : language;
-    try (var ignored = WorkspaceContextHolder.forUri(anyWorkspaceUri())) {
+    try (var ignored = WorkspaceContextHolder.forUri(workspaceResolver.resolveWorkspaceUri(root))) {
       var typeRef = typeService.resolve(typeName, fileType)
         .orElseThrow(() -> new IllegalArgumentException("Type is not found: " + typeName));
 
@@ -139,13 +143,5 @@ public class TypeInfoTool {
       .map(member -> TypeMemberDto.from(member, language))
       .sorted(BY_NAME)
       .toList();
-  }
-
-  private URI anyWorkspaceUri() {
-    return serverContextProvider.getAllContexts().values().stream()
-      .findFirst()
-      .map(ServerContext::getWorkspaceUri)
-      .orElseThrow(() -> new IllegalArgumentException(
-        "No registered workspace. Open a workspace via MCP roots first."));
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
@@ -54,6 +54,7 @@ import org.eclipse.lsp4j.Range;
 import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
+import java.net.URI;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
@@ -295,6 +296,22 @@ public class TypeService {
     return globalScopeProvider.moduleUriByType(typeRef)
       .map(uri -> requestingContext.getServerContext().getDocument(uri))
       .<SourceDefinedSymbol>map(documentContext -> documentContext.getSymbolTree().getModule());
+  }
+
+  /**
+   * URI исходного файла, в котором объявлен тип. Без загрузки {@code DocumentContext}'а —
+   * годится для запросов без активного документа-потребителя (например, MCP-инструменты).
+   *
+   * @param typeRef тип.
+   * @return URI модуля-объявления для {@link TypeKind#USER} и {@link TypeKind#CONFIGURATION};
+   *   {@code empty} для платформенных/примитивных типов или если объявление недоступно.
+   */
+  public Optional<URI> definingUri(TypeRef typeRef) {
+    return switch (typeRef.kind()) {
+      case USER -> userTypeDeclaration(typeRef).map(symbol -> symbol.getOwner().getUri());
+      case CONFIGURATION -> globalScopeProvider.moduleUriByType(typeRef);
+      default -> Optional.empty();
+    };
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpHttpServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpHttpServerTest.java
@@ -73,7 +73,7 @@ class McpHttpServerTest {
     assertThat(toolNames)
       .containsExactlyInAnyOrder(
         "analyze_file", "document_symbols", "find_references", "call_hierarchy", "hover", "definition",
-        "type_info", "type_at_position");
+        "type_info", "type_at_position", "global_member_info");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsBootstrapperTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsBootstrapperTest.java
@@ -22,7 +22,6 @@
 package com.github._1c_syntax.bsl.languageserver.mcp;
 
 import io.modelcontextprotocol.server.McpSyncServerExchange;
-import io.modelcontextprotocol.spec.McpSchema;
 import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
 import io.modelcontextprotocol.spec.McpSchema.ListRootsResult;
 import io.modelcontextprotocol.spec.McpSchema.Root;
@@ -64,7 +63,7 @@ class McpRootsBootstrapperTest {
   void requestsRootsAndForwardsThemToConsumer() {
     var roots = List.of(new Root("file:///D:/repo", "repo"));
     var exchange = exchangeWithCapabilities(capsWithRoots());
-    when(exchange.listRoots()).thenReturn(new ListRootsResult(roots));
+    when(exchange.listRoots()).thenReturn(new ListRootsResult(roots, null, null));
 
     bootstrapper.bootstrapIfNeeded(exchange);
 
@@ -76,7 +75,7 @@ class McpRootsBootstrapperTest {
   void requestsRootsOnlyOnce() {
     var roots = List.of(new Root("file:///D:/repo", "repo"));
     var exchange = exchangeWithCapabilities(capsWithRoots());
-    when(exchange.listRoots()).thenReturn(new ListRootsResult(roots));
+    when(exchange.listRoots()).thenReturn(new ListRootsResult(roots, null, null));
 
     bootstrapper.bootstrapIfNeeded(exchange);
     bootstrapper.bootstrapIfNeeded(exchange);
@@ -128,7 +127,7 @@ class McpRootsBootstrapperTest {
   @Test
   void skipsForwardingWhenServerReturnsEmptyRoots() {
     var exchange = exchangeWithCapabilities(capsWithRoots());
-    when(exchange.listRoots()).thenReturn(new ListRootsResult(List.of()));
+    when(exchange.listRoots()).thenReturn(new ListRootsResult(List.of(), null, null));
 
     bootstrapper.bootstrapIfNeeded(exchange);
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsBootstrapperTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsBootstrapperTest.java
@@ -1,0 +1,138 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp;
+
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema;
+import io.modelcontextprotocol.spec.McpSchema.ClientCapabilities;
+import io.modelcontextprotocol.spec.McpSchema.ListRootsResult;
+import io.modelcontextprotocol.spec.McpSchema.Root;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.never;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+/**
+ * Проверки проактивного запроса {@code roots/list} при первом tool-вызове.
+ */
+class McpRootsBootstrapperTest {
+
+  private final McpRootsChangeConsumer consumer = mock(McpRootsChangeConsumer.class);
+  private final McpRootsBootstrapper bootstrapper = new McpRootsBootstrapper(consumer);
+
+  private static McpSyncServerExchange exchangeWithCapabilities(@org.jspecify.annotations.Nullable ClientCapabilities caps) {
+    var exchange = mock(McpSyncServerExchange.class);
+    when(exchange.getClientCapabilities()).thenReturn(caps);
+    return exchange;
+  }
+
+  private static ClientCapabilities capsWithRoots() {
+    return ClientCapabilities.builder().roots(true).build();
+  }
+
+  private static ClientCapabilities capsWithoutRoots() {
+    return ClientCapabilities.builder().build();
+  }
+
+  @Test
+  void requestsRootsAndForwardsThemToConsumer() {
+    var roots = List.of(new Root("file:///D:/repo", "repo"));
+    var exchange = exchangeWithCapabilities(capsWithRoots());
+    when(exchange.listRoots()).thenReturn(new ListRootsResult(roots));
+
+    bootstrapper.bootstrapIfNeeded(exchange);
+
+    verify(exchange, times(1)).listRoots();
+    verify(consumer, times(1)).accept(exchange, roots);
+  }
+
+  @Test
+  void requestsRootsOnlyOnce() {
+    var roots = List.of(new Root("file:///D:/repo", "repo"));
+    var exchange = exchangeWithCapabilities(capsWithRoots());
+    when(exchange.listRoots()).thenReturn(new ListRootsResult(roots));
+
+    bootstrapper.bootstrapIfNeeded(exchange);
+    bootstrapper.bootstrapIfNeeded(exchange);
+    bootstrapper.bootstrapIfNeeded(exchange);
+
+    verify(exchange, times(1)).listRoots();
+    verify(consumer, times(1)).accept(any(), any());
+  }
+
+  @Test
+  void skipsRequestWhenClientDoesNotDeclareRootsCapability() {
+    var exchange = exchangeWithCapabilities(capsWithoutRoots());
+
+    bootstrapper.bootstrapIfNeeded(exchange);
+
+    verify(exchange, never()).listRoots();
+    verify(consumer, never()).accept(any(), any());
+  }
+
+  @Test
+  void skipsRequestWhenClientHasNoCapabilitiesAtAll() {
+    var exchange = exchangeWithCapabilities(null);
+
+    bootstrapper.bootstrapIfNeeded(exchange);
+
+    verify(exchange, never()).listRoots();
+    verify(consumer, never()).accept(any(), any());
+  }
+
+  @Test
+  void tolerantToNullExchange() {
+    bootstrapper.bootstrapIfNeeded(null);
+
+    verify(consumer, never()).accept(any(), any());
+  }
+
+  @Test
+  void swallowsListRootsFailureAndMarksAttempted() {
+    var exchange = exchangeWithCapabilities(capsWithRoots());
+    when(exchange.listRoots()).thenThrow(new RuntimeException("transport closed"));
+
+    bootstrapper.bootstrapIfNeeded(exchange);
+    bootstrapper.bootstrapIfNeeded(exchange);
+
+    verify(exchange, times(1)).listRoots();
+    verify(consumer, never()).accept(any(), any());
+  }
+
+  @Test
+  void skipsForwardingWhenServerReturnsEmptyRoots() {
+    var exchange = exchangeWithCapabilities(capsWithRoots());
+    when(exchange.listRoots()).thenReturn(new ListRootsResult(List.of()));
+
+    bootstrapper.bootstrapIfNeeded(exchange);
+
+    verify(exchange, times(1)).listRoots();
+    verify(consumer, never()).accept(eq(exchange), any());
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumerTest.java
@@ -28,6 +28,7 @@ import org.junit.jupiter.api.Test;
 import java.nio.file.Path;
 import java.util.List;
 
+import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Mockito.doThrow;
 import static org.mockito.Mockito.mock;
@@ -72,6 +73,39 @@ class McpRootsChangeConsumerTest {
     consumer.accept(null, List.of(root("src/test/resources/cli")));
 
     verify(bootstrap, times(2)).index(any(Path.class));
+  }
+
+  @Test
+  void normalizesWindowsStyleFileUriBeforeRegistration() {
+    // Claude Code 2.1.178 на Windows шлёт roots вида `file://D:\path\with\backslashes`
+    // (буква диска как «host» + backslash в path). Absolute.uri такое не разбирает —
+    // нормализуем до RFC 8089 file:///D:/path до передачи в Absolute.
+    var path = Absolute.path("src/test/resources/cli");
+    var driveLetter = path.getRoot().toString().substring(0, 2); // "D:"
+    var withoutRoot = path.subpath(0, path.getNameCount()).toString(); // backslashes на Windows
+    var brokenUri = "file://" + driveLetter + "\\" + withoutRoot;
+
+    consumer.accept(null, List.of(new Root(brokenUri, "broken")));
+
+    verify(bootstrap).index(path);
+  }
+
+  @Test
+  void normalizeWindowsFileUriRewritesDriveLetterAsHost() {
+    assertThat(McpRootsChangeConsumer.normalizeWindowsFileUri("file://D:\\git\\1C\\upp\\src\\cf"))
+      .isEqualTo("file:///D:/git/1C/upp/src/cf");
+  }
+
+  @Test
+  void normalizeWindowsFileUriKeepsRfcCompliantValueUntouched() {
+    assertThat(McpRootsChangeConsumer.normalizeWindowsFileUri("file:///D:/git/1C/upp/src/cf"))
+      .isEqualTo("file:///D:/git/1C/upp/src/cf");
+  }
+
+  @Test
+  void normalizeWindowsFileUriIgnoresNonFileSchemes() {
+    assertThat(McpRootsChangeConsumer.normalizeWindowsFileUri("https://example.com/path"))
+      .isEqualTo("https://example.com/path");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpRootsChangeConsumerTest.java
@@ -24,6 +24,8 @@ package com.github._1c_syntax.bsl.languageserver.mcp;
 import com.github._1c_syntax.utils.Absolute;
 import io.modelcontextprotocol.spec.McpSchema.Root;
 import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledOnOs;
+import org.junit.jupiter.api.condition.OS;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -76,10 +78,14 @@ class McpRootsChangeConsumerTest {
   }
 
   @Test
+  @EnabledOnOs(OS.WINDOWS)
   void normalizesWindowsStyleFileUriBeforeRegistration() {
     // Claude Code 2.1.178 на Windows шлёт roots вида `file://D:\path\with\backslashes`
     // (буква диска как «host» + backslash в path). Absolute.uri такое не разбирает —
-    // нормализуем до RFC 8089 file:///D:/path до передачи в Absolute.
+    // нормализуем до RFC 8089 file:///D:/path до передачи в Absolute. Соответствие пути
+    // Windows-стилю выводится из реального filesystem-роута тестового каталога, поэтому
+    // end-to-end ассерт ограничен Windows; кросс-платформенно само нормализаторное правило
+    // покрыто чистыми string-тестами normalizeWindowsFileUri* ниже.
     var path = Absolute.path("src/test/resources/cli");
     var driveLetter = path.getRoot().toString().substring(0, 2); // "D:"
     var withoutRoot = path.subpath(0, path.getNameCount()).toString(); // backslashes на Windows

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpSseServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpSseServerTest.java
@@ -69,7 +69,7 @@ class McpSseServerTest {
     assertThat(toolNames)
       .containsExactlyInAnyOrder(
         "analyze_file", "document_symbols", "find_references", "call_hierarchy", "hover", "definition",
-        "type_info", "type_at_position");
+        "type_info", "type_at_position", "global_member_info");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpStreamableServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpStreamableServerTest.java
@@ -64,7 +64,7 @@ class McpStreamableServerTest {
     assertThat(toolNames)
       .containsExactlyInAnyOrder(
         "analyze_file", "document_symbols", "find_references", "call_hierarchy", "hover", "definition",
-        "type_info", "type_at_position");
+        "type_info", "type_at_position", "global_member_info");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapperTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapperTest.java
@@ -54,16 +54,18 @@ class McpToolSpecificationsBootstrapWrapperTest {
   private static SyncToolSpecification toolSpec(
     String name, BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> handler
   ) {
-    return new SyncToolSpecification(Tool.builder().name(name).description("desc").build(), handler);
+    var tool = Tool.builder(name, Map.<String, Object>of()).description("desc").build();
+    return new SyncToolSpecification(tool, handler);
   }
 
   private static CallToolResult okResult() {
-    return new CallToolResult(List.<io.modelcontextprotocol.spec.McpSchema.Content>of(new TextContent("ok")),
+    var text = TextContent.builder("ok").build();
+    return new CallToolResult(List.<io.modelcontextprotocol.spec.McpSchema.Content>of(text),
       false, null, Map.of());
   }
 
   private static CallToolRequest emptyRequest(String name) {
-    return new CallToolRequest(name, Map.of());
+    return CallToolRequest.builder().name(name).build();
   }
 
   private static ObjectProvider<McpRootsBootstrapper> providerOf(McpRootsBootstrapper bootstrapper) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapperTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapperTest.java
@@ -1,0 +1,181 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp;
+
+import io.modelcontextprotocol.server.McpServerFeatures.SyncToolSpecification;
+import io.modelcontextprotocol.server.McpSyncServerExchange;
+import io.modelcontextprotocol.spec.McpSchema.CallToolRequest;
+import io.modelcontextprotocol.spec.McpSchema.CallToolResult;
+import io.modelcontextprotocol.spec.McpSchema.TextContent;
+import io.modelcontextprotocol.spec.McpSchema.Tool;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.ObjectProvider;
+
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.function.BiFunction;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.doNothing;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class McpToolSpecificationsBootstrapWrapperTest {
+
+  private final McpRootsBootstrapper bootstrapper = mock(McpRootsBootstrapper.class);
+  private final ObjectProvider<McpRootsBootstrapper> provider = providerOf(bootstrapper);
+  private final McpToolSpecificationsBootstrapWrapper wrapper = new McpToolSpecificationsBootstrapWrapper(provider);
+
+  private static SyncToolSpecification toolSpec(
+    String name, BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> handler
+  ) {
+    return new SyncToolSpecification(Tool.builder().name(name).description("desc").build(), handler);
+  }
+
+  private static CallToolResult okResult() {
+    return new CallToolResult(List.<io.modelcontextprotocol.spec.McpSchema.Content>of(new TextContent("ok")),
+      false, null, Map.of());
+  }
+
+  private static CallToolRequest emptyRequest(String name) {
+    return new CallToolRequest(name, Map.of());
+  }
+
+  private static ObjectProvider<McpRootsBootstrapper> providerOf(McpRootsBootstrapper bootstrapper) {
+    @SuppressWarnings("unchecked")
+    ObjectProvider<McpRootsBootstrapper> mocked = mock(ObjectProvider.class);
+    when(mocked.getObject()).thenReturn(bootstrapper);
+    return mocked;
+  }
+
+  @Test
+  void leavesBeansWithOtherNameUntouched() {
+    var original = List.of(toolSpec("noop", (ex, req) -> okResult()));
+
+    var processed = wrapper.postProcessAfterInitialization(original, "anotherBean");
+
+    assertThat(processed).isSameAs(original);
+    verifyNoInteractions(bootstrapper);
+  }
+
+  @Test
+  void leavesNonListBeansUntouched() {
+    var bean = new Object();
+
+    var processed = wrapper.postProcessAfterInitialization(bean, "toolSpecs");
+
+    assertThat(processed).isSameAs(bean);
+    verifyNoInteractions(bootstrapper);
+  }
+
+  @Test
+  void wrapsEverySpecificationAndPreservesToolMetadata() {
+    var calls = new AtomicInteger();
+    BiFunction<McpSyncServerExchange, CallToolRequest, CallToolResult> handler = (ex, req) -> {
+      calls.incrementAndGet();
+      return okResult();
+    };
+    var specs = List.of(toolSpec("alpha", handler), toolSpec("beta", handler));
+
+    @SuppressWarnings("unchecked")
+    var wrapped = (List<SyncToolSpecification>) wrapper.postProcessAfterInitialization(specs, "toolSpecs");
+
+    assertThat(wrapped).hasSize(2);
+    assertThat(wrapped).extracting(SyncToolSpecification::tool).extracting(Tool::name).containsExactly("alpha", "beta");
+    for (var spec : wrapped) {
+      assertThat(spec.callHandler()).isNotSameAs(handler);
+    }
+  }
+
+  @Test
+  void invokesBootstrapBeforeDelegatingToOriginalHandler() {
+    var marker = new AtomicInteger();
+    doNothing().when(bootstrapper).bootstrapIfNeeded(any());
+
+    var original = toolSpec("alpha", (ex, req) -> {
+      // Bootstrap должен быть вызван к этому моменту.
+      verify(bootstrapper, times(1)).bootstrapIfNeeded(ex);
+      marker.set(42);
+      return okResult();
+    });
+
+    @SuppressWarnings("unchecked")
+    var wrapped = (List<SyncToolSpecification>)
+      wrapper.postProcessAfterInitialization(List.of(original), "toolSpecs");
+
+    var exchange = mock(McpSyncServerExchange.class);
+    var result = wrapped.get(0).callHandler().apply(exchange, emptyRequest("alpha"));
+
+    assertThat(marker.get()).isEqualTo(42);
+    assertThat(result.content()).hasSize(1);
+  }
+
+  @Test
+  void stillCallsOriginalHandlerIfBootstrapFails() {
+    doThrow(new RuntimeException("transport down")).when(bootstrapper).bootstrapIfNeeded(any());
+    var marker = new AtomicInteger();
+    var original = toolSpec("alpha", (ex, req) -> {
+      marker.set(1);
+      return okResult();
+    });
+
+    @SuppressWarnings("unchecked")
+    var wrapped = (List<SyncToolSpecification>)
+      wrapper.postProcessAfterInitialization(List.of(original), "toolSpecs");
+    wrapped.get(0).callHandler().apply(mock(McpSyncServerExchange.class), emptyRequest("alpha"));
+
+    assertThat(marker.get()).isEqualTo(1);
+  }
+
+  @Test
+  void emptyToolListProducesEmptyWrappedList() {
+    @SuppressWarnings("unchecked")
+    var wrapped = (List<SyncToolSpecification>)
+      wrapper.postProcessAfterInitialization(List.<SyncToolSpecification>of(), "toolSpecs");
+
+    assertThat(wrapped).isEmpty();
+    verifyNoInteractions(bootstrapper);
+  }
+
+  @Test
+  void leavesNonToolSpecElementsInTheList() {
+    var stranger = "stranger";
+    var spec = toolSpec("alpha", (ex, req) -> okResult());
+    var source = List.of(stranger, spec);
+
+    @SuppressWarnings("unchecked")
+    var wrapped = (List<Object>) wrapper.postProcessAfterInitialization(source, "toolSpecs");
+
+    assertThat(wrapped).hasSize(2);
+    assertThat(wrapped.get(0)).isSameAs(stranger);
+    assertThat(wrapped.get(1)).isInstanceOfSatisfying(SyncToolSpecification.class, w -> {
+      assertThat(w.tool().name()).isEqualTo("alpha");
+      assertThat(w.callHandler()).isNotSameAs(spec.callHandler());
+    });
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolsTest.java
@@ -62,6 +62,7 @@ class McpToolsTest {
 
   private static final String SRC_DIR = "src/test/resources/providers";
   private static final String FILE = SRC_DIR + "/callHierarchy.bsl";
+  private static final String WORKSPACE_ROOT = Absolute.path(SRC_DIR).toUri().toString();
 
   // Объявление ПерваяФункция и место её вызова в callHierarchy.bsl.
   private static final int DECLARATION_LINE = 6;
@@ -159,7 +160,7 @@ class McpToolsTest {
 
   @Test
   void typeInfoReturnsMethodsAndPropertiesOfPlatformType() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, WORKSPACE_ROOT, null);
 
     assertThat(result.name()).isEqualTo("Массив");
     assertThat(result.methods()).extracting(TypeMemberDto::name).contains("Добавить", "Количество");
@@ -167,7 +168,7 @@ class McpToolsTest {
 
   @Test
   void typeInfoReturnsMethodsAndPropertiesWithOsFileType() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.OS, null, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.OS, WORKSPACE_ROOT, null);
 
     assertThat(result.name()).isEqualTo("Массив");
     assertThat(result.methods()).extracting(TypeMemberDto::name).contains("Добавить", "Количество");
@@ -175,13 +176,13 @@ class McpToolsTest {
 
   @Test
   void typeInfoThrowsForUnknownType() {
-    assertThatThrownBy(() -> typeInfoTool.typeInfo("НетТакогоТипа", FileType.BSL, null, null))
+    assertThatThrownBy(() -> typeInfoTool.typeInfo("НетТакогоТипа", FileType.BSL, WORKSPACE_ROOT, null))
       .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void typeInfoReturnsConstructorsForPlatformClass() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, WORKSPACE_ROOT, null);
 
     assertThat(result.constructors()).isNotEmpty();
     assertThat(result.constructors().get(0).parameters()).isNotNull();
@@ -189,7 +190,7 @@ class McpToolsTest {
 
   @Test
   void typeInfoExposesEventsListEvenIfEmpty() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, WORKSPACE_ROOT, null);
 
     assertThat(result.events()).isNotNull();
     // У стандартных коллекций событий нет — но поле всегда присутствует.
@@ -198,8 +199,8 @@ class McpToolsTest {
 
   @Test
   void typeInfoAcceptsExplicitLanguageParameter() {
-    var ru = typeInfoTool.typeInfo("Массив", FileType.BSL, Language.RU, null);
-    var en = typeInfoTool.typeInfo("Массив", FileType.BSL, Language.EN, null);
+    var ru = typeInfoTool.typeInfo("Массив", FileType.BSL, WORKSPACE_ROOT, Language.RU);
+    var en = typeInfoTool.typeInfo("Массив", FileType.BSL, WORKSPACE_ROOT, Language.EN);
 
     assertThat(ru.methods()).isNotEmpty();
     assertThat(en.methods()).isNotEmpty();
@@ -210,14 +211,14 @@ class McpToolsTest {
 
   @Test
   void typeInfoReturnsNullDefinedAtForPlatformType() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, WORKSPACE_ROOT, null);
 
     assertThat(result.definedAt()).isNull();
   }
 
   @Test
   void globalMemberInfoResolvesPlatformFunction() {
-    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, null, null);
+    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, WORKSPACE_ROOT, null);
 
     assertThat(result.kind()).isEqualTo("FUNCTION");
     assertThat(result.member().kind()).isEqualTo("METHOD");
@@ -227,7 +228,7 @@ class McpToolsTest {
 
   @Test
   void globalMemberInfoResolvesByEnglishAlias() {
-    var result = globalMemberInfoTool.globalMemberInfo("Message", FileType.BSL, null, null);
+    var result = globalMemberInfoTool.globalMemberInfo("Message", FileType.BSL, WORKSPACE_ROOT, null);
 
     assertThat(result.kind()).isEqualTo("FUNCTION");
     assertThat(result.member().kind()).isEqualTo("METHOD");
@@ -235,51 +236,47 @@ class McpToolsTest {
 
   @Test
   void globalMemberInfoThrowsForUnknownName() {
-    assertThatThrownBy(() -> globalMemberInfoTool.globalMemberInfo("НетТакогоИмени", FileType.BSL, null, null))
+    assertThatThrownBy(() -> globalMemberInfoTool.globalMemberInfo("НетТакогоИмени", FileType.BSL, WORKSPACE_ROOT, null))
       .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void globalMemberInfoAcceptsOscriptFileType() {
-    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.OS, null, null);
+    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.OS, WORKSPACE_ROOT, null);
 
     assertThat(result.kind()).isEqualTo("FUNCTION");
   }
 
   @Test
-  void typeInfoAcceptsExplicitRoot() {
-    var explicitRoot = Absolute.path(SRC_DIR).toUri().toString();
-
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, explicitRoot);
-
-    assertThat(result.name()).isEqualTo("Массив");
-  }
-
-  @Test
-  void typeInfoThrowsWhenExplicitRootIsUnknown() {
+  void typeInfoThrowsWhenRootIsUnknown() {
     var unknownRoot = Absolute.path("src/test/resources/diagnostics").toUri().toString();
 
-    assertThatThrownBy(() -> typeInfoTool.typeInfo("Массив", FileType.BSL, null, unknownRoot))
+    assertThatThrownBy(() -> typeInfoTool.typeInfo("Массив", FileType.BSL, unknownRoot, null))
       .isInstanceOf(IllegalArgumentException.class)
       .hasMessageContaining("No registered workspace matches root");
   }
 
   @Test
-  void globalMemberInfoAcceptsExplicitRoot() {
-    var explicitRoot = Absolute.path(SRC_DIR).toUri().toString();
+  void globalMemberInfoThrowsWhenRootIsUnknown() {
+    var unknownRoot = Absolute.path("src/test/resources/diagnostics").toUri().toString();
 
-    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, null, explicitRoot);
-
-    assertThat(result.kind()).isEqualTo("FUNCTION");
+    assertThatThrownBy(() -> globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, unknownRoot, null))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("No registered workspace matches root");
   }
 
   @Test
-  void globalMemberInfoThrowsWhenExplicitRootIsUnknown() {
-    var unknownRoot = Absolute.path("src/test/resources/diagnostics").toUri().toString();
-
-    assertThatThrownBy(() -> globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, null, unknownRoot))
+  void typeInfoThrowsWhenRootIsMissing() {
+    assertThatThrownBy(() -> typeInfoTool.typeInfo("Массив", FileType.BSL, "  ", null))
       .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("No registered workspace matches root");
+      .hasMessageContaining("Workspace root is required");
+  }
+
+  @Test
+  void globalMemberInfoThrowsWhenRootIsMissing() {
+    assertThatThrownBy(() -> globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, null, null))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Workspace root is required");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolsTest.java
@@ -21,12 +21,14 @@
  */
 package com.github._1c_syntax.bsl.languageserver.mcp;
 
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.mcp.tools.AnalyzeFileTool;
 import com.github._1c_syntax.bsl.languageserver.mcp.tools.CallHierarchyTool;
 import com.github._1c_syntax.bsl.languageserver.mcp.tools.DefinitionTool;
 import com.github._1c_syntax.bsl.languageserver.mcp.tools.DocumentSymbolsTool;
 import com.github._1c_syntax.bsl.languageserver.mcp.tools.FindReferencesTool;
+import com.github._1c_syntax.bsl.languageserver.mcp.tools.GlobalMemberInfoTool;
 import com.github._1c_syntax.bsl.languageserver.mcp.tools.HoverTool;
 import com.github._1c_syntax.bsl.languageserver.mcp.tools.TypeAtPositionTool;
 import com.github._1c_syntax.bsl.languageserver.mcp.tools.TypeInfoTool;
@@ -85,6 +87,8 @@ class McpToolsTest {
   private TypeInfoTool typeInfoTool;
   @Autowired
   private TypeAtPositionTool typeAtPositionTool;
+  @Autowired
+  private GlobalMemberInfoTool globalMemberInfoTool;
   @Autowired
   private McpRootsChangeConsumer rootsChangeConsumer;
 
@@ -155,7 +159,7 @@ class McpToolsTest {
 
   @Test
   void typeInfoReturnsMethodsAndPropertiesOfPlatformType() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL);
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null);
 
     assertThat(result.name()).isEqualTo("Массив");
     assertThat(result.methods()).extracting(TypeMemberDto::name).contains("Добавить", "Количество");
@@ -163,7 +167,7 @@ class McpToolsTest {
 
   @Test
   void typeInfoReturnsMethodsAndPropertiesWithOsFileType() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.OS);
+    var result = typeInfoTool.typeInfo("Массив", FileType.OS, null);
 
     assertThat(result.name()).isEqualTo("Массив");
     assertThat(result.methods()).extracting(TypeMemberDto::name).contains("Добавить", "Количество");
@@ -171,8 +175,75 @@ class McpToolsTest {
 
   @Test
   void typeInfoThrowsForUnknownType() {
-    assertThatThrownBy(() -> typeInfoTool.typeInfo("НетТакогоТипа", FileType.BSL))
+    assertThatThrownBy(() -> typeInfoTool.typeInfo("НетТакогоТипа", FileType.BSL, null))
       .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void typeInfoReturnsConstructorsForPlatformClass() {
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null);
+
+    assertThat(result.constructors()).isNotEmpty();
+    assertThat(result.constructors().get(0).parameters()).isNotNull();
+  }
+
+  @Test
+  void typeInfoExposesEventsListEvenIfEmpty() {
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null);
+
+    assertThat(result.events()).isNotNull();
+    // У стандартных коллекций событий нет — но поле всегда присутствует.
+    assertThat(result.events()).allSatisfy(event -> assertThat(event.kind()).isEqualTo("EVENT"));
+  }
+
+  @Test
+  void typeInfoAcceptsExplicitLanguageParameter() {
+    var ru = typeInfoTool.typeInfo("Массив", FileType.BSL, Language.RU);
+    var en = typeInfoTool.typeInfo("Массив", FileType.BSL, Language.EN);
+
+    assertThat(ru.methods()).isNotEmpty();
+    assertThat(en.methods()).isNotEmpty();
+    // В обоих локалях имя типа корректное (хоть оно может быть только в одной локали).
+    assertThat(ru.name()).isNotBlank();
+    assertThat(en.name()).isNotBlank();
+  }
+
+  @Test
+  void typeInfoReturnsNullDefinedAtForPlatformType() {
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null);
+
+    assertThat(result.definedAt()).isNull();
+  }
+
+  @Test
+  void globalMemberInfoResolvesPlatformFunction() {
+    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, null);
+
+    assertThat(result.kind()).isEqualTo("FUNCTION");
+    assertThat(result.member().kind()).isEqualTo("METHOD");
+    assertThat(result.member().name()).isEqualTo("Сообщить");
+    assertThat(result.member().signatures()).isNotNull();
+  }
+
+  @Test
+  void globalMemberInfoResolvesByEnglishAlias() {
+    var result = globalMemberInfoTool.globalMemberInfo("Message", FileType.BSL, null);
+
+    assertThat(result.kind()).isEqualTo("FUNCTION");
+    assertThat(result.member().kind()).isEqualTo("METHOD");
+  }
+
+  @Test
+  void globalMemberInfoThrowsForUnknownName() {
+    assertThatThrownBy(() -> globalMemberInfoTool.globalMemberInfo("НетТакогоИмени", FileType.BSL, null))
+      .isInstanceOf(IllegalArgumentException.class);
+  }
+
+  @Test
+  void globalMemberInfoAcceptsOscriptFileType() {
+    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.OS, null);
+
+    assertThat(result.kind()).isEqualTo("FUNCTION");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolsTest.java
@@ -159,7 +159,7 @@ class McpToolsTest {
 
   @Test
   void typeInfoReturnsMethodsAndPropertiesOfPlatformType() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, null);
 
     assertThat(result.name()).isEqualTo("Массив");
     assertThat(result.methods()).extracting(TypeMemberDto::name).contains("Добавить", "Количество");
@@ -167,7 +167,7 @@ class McpToolsTest {
 
   @Test
   void typeInfoReturnsMethodsAndPropertiesWithOsFileType() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.OS, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.OS, null, null);
 
     assertThat(result.name()).isEqualTo("Массив");
     assertThat(result.methods()).extracting(TypeMemberDto::name).contains("Добавить", "Количество");
@@ -175,13 +175,13 @@ class McpToolsTest {
 
   @Test
   void typeInfoThrowsForUnknownType() {
-    assertThatThrownBy(() -> typeInfoTool.typeInfo("НетТакогоТипа", FileType.BSL, null))
+    assertThatThrownBy(() -> typeInfoTool.typeInfo("НетТакогоТипа", FileType.BSL, null, null))
       .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void typeInfoReturnsConstructorsForPlatformClass() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, null);
 
     assertThat(result.constructors()).isNotEmpty();
     assertThat(result.constructors().get(0).parameters()).isNotNull();
@@ -189,7 +189,7 @@ class McpToolsTest {
 
   @Test
   void typeInfoExposesEventsListEvenIfEmpty() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, null);
 
     assertThat(result.events()).isNotNull();
     // У стандартных коллекций событий нет — но поле всегда присутствует.
@@ -198,8 +198,8 @@ class McpToolsTest {
 
   @Test
   void typeInfoAcceptsExplicitLanguageParameter() {
-    var ru = typeInfoTool.typeInfo("Массив", FileType.BSL, Language.RU);
-    var en = typeInfoTool.typeInfo("Массив", FileType.BSL, Language.EN);
+    var ru = typeInfoTool.typeInfo("Массив", FileType.BSL, Language.RU, null);
+    var en = typeInfoTool.typeInfo("Массив", FileType.BSL, Language.EN, null);
 
     assertThat(ru.methods()).isNotEmpty();
     assertThat(en.methods()).isNotEmpty();
@@ -210,14 +210,14 @@ class McpToolsTest {
 
   @Test
   void typeInfoReturnsNullDefinedAtForPlatformType() {
-    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null);
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, null);
 
     assertThat(result.definedAt()).isNull();
   }
 
   @Test
   void globalMemberInfoResolvesPlatformFunction() {
-    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, null);
+    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, null, null);
 
     assertThat(result.kind()).isEqualTo("FUNCTION");
     assertThat(result.member().kind()).isEqualTo("METHOD");
@@ -227,7 +227,7 @@ class McpToolsTest {
 
   @Test
   void globalMemberInfoResolvesByEnglishAlias() {
-    var result = globalMemberInfoTool.globalMemberInfo("Message", FileType.BSL, null);
+    var result = globalMemberInfoTool.globalMemberInfo("Message", FileType.BSL, null, null);
 
     assertThat(result.kind()).isEqualTo("FUNCTION");
     assertThat(result.member().kind()).isEqualTo("METHOD");
@@ -235,15 +235,51 @@ class McpToolsTest {
 
   @Test
   void globalMemberInfoThrowsForUnknownName() {
-    assertThatThrownBy(() -> globalMemberInfoTool.globalMemberInfo("НетТакогоИмени", FileType.BSL, null))
+    assertThatThrownBy(() -> globalMemberInfoTool.globalMemberInfo("НетТакогоИмени", FileType.BSL, null, null))
       .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test
   void globalMemberInfoAcceptsOscriptFileType() {
-    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.OS, null);
+    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.OS, null, null);
 
     assertThat(result.kind()).isEqualTo("FUNCTION");
+  }
+
+  @Test
+  void typeInfoAcceptsExplicitRoot() {
+    var explicitRoot = Absolute.path(SRC_DIR).toUri().toString();
+
+    var result = typeInfoTool.typeInfo("Массив", FileType.BSL, null, explicitRoot);
+
+    assertThat(result.name()).isEqualTo("Массив");
+  }
+
+  @Test
+  void typeInfoThrowsWhenExplicitRootIsUnknown() {
+    var unknownRoot = Absolute.path("src/test/resources/diagnostics").toUri().toString();
+
+    assertThatThrownBy(() -> typeInfoTool.typeInfo("Массив", FileType.BSL, null, unknownRoot))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("No registered workspace matches root");
+  }
+
+  @Test
+  void globalMemberInfoAcceptsExplicitRoot() {
+    var explicitRoot = Absolute.path(SRC_DIR).toUri().toString();
+
+    var result = globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, null, explicitRoot);
+
+    assertThat(result.kind()).isEqualTo("FUNCTION");
+  }
+
+  @Test
+  void globalMemberInfoThrowsWhenExplicitRootIsUnknown() {
+    var unknownRoot = Absolute.path("src/test/resources/diagnostics").toUri().toString();
+
+    assertThatThrownBy(() -> globalMemberInfoTool.globalMemberInfo("Сообщить", FileType.BSL, null, unknownRoot))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("No registered workspace matches root");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpWorkspaceResolverTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpWorkspaceResolverTest.java
@@ -47,30 +47,17 @@ class McpWorkspaceResolverTest {
   }
 
   @Test
-  void picksAnyRegisteredWorkspaceWhenRootIsNull() {
-    var uri = Absolute.path("src/test/resources/cli").toUri();
-    var ctx = contextOf(uri);
-    when(serverContextProvider.getAllContexts()).thenReturn(Map.of(uri, ctx));
-
-    assertThat(resolver.resolveWorkspaceUri(null)).isEqualTo(uri);
-  }
-
-  @Test
-  void picksAnyRegisteredWorkspaceWhenRootIsBlank() {
-    var uri = Absolute.path("src/test/resources/cli").toUri();
-    var ctx = contextOf(uri);
-    when(serverContextProvider.getAllContexts()).thenReturn(Map.of(uri, ctx));
-
-    assertThat(resolver.resolveWorkspaceUri("   ")).isEqualTo(uri);
-  }
-
-  @Test
-  void throwsWhenNoWorkspacesAndRootNotRequested() {
-    when(serverContextProvider.getAllContexts()).thenReturn(Map.of());
-
+  void throwsWhenRootIsNull() {
     assertThatThrownBy(() -> resolver.resolveWorkspaceUri(null))
       .isInstanceOf(IllegalArgumentException.class)
-      .hasMessageContaining("Open a workspace via MCP roots first");
+      .hasMessageContaining("Workspace root is required");
+  }
+
+  @Test
+  void throwsWhenRootIsBlank() {
+    assertThatThrownBy(() -> resolver.resolveWorkspaceUri("   "))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Workspace root is required");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpWorkspaceResolverTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpWorkspaceResolverTest.java
@@ -1,0 +1,112 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp;
+
+import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
+import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.utils.Absolute;
+import org.junit.jupiter.api.Test;
+
+import java.net.URI;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class McpWorkspaceResolverTest {
+
+  private final ServerContextProvider serverContextProvider = mock(ServerContextProvider.class);
+  private final McpWorkspaceResolver resolver = new McpWorkspaceResolver(serverContextProvider);
+
+  private static ServerContext contextOf(URI uri) {
+    var ctx = mock(ServerContext.class);
+    when(ctx.getWorkspaceUri()).thenReturn(uri);
+    return ctx;
+  }
+
+  @Test
+  void picksAnyRegisteredWorkspaceWhenRootIsNull() {
+    var uri = Absolute.path("src/test/resources/cli").toUri();
+    var ctx = contextOf(uri);
+    when(serverContextProvider.getAllContexts()).thenReturn(Map.of(uri, ctx));
+
+    assertThat(resolver.resolveWorkspaceUri(null)).isEqualTo(uri);
+  }
+
+  @Test
+  void picksAnyRegisteredWorkspaceWhenRootIsBlank() {
+    var uri = Absolute.path("src/test/resources/cli").toUri();
+    var ctx = contextOf(uri);
+    when(serverContextProvider.getAllContexts()).thenReturn(Map.of(uri, ctx));
+
+    assertThat(resolver.resolveWorkspaceUri("   ")).isEqualTo(uri);
+  }
+
+  @Test
+  void throwsWhenNoWorkspacesAndRootNotRequested() {
+    when(serverContextProvider.getAllContexts()).thenReturn(Map.of());
+
+    assertThatThrownBy(() -> resolver.resolveWorkspaceUri(null))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("Open a workspace via MCP roots first");
+  }
+
+  @Test
+  void resolvesExplicitRootByExactMatch() {
+    var first = Absolute.path("src/test/resources/cli").toUri();
+    var second = Absolute.path("src/test/resources/providers").toUri();
+    Map<URI, ServerContext> contexts = new LinkedHashMap<>();
+    contexts.put(first, contextOf(first));
+    contexts.put(second, contextOf(second));
+    when(serverContextProvider.getAllContexts()).thenReturn(contexts);
+
+    assertThat(resolver.resolveWorkspaceUri(second.toString())).isEqualTo(second);
+  }
+
+  @Test
+  void normalisesRootBeforeMatching() {
+    var registered = Absolute.path("src/test/resources/cli").toUri();
+    var ctx = contextOf(registered);
+    when(serverContextProvider.getAllContexts()).thenReturn(Map.of(registered, ctx));
+
+    // Та же папка, но обращаемся к ней через ./ — Absolute.uri нормализует обе формы к одному URI.
+    var pathThroughDot = Absolute.path("./src/test/resources/cli").toUri().toString();
+
+    assertThat(resolver.resolveWorkspaceUri(pathThroughDot)).isEqualTo(registered);
+  }
+
+  @Test
+  void throwsWhenExplicitRootDoesNotMatchAnyRegisteredWorkspace() {
+    var uri = Absolute.path("src/test/resources/cli").toUri();
+    var ctx = contextOf(uri);
+    when(serverContextProvider.getAllContexts()).thenReturn(Map.of(uri, ctx));
+
+    var orphan = Absolute.path("src/test/resources/providers").toUri().toString();
+
+    assertThatThrownBy(() -> resolver.resolveWorkspaceUri(orphan))
+      .isInstanceOf(IllegalArgumentException.class)
+      .hasMessageContaining("No registered workspace matches root");
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberDtoTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberDtoTest.java
@@ -1,0 +1,183 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp.dto;
+
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
+import com.github._1c_syntax.bsl.languageserver.types.model.AccessMode;
+import com.github._1c_syntax.bsl.languageserver.types.model.Availability;
+import com.github._1c_syntax.bsl.languageserver.types.model.BilingualString;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.PlatformMetadata;
+import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TypeMemberDtoTest {
+
+  private static final TypeRef STRING_TYPE = new TypeRef(TypeKind.PRIMITIVE, "Строка");
+  private static final TypeRef NUMBER_TYPE = new TypeRef(TypeKind.PRIMITIVE, "Число");
+
+  @Test
+  void mapsMethodWithSignatures() {
+    var signature = new SignatureDescriptor(
+      List.of(new ParameterDescriptor("Шаблон", TypeSet.of(STRING_TYPE), false, "Шаблон")),
+      TypeSet.of(STRING_TYPE),
+      "Соединить параметры по шаблону"
+    );
+    var method = new MemberDescriptor(
+      "СтрШаблон",
+      MemberKind.METHOD,
+      "Возвращает строку",
+      TypeSet.of(STRING_TYPE),
+      List.of(signature),
+      null,
+      false,
+      PlatformMetadata.EMPTY
+    );
+
+    var dto = TypeMemberDto.from(method, Language.RU);
+
+    assertThat(dto.name()).isEqualTo("СтрШаблон");
+    assertThat(dto.kind()).isEqualTo("METHOD");
+    assertThat(dto.types()).containsExactly("Строка");
+    assertThat(dto.description()).isEqualTo("Возвращает строку");
+    assertThat(dto.signatures()).hasSize(1);
+    assertThat(dto.signatures().get(0).parameters()).hasSize(1);
+    assertThat(dto.async()).isFalse();
+    assertThat(dto.metadata()).isNull();
+  }
+
+  @Test
+  void propertyHasEmptySignaturesList() {
+    var property = MemberDescriptor.property("Количество", NUMBER_TYPE);
+
+    var dto = TypeMemberDto.from(property, Language.RU);
+
+    assertThat(dto.kind()).isEqualTo("PROPERTY");
+    assertThat(dto.signatures()).isEmpty();
+    assertThat(dto.types()).containsExactly("Число");
+  }
+
+  @Test
+  void eventKeepsSignaturesFromMember() {
+    var signature = new SignatureDescriptor(
+      List.of(new ParameterDescriptor("Отказ", TypeSet.EMPTY, false, "")),
+      TypeSet.EMPTY,
+      ""
+    );
+    var event = new MemberDescriptor(
+      "ПередЗаписью",
+      MemberKind.EVENT,
+      "Срабатывает перед записью",
+      TypeSet.EMPTY,
+      List.of(signature),
+      null,
+      false,
+      PlatformMetadata.EMPTY
+    );
+
+    var dto = TypeMemberDto.from(event, Language.RU);
+
+    assertThat(dto.kind()).isEqualTo("EVENT");
+    assertThat(dto.signatures()).hasSize(1);
+    assertThat(dto.signatures().get(0).parameters()).extracting("name").containsExactly("Отказ");
+  }
+
+  @Test
+  void carriesAsyncFlag() {
+    var asyncMethod = MemberDescriptor.method("ВопросАсинх").withAsync(true);
+
+    var dto = TypeMemberDto.from(asyncMethod, Language.RU);
+
+    assertThat(dto.async()).isTrue();
+  }
+
+  @Test
+  void platformMetadataIsExposedWhenNotEmpty() {
+    var metadata = new PlatformMetadata(
+      "8.3.20",
+      "",
+      List.of(),
+      Set.of(Availability.SERVER),
+      AccessMode.READ,
+      BilingualString.EMPTY,
+      BilingualString.EMPTY,
+      List.of(),
+      List.of()
+    );
+    var member = new MemberDescriptor(
+      "Свойство",
+      MemberKind.PROPERTY,
+      "",
+      TypeSet.of(STRING_TYPE),
+      List.of(),
+      null,
+      false,
+      metadata
+    );
+
+    var dto = TypeMemberDto.from(member, Language.RU);
+
+    assertThat(dto.metadata()).isNotNull();
+    assertThat(dto.metadata().sinceVersion()).isEqualTo("8.3.20");
+    assertThat(dto.metadata().availabilities()).containsExactly("SERVER");
+    assertThat(dto.metadata().accessMode()).isEqualTo("READ");
+  }
+
+  @Test
+  void picksEnglishLocaleWhenRequested() {
+    var member = new MemberDescriptor(
+      BilingualString.of("Добавить", "Add"),
+      MemberKind.METHOD,
+      BilingualString.of("Добавить элемент", "Adds an item"),
+      TypeSet.EMPTY,
+      List.of(),
+      null,
+      false,
+      PlatformMetadata.EMPTY
+    );
+
+    var dto = TypeMemberDto.from(member, Language.EN);
+
+    assertThat(dto.name()).isEqualTo("Add");
+    assertThat(dto.description()).isEqualTo("Adds an item");
+  }
+
+  @Test
+  void blankDescriptionBecomesNull() {
+    var member = new MemberDescriptor("Метод", MemberKind.METHOD, "", TypeSet.EMPTY, List.of(),
+      null, false, PlatformMetadata.EMPTY);
+
+    var dto = TypeMemberDto.from(member, Language.RU);
+
+    assertThat(dto.description()).isNull();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberMetadataDtoTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeMemberMetadataDtoTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp.dto;
+
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
+import com.github._1c_syntax.bsl.languageserver.types.model.AccessMode;
+import com.github._1c_syntax.bsl.languageserver.types.model.Availability;
+import com.github._1c_syntax.bsl.languageserver.types.model.BilingualString;
+import com.github._1c_syntax.bsl.languageserver.types.model.PlatformMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TypeMemberMetadataDtoTest {
+
+  @Test
+  void emptyMetadataIsEmpty() {
+    assertThat(TypeMemberMetadataDto.EMPTY.isEmpty()).isTrue();
+    assertThat(TypeMemberMetadataDto.from(PlatformMetadata.EMPTY, Language.RU).isEmpty()).isTrue();
+  }
+
+  @Test
+  void mapsAllStringAndCollectionFields() {
+    var metadata = new PlatformMetadata(
+      "8.3.20",
+      "8.3.27",
+      List.of("ОбработкаОшибок.ПодробноеПредставлениеОшибки"),
+      Set.of(Availability.SERVER, Availability.THIN_CLIENT),
+      AccessMode.READ,
+      BilingualString.of("Возвращает число", "Returns a number"),
+      BilingualString.of("Замечание", "Note"),
+      List.of(BilingualString.of("Пример1", "Example1")),
+      List.of(BilingualString.of("См. Сообщить", "See Message"))
+    );
+
+    var dto = TypeMemberMetadataDto.from(metadata, Language.RU);
+
+    assertThat(dto.sinceVersion()).isEqualTo("8.3.20");
+    assertThat(dto.deprecatedSinceVersion()).isEqualTo("8.3.27");
+    assertThat(dto.recommendedReplacements()).containsExactly("ОбработкаОшибок.ПодробноеПредставлениеОшибки");
+    assertThat(dto.availabilities()).containsExactly("SERVER", "THIN_CLIENT");
+    assertThat(dto.accessMode()).isEqualTo("READ");
+    assertThat(dto.returnValueDescription()).isEqualTo("Возвращает число");
+    assertThat(dto.notes()).isEqualTo("Замечание");
+    assertThat(dto.examples()).containsExactly("Пример1");
+    assertThat(dto.seeAlso()).containsExactly("См. Сообщить");
+    assertThat(dto.isEmpty()).isFalse();
+  }
+
+  @Test
+  void picksEnglishLocaleForBilingualFields() {
+    var metadata = new PlatformMetadata(
+      "",
+      "",
+      List.of(),
+      Set.of(),
+      null,
+      BilingualString.of("Возвращает число", "Returns a number"),
+      BilingualString.of("Замечание", "Note"),
+      List.of(BilingualString.of("Пример1", "Example1")),
+      List.of(BilingualString.of("См. Сообщить", "See Message"))
+    );
+
+    var dto = TypeMemberMetadataDto.from(metadata, Language.EN);
+
+    assertThat(dto.returnValueDescription()).isEqualTo("Returns a number");
+    assertThat(dto.notes()).isEqualTo("Note");
+    assertThat(dto.examples()).containsExactly("Example1");
+    assertThat(dto.seeAlso()).containsExactly("See Message");
+  }
+
+  @Test
+  void nullsOutBlankFields() {
+    var metadata = new PlatformMetadata(
+      "  ",
+      "",
+      List.of(),
+      Set.of(),
+      null,
+      BilingualString.of(" ", " "),
+      BilingualString.EMPTY,
+      List.of(),
+      List.of()
+    );
+
+    var dto = TypeMemberMetadataDto.from(metadata, Language.RU);
+
+    assertThat(dto.sinceVersion()).isNull();
+    assertThat(dto.deprecatedSinceVersion()).isNull();
+    assertThat(dto.accessMode()).isNull();
+    assertThat(dto.returnValueDescription()).isNull();
+    assertThat(dto.notes()).isNull();
+    assertThat(dto.isEmpty()).isTrue();
+  }
+
+  @Test
+  void availabilitiesAreSortedAlphabetically() {
+    var metadata = new PlatformMetadata(
+      "", "", List.of(),
+      Set.of(Availability.WEB_CLIENT, Availability.SERVER, Availability.THIN_CLIENT),
+      null,
+      BilingualString.EMPTY, BilingualString.EMPTY,
+      List.of(), List.of()
+    );
+
+    var dto = TypeMemberMetadataDto.from(metadata, Language.RU);
+
+    assertThat(dto.availabilities()).containsExactly("SERVER", "THIN_CLIENT", "WEB_CLIENT");
+  }
+
+  @Test
+  void blankBilingualEntriesAreDropped() {
+    var metadata = new PlatformMetadata(
+      "", "", List.of(), Set.of(), null,
+      BilingualString.EMPTY,
+      BilingualString.EMPTY,
+      List.of(
+        BilingualString.of("Пример1", "Example1"),
+        BilingualString.of("", ""),
+        BilingualString.of(" ", " ")
+      ),
+      List.of()
+    );
+
+    var dto = TypeMemberMetadataDto.from(metadata, Language.RU);
+
+    assertThat(dto.examples()).containsExactly("Пример1");
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeParameterDtoTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/dto/TypeParameterDtoTest.java
@@ -1,0 +1,99 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.mcp.dto;
+
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
+import com.github._1c_syntax.bsl.languageserver.types.model.BilingualString;
+import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class TypeParameterDtoTest {
+
+  private static final TypeRef STRING_TYPE = new TypeRef(TypeKind.PRIMITIVE, "Строка");
+
+  @Test
+  void mapsRequiredFields() {
+    var parameter = new ParameterDescriptor("Шаблон", TypeSet.of(STRING_TYPE), false, "Шаблон строки");
+
+    var dto = TypeParameterDto.from(parameter, Language.RU);
+
+    assertThat(dto.name()).isEqualTo("Шаблон");
+    assertThat(dto.types()).containsExactly("Строка");
+    assertThat(dto.optional()).isFalse();
+    assertThat(dto.variadic()).isFalse();
+    assertThat(dto.defaultValue()).isNull();
+    assertThat(dto.description()).isEqualTo("Шаблон строки");
+  }
+
+  @Test
+  void carriesVariadicFlag() {
+    var parameter = new ParameterDescriptor("Параметры", TypeSet.EMPTY, true, "")
+      .withVariadic(true);
+
+    var dto = TypeParameterDto.from(parameter, Language.RU);
+
+    assertThat(dto.variadic()).isTrue();
+    assertThat(dto.optional()).isTrue();
+    assertThat(dto.description()).isNull();
+  }
+
+  @Test
+  void exposesDefaultValueWhenPresent() {
+    var parameter = new ParameterDescriptor("Кодировка", TypeSet.of(STRING_TYPE), true, "Кодировка", "UTF-8");
+
+    var dto = TypeParameterDto.from(parameter, Language.RU);
+
+    assertThat(dto.defaultValue()).isEqualTo("UTF-8");
+    assertThat(dto.optional()).isTrue();
+  }
+
+  @Test
+  void picksEnglishLocaleForBilingualNameAndDescription() {
+    var parameter = new ParameterDescriptor(
+      BilingualString.of("Шаблон", "Template"),
+      TypeSet.of(STRING_TYPE),
+      false,
+      BilingualString.of("Шаблон строки", "String template"),
+      ""
+    );
+
+    var dto = TypeParameterDto.from(parameter, Language.EN);
+
+    assertThat(dto.name()).isEqualTo("Template");
+    assertThat(dto.description()).isEqualTo("String template");
+  }
+
+  @Test
+  void blankDefaultValueAndDescriptionBecomeNull() {
+    var parameter = new ParameterDescriptor("Параметр", TypeSet.EMPTY, false, "", "");
+
+    var dto = TypeParameterDto.from(parameter, Language.RU);
+
+    assertThat(dto.defaultValue()).isNull();
+    assertThat(dto.description()).isNull();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/TypeServiceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/TypeServiceTest.java
@@ -127,6 +127,33 @@ class TypeServiceTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void definingUriEmptyForPlatformType() {
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+    var variableSymbol = documentContext.getSymbolTree()
+      .getVariableSymbol("ДругоеИмяМассива", documentContext.getSymbolTree().getModule()).orElseThrow();
+    var reference = referenceOf(documentContext, variableSymbol);
+    var typeRef = typeService.typesAt(reference).refs().iterator().next();
+
+    var uri = typeService.definingUri(typeRef);
+
+    assertThat(uri).isEmpty();
+  }
+
+  @Test
+  void definingUriEmptyForUnknownTypeRef() {
+    var uri = typeService.definingUri(com.github._1c_syntax.bsl.languageserver.types.model.TypeRef.UNKNOWN);
+
+    assertThat(uri).isEmpty();
+  }
+
+  @Test
+  void definingUriEmptyForAnyTypeRef() {
+    var uri = typeService.definingUri(com.github._1c_syntax.bsl.languageserver.types.model.TypeRef.ANY);
+
+    assertThat(uri).isEmpty();
+  }
+
+  @Test
   void membersOfArrayResolved() {
     // given
     var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);


### PR DESCRIPTION
## Summary

Три темы вокруг MCP-режима bsl-language-server.

### 1. Roots bootstrap

`McpRootsBootstrapper` — при первом tool-вызове сервер сам шлёт клиенту `roots/list`, если тот объявил `roots`-capability в `initialize`. По MCP-спеке клиент должен ответить на этот запрос. Без проактивного запроса bsl-ls регистрирует workspace только по уведомлению `notifications/roots/list_changed`, а клиенты (Claude Code 2.1.178 в частности) шлют его только при последующих изменениях roots, а не на инициализацию. Симптом: все workspace-зависимые tools падали с «No registered workspace» сразу после подключения.

`McpToolSpecificationsBootstrapWrapper` — `BeanPostProcessor` оборачивает каждый `SyncToolSpecification` из bean'а `toolSpecs`, прозрачно вызывая bootstrap перед делегированием в исходный `callHandler`. Существующие `@McpTool`-методы про bootstrap не знают (diff в них — нулевой).

`McpRootsChangeConsumer.normalizeWindowsFileUri` — фикс под windows-патологию: Claude Code 2.1.178 на Windows шлёт roots вида `file://D:\path\with\backslashes` (буква диска как «host» + backslash в path). `Absolute.uri` такое не разбирает → root отбрасывается с warn'ом, workspace не регистрируется. Нормализуем до RFC 8089 `file:///D:/path/with/forward-slashes` до передачи в `Absolute`.

### 2. Расширенный `type_info`

- Параметр `language` (RU/EN, default RU): имена, описания, билингв-поля платформенной метаинформации возвращаются на выбранной локали.
- Новые поля `Result`: `constructors`, `events`, `definedAt` (URI исходного файла-объявления для USER/CONFIGURATION).
- `TypeMemberDto`: добавлены `async` и `metadata` (`TypeMemberMetadataDto` со `sinceVersion` / `deprecatedSinceVersion` / `recommendedReplacements` / `availabilities` / `accessMode` / `returnValueDescription` / `notes` / `examples` / `seeAlso`).
- `TypeParameterDto`: добавлены `variadic` и `description`.

Чтобы получить URI определения без активного `DocumentContext`'а (MCP-tool вызывается «снаружи» документа), добавлен публичный `TypeService.definingUri(TypeRef)` — лёгкий вариант существующего `definingSymbol(TypeRef, DocumentContext)`.

### 3. Новый MCP-tool `global_member_info`

Резолв глобальной функции / свойства / системного перечисления через `GlobalScopeProvider`. Для функций возвращает полный `TypeMemberDto` с сигнатурами и метаинформацией; для глобальных свойств/перечислений — упрощённый дескриптор с типом значения и описанием. Покрывает кейсы вроде «расскажи про `Сообщить`/`Message`», «какой тип у `Метаданные`», без необходимости открывать конкретный файл.

## Test plan

- [x] `TypeMemberMetadataDtoTest`, `TypeMemberDtoTest`, `TypeParameterDtoTest` — DTO-маппинг (билингв-локаль, blank → null, сортировка, generic-семантика).
- [x] `McpRootsBootstrapperTest` — proactive `listRoots`, идемпотентность (только раз), отсутствие capability, `null` exchange, ошибка `listRoots` swallow, пустой набор.
- [x] `McpToolSpecificationsBootstrapWrapperTest` — обёртка другие bean'ы не трогает, не-List не трогает, при обёртке tool-метадата сохраняется, bootstrap вызывается до handler'а, при ошибке bootstrap'а original всё равно выполняется.
- [x] `McpRootsChangeConsumerTest` — windows-URI нормализация (изолированный helper + end-to-end с `Root`).
- [x] `McpToolsTest` — расширен сценариями `type_info` (`constructors`/`events`/`language`/`definedAt`) и кейсами `global_member_info` (function / EN alias / unknown / OS file type).
- [x] `TypeServiceTest` — `definingUri` для `PLATFORM`/`UNKNOWN`/`ANY` (везде `Optional.empty()`).
- [x] Локально проходят все mcp-related тесты (`McpRootsBootstrapperTest`, `McpRootsChangeConsumerTest`, `McpToolsTest`, `McpHttpServerTest`, `McpSseServerTest`, `McpStreamableServerTest`, `McpToolSpecificationsBootstrapWrapperTest`, DTO-тесты, `TypeServiceTest`).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Added an MCP tool to fetch global member information by name with explicit workspace/root selection.
  * Enhanced `type_info` to be root/workspace aware and locale aware, including events, constructors, and `definedAt`.
  * Extended exported member/parameter metadata (async, richer member metadata, variadic, and additional localized details).
  * Proactively bootstraps MCP roots/list when supported by the client.

* **Bug Fixes**
  * Improved Windows `file://` URI normalization for correct path conversion.

* **Tests**
  * Added coverage for roots bootstrapping, tool registration/wrapping, workspace/root resolution, and DTO mappings.

* **Chores**
  * Added support for resolving a type’s defining URI.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->