### PR TITLE
feat(lsp): использовать MessageType.Debug для отладочных логов (LSP 3.18)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/LanguageClientAwareAppender.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/LanguageClientAwareAppender.java
@@ -49,8 +49,8 @@ public class LanguageClientAwareAppender
   protected static LanguageClientAwareAppender INSTANCE;
 
   private static final Map<Level, MessageType> loggingLevels = Map.of(
-    Level.TRACE, MessageType.Log,
-    Level.DEBUG, MessageType.Log,
+    Level.TRACE, MessageType.Debug,
+    Level.DEBUG, MessageType.Debug,
     Level.ERROR, MessageType.Error,
     Level.INFO, MessageType.Info,
     Level.WARN, MessageType.Warning

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/LanguageClientAwareAppenderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/LanguageClientAwareAppenderTest.java
@@ -1,0 +1,109 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.infrastructure;
+
+import ch.qos.logback.classic.Level;
+import ch.qos.logback.classic.spi.ILoggingEvent;
+import com.github._1c_syntax.bsl.languageserver.LanguageClientHolder;
+import org.eclipse.lsp4j.MessageParams;
+import org.eclipse.lsp4j.MessageType;
+import org.eclipse.lsp4j.services.LanguageClient;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentCaptor;
+
+import java.io.IOException;
+import java.time.Instant;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
+
+class LanguageClientAwareAppenderTest {
+
+  @ParameterizedTest
+  @CsvSource({
+    "TRACE, Debug",
+    "DEBUG, Debug",
+    "INFO, Info",
+    "WARN, Warning",
+    "ERROR, Error"
+  })
+  void shouldMapLogbackLevelToMessageType(String levelName, String messageTypeName) throws IOException {
+    // given
+    var level = Level.valueOf(levelName);
+    var expectedMessageType = MessageType.valueOf(messageTypeName);
+
+    var languageClient = mock(LanguageClient.class);
+    var clientHolder = mock(LanguageClientHolder.class);
+    when(clientHolder.isConnected()).thenReturn(true);
+    when(clientHolder.getClient()).thenReturn(Optional.of(languageClient));
+
+    var appender = new LanguageClientAwareAppender();
+    appender.setClientHolder(clientHolder);
+
+    var event = mockEvent(level);
+
+    // when
+    appender.writeOut(event);
+
+    // then
+    var captor = ArgumentCaptor.forClass(MessageParams.class);
+    verify(languageClient).logMessage(captor.capture());
+
+    assertThat(captor.getValue().getType()).isEqualTo(expectedMessageType);
+  }
+
+  @Test
+  void shouldNotSendToClientWhenNotConnected() throws IOException {
+    // given
+    var languageClient = mock(LanguageClient.class);
+    var clientHolder = mock(LanguageClientHolder.class);
+    when(clientHolder.isConnected()).thenReturn(false);
+
+    var appender = new LanguageClientAwareAppender();
+    appender.setClientHolder(clientHolder);
+    appender.setEncoder(mock(ch.qos.logback.core.encoder.Encoder.class));
+
+    var event = mockEvent(Level.DEBUG);
+
+    // when
+    appender.writeOut(event);
+
+    // then
+    verifyNoInteractions(languageClient);
+  }
+
+  private static ILoggingEvent mockEvent(Level level) {
+    var event = mock(ILoggingEvent.class);
+    when(event.getLevel()).thenReturn(level);
+    when(event.getInstant()).thenReturn(Instant.EPOCH);
+    when(event.getThreadName()).thenReturn("main");
+    when(event.getLoggerName()).thenReturn("com.example.Logger");
+    when(event.getFormattedMessage()).thenReturn("message");
+    return event;
+  }
+}


### PR DESCRIPTION
LSP 3.18 добавил уровень сообщений MessageType.Debug для window/logMessage.
В мосте SLF4J→LSP (LanguageClientAwareAppender) уровни логирования TRACE и
DEBUG теперь транслируются клиенту как MessageType.Debug вместо MessageType.Log.
Это позволяет клиенту отделять отладочные сообщения от обычного лога.

Добавлены тесты на маппинг уровней логирования в MessageType.

Closes #4153

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01PAS6VLwMmxXp76exqBn4Um

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected classification of debug-level log messages in language server communications to properly identify them as debug messages.

* **Tests**
  * Added comprehensive test suite validating logging level mappings and message delivery behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->