### PR TITLE
Replace Spring's @Nullable with JSpecify @Nullable annotation

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FoldingRangeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/FoldingRangeProvider.java
@@ -31,8 +31,8 @@ import org.eclipse.lsp4j.FoldingRange;
 import org.eclipse.lsp4j.FoldingRangeCapabilities;
 import org.eclipse.lsp4j.FoldingRangeSupportCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
+import org.jspecify.annotations.Nullable;
 import org.springframework.context.event.EventListener;
-import org.springframework.lang.Nullable;
 import org.springframework.stereotype.Component;
 
 import java.util.Collection;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapperTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpToolSpecificationsBootstrapWrapperTest.java
@@ -65,7 +65,7 @@ class McpToolSpecificationsBootstrapWrapperTest {
   }
 
   private static CallToolRequest emptyRequest(String name) {
-    return CallToolRequest.builder().name(name).build();
+    return CallToolRequest.builder(name).build();
   }
 
   private static ObjectProvider<McpRootsBootstrapper> providerOf(McpRootsBootstrapper bootstrapper) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FoldingRangeProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/FoldingRangeProviderTest.java
@@ -31,10 +31,10 @@ import org.eclipse.lsp4j.FoldingRangeSupportCapabilities;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
+import org.jspecify.annotations.Nullable;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
-import org.springframework.lang.Nullable;
 import org.springframework.test.context.bean.override.mockito.MockitoSpyBean;
 
 import java.util.List;


### PR DESCRIPTION
## Описание
Заменены импорты аннотации `@Nullable` с `org.springframework.lang.Nullable` на `org.jspecify.annotations.Nullable` в двух файлах:
- `FoldingRangeProvider.java`
- `FoldingRangeProviderTest.java`

Также исправлен вызов builder-метода в `McpToolSpecificationsBootstrapWrapperTest.java` - изменен с `.name(name).build()` на конструктор-подобный вызов `.builder(name).build()`.

## Связанные задачи
Closes 

## Чеклист

### Общие

- [ ] Ветка PR обновлена из develop
- [ ] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно
Изменения касаются миграции на JSpecify аннотации для лучшей совместимости и стандартизации null-safety аннотаций в проекте.

https://claude.ai/code/session_01PkqfaZ2F1s8JiMAP1zi5ca

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Standardized nullable annotations across the codebase for improved code consistency.
  * Updated test helper methods for better code clarity.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->