### PR TITLE
Отделять счётчик вариантов синтаксиса от имени в labelDetails

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -1088,7 +1088,7 @@ public final class CompletionProvider {
       }
       var labelDetails = new CompletionItemLabelDetails();
       if (!signature.isBlank()) {
-        labelDetails.setDetail(signature);
+        labelDetails.setDetail(formatLabelDetail(signature));
       }
       if (!type.isBlank()) {
         labelDetails.setDescription(type);
@@ -1106,6 +1106,24 @@ public final class CompletionProvider {
     if (sb.length() > 0) {
       item.setDetail(sb.toString());
     }
+  }
+
+  /**
+   * Готовит значение для {@link CompletionItemLabelDetails#setDetail}: клиент рендерит его вплотную
+   * к label, без разделителя. Список параметров «{@code (...)}» так и должен примыкать к имени
+   * («{@code Метод(Пар)}»), а вот счётчик вариантов синтаксиса иначе склеивается с именем типа
+   * («{@code Массив3 варианта синтаксиса}»), поэтому его отделяем пробелом и берём в скобки —
+   * получается «{@code Массив (3 варианта синтаксиса)}». Распознаём список параметров по ведущей
+   * «{@code (}» (счётчик вариантов с неё не начинается).
+   *
+   * @param signature сигнатура «{@code (...)}» либо строка-счётчик вариантов синтаксиса.
+   * @return значение для {@code labelDetails.detail}.
+   */
+  private static String formatLabelDetail(String signature) {
+    if (signature.startsWith("(")) {
+      return signature;
+    }
+    return " (" + signature + ")";
   }
 
   /** Сигнатура «{@code (Пар1, Пар2?)}» с пометкой «?» у необязательных параметров. */

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -1449,6 +1449,39 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void multiSignatureCountInLabelDetailsIsSeparatedFromLabel() {
+    // given
+    // Счётчик вариантов синтаксиса в labelDetails.detail клиент рендерит вплотную к label,
+    // поэтому без разделителя имя и счётчик слипались («Массив3 варианта синтаксиса»). Ожидаем,
+    // что счётчик отделён пробелом и взят в скобки: label + detail « (N вариантов синтаксиса)».
+    // Метод Скопировать у ТаблицаЗначений имеет несколько вариантов синтаксиса.
+    enableLabelDetailsSupport(true);
+    var documentContext = TestUtils.getDocumentContext("ТЗ = Новый ТаблицаЗначений;\nТЗ.");
+
+    // when
+    CompletionItem copy;
+    languageServerConfiguration.setLanguage(Language.RU);
+    try {
+      copy = dotCompletionItem(documentContext, new Position(1, 3), "Скопировать");
+    } finally {
+      languageServerConfiguration.setLanguage(Language.DEFAULT_LANGUAGE);
+    }
+
+    // then
+    var labelDetails = copy.getLabelDetails();
+    assertThat(labelDetails)
+      .as("при поддержке labelDetailsSupport счётчик вариантов кладётся в labelDetails")
+      .isNotNull();
+    assertThat(labelDetails.getDetail())
+      .as("счётчик вариантов синтаксиса отделён пробелом и взят в скобки, чтобы не слипаться с label")
+      .startsWith(" (")
+      .endsWith("синтаксиса)");
+    assertThat(copy.getDetail())
+      .as("плоский detail не дублируется при labelDetails")
+      .isNull();
+  }
+
+  @Test
   void propertyTypeGoesToLabelDetailsDescriptionWhenClientSupportsLabelDetails() {
     // given
     enableLabelDetailsSupport(true);


### PR DESCRIPTION
В автодополнении при поддержке клиентом completionItem.labelDetailsSupport
счётчик вариантов синтаксиса кладётся в labelDetails.detail, который клиент
рендерит вплотную к label без разделителя. Из-за этого имя и счётчик слипались:
«Массив3 варианта синтаксиса».

Теперь счётчик отделяется пробелом и берётся в скобки —
«Массив (3 варианта синтаксиса)». Список параметров «(...)» по-прежнему
примыкает к имени («Метод(Пар)»), как и положено сигнатуре.

Co-Authored-By: Claude Opus 4.8 (1M context) <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_013JeypFddC4Yt74YmZsdwML

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Enhanced signature formatting in code completion suggestions to improve display with label details support, ensuring proper spacing and parentheses formatting for method and property signatures.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->