### PR TITLE
feat(semantictokens): не красить собственные реквизиты конфигурации как defaultLibrary

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
@@ -70,9 +70,6 @@ public class PlatformMemberMethodCallSemanticTokensSupplier
     SemanticTokenModifiers.Async
   };
 
-  private static final String[] ASYNC_MODIFIERS = {SemanticTokenModifiers.Async};
-  private static final String[] NO_MODIFIERS = new String[0];
-
   private final ReferenceIndex referenceIndex;
 
   public PlatformMemberMethodCallSemanticTokensSupplier(TypeService typeService,
@@ -117,14 +114,7 @@ public class PlatformMemberMethodCallSemanticTokensSupplier
   }
 
   static String[] modifiers(MemberDescriptor descriptor) {
-    // DefaultLibrary — только для членов стандартной библиотеки/платформы.
-    // Через accessCall сюда сейчас попадают лишь методы платформенных типов
-    // (вызовы методов общих модулей красит MethodCallSemanticTokensSupplier и
-    // здесь они пропускаются), но флаг учитываем симметрично с property-сапплаером.
-    if (descriptor.standardLibrary()) {
-      return descriptor.async() ? DEFAULT_LIBRARY_ASYNC_MODIFIERS : DEFAULT_LIBRARY_MODIFIERS;
-    }
-    return descriptor.async() ? ASYNC_MODIFIERS : NO_MODIFIERS;
+    return descriptor.async() ? DEFAULT_LIBRARY_ASYNC_MODIFIERS : DEFAULT_LIBRARY_MODIFIERS;
   }
 
   private Set<Position> collectSourceDefinedCallSites(DocumentContext documentContext) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberMethodCallSemanticTokensSupplier.java
@@ -70,6 +70,9 @@ public class PlatformMemberMethodCallSemanticTokensSupplier
     SemanticTokenModifiers.Async
   };
 
+  private static final String[] ASYNC_MODIFIERS = {SemanticTokenModifiers.Async};
+  private static final String[] NO_MODIFIERS = new String[0];
+
   private final ReferenceIndex referenceIndex;
 
   public PlatformMemberMethodCallSemanticTokensSupplier(TypeService typeService,
@@ -114,7 +117,14 @@ public class PlatformMemberMethodCallSemanticTokensSupplier
   }
 
   static String[] modifiers(MemberDescriptor descriptor) {
-    return descriptor.async() ? DEFAULT_LIBRARY_ASYNC_MODIFIERS : DEFAULT_LIBRARY_MODIFIERS;
+    // DefaultLibrary — только для членов стандартной библиотеки/платформы.
+    // Через accessCall сюда сейчас попадают лишь методы платформенных типов
+    // (вызовы методов общих модулей красит MethodCallSemanticTokensSupplier и
+    // здесь они пропускаются), но флаг учитываем симметрично с property-сапплаером.
+    if (descriptor.standardLibrary()) {
+      return descriptor.async() ? DEFAULT_LIBRARY_ASYNC_MODIFIERS : DEFAULT_LIBRARY_MODIFIERS;
+    }
+    return descriptor.async() ? ASYNC_MODIFIERS : NO_MODIFIERS;
   }
 
   private Set<Position> collectSourceDefinedCallSites(DocumentContext documentContext) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
@@ -96,19 +96,18 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier
 
   @Override
   protected void emit(List<SemanticTokenEntry> entries, DocumentContext documentContext, Range range) {
-    // Для accessProperty memberAt возвращает только свойство (метод — только для
-    // accessCall). Модификатор DefaultLibrary вешаем лишь на члены стандартной
-    // библиотеки/платформы (свойства платформенных типов, стандартные реквизиты);
-    // собственные и общие реквизиты конфигурации — просто Property.
-    typeService.memberAt(documentContext, range.getStart())
-      .map(TypeService.TypedMember::descriptor)
-      .ifPresent(descriptor -> {
-        if (descriptor.standardLibrary()) {
-          helper.addRange(entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS);
-        } else {
-          helper.addRange(entries, range, SemanticTokenTypes.Property);
-        }
-      });
+    var member = typeService.memberAt(documentContext, range.getStart());
+    if (member.isEmpty()) {
+      return;
+    }
+    // Через accessProperty резолвится только свойство. Модификатор DefaultLibrary
+    // получают лишь члены стандартной библиотеки или платформы. У собственных и
+    // общих реквизитов конфигурации его быть не должно — остаётся обычный Property.
+    if (member.get().descriptor().standardLibrary()) {
+      helper.addRange(entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS);
+    } else {
+      helper.addRange(entries, range, SemanticTokenTypes.Property);
+    }
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplier.java
@@ -97,10 +97,18 @@ public class PlatformMemberPropertyAccessSemanticTokensSupplier
   @Override
   protected void emit(List<SemanticTokenEntry> entries, DocumentContext documentContext, Range range) {
     // Для accessProperty memberAt возвращает только свойство (метод — только для
-    // accessCall), поэтому достаточно проверки наличия члена.
-    if (typeService.memberAt(documentContext, range.getStart()).isPresent()) {
-      helper.addRange(entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS);
-    }
+    // accessCall). Модификатор DefaultLibrary вешаем лишь на члены стандартной
+    // библиотеки/платформы (свойства платформенных типов, стандартные реквизиты);
+    // собственные и общие реквизиты конфигурации — просто Property.
+    typeService.memberAt(documentContext, range.getStart())
+      .map(TypeService.TypedMember::descriptor)
+      .ifPresent(descriptor -> {
+        if (descriptor.standardLibrary()) {
+          helper.addRange(entries, range, SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS);
+        } else {
+          helper.addRange(entries, range, SemanticTokenTypes.Property);
+        }
+      });
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
@@ -50,6 +50,12 @@ import java.util.Optional;
  * @param generic              признак «слотового» члена generic-типа платформы
  * @param metadata             платформенные метаданные
  * @param async                асинхронный метод (await-стиль, суффикс Асинх/Async)
+ * @param standardLibrary      признак «член стандартной библиотеки/платформы»: член
+ *                             платформенного типа либо стандартный реквизит объекта
+ *                             конфигурации (Наименование/Код/Ссылка/…). Для собственных
+ *                             и общих реквизитов конфигурации — {@code false}. Управляет
+ *                             модификатором {@code defaultLibrary} семантических токенов;
+ *                             по умолчанию (compat-конструкторы) {@code true}
  */
 public record MemberDescriptor(
   BilingualString bilingualName,
@@ -60,7 +66,8 @@ public record MemberDescriptor(
   @Nullable Symbol sourceSymbol,
   boolean generic,
   PlatformMetadata metadata,
-  boolean async
+  boolean async,
+  boolean standardLibrary
 ) {
 
   public MemberDescriptor {
@@ -79,12 +86,20 @@ public record MemberDescriptor(
     }
   }
 
-  /** Compat-конструктор без {@code async} (async = false). */
+  /** Compat-конструктор без {@code standardLibrary} (standardLibrary = true). */
+  public MemberDescriptor(BilingualString bilingualName, MemberKind kind, BilingualString bilingualDescription,
+                          TypeSet returnTypes, List<SignatureDescriptor> signatures, @Nullable Symbol sourceSymbol,
+                          boolean generic, PlatformMetadata metadata, boolean async) {
+    this(bilingualName, kind, bilingualDescription, returnTypes, signatures, sourceSymbol,
+      generic, metadata, async, true);
+  }
+
+  /** Compat-конструктор без {@code async} (async = false, standardLibrary = true). */
   public MemberDescriptor(BilingualString bilingualName, MemberKind kind, BilingualString bilingualDescription,
                           TypeSet returnTypes, List<SignatureDescriptor> signatures, @Nullable Symbol sourceSymbol,
                           boolean generic, PlatformMetadata metadata) {
     this(bilingualName, kind, bilingualDescription, returnTypes, signatures, sourceSymbol,
-      generic, metadata, false);
+      generic, metadata, false, true);
   }
 
   /** Compat-конструктор: одноязычные {@code name}/{@code description}. */
@@ -178,37 +193,51 @@ public record MemberDescriptor(
   /** Копия дескриптора с прикреплённым символом-источником. */
   public MemberDescriptor withSourceSymbol(Symbol symbol) {
     return new MemberDescriptor(bilingualName, kind, bilingualDescription, returnTypes,
-      signatures, symbol, generic, metadata, async);
+      signatures, symbol, generic, metadata, async, standardLibrary);
   }
 
   /** Копия дескриптора с заменёнными метаданными платформы. */
   public MemberDescriptor withMetadata(PlatformMetadata newMetadata) {
     return new MemberDescriptor(bilingualName, kind, bilingualDescription, returnTypes,
-      signatures, sourceSymbol, generic, newMetadata, async);
+      signatures, sourceSymbol, generic, newMetadata, async, standardLibrary);
   }
 
   /** Копия дескриптора с заполненным двуязычным именем (ru + en). */
   public MemberDescriptor withBilingualName(BilingualString newName) {
     return new MemberDescriptor(newName,
-      kind, bilingualDescription, returnTypes, signatures, sourceSymbol, generic, metadata, async);
+      kind, bilingualDescription, returnTypes, signatures, sourceSymbol, generic, metadata, async,
+      standardLibrary);
   }
 
   /** Копия дескриптора с заполненным двуязычным описанием (ru + en). */
   public MemberDescriptor withBilingualDescription(BilingualString newDescription) {
     return new MemberDescriptor(bilingualName, kind, newDescription,
-      returnTypes, signatures, sourceSymbol, generic, metadata, async);
+      returnTypes, signatures, sourceSymbol, generic, metadata, async, standardLibrary);
   }
 
   /** Копия дескриптора с признаком асинхронности. */
   public MemberDescriptor withAsync(boolean newAsync) {
     return new MemberDescriptor(bilingualName, kind, bilingualDescription, returnTypes,
-      signatures, sourceSymbol, generic, metadata, newAsync);
+      signatures, sourceSymbol, generic, metadata, newAsync, standardLibrary);
+  }
+
+  /**
+   * Копия дескриптора с признаком принадлежности к стандартной библиотеке/платформе.
+   * Для собственных и общих реквизитов конфигурации выставляется {@code false}, чтобы
+   * семантические токены не вешали на них модификатор {@code defaultLibrary}.
+   */
+  public MemberDescriptor withStandardLibrary(boolean newStandardLibrary) {
+    if (this.standardLibrary == newStandardLibrary) {
+      return this;
+    }
+    return new MemberDescriptor(bilingualName, kind, bilingualDescription, returnTypes,
+      signatures, sourceSymbol, generic, metadata, async, newStandardLibrary);
   }
 
   /** Копия дескриптора с подменёнными сигнатурами. */
   public MemberDescriptor withSignatures(List<SignatureDescriptor> newSignatures) {
     return new MemberDescriptor(bilingualName, kind, bilingualDescription, returnTypes,
-      newSignatures, sourceSymbol, generic, metadata, async);
+      newSignatures, sourceSymbol, generic, metadata, async, standardLibrary);
   }
 
   /** Копия дескриптора с признаком generic (placeholder в имени). */
@@ -217,7 +246,7 @@ public record MemberDescriptor(
       return this;
     }
     return new MemberDescriptor(bilingualName, kind, bilingualDescription, returnTypes,
-      signatures, sourceSymbol, newGeneric, metadata, async);
+      signatures, sourceSymbol, newGeneric, metadata, async, standardLibrary);
   }
 
   /** Compat shortcut для двуязычных имён ru/en строками. */
@@ -260,7 +289,7 @@ public record MemberDescriptor(
       return this;
     }
     return new MemberDescriptor(bilingualName, kind, bilingualDescription,
-      newReturnTypes, newSignatures, sourceSymbol, generic, metadata, async);
+      newReturnTypes, newSignatures, sourceSymbol, generic, metadata, async, standardLibrary);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
@@ -249,11 +249,6 @@ public record MemberDescriptor(
       signatures, sourceSymbol, newGeneric, metadata, async, standardLibrary);
   }
 
-  /** Compat shortcut для двуязычных имён ru/en строками. */
-  public MemberDescriptor withLocalizedNames(String newNameRu, String newNameEn) {
-    return withBilingualName(BilingualString.of(newNameRu, newNameEn));
-  }
-
   /**
    * Возвращает копию дескриптора, в которой placeholder'ы {@code <X>} в
    * {@link #returnTypes} и {@link SignatureDescriptor#returnType} заменены

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinTypesJsonLoader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinTypesJsonLoader.java
@@ -189,9 +189,9 @@ public class BuiltinTypesJsonLoader {
       var nameRu = stringField(m, "nameRu");
       var nameEn = stringField(m, "nameEn");
       if (!nameRu.isEmpty() || !nameEn.isEmpty()) {
-        descriptor = descriptor.withLocalizedNames(nameRu, nameEn);
+        descriptor = descriptor.withBilingualName(BilingualString.of(nameRu, nameEn));
       } else if (name != null && !name.isEmpty()) {
-        descriptor = descriptor.withLocalizedNames(name, name);
+        descriptor = descriptor.withBilingualName(BilingualString.of(name, name));
       }
       // Двуязычное описание: опциональные `descriptionRu`/`descriptionEn`.
       // Если заданы — приоритетнее моноязычного `description` (которое

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -520,7 +520,8 @@ public class ConfigurationTypesProvider {
         typeRegistry.registerMemberSource(collRef, columnSource, FileType.BSL);
       }
 
-      tsMembers.add(MemberDescriptor.property(tsName, collRef));
+      // Табличная часть — метаданные конфигурации, не платформенный API → не defaultLibrary.
+      tsMembers.add(MemberDescriptor.property(tsName, collRef).withStandardLibrary(false));
     }
     if (!tsMembers.isEmpty()) {
       var immutableTs = List.copyOf(tsMembers);
@@ -829,6 +830,9 @@ public class ConfigurationTypesProvider {
       if (!meta.isEmpty()) {
         descriptor = descriptor.withMetadata(meta);
       }
+      // Стандартные реквизиты (Наименование/Код/Ссылка/…) — часть платформенной
+      // объектной модели → defaultLibrary; собственные реквизиты конфигурации — нет.
+      descriptor = descriptor.withStandardLibrary(attribute instanceof StandardAttribute);
       result.add(descriptor);
     }
     return result;
@@ -934,13 +938,16 @@ public class ConfigurationTypesProvider {
         continue;
       }
       var returnTypes = resolveCommonAttributeReturnTypes(ca);
+      MemberDescriptor descriptor;
       if (returnTypes.isEmpty()) {
-        result.add(MemberDescriptor.property(attrName));
+        descriptor = MemberDescriptor.property(attrName);
       } else if (returnTypes.size() == 1) {
-        result.add(MemberDescriptor.property(attrName, returnTypes.refs().iterator().next()));
+        descriptor = MemberDescriptor.property(attrName, returnTypes.refs().iterator().next());
       } else {
-        result.add(MemberDescriptor.property(attrName, returnTypes, ""));
+        descriptor = MemberDescriptor.property(attrName, returnTypes, "");
       }
+      // Общие реквизиты — метаданные конфигурации, не платформенный API → не defaultLibrary.
+      result.add(descriptor.withStandardLibrary(false));
     }
     return result;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/GlobalScopeProvider.java
@@ -1055,7 +1055,7 @@ public class GlobalScopeProvider {
       var nameRu = stringEntry(entry, "nameRu");
       var nameEn = stringEntry(entry, "nameEn");
       if (!nameRu.isEmpty() || !nameEn.isEmpty()) {
-        descriptor = descriptor.withLocalizedNames(nameRu, nameEn);
+        descriptor = descriptor.withBilingualName(BilingualString.of(nameRu, nameEn));
       }
       if (Boolean.TRUE.equals(entry.get("async"))) {
         descriptor = descriptor.withAsync(true);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/PlatformMemberPropertyAccessSemanticTokensSupplierTest.java
@@ -191,6 +191,52 @@ class PlatformMemberPropertyAccessSemanticTokensSupplierTest extends AbstractSer
   }
 
   @Test
+  void testStandardAttributeColoredAsDefaultLibrary() {
+    // given — типизированный объект справочника; обращение к стандартному
+    // реквизиту Наименование (часть платформенной объектной модели).
+    initServerContext(PATH_TO_METADATA);
+    String bsl = """
+      // Параметры:
+      //  Объект - СправочникОбъект.Справочник1
+      Процедура Тест(Объект)
+          А = Объект.Наименование;
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — стандартный реквизит подсвечивается как Property + DefaultLibrary.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(3, 15, 12, SemanticTokenTypes.Property,
+        Set.of(SemanticTokenModifiers.DefaultLibrary), "Наименование")
+    ));
+  }
+
+  @Test
+  void testOwnAttributeColoredAsPlainProperty() {
+    // given — типизированный объект справочника; обращение к собственному
+    // реквизиту Реквизит1, заведённому разработчиком конфигурации.
+    initServerContext(PATH_TO_METADATA);
+    String bsl = """
+      // Параметры:
+      //  Объект - СправочникОбъект.Справочник1
+      Процедура Тест(Объект)
+          А = Объект.Реквизит1;
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — собственный реквизит — просто Property, без DefaultLibrary.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(3, 15, 9, SemanticTokenTypes.Property,
+        Set.of(), "Реквизит1")
+    ));
+  }
+
+  @Test
   void testGlobalChainInCallStatementSkipped() {
     // given — глобальная цепочка в statement-позиции (callStatement): база — Справочники.
     initServerContext(PATH_TO_METADATA);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptorFactoryTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptorFactoryTest.java
@@ -155,12 +155,12 @@ class MemberDescriptorFactoryTest {
   }
 
   @Test
-  void withLocalizedNamesAcceptsRuAndEnAtOnce() {
+  void withBilingualNameAcceptsRuAndEnAtOnce() {
     // given
     var base = MemberDescriptor.method("F");
 
     // when
-    var updated = base.withLocalizedNames("F-ru", "F-en");
+    var updated = base.withBilingualName(BilingualString.of("F-ru", "F-en"));
 
     // then
     assertThat(updated.displayName(Language.RU)).isEqualTo("F-ru");


### PR DESCRIPTION
Closes #3996

## Проблема

`PlatformMemberPropertyAccessSemanticTokensSupplier` (PR #3989) вешал модификатор LSP `defaultLibrary` на **все** разрезолвленные свойства. Но `defaultLibrary` означает «символ из стандартной библиотеки/платформы». Это верно для свойств платформенных типов и **стандартных** реквизитов (`Наименование`, `Код`, `Ссылка`, …), но **не** для собственных реквизитов конфигурации (`Контрагент.ИНН`), которые завёл разработчик.

```bsl
Х = Объект.Наименование; // стандартный реквизит → Property + DefaultLibrary (ок)
У = Объект.ИНН;          // собственный реквизит → теперь просто Property
```

## Что сделано

1. **`MemberDescriptor`** — добавлен признак `standardLibrary` (по умолчанию `true`, чтобы все платформенные источники остались как есть). Все compat-конструкторы и `with…`-методы проносят флаг. Заодно убран избыточный шорткат `withLocalizedNames` (был сахаром над `withBilingualName(BilingualString.of(...))`) — это удержало число методов записи под лимитом Sonar S1448.
2. **`ConfigurationTypesProvider`** — дискриминатор `attribute instanceof StandardAttribute` в `buildAttributeMembers` (тот же, что на `:978`): стандартные реквизиты → `true`, собственные → `false`. Общие реквизиты (`buildCommonAttributeMembers`) и имена/колонки табличных частей → `false`.
3. **`PlatformMemberPropertyAccessSemanticTokensSupplier`** — `defaultLibrary` вешается только при `standardLibrary`, иначе просто `Property`.

## Тесты

`PlatformMemberPropertyAccessSemanticTokensSupplierTest`:
- `testStandardAttributeColoredAsDefaultLibrary` — `Объект.Наименование` → `Property + DefaultLibrary`;
- `testOwnAttributeColoredAsPlainProperty` — `Объект.Реквизит1` → `Property` без модификаторов.

Прогон: semantictokens / types / hover / completion — зелёные.

## Пункт 3 issue (симметрия для методов) — отдельно, нужно согласовать

**Не входит в этот PR.** Экспортные методы общих модулей (`ОбщегоНазначения.X`) через `PlatformMemberMethodCallSemanticTokensSupplier` не проходят — их красит `MethodCallSemanticTokensSupplier` по `ReferenceIndex`, а сюда попадают только методы платформенных типов (для них `defaultLibrary` корректен). Чтобы снять `defaultLibrary` с методов общих модулей, нужно трогать `MethodCallSemanticTokensSupplier` — предлагаю вынести в отдельный issue/PR. Согласны?

Аналогично вне scope (домен `GlobalScope` / generic-expansion): значения перечислений, предопределённые, поля записей регистров.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Improved semantic highlighting: standard library and platform attributes are now visually distinguished from custom configuration attributes.

* **Tests**
  * Added test coverage verifying that built-in attributes receive distinct semantic tokens from user-defined attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->