### PR TITLE
Учитывать variadic-параметры в EventHandlerInvalidSignatureDiagnostic

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnostic.java
@@ -94,8 +94,12 @@ public class EventHandlerInvalidSignatureDiagnostic extends AbstractDiagnostic i
     var requiredCounts = contractSignatures.stream()
       .mapToInt(sig -> (int) sig.parameters().stream().filter(p -> !p.optional()).count())
       .toArray();
+    // Вариадик-хвост (например, конструктор OneScript-класса ПриСозданииОбъекта)
+    // принимает переменное число аргументов — верхняя граница не ограничена.
     var totalCounts = contractSignatures.stream()
-      .mapToInt(sig -> sig.parameters().size())
+      .mapToInt(sig -> hasVariadicTail(sig)
+        ? Integer.MAX_VALUE
+        : sig.parameters().size())
       .toArray();
     int userParamCount = method.getParameters().size();
     if (fitsAnySignature(userParamCount, requiredCounts, totalCounts)) {
@@ -106,6 +110,11 @@ public class EventHandlerInvalidSignatureDiagnostic extends AbstractDiagnostic i
     int expected = Arrays.stream(totalCounts).max().orElse(0);
     diagnosticStorage.addDiagnostic(method.getSubNameRange(),
       info.getMessage(method.getName(), expected, userParamCount));
+  }
+
+  private static boolean hasVariadicTail(SignatureDescriptor signature) {
+    var parameters = signature.parameters();
+    return !parameters.isEmpty() && parameters.get(parameters.size() - 1).variadic();
   }
 
   private static boolean fitsAnySignature(int userParamCount, int[] requiredCounts, int[] totalCounts) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnosticTest.java
@@ -75,6 +75,27 @@ class EventHandlerInvalidSignatureDiagnosticTest
   }
 
   @Test
+  void silentForVariadicContract() {
+    // Конструктор OneScript-класса ПриСозданииОбъекта принимает переменное
+    // число параметров — любое количество объявленных аргументов допустимо.
+    var variadicParam = new ParameterDescriptor(
+      BilingualString.of("Значение", "Value"),
+      TypeSet.EMPTY, true, BilingualString.EMPTY, "", true);
+    var contract = MemberDescriptor.event("ПриЗаписи", "",
+      List.of(new SignatureDescriptor(List.of(variadicParam), TypeSet.EMPTY, "")));
+    stubAsHandler("ПриЗаписи", contract);
+
+    var src = """
+      Процедура ПриЗаписи(КоордХ, КоордУ)
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(src);
+    var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
+
+    assertThat(diagnostics).isEmpty();
+  }
+
+  @Test
   void silentWhenContractEmpty() {
     // Контракт без сигнатур — диагностика молчит (нечем сравнивать).
     stubAsHandler("ПередЗаписью", MemberDescriptor.event("ПередЗаписью", "", List.of()));


### PR DESCRIPTION
Конструктор OneScript-класса ПриСозданииОбъекта принимает переменное
число параметров (variadic-хвост), но диагностика использовала
parameters().size() как жёсткую верхнюю границу арности. Из-за этого
объявление двух и более параметров ложно срабатывало с сообщением
"ожидается до 1 параметров".

Теперь сигнатура с variadic-хвостом считается без верхней границы.

Fixes #4159

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01Y4XVqU9w51WD7kPzQJ23gT

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Event handler signature validation now correctly handles variadic parameters. Event handlers with variadic last parameters are no longer subject to parameter count restrictions and will not trigger invalid signature diagnostics, enabling more flexible event handler implementations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->