### PR TITLE
fix(inlayhints): не задваивать подсказки параметров конструктора oscript-класса

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplier.java
@@ -29,6 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.languageserver.types.util.SignatureSelection;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
@@ -207,6 +208,12 @@ public class PlatformMethodCallInlayHintSupplier
     var fileType = documentContext.getFileType();
     var ref = typeService.resolve(typeName, fileType).orElse(null);
     if (ref == null) {
+      return;
+    }
+    // Конструкторы source-defined типов (OneScript-классы, ПриСозданииОбъекта)
+    // покрывает SourceDefinedMethodCallInlayHintSupplier — иначе подсказки
+    // имён параметров задвоились бы. Здесь обрабатываем только платформенные.
+    if (ref.kind() == TypeKind.USER) {
       return;
     }
     var constructors = typeService.getConstructors(ref, fileType);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintSupplierTest.java
@@ -45,8 +45,32 @@ class PlatformMethodCallInlayHintSupplierTest extends AbstractServerContextAware
   private static final String FILE_PATH =
     "./src/test/resources/types/PlatformMethodInlayHints.bsl";
 
+  private static final String CONSTRUCTOR_FIXTURE_DIR =
+    "src/test/resources/oscript-libraries/constructor-inlay-test";
+  private static final String CONSTRUCTOR_CALLER_PATH = CONSTRUCTOR_FIXTURE_DIR + "/src/Классы/Caller.os";
+
   @Autowired
   private PlatformMethodCallInlayHintSupplier supplier;
+
+  @Autowired
+  private com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex oScriptLibraryIndex;
+
+  @Test
+  void noHintsForSourceDefinedOScriptConstructor() {
+    // given — конструктор OneScript-класса (ПриСозданииОбъекта) source-defined и
+    // покрывается SourceDefinedMethodCallInlayHintSupplier'ом; платформенный
+    // supplier не должен дублировать эти подсказки.
+    initServerContext(java.nio.file.Path.of(CONSTRUCTOR_FIXTURE_DIR).toAbsolutePath());
+    oScriptLibraryIndex.reindex(context);
+
+    var documentContext = TestUtils.getDocumentContextFromFile(CONSTRUCTOR_CALLER_PATH, context);
+
+    // when
+    var hints = supplier.getInlayHints(documentContext, fullRangeParams(documentContext));
+
+    // then
+    assertThat(hints).isEmpty();
+  }
 
   @Test
   void hintsTooltipContainsTypesAndOptionalLabel() {


### PR DESCRIPTION
Конструктор OneScript-класса (ПриСозданииОбъекта) — source-defined символ,
и подсказки имён его параметров уже выдаёт SourceDefinedMethodCallInlayHintSupplier
(через ссылку на конструктор в индексе). Однако PlatformMethodCallInlayHintSupplier
в ветке Новый Тип(...) резолвил конструкторы любого типа через TypeService и
выдавал те же подсказки повторно — в итоге каждое имя параметра показывалось
дважды в одной позиции.

Ветка обычных методов уже фильтрует source-defined (sourceSymbol == null);
для конструкторов добавлена симметричная фильтрация: платформенный supplier
пропускает типы TypeKind.USER, оставляя их source-defined supplier'у.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01UE1EVZoWWZHyqqCs1UxfhH

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed duplicate inlay hints appearing for user-defined constructors in OneScript code.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->