### PR TITLE
fix(types): не удерживать DocumentContext в кэше контрактов событий

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndex.java
@@ -26,7 +26,6 @@ import com.github._1c_syntax.bsl.languageserver.context.events.ConfigurationType
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
-import com.github._1c_syntax.utils.Lazy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.event.EventListener;
 import org.springframework.stereotype.Component;
@@ -57,7 +56,7 @@ public class EventContractsIndex extends AbstractDocumentLifecycleClearableIndex
 
   private final EventHandlerResolver eventHandlerResolver;
 
-  private final Map<URI, Lazy<Map<String, Optional<MemberDescriptor>>>> contractsByUri
+  private final Map<URI, Map<String, Optional<MemberDescriptor>>> contractsByUri
     = new ConcurrentHashMap<>();
 
   /**
@@ -65,11 +64,11 @@ public class EventContractsIndex extends AbstractDocumentLifecycleClearableIndex
    * либо {@link Optional#empty()}, если метод не является обработчиком.
    */
   public Optional<MemberDescriptor> getContract(DocumentContext documentContext, String methodName) {
-    var lazy = contractsByUri.computeIfAbsent(
+    var contracts = contractsByUri.computeIfAbsent(
       documentContext.getUri(),
-      uri -> new Lazy<>(() -> buildFor(documentContext))
+      uri -> buildFor(documentContext)
     );
-    return lazy.getOrCompute().getOrDefault(methodName.toLowerCase(Locale.ROOT), Optional.empty());
+    return contracts.getOrDefault(methodName.toLowerCase(Locale.ROOT), Optional.empty());
   }
 
   @Override


### PR DESCRIPTION
EventContractsIndex кэшировал значение как Lazy, supplier которого
(`() -> buildFor(documentContext)`) захватывал весь DocumentContext.
Lazy из io.github.1c-syntax:utils не обнуляет supplier после вычисления,
поэтому каждая запись держала сильную ссылку на DocumentContext вместе
с его SymbolTree (который clearSecondaryData не освобождает). В итоге
индекс, кэширующий крошечную карту «имя метода → контракт», пиннил
деревья символов всех проанализированных модулей.

computeIfAbsent сам откладывает вычисление до первого обращения и
выполняет buildFor однократно, поэтому Lazy здесь избыточен. Храним
готовую карту напрямую — захвата DocumentContext больше нет. buildFor
не реентрантен к contractsByUri, так что выполнение под bin-локом CHM
безопасно.

https://claude.ai/code/session_01UXaicRdUwd7Dm6Qfk8PA7K