### PR TITLE
feat(completion): нечёткий поиск в автодополнении (подстрока + подпоследовательность)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -40,6 +40,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex;
 import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
 import com.github._1c_syntax.bsl.languageserver.types.scope.UseDirectiveScanner;
+import com.github._1c_syntax.bsl.languageserver.utils.FuzzyMatcher;
 import com.github._1c_syntax.bsl.parser.description.MethodDescription;
 import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import com.github._1c_syntax.bsl.support.CompatibilityMode;
@@ -118,6 +119,7 @@ public final class CompletionProvider {
   private final LanguageServerConfiguration configuration;
   private final ClientCapabilitiesHolder clientCapabilitiesHolder;
   private final JsonMapper jsonMapper;
+  private final FuzzyMatcher fuzzyMatcher;
 
   // Кэшируется на initialize. snippetSupport — gate для вставки `Метод($0)` сниппета и
   // прикрепления `editor.action.triggerParameterHints` к completion item.
@@ -692,11 +694,21 @@ public final class CompletionProvider {
     return CompletionItemKind.Variable;
   }
 
-  private static boolean matches(String name, String lowerPrefix) {
+  /**
+   * Совпадает ли имя кандидата с набранным префиксом. Пустой префикс совпадает со всеми.
+   * Непустой матчится нечётко ({@link FuzzyMatcher}): префикс, непрерывная подстрока в середине
+   * имени и разбросанная подпоследовательность — чтобы {@code Сцена} находил и {@code СтартовыйСценарий},
+   * и {@code ТекущийСценарий}, а не только начинающиеся на префикс.
+   *
+   * @param name        имя кандидата (в исходном регистре).
+   * @param lowerPrefix набранный префикс в нижнем регистре.
+   * @return {@code true}, если кандидат должен попасть в автодополнение.
+   */
+  private boolean matches(String name, String lowerPrefix) {
     if (lowerPrefix.isEmpty()) {
       return true;
     }
-    return name.toLowerCase(Locale.ROOT).startsWith(lowerPrefix);
+    return fuzzyMatcher.matches(name, lowerPrefix);
   }
 
   private static boolean isAfterNew(String line, int prefixStart) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
@@ -29,8 +29,10 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymb
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.variable.VariableKind;
+import com.github._1c_syntax.bsl.languageserver.utils.FuzzyMatcher;
 import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.types.ScriptVariant;
+import lombok.RequiredArgsConstructor;
 import org.apache.commons.collections4.trie.PatriciaTrie;
 import org.apache.commons.lang3.StringUtils;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
@@ -119,7 +121,14 @@ import java.util.concurrent.locks.ReentrantReadWriteLock;
  * рабочих областей). Записи {@link Entry} неизменяемы и безопасно покидают блокировку в составе результата.
  */
 @Component
+@RequiredArgsConstructor
 public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableIndex {
+
+  /**
+   * Нечёткий матчер для fuzzy-хвоста ({@link #searchFuzzyTail(String, Collection, CancelChecker)}):
+   * непрерывная подстрока и подпоследовательность со скорингом позиции.
+   */
+  private final FuzzyMatcher fuzzyMatcher;
 
   /**
    * Частота проверки отмены запроса (раз в N просмотренных записей).
@@ -165,20 +174,9 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
    */
   private static final int SCORE_MULTI_WORD_UNORDERED = 4;
 
-  /**
-   * Скор совпадения запроса как непрерывной подстроки имени (но не префикса слова). Относится к
-   * fuzzy-хвосту ({@link #searchFuzzyTail(String, Collection, CancelChecker)}), а не к древесному
-   * {@link #search(String, CancelChecker)}.
-   */
-  private static final int SCORE_SUBSTRING = 5;
-
-  /**
-   * Базовый скор совпадения запроса как подпоследовательности имени; к нему прибавляется
-   * позиция первого совпавшего символа (более ранняя позиция — релевантнее). Относится к
-   * fuzzy-хвосту ({@link #searchFuzzyTail(String, Collection, CancelChecker)}), а не к древесному
-   * {@link #search(String, CancelChecker)}.
-   */
-  private static final int SCORE_SUBSEQUENCE = 6;
+  // Скоры подстрочного (FuzzyMatcher.SCORE_SUBSTRING = 5) и подпоследовательностного
+  // (FuzzyMatcher.SCORE_SUBSEQUENCE = 6 + позиция) совпадений принадлежат fuzzy-хвосту и живут в
+  // FuzzyMatcher; они ранжируются ниже всех древесных скоров (0..4) этого индекса.
 
   private static final Set<VariableKind> SUPPORTED_VARIABLE_KINDS = EnumSet.of(
     VariableKind.MODULE,
@@ -368,7 +366,8 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
    * потоковой дослыки нижнеранжированных результатов через partial result progress, а не для
    * синхронного ответа. Возвращаются только записи, которых НЕТ в {@code exclude} (сравнение по
    * идентичности), отсортированные тем же {@link Scored}-порядком: подстрочные
-   * ({@link #SCORE_SUBSTRING}) выше подпоследовательностных ({@link #SCORE_SUBSEQUENCE}{@code  + позиция}),
+   * ({@link FuzzyMatcher#SCORE_SUBSTRING}) выше подпоследовательностных
+   * ({@link FuzzyMatcher#SCORE_SUBSEQUENCE}{@code  + позиция}),
    * при равном скоре раньше более короткое имя, затем более ранняя позиция. Пустой запрос даёт пустой
    * список (полная выдача — это путь пустого запроса {@code search}, fuzzy там не нужен).
    * <p>
@@ -409,21 +408,21 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
    * Вычислить скор записи для fuzzy-хвоста, учитывая исключение уже отданных быстрым путём записей.
    * <p>
    * Запись, присутствующая в {@code exclude} (сравнение по идентичности), отбрасывается ({@code -1}),
-   * иначе возвращается её fuzzy-скор {@link #fuzzyScore(String, String)} (тоже {@code -1}, если
-   * совпадения нет). Выделено из цикла
+   * иначе возвращается её fuzzy-скор {@link FuzzyMatcher#fuzzyScore(String, String)} (тоже {@code -1},
+   * если совпадения нет). Выделено из цикла
    * {@link #searchFuzzyTail(String, Collection, CancelChecker)}, чтобы условия отбора не приходилось
    * выражать множественными {@code continue}.
    *
    * @param entry      запись-кандидат
    * @param lowerQuery lowercase-запрос (непустой)
    * @param exclude    записи, уже отданные быстрым путём (сравнение по идентичности)
-   * @return скор {@code >= SCORE_SUBSTRING}, либо {@code -1}, если запись исключена или не совпала
+   * @return скор {@code >= FuzzyMatcher.SCORE_SUBSTRING}, либо {@code -1}, если запись исключена или не совпала
    */
-  private static int fuzzyTailScore(Entry entry, String lowerQuery, Collection<Entry> exclude) {
+  private int fuzzyTailScore(Entry entry, String lowerQuery, Collection<Entry> exclude) {
     if (exclude.contains(entry)) {
       return -1;
     }
-    return fuzzyScore(entry.lowerName(), lowerQuery);
+    return fuzzyMatcher.fuzzyScore(entry.lowerName(), lowerQuery);
   }
 
   /**
@@ -446,49 +445,6 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
     } finally {
       lock.readLock().unlock();
     }
-  }
-
-  /**
-   * Вычислить скор «не-префиксного» fuzzy-совпадения lowercase-имени с lowercase-запросом.
-   * <p>
-   * Меньшее значение — релевантнее: {@link #SCORE_SUBSTRING} — непрерывная подстрока,
-   * {@link #SCORE_SUBSEQUENCE}{@code  + позиция первого совпавшего символа} — подпоследовательность.
-   *
-   * @param lowerName  lowercase-имя символа
-   * @param lowerQuery lowercase-запрос (непустой)
-   * @return скор {@code >= SCORE_SUBSTRING}, либо {@code -1}, если совпадения нет
-   */
-  private static int fuzzyScore(String lowerName, String lowerQuery) {
-    if (lowerName.contains(lowerQuery)) {
-      return SCORE_SUBSTRING;
-    }
-    var firstMatch = subsequenceFirstIndex(lowerName, lowerQuery);
-    if (firstMatch >= 0) {
-      return SCORE_SUBSEQUENCE + firstMatch;
-    }
-    return -1;
-  }
-
-  /**
-   * Проверить, что {@code lowerQuery} — подпоследовательность {@code lowerName}, и вернуть индекс
-   * символа имени, на котором совпал первый символ запроса.
-   *
-   * @param lowerName  lowercase-имя символа
-   * @param lowerQuery lowercase-запрос (непустой)
-   * @return индекс первого совпавшего символа, либо {@code -1}, если не подпоследовательность
-   */
-  private static int subsequenceFirstIndex(String lowerName, String lowerQuery) {
-    var firstMatch = -1;
-    var queryIndex = 0;
-    for (var nameIndex = 0; nameIndex < lowerName.length() && queryIndex < lowerQuery.length(); nameIndex++) {
-      if (lowerName.charAt(nameIndex) == lowerQuery.charAt(queryIndex)) {
-        if (queryIndex == 0) {
-          firstMatch = nameIndex;
-        }
-        queryIndex++;
-      }
-    }
-    return queryIndex == lowerQuery.length() ? firstMatch : -1;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/FuzzyMatcher.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/FuzzyMatcher.java
@@ -1,0 +1,147 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.utils;
+
+import org.springframework.stereotype.Component;
+
+import java.util.Locale;
+
+/**
+ * Нечёткое (fuzzy) сопоставление имени с запросом: непрерывная подстрока в любом
+ * месте имени и разбросанная подпоследовательность, со скорингом качества совпадения.
+ * <p>
+ * Скор — целое, где <b>меньшее значение релевантнее</b>. Лестница совпадений:
+ * точное имя ({@link #SCORE_EXACT}) → префикс полного имени ({@link #SCORE_PREFIX}) →
+ * непрерывная подстрока в середине имени ({@link #SCORE_SUBSTRING}) →
+ * подпоследовательность ({@link #SCORE_SUBSEQUENCE}{@code  + позиция первого совпавшего символа}:
+ * более раннее начало совпадения релевантнее). Несовпадение — {@link #NO_MATCH}.
+ * <p>
+ * Метод {@link #fuzzyScore(String, String)} (только подстрока/подпоследовательность) переиспользуется
+ * как «грязный» fuzzy-хвост поиска по символам воркспейса; {@link #score(String, String)} добавляет
+ * сверху точное/префиксное совпадение и применяется в автодополнении.
+ */
+@Component
+public class FuzzyMatcher {
+
+  /**
+   * Совпадения нет.
+   */
+  public static final int NO_MATCH = -1;
+
+  /**
+   * Скор точного совпадения имени с запросом (наиболее релевантно).
+   */
+  public static final int SCORE_EXACT = 0;
+
+  /**
+   * Скор совпадения полного имени по префиксу запроса.
+   */
+  public static final int SCORE_PREFIX = 1;
+
+  /**
+   * Скор совпадения запроса как непрерывной подстроки имени (но не префикса имени).
+   */
+  public static final int SCORE_SUBSTRING = 5;
+
+  /**
+   * Базовый скор совпадения запроса как подпоследовательности имени; к нему прибавляется
+   * позиция первого совпавшего символа (более ранняя позиция — релевантнее).
+   */
+  public static final int SCORE_SUBSEQUENCE = 6;
+
+  /**
+   * Скор совпадения имени с запросом: точное / префиксное / подстрока / подпоследовательность.
+   * <p>
+   * Имя приводится к нижнему регистру внутри метода ({@link Locale#ROOT}); запрос должен быть
+   * передан уже в нижнем регистре и непустым.
+   *
+   * @param name       имя-кандидат (в исходном регистре)
+   * @param lowerQuery запрос в нижнем регистре, непустой
+   * @return скор {@code >= SCORE_EXACT} (меньше — релевантнее), либо {@link #NO_MATCH}, если совпадения нет
+   */
+  public int score(String name, String lowerQuery) {
+    var lowerName = name.toLowerCase(Locale.ROOT);
+    if (lowerName.equals(lowerQuery)) {
+      return SCORE_EXACT;
+    }
+    if (lowerName.startsWith(lowerQuery)) {
+      return SCORE_PREFIX;
+    }
+    return fuzzyScore(lowerName, lowerQuery);
+  }
+
+  /**
+   * Совпадает ли имя с запросом хотя бы как подпоследовательность (любой уровень лестницы).
+   *
+   * @param name       имя-кандидат (в исходном регистре)
+   * @param lowerQuery запрос в нижнем регистре, непустой
+   * @return {@code true}, если совпадение есть
+   */
+  public boolean matches(String name, String lowerQuery) {
+    return score(name, lowerQuery) != NO_MATCH;
+  }
+
+  /**
+   * Скор «не-префиксного» fuzzy-совпадения lowercase-имени с lowercase-запросом:
+   * непрерывная подстрока ({@link #SCORE_SUBSTRING}) либо подпоследовательность
+   * ({@link #SCORE_SUBSEQUENCE}{@code  + позиция первого совпавшего символа}).
+   * <p>
+   * Оба аргумента должны быть уже в нижнем регистре (приведение — забота вызывающего, у которого
+   * lowercase-имя может быть предвычислено).
+   *
+   * @param lowerName  lowercase-имя кандидата
+   * @param lowerQuery lowercase-запрос, непустой
+   * @return скор {@code >= SCORE_SUBSTRING}, либо {@link #NO_MATCH}, если совпадения нет
+   */
+  public int fuzzyScore(String lowerName, String lowerQuery) {
+    if (lowerName.contains(lowerQuery)) {
+      return SCORE_SUBSTRING;
+    }
+    var firstMatch = subsequenceFirstIndex(lowerName, lowerQuery);
+    if (firstMatch >= 0) {
+      return SCORE_SUBSEQUENCE + firstMatch;
+    }
+    return NO_MATCH;
+  }
+
+  /**
+   * Проверить, что {@code lowerQuery} — подпоследовательность {@code lowerName}, и вернуть индекс
+   * символа имени, на котором совпал первый символ запроса.
+   *
+   * @param lowerName  lowercase-имя кандидата
+   * @param lowerQuery lowercase-запрос, непустой
+   * @return индекс первого совпавшего символа, либо {@code -1}, если не подпоследовательность
+   */
+  private static int subsequenceFirstIndex(String lowerName, String lowerQuery) {
+    var firstMatch = -1;
+    var queryIndex = 0;
+    for (var nameIndex = 0; nameIndex < lowerName.length() && queryIndex < lowerQuery.length(); nameIndex++) {
+      if (lowerName.charAt(nameIndex) == lowerQuery.charAt(queryIndex)) {
+        if (queryIndex == 0) {
+          firstMatch = nameIndex;
+        }
+        queryIndex++;
+      }
+    }
+    return queryIndex == lowerQuery.length() ? firstMatch : -1;
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -420,6 +420,46 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void noDotCompletionMatchesSubstringInsideGlobalName() {
+    // given - набрана подстрока из середины имени глобальной функции «Сообщить»
+    // (startsWith такое не нашёл бы — имя не начинается на «общ»)
+    var content = "общ";
+    var documentContext = TestUtils.getDocumentContext(content);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    // when
+    params.setPosition(new Position(0, 3));
+
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    assertThat(items)
+      .extracting(CompletionItem::getLabel)
+      .contains("Сообщить");
+  }
+
+  @Test
+  void noDotCompletionMatchesSubsequenceInGlobalName() {
+    // given - набрана разбросанная подпоследовательность имени «Сообщить» (С..б..щ),
+    // не являющаяся непрерывной подстрокой
+    var content = "Сбщ";
+    var documentContext = TestUtils.getDocumentContext(content);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    // when
+    params.setPosition(new Position(0, 3));
+
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    assertThat(items)
+      .extracting(CompletionItem::getLabel)
+      .contains("Сообщить");
+  }
+
+  @Test
   void testDotCompletionReturnsPropertiesAsProperties() {
     // ТЗ = Новый ТаблицаЗначений;
     // ТЗ.Колонки.Добавить("Имя");

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
@@ -29,6 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextCo
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
 import com.github._1c_syntax.bsl.languageserver.types.index.WorkspaceSymbolIndex;
+import com.github._1c_syntax.bsl.languageserver.utils.FuzzyMatcher;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.types.MDOType;
@@ -90,7 +91,7 @@ class SymbolProviderScriptVariantTest {
     when(documentContext.getSymbolTree()).thenReturn(symbolTree);
 
     // имя контейнера вычисляется индексом на момент индексации в варианте языка проекта
-    var index = new WorkspaceSymbolIndex();
+    var index = new WorkspaceSymbolIndex(new FuzzyMatcher());
     index.handleContentChanged(new DocumentContextContentChangedEvent(documentContext));
 
     // запрос без partialResultToken: клиент не используется, древесная выдача отдаётся синхронно

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/FuzzyMatcherTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/FuzzyMatcherTest.java
@@ -1,0 +1,111 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.utils;
+
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class FuzzyMatcherTest {
+
+  private final FuzzyMatcher matcher = new FuzzyMatcher();
+
+  @Test
+  void exactMatchScoresHighest() {
+    // given
+    var name = "Сообщить";
+
+    // when
+    var score = matcher.score(name, "сообщить");
+
+    // then
+    assertThat(score).isEqualTo(FuzzyMatcher.SCORE_EXACT);
+  }
+
+  @Test
+  void prefixMatchScoresBelowExact() {
+    // given
+    var name = "Сообщить";
+
+    // when
+    var score = matcher.score(name, "сооб");
+
+    // then
+    assertThat(score).isEqualTo(FuzzyMatcher.SCORE_PREFIX);
+  }
+
+  @Test
+  void substringInsideNameMatches() {
+    // given - «общ» внутри «Сообщить», но не префикс
+    var name = "Сообщить";
+
+    // when
+    var score = matcher.score(name, "общ");
+
+    // then
+    assertThat(score).isEqualTo(FuzzyMatcher.SCORE_SUBSTRING);
+  }
+
+  @Test
+  void subsequenceMatchesAndRanksBelowSubstring() {
+    // given - «Сбщ» — подпоследовательность «Сообщить», но не непрерывная подстрока
+    var name = "Сообщить";
+
+    // when
+    var score = matcher.score(name, "сбщ");
+
+    // then
+    assertThat(score).isGreaterThanOrEqualTo(FuzzyMatcher.SCORE_SUBSEQUENCE);
+    assertThat(matcher.score(name, "общ")).isLessThan(score);
+  }
+
+  @Test
+  void earlierSubsequenceStartRanksBetter() {
+    // given - запрос «аб» совпадает как подпоследовательность с разной позицией старта
+    // when
+    var earlier = matcher.score("абвгд", "ад");
+    var later = matcher.score("xабгд", "ад");
+
+    // then - более раннее начало совпадения релевантнее (меньший скор)
+    assertThat(earlier).isLessThan(later);
+  }
+
+  @Test
+  void noMatchReturnsSentinel() {
+    // given
+    var name = "Сообщить";
+
+    // when
+    var score = matcher.score(name, "xyz");
+
+    // then
+    assertThat(score).isEqualTo(FuzzyMatcher.NO_MATCH);
+    assertThat(matcher.matches(name, "xyz")).isFalse();
+  }
+
+  @Test
+  void matchesIsCaseInsensitiveOnName() {
+    // given - имя в верхнем регистре, запрос уже в нижнем
+    // when / then
+    assertThat(matcher.matches("МАССИВ", "сив")).isTrue();
+  }
+}


### PR DESCRIPTION
Закрывает #4142.

## Проблема

Автодополнение матчило кандидатов только по префиксу (`CompletionProvider.matches()` = `startsWith`), поэтому подстрока в середине слова и разбросанная подпоследовательность на сервере не находились вовсе: набор `Сцена` не показывал `ТекущийСценарий` (он на «Т», в кэше префикса `С*` его не было).

## Решение

- Выделен переиспользуемый компонент **`FuzzyMatcher`** (`utils`): точное / префиксное совпадение, непрерывная подстрока, подпоследовательность со скорингом позиции первого совпавшего символа. Меньший скор — релевантнее.
- `CompletionProvider.matches()` теперь нечёткий через `FuzzyMatcher`. Затрагивает все ветки no-dot/dot completion (глобальные функции/свойства, классы для `Новый`, составные имена MD-объектов, кейворды, локальные методы/переменные, члены типа).
- `WorkspaceSymbolIndex` переиспользует тот же `FuzzyMatcher` в fuzzy-хвосте — дублирующие `fuzzyScore`/`subsequenceFirstIndex` убраны, константы `SCORE_SUBSTRING`/`SCORE_SUBSEQUENCE` переехали в компонент. Поведение и ранжирование `workspace/symbol` не меняются.

## Почему `isIncomplete` остаётся `false`

`isIncomplete=true` заставил бы клиент перезапрашивать completion на каждый keystroke, а каждый такой запрос через `awaitLatest()` ждёт перестройку `DocumentContext` (eager `computeSymbolTree` на весь модуль) — дорого при печати.

Этого не требуется: fuzzy-матч **монотонен** — для запроса `Q1`, у которого `Q0` является префиксом, `match(Q1) ⊆ match(Q0)` (и для подстроки, и для подпоследовательности). Значит набор первого запроса остаётся надмножеством для всего, что пользователь допечатает, и клиент доберёт нужное локальной fuzzy-фильтрацией без перезапроса и без ожидания rebuild.

## Тесты

- `FuzzyMatcherTest` — exact/prefix/substring/subsequence, ранжирование, позиция старта подпоследовательности, регистронезависимость.
- `CompletionProviderTest` — `Сообщить` находится по подстроке `общ` и по подпоследовательности `Сбщ` (given/when/then).
- Прежние `WorkspaceSymbolIndexTest` / `SymbolProvider*Test` остаются зелёными (рефакторинг поведение не меняет).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced fuzzy matching for code completion, enabling matches on non-contiguous character sequences and substrings in addition to standard prefix matching
  * Enhanced symbol search ranking with fuzzy scoring to improve result relevance and ordering

* **Tests**
  * Added comprehensive test coverage for fuzzy matching behavior in code completion and symbol resolution

<!-- end of auto-generated comment: release notes by coderabbit.ai -->