### PR TITLE
fix(sentry): не падать на null-версии сервера при инициализации Sentry

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/sentry/SentryScopeConfigurer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/sentry/SentryScopeConfigurer.java
@@ -105,7 +105,10 @@ public class SentryScopeConfigurer {
   }
 
   private String getEnvironment() {
-    return resolveEnvironment(serverInfo.getVersion());
+    var version = serverInfo.getVersion();
+    // Версия может быть null при запуске без манифеста (из IDE/исходников);
+    // resolveEnvironment ожидает не-null, поэтому неизвестную версию трактуем как feature.
+    return version == null ? "feature" : resolveEnvironment(version);
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/aop/sentry/SentryScopeConfigurerOptionsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/aop/sentry/SentryScopeConfigurerOptionsTest.java
@@ -1,0 +1,48 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.aop.sentry;
+
+import io.sentry.SentryOptions;
+import org.eclipse.lsp4j.ServerInfo;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+class SentryScopeConfigurerOptionsTest {
+
+  @Test
+  void resolvesFeatureEnvironmentWhenServerVersionIsNull() {
+    // given
+    var serverInfo = mock(ServerInfo.class);
+    when(serverInfo.getVersion()).thenReturn(null);
+    var configurer = new SentryScopeConfigurer(serverInfo, mock(PermissionFilterBeforeSendCallback.class));
+    var options = new SentryOptions();
+
+    // when
+    configurer.sentryOptionsConfiguration().configure(options);
+
+    // then
+    assertThat(options.getEnvironment()).isEqualTo("feature");
+  }
+}


### PR DESCRIPTION
## Проблема

`SentryScopeConfigurer.resolveEnvironment(version)` бросает `NullPointerException` на `version.matches(...)`, когда `serverInfo.getVersion()` возвращает `null`. Версия равна `null` при запуске без манифеста (из IDE/исходников — в `META-INF/MANIFEST.MF` нет `Implementation-Version`). Если при этом задан `sentry.dsn`, лямбда `sentryOptionsConfiguration` вызывается при инициализации Sentry SDK на старте контекста → падение.

## Решение

`getEnvironment()` трактует `null`-версию как окружение `feature` (как и любую неизвестную строку версии). `resolveEnvironment(String)` сохраняет не-null контракт — null обрабатывается в вызывающем методе.

## Тест

`SentryScopeConfigurerOptionsTest` (Mockito-юнит): `sentryOptionsConfiguration().configure(options)` при `getVersion()==null` не падает и выставляет environment `feature`. Сначала написан красный (воспроизводит NPE), затем фикс.

🤖 Generated with [Claude Code](https://claude.com/claude-code)