### PR TITLE
feat(infrastructure): виртуальные потоки для исполнителей запросов LSP

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLTextDocumentService.java
@@ -137,7 +137,7 @@ import org.eclipse.lsp4j.services.TextDocumentService;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Component;
 
 import java.net.URI;
@@ -191,7 +191,7 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
   private final LanguageServerConfiguration configuration;
 
   @Qualifier("textDocumentServiceExecutor")
-  private final ThreadPoolTaskExecutor taskExecutor;
+  private final AsyncTaskExecutor taskExecutor;
 
   // Executors per document URI to serialize didChange operations and avoid race conditions
   private final Map<URI, DocumentChangeExecutor> documentExecutors = new ConcurrentHashMap<>();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/BSLWorkspaceService.java
@@ -48,7 +48,7 @@ import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.eclipse.lsp4j.services.WorkspaceService;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 import org.springframework.stereotype.Component;
 
 import java.io.File;
@@ -75,7 +75,7 @@ public class BSLWorkspaceService implements WorkspaceService {
   private final SymbolProvider symbolProvider;
   private final ServerContextProvider serverContextProvider;
   @Qualifier("workspaceServiceExecutor")
-  private final ThreadPoolTaskExecutor executor;
+  private final AsyncTaskExecutor executor;
   @Qualifier("populateContextExecutor")
   private final ExecutorService populateContextExecutor;
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/SentryAspect.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/SentryAspect.java
@@ -37,7 +37,7 @@ import org.eclipse.lsp4j.MessageType;
 import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
+import org.springframework.core.task.AsyncTaskExecutor;
 
 import java.util.concurrent.CompletableFuture;
 
@@ -49,7 +49,7 @@ import java.util.concurrent.CompletableFuture;
 public class SentryAspect {
 
   @Setter(onMethod_ = {@Autowired, @Qualifier("sentryExecutor")})
-  private ThreadPoolTaskExecutor executor;
+  private AsyncTaskExecutor executor;
 
   @Setter(onMethod_ = {@Autowired})
   @Nullable

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration.java
@@ -25,9 +25,10 @@ import io.sentry.spring7.SentryTaskDecorator;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
 import org.springframework.context.annotation.ScopedProxyMode;
+import org.springframework.core.task.AsyncTaskExecutor;
+import org.springframework.core.task.SimpleAsyncTaskExecutor;
 import org.springframework.core.task.TaskDecorator;
 import org.springframework.core.task.support.ContextPropagatingTaskDecorator;
-import org.springframework.scheduling.concurrent.ThreadPoolTaskExecutor;
 
 import java.net.URI;
 import java.util.Optional;
@@ -46,8 +47,9 @@ import java.util.concurrent.ForkJoinWorkerThread;
  * Исключение: {@code computeConfigurationExecutor} — singleton, т.к. вызывает
  * внешнюю библиотеку MDClasses, не использующую ThreadLocal из BSL LS.
  * <p>
- * Остальные исполнители реализуются через {@link ThreadPoolTaskExecutor} (cached thread pool)
- * с {@link TaskDecorator} для прокидывания контекста.
+ * Остальные исполнители — короткоживущие обработчики запросов LSP без {@code parallelStream()}
+ * внутри — реализуются через {@link SimpleAsyncTaskExecutor} в режиме виртуальных потоков
+ * ({@code setVirtualThreads(true)}) с {@link TaskDecorator} для прокидывания контекста.
  */
 @Configuration
 public class ExecutorConfiguration {
@@ -69,21 +71,23 @@ public class ExecutorConfiguration {
     return runnable -> sentryDecorator.decorate(contextPropagatingDecorator.decorate(runnable));
   }
 
-  // --- ThreadPoolTaskExecutor beans (no parallelStream inside) ---
+  // --- Virtual-thread beans (no parallelStream inside) ---
+  // Короткие задачи-обработчики запросов LSP: один виртуальный поток на задачу,
+  // TaskDecorator переносит контекст (Sentry + micrometer) через async-границу.
 
-  @Bean(destroyMethod = "shutdown")
-  public ThreadPoolTaskExecutor textDocumentServiceExecutor(TaskDecorator compositeTaskDecorator) {
-    return createThreadPoolExecutor(compositeTaskDecorator, "text-document-service-");
+  @Bean
+  public AsyncTaskExecutor textDocumentServiceExecutor(TaskDecorator compositeTaskDecorator) {
+    return createVirtualThreadExecutor(compositeTaskDecorator, "text-document-service-");
   }
 
-  @Bean(destroyMethod = "shutdown")
-  public ThreadPoolTaskExecutor workspaceServiceExecutor(TaskDecorator compositeTaskDecorator) {
-    return createThreadPoolExecutor(compositeTaskDecorator, "workspace-service-");
+  @Bean
+  public AsyncTaskExecutor workspaceServiceExecutor(TaskDecorator compositeTaskDecorator) {
+    return createVirtualThreadExecutor(compositeTaskDecorator, "workspace-service-");
   }
 
-  @Bean(destroyMethod = "shutdown")
-  public ThreadPoolTaskExecutor sentryExecutor(TaskDecorator compositeTaskDecorator) {
-    return createThreadPoolExecutor(compositeTaskDecorator, "sentry-");
+  @Bean
+  public AsyncTaskExecutor sentryExecutor(TaskDecorator compositeTaskDecorator) {
+    return createVirtualThreadExecutor(compositeTaskDecorator, "sentry-");
   }
 
   // --- ForkJoinPool beans (parallelStream runs inside) ---
@@ -126,13 +130,11 @@ public class ExecutorConfiguration {
     return createWorkspaceForkJoinPool("cli-");
   }
 
-  private static ThreadPoolTaskExecutor createThreadPoolExecutor(
+  private static AsyncTaskExecutor createVirtualThreadExecutor(
     TaskDecorator taskDecorator, String threadNamePrefix) {
-    var executor = new ThreadPoolTaskExecutor();
-    executor.setQueueCapacity(0);
-    executor.setThreadNamePrefix(threadNamePrefix);
+    var executor = new SimpleAsyncTaskExecutor(threadNamePrefix);
+    executor.setVirtualThreads(true);
     executor.setTaskDecorator(taskDecorator);
-    executor.initialize();
     return executor;
   }
 

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,6 +1,9 @@
 server.port=8025
 spring.main.banner-mode=off
 spring.main.log-startup-info=false
+# Виртуальные потоки для веб-контейнера, планировщика и @Async по умолчанию.
+# Кастомные исполнители LSP заданы явно в ExecutorConfiguration.
+spring.threads.virtual.enabled=true
 spring.cache.cache-names=testIds,testSources
 spring.cache.caffeine.spec=maximumSize=500,expireAfterAccess=600s
 logging.level.org.springframework.boot.autoconfigure.logging=INFO

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/BSLLanguageServerTest.java
@@ -468,7 +468,7 @@ class BSLLanguageServerTest {
 
   /**
    * Группа тестов shutdown/exit изолирована в @Nested-классе с fullRefresh: их методы рвут
-   * singleton-state (флаг shutdownWasCalled на BSLLanguageServer, плюс ThreadPoolTaskExecutor,
+   * singleton-state (флаг shutdownWasCalled на BSLLanguageServer, плюс AsyncTaskExecutor,
    * закрываемый textDocumentService.reset() в shutdown()), которое lite-cleanup не пересоздаёт.
    * Полный Spring refresh между методами этой группы — единственный способ получить свежие
    * BSLLanguageServer и executor.


### PR DESCRIPTION
## Что

Cached-пулы обработчиков запросов LSP (`textDocumentServiceExecutor`, `workspaceServiceExecutor`, `sentryExecutor`) переведены с `ThreadPoolTaskExecutor` на `SimpleAsyncTaskExecutor` в режиме виртуальных потоков (`setVirtualThreads(true)`). Это I/O-bound задачи «один запрос — одна задача», для которых виртуальные потоки оптимальны; `TaskDecorator` (Sentry + micrometer) для переноса контекста сохранён.

Добавлен глобальный флаг `spring.threads.virtual.enabled=true` (веб-контейнер websocket/MCP, планировщик, дефолтный `@Async`).

## Чего здесь намеренно НЕТ

Тяжёлые `ForkJoinPool`-исполнители (диагностики, парсинг, populate, semantic tokens, CLI) **оставлены на ForkJoinPool**. Перевод их на VT-fan-out был испробован и откатан: их вложенный мелкозернистый `parallelStream` — CPU-bound и опирается на work-stealing. Замер SmokyTest:

| Вариант | Время |
|---|---|
| ForkJoinPool (как сейчас) | **60 с** |
| unbounded VT fan-out | 8019 с (×133) |
| bounded VT fan-out | >720 с (starvation на вложенных задачах) |

## Проверка

`./gradlew compileJava`, `spotlessJavaCheck`, `SmokyTest` (~60 с), `BSLWorkspaceServiceTest`, `BSLTextDocumentServiceTest` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized async task execution throughout the language server by adopting virtual threads, enabling more efficient concurrent request handling and reduced resource overhead.
  * Updated executor configuration to leverage modern threading capabilities with improved context propagation for better performance in high-concurrency scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->