### PR TITLE
fix(inlayhints): вести ссылку хинта типа OneScript-класса к конструктору

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplier.java
@@ -54,9 +54,12 @@ import java.util.Optional;
  * Метка хинта рендерится единственной частью {@link InlayHintLabelPart}: когда
  * выведенный тип объявлен в исходниках рабочей области (общий модуль, модуль
  * менеджера объекта конфигурации, класс/модуль OneScript), к части привязывается
- * ссылка ({@link InlayHintLabelPart#setLocation}) на объявление типа — клик по
- * подсказке выполняет переход к модулю/классу. Объявление типа уже известно на
- * этапе построения хинта, поэтому ссылка проставляется жадно. Платформенные и
+ * ссылка ({@link InlayHintLabelPart#setLocation}) на объявляющий символ типа
+ * ({@link com.github._1c_syntax.bsl.languageserver.types.TypeService#definingSymbol}) —
+ * клик по подсказке выполняет переход. Для OneScript-класса этим символом служит
+ * его конструктор {@code ПриСозданииОбъекта} (по нему hover и go-to-definition
+ * осмысленны), для прочих — объявляющий модуль/класс. Символ уже известен на этапе
+ * построения хинта, поэтому ссылка проставляется жадно. Платформенные и
  * примитивные типы ({@code Массив}, {@code Строка}, …) объявляющего
  * исходник-символа не имеют — для них метка остаётся без ссылки.
  * <p>
@@ -148,8 +151,11 @@ public class VariableTypeInlayHintSupplier implements InlayHintSupplier<Variable
       documentContext.getUri(), getId(), inferredType.qualifiedName()
     ));
 
-    // Объявление типа (если есть) уже известно — ссылка части метки проставляется
-    // жадно. Платформенные/примитивные типы исходник-символа не имеют — без ссылки.
+    // Объявляющий символ типа (если есть) уже известен — ссылка части метки
+    // проставляется жадно. Платформенные/примитивные типы исходник-символа не имеют
+    // — без ссылки. Для OneScript-класса definingSymbol возвращает конструктор
+    // ПриСозданииОбъекта: по нему hover и go-to-definition в позиции ссылки
+    // осмысленны, тогда как первый токен модуля-класса часто — ключевое слово Перем.
     typeService.definingSymbol(inferredType, documentContext).ifPresent(declaration -> {
       var targetUri = declaration.getOwner().getUri().toString();
       labelPart.setLocation(new Location(targetUri, declaration.getSelectionRange()));

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.ModuleSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver;
@@ -234,12 +235,15 @@ public class TypeService {
   }
 
   /**
-   * Символ-источник, объявивший тип, если такой есть в исходниках рабочей области.
+   * Символ-источник, объявляющий тип (цель go-to-definition и hover), если такой
+   * есть в исходниках рабочей области.
    * <p>
    * Покрывает типы, у которых есть объявляющий их модуль/класс:
    * <ul>
    *   <li>{@link TypeKind#USER} — пользовательские типы OneScript (классы и модули):
-   *       объявление хранится в самом {@link UserType#getDeclaration()};</li>
+   *       объявление хранится в самом {@link UserType#getDeclaration()}. Для класса
+   *       с конструктором предпочитается символ конструктора
+   *       ({@code ПриСозданииОбъекта}) — см. ниже;</li>
    *   <li>{@link TypeKind#CONFIGURATION} — общие модули и модули менеджеров объектов
    *       конфигурации: документ-модуль находится обратным индексом
    *       {@link GlobalScopeProvider#moduleUriByType(TypeRef)}, а его символ —
@@ -248,6 +252,18 @@ public class TypeService {
    * Для платформенных/примитивных типов ({@link TypeKind#PLATFORM},
    * {@link TypeKind#PRIMITIVE}) и служебных {@code Unknown}/{@code Any}
    * объявляющего исходник-символа нет — возвращается {@code empty}.
+   * <p>
+   * <b>Почему для OneScript-класса предпочтён конструктор, а не модуль.</b> У языка
+   * нет отдельного оператора «объявление класса»: класс — это весь {@code .os}-файл,
+   * а его {@link ModuleSymbol#getSelectionRange()} указывает на первый токен файла,
+   * которым часто оказывается {@code Перем} (объявление поля). Потребитель —
+   * {@code InlayHintLabelPart.location}, семантика которого в клиенте: выполнить
+   * hover и go-to-definition <b>в позиции</b> ссылки. На {@code Перем} hover даёт
+   * бесполезное описание ключевого слова, а go-to-definition не находит
+   * source-defined символа и переход не срабатывает. Имя конструктора — это
+   * source-defined метод: hover показывает его сигнатуру, а go-to-definition ведёт
+   * к нему. Для класса без конструктора и не-USER типов цель — модуль/класс
+   * (переход к началу файла).
    *
    * @param typeRef           тип, чей объявляющий символ нужен.
    * @param requestingContext контекст документа-потребителя; через него находится
@@ -258,10 +274,24 @@ public class TypeService {
    */
   public Optional<SourceDefinedSymbol> definingSymbol(TypeRef typeRef, DocumentContext requestingContext) {
     return switch (typeRef.kind()) {
-      case USER -> userTypeDeclaration(typeRef);
+      case USER -> userTypeDeclaration(typeRef).map(TypeService::preferConstructor);
       case CONFIGURATION -> configurationModuleSymbol(typeRef, requestingContext);
       default -> Optional.empty();
     };
+  }
+
+  /**
+   * Для символа-модуля OneScript-класса предпочесть символ конструктора
+   * {@code ПриСозданииОбъекта}, если он есть; иначе вернуть сам символ-модуль
+   * без изменений.
+   */
+  private static SourceDefinedSymbol preferConstructor(SourceDefinedSymbol declaration) {
+    if (declaration instanceof ModuleSymbol module) {
+      return module.getOwner().getSymbolTree().getConstructor()
+        .map(SourceDefinedSymbol.class::cast)
+        .orElse(declaration);
+    }
+    return declaration;
   }
 
   private Optional<SourceDefinedSymbol> userTypeDeclaration(TypeRef typeRef) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintOScriptLinkTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintOScriptLinkTest.java
@@ -73,7 +73,10 @@ class VariableTypeInlayHintOScriptLinkTest extends AbstractServerContextAwareTes
     var method = documentContext.getSymbolTree().getMethods().getFirst();
     var params = new InlayHintParams(textDocumentIdentifier, method.getRange());
 
-    var loggerUri = Absolute.uri(FIXTURE_ROOT.resolve("src/Логгер.os").toUri());
+    var loggerPath = FIXTURE_ROOT.resolve("src/Логгер.os");
+    var loggerUri = Absolute.uri(loggerPath.toUri());
+    var loggerContext = TestUtils.getDocumentContextFromFile(loggerPath.toString(), context);
+    var loggerConstructor = loggerContext.getSymbolTree().getConstructor().orElseThrow();
 
     // when
     var inlayHints = supplier.getInlayHints(documentContext, params);
@@ -86,8 +89,11 @@ class VariableTypeInlayHintOScriptLinkTest extends AbstractServerContextAwareTes
       .satisfies(this::assertLinksToLogger);
 
     InlayHint inlayHint = inlayHints.getFirst();
-    assertThat(inlayHint.getLabel().getRight().getFirst().getLocation().getUri())
-      .isEqualTo(loggerUri.toString());
+    var location = inlayHint.getLabel().getRight().getFirst().getLocation();
+    assertThat(location.getUri()).isEqualTo(loggerUri.toString());
+    // ссылка ведёт к конструктору ПриСозданииОбъекта, а не к первому токену модуля:
+    // только так hover и go-to-definition в позиции ссылки осмысленны.
+    assertThat(location.getRange()).isEqualTo(loggerConstructor.getSelectionRange());
   }
 
   private void assertLinksToLogger(InlayHint inlayHint) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/TypeServiceDefiningSymbolTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/TypeServiceDefiningSymbolTest.java
@@ -1,0 +1,135 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.ModuleSymbol;
+import com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Покрывает развилку {@link TypeService#definingSymbol} для {@link TypeKind#USER}-типов
+ * OneScript: для класса с конструктором цель — символ конструктора, для класса без
+ * конструктора — символ-модуль, для не-модульного объявления — сам символ как есть,
+ * для платформенного типа — {@code empty}.
+ */
+@CleanupContextBeforeClassAndAfterClass
+class TypeServiceDefiningSymbolTest extends AbstractServerContextAwareTest {
+
+  private static final Path FIXTURE_ROOT =
+    Path.of("src/test/resources/oscript-libraries/autumn-di").toAbsolutePath();
+
+  @Autowired
+  private TypeService typeService;
+
+  @Autowired
+  private TypeRegistry typeRegistry;
+
+  @Autowired
+  private com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex index;
+
+  private com.github._1c_syntax.bsl.languageserver.context.DocumentContext requestingContext;
+
+  @BeforeEach
+  void setup() {
+    initServerContext(FIXTURE_ROOT, false);
+    index.reindex(context);
+    // Для USER-ветки requestingContext не используется — годится любой документ.
+    requestingContext = TestUtils.getDocumentContextFromFile(
+      FIXTURE_ROOT.resolve("src/Логгер.os").toString(), context);
+  }
+
+  @Test
+  void classWithConstructorResolvesToConstructorSymbol() {
+    // given: «Логгер» объявляет ПриСозданииОбъекта.
+    var typeRef = typeService.resolve("Логгер", FileType.OS).orElseThrow();
+
+    // when
+    var symbol = typeService.definingSymbol(typeRef, requestingContext);
+
+    // then
+    assertThat(symbol)
+      .as("класс с конструктором должен резолвиться в ConstructorSymbol")
+      .get()
+      .isInstanceOf(ConstructorSymbol.class);
+  }
+
+  @Test
+  void classWithoutConstructorResolvesToModuleSymbol() {
+    // given: «Лог» — класс без ПриСозданииОбъекта (ветка orElse в preferConstructor).
+    var typeRef = typeService.resolve("Лог", FileType.OS).orElseThrow();
+
+    // when
+    var symbol = typeService.definingSymbol(typeRef, requestingContext);
+
+    // then
+    assertThat(symbol)
+      .as("класс без конструктора должен резолвиться в ModuleSymbol")
+      .get()
+      .isInstanceOf(ModuleSymbol.class);
+  }
+
+  @Test
+  void platformTypeHasNoDefiningSymbol() {
+    // given: платформенный «Массив» объявляющего исходник-символа не имеет.
+    var typeRef = typeService.resolve("Массив", FileType.OS).orElseThrow();
+
+    // when
+    var symbol = typeService.definingSymbol(typeRef, requestingContext);
+
+    // then
+    assertThat(symbol)
+      .as("платформенный тип не имеет объявляющего символа в исходниках")
+      .isEmpty();
+  }
+
+  @Test
+  void nonModuleDeclarationIsReturnedAsIs() {
+    // given: defensive-ветка preferConstructor — объявление типа не ModuleSymbol.
+    // На практике registerUserType всегда получает ModuleSymbol, поэтому собираем
+    // искусственный USER-тип, объявление которого — метод класса «Лог».
+    var logContext = TestUtils.getDocumentContextFromFile(
+      FIXTURE_ROOT.resolve("src/Лог.os").toString(), context);
+    MethodSymbol method = logContext.getSymbolTree().getMethods().getFirst();
+    var typeRef = typeRegistry.registerUserType("ИскусственныйНемодульныйТип", method, FileType.OS);
+
+    // when
+    var symbol = typeService.definingSymbol(typeRef, requestingContext);
+
+    // then
+    assertThat(symbol)
+      .as("не-модульное объявление возвращается без изменений")
+      .get()
+      .isSameAs(method);
+  }
+}


### PR DESCRIPTION
Для inlay-хинта выведенного типа ссылка части метки указывала на
ModuleSymbol.selectionRange — первый токен файла класса. У OneScript-класса
это часто `Перем X Экспорт;`, поэтому по семантике InlayHintLabelPart.location
(редактор выполняет hover и go-to-definition в позиции ссылки) ховер показывал
бесполезное описание ключевого слова «Перем», а переход не срабатывал
(на ключевом слове нет source-defined символа).

TypeService.definingSymbol для USER-типа теперь предпочитает символ
конструктора ПриСозданииОбъекта: по нему ховер показывает сигнатуру,
а go-to-definition ведёт к конструктору. Для класса без конструктора и
не-USER типов поведение прежнее (модуль/класс). definingUri (MCP definedAt)
не затронут — конструктор лежит в том же файле.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E62gU2XQC9P3axN9mGR69P

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved inlay hint linking behavior for OneScript classes to target constructor symbols when available, providing more precise navigation to class initialization code.

* **Tests**
  * Updated test coverage to verify correct linking of type hints to constructor symbols for OneScript classes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->