### PR TITLE
fix(diagnostics): сбрасывать Lazy-кэш диагностик до workspace/diagnostic/refresh

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DiagnosticProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/DiagnosticProvider.java
@@ -188,21 +188,25 @@ public final class DiagnosticProvider {
   }
 
   /**
-   * Обновляет диагностики у клиента. При поддержке клиентом pull-refresh —
-   * отправляет {@code workspace/diagnostic/refresh}. Иначе чистит кэш и push'ит
-   * свежие диагностики у открытых документов: закрытые не используются клиентом
-   * прямо сейчас, а {@code AnalyzeProjectOnStart} их обработает отдельно.
+   * Обновляет диагностики у клиента. Сначала чистит закэшированные диагностики у открытых
+   * документов: иначе при следующем {@code textDocument/diagnostic} (pull-режим) или
+   * {@code documentContext::getDiagnostics} (push) клиент получит закэшированное значение,
+   * вычисленное на ещё неполном контексте. Дальше — при поддержке клиентом pull-refresh
+   * отправляется {@code workspace/diagnostic/refresh}; иначе свежие диагностики push'атся
+   * самим сервером. Закрытые документы не трогаем — клиенту они сейчас не нужны,
+   * {@code AnalyzeProjectOnStart} их обработает отдельно.
    */
   private void refreshDiagnostics(ServerContext serverContext) {
+    var opened = serverContext.getOpenedDocuments();
+    opened.forEach(DocumentContext::clearDiagnostics);
     if (clientSupportsRefresh) {
       clientHolder.execIfConnected((LanguageClient languageClient) -> {
-        LOGGER.debug("Requesting diagnostic refresh from client");
+        LOGGER.debug("Requesting diagnostic refresh from client ({} opened documents cleared)",
+          opened.size());
         languageClient.refreshDiagnostics();
       });
       return;
     }
-    var opened = serverContext.getOpenedDocuments();
-    opened.forEach(DocumentContext::clearDiagnostics);
     LOGGER.debug("Pushing recomputed diagnostics to {} opened document(s)", opened.size());
     opened.forEach(this::computeAndPublishDiagnostics);
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DiagnosticProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DiagnosticProviderTest.java
@@ -53,6 +53,7 @@ import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 
 @SpringBootTest
 class DiagnosticProviderTest {
@@ -215,6 +216,31 @@ class DiagnosticProviderTest {
     );
 
     // then
+    verify(languageClient, times(1)).refreshDiagnostics();
+  }
+
+  @Test
+  void testServerContextPopulatedClearsCachedDiagnosticsForPullClient() {
+    // given: pull-клиент (VSCode) объявил refreshSupport — мы не должны полагаться на то,
+    // что он сам вычищает наш кэш. Иначе после workspace/diagnostic/refresh клиент перезапросит
+    // textDocument/diagnostic, а получит закэшированную диагностику, посчитанную ещё до
+    // наполнения контекста.
+    initializeRefreshSupport(true);
+
+    var languageClient = mock(LanguageClient.class);
+    languageClientHolder.connect(languageClient);
+
+    var openedA = mock(DocumentContext.class);
+    var openedB = mock(DocumentContext.class);
+    var serverContext = mock(ServerContext.class);
+    when(serverContext.getOpenedDocuments()).thenReturn(java.util.Set.of(openedA, openedB));
+
+    // when
+    diagnosticProvider.handleServerContextPopulatedEvent(new ServerContextPopulatedEvent(serverContext));
+
+    // then
+    verify(openedA, times(1)).clearDiagnostics();
+    verify(openedB, times(1)).clearDiagnostics();
     verify(languageClient, times(1)).refreshDiagnostics();
   }
 


### PR DESCRIPTION
## Summary

После наполнения контекста сервера (`ServerContextPopulatedEvent`) межфайловые диагностики открытых документов (`UnusedLocalMethod`, `EventHandler*`, обращения к общим модулям и т.п.) могут устареть, поэтому мы шлём pull-клиенту (VSCode 1.94+ с `refreshSupport`) запрос `workspace/diagnostic/refresh`. Однако в pull-ветке мы **не** сбрасывали `Lazy<List<Diagnostic>>`-кэш в `DocumentContext`. Клиент перезапрашивал через `textDocument/diagnostic` → `DiagnosticProvider.getDiagnostic(...)` → `documentContext.getDiagnostics()` → `Lazy.getOrCompute()` возвращал закэшированное значение, посчитанное до наполнения контекста.

Симптом: диагностики «висят» в редакторе до переоткрытия файла (`didOpen` → `rebuildDocument` сбрасывает кэш). Раньше работало, потому что push-ветка чистила кэш — но для pull-клиента она не выполняется.

`clearDiagnostics()` теперь вызывается **до** выбора ветки — кэш сбрасывается одинаково для pull- и push-клиента, refresh уходит уже после.

## Test plan

- [x] Новый кейс `DiagnosticProviderTest.testServerContextPopulatedClearsCachedDiagnosticsForPullClient` — проверяет что при pull-клиенте перед `refreshDiagnostics()` зовётся `clearDiagnostics()` на каждом открытом документе.
- [x] Существующие кейсы `testServerContextPopulatedRequestsRefreshWhenClientSupportsRefresh` / `testServerContextPopulatedDoesNotRequestRefreshWhenClientDoesNotSupportRefresh` остаются зелёными.
- [x] Ручная проверка в VSCode 1.94+ на 1С-проекте — открыть `.bsl`-файл во время индексации, дождаться завершения `populateContext`: диагностики переактуализируются без необходимости переоткрывать файл.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved diagnostic refresh behavior for open documents—cached diagnostics are now consistently cleared before refresh operations are initiated, ensuring accurate and timely code analysis updates.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->