### PR TITLE
Fix trailing variable description links and semantic token positions

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ dependencies {
     api("org.springframework.ai:spring-ai-starter-mcp-server-webmvc")
 
     // 1c-syntax
-    api("io.github.1c-syntax:bsl-parser:0.37.0")
+    api("io.github.1c-syntax:bsl-parser:0.37.1")
     api("io.github.1c-syntax:utils:0.7.2")
     api("io.github.1c-syntax:mdclasses:0.19.1")
     api("io.github.1c-syntax:bsl-common-library:0.11.0")

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ dependencies {
     api("org.springframework.ai:spring-ai-starter-mcp-server-webmvc")
 
     // 1c-syntax
-    api("io.github.1c-syntax:bsl-parser:0.36.0")
+    api("io.github.1c-syntax:bsl-parser:0.37.0")
     api("io.github.1c-syntax:utils:0.7.2")
     api("io.github.1c-syntax:mdclasses:0.19.1")
     api("io.github.1c-syntax:bsl-common-library:0.11.0")

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/documentlink/SeeReferenceDocumentLinkSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/documentlink/SeeReferenceDocumentLinkSupplier.java
@@ -25,6 +25,8 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Describable;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.parser.description.SourceDefinedSymbolDescription;
+import com.github._1c_syntax.bsl.parser.description.VariableDescription;
 import com.github._1c_syntax.bsl.parser.description.support.Hyperlink;
 import com.github._1c_syntax.bsl.parser.description.support.SimpleRange;
 import com.github._1c_syntax.bsl.types.ModuleType;
@@ -66,13 +68,35 @@ public class SeeReferenceDocumentLinkSupplier implements DocumentLinkSupplier {
       symbolTree.getVariables().stream()
     ).forEach(describable ->
       describable.getDescription().ifPresent(description ->
-        description.getLinks().forEach(link ->
-          addLinkIfResolvable(documentContext, link, documentLinks)
-        )
+        addLinksFromDescription(documentContext, description, documentLinks)
       )
     );
 
     return documentLinks;
+  }
+
+  /**
+   * Добавляет ссылки «См.» из описания символа, включая описание висячего (trailing)
+   * комментария переменной.
+   * <p>
+   * Висячий комментарий ({@code Перем П; // См. ДругойМетод}) хранится отдельным
+   * {@link VariableDescription} в {@link VariableDescription#getTrailingDescription()},
+   * и его ссылки не попадают в {@code getLinks()} основного описания, поэтому обрабатываются явно.
+   */
+  private static void addLinksFromDescription(
+    DocumentContext documentContext,
+    SourceDefinedSymbolDescription description,
+    List<DocumentLink> documentLinks
+  ) {
+    description.getLinks().forEach(link ->
+      addLinkIfResolvable(documentContext, link, documentLinks)
+    );
+
+    if (description instanceof VariableDescription variableDescription) {
+      variableDescription.getTrailingDescription().ifPresent(trailingDescription ->
+        addLinksFromDescription(documentContext, trailingDescription, documentLinks)
+      );
+    }
   }
 
   private static void addLinkIfResolvable(

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/documentlink/TypeDefinitionDocumentLinkSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/documentlink/TypeDefinitionDocumentLinkSupplier.java
@@ -1,0 +1,150 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.documentlink;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.Describable;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
+import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.parser.description.SourceDefinedSymbolDescription;
+import com.github._1c_syntax.bsl.parser.description.VariableDescription;
+import com.github._1c_syntax.bsl.parser.description.support.DescriptionElement;
+import lombok.RequiredArgsConstructor;
+import org.eclipse.lsp4j.DocumentLink;
+import org.springframework.stereotype.Component;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Optional;
+import java.util.stream.Stream;
+
+/**
+ * Сапплаер кликабельных ссылок на тип в описаниях символов (методов и переменных).
+ * <p>
+ * В doc-комментарии типы упоминаются в структурных позициях (типы параметров/возвращаемого
+ * значения метода, тип переменной по нотации «тип в начале»). Сапплаер разрешает каждое такое
+ * имя типа через {@link TypeService} и, если у типа есть объявляющий исходный символ
+ * ({@link TypeService#definingSymbol}), формирует {@link DocumentLink} на его местоположение.
+ * <p>
+ * Ссылки создаются только для типов с источниковым символом ({@code USER}/{@code CONFIGURATION}):
+ * платформенные/примитивные типы объявляющего символа не имеют и пропускаются. Это же служит
+ * гвардом для описаний переменных — произвольный текст в висячем комментарии не резолвится
+ * в тип и ссылку не порождает.
+ */
+@Component
+@RequiredArgsConstructor
+public class TypeDefinitionDocumentLinkSupplier implements DocumentLinkSupplier {
+
+  private final TypeService typeService;
+
+  @Override
+  public List<DocumentLink> getDocumentLinks(DocumentContext documentContext) {
+    var documentLinks = new ArrayList<DocumentLink>();
+
+    var symbolTree = documentContext.getSymbolTree();
+    Stream.<Describable>concat(
+      symbolTree.getMethods().stream(),
+      symbolTree.getVariables().stream()
+    ).forEach(describable ->
+      describable.getDescription().ifPresent(description ->
+        addTypeLinksFromDescription(documentContext, description, documentLinks)
+      )
+    );
+
+    return documentLinks;
+  }
+
+  private void addTypeLinksFromDescription(
+    DocumentContext documentContext,
+    SourceDefinedSymbolDescription description,
+    List<DocumentLink> documentLinks
+  ) {
+    for (var element : description.getElements()) {
+      if (element.type() != DescriptionElement.Type.TYPE_NAME) {
+        continue;
+      }
+      addTypeLink(documentContext, description, element, documentLinks);
+    }
+
+    if (description instanceof VariableDescription variableDescription) {
+      variableDescription.getTrailingDescription().ifPresent(trailingDescription ->
+        addTypeLinksFromDescription(documentContext, trailingDescription, documentLinks)
+      );
+    }
+  }
+
+  private void addTypeLink(
+    DocumentContext documentContext,
+    SourceDefinedSymbolDescription description,
+    DescriptionElement element,
+    List<DocumentLink> documentLinks
+  ) {
+    elementText(element, description)
+      .flatMap(typeName -> typeService.resolve(typeName, documentContext.getFileType()))
+      .flatMap(typeRef -> typeService.definingSymbol(typeRef, documentContext))
+      .ifPresent(symbol -> {
+        var elementRange = element.range();
+        var range = Ranges.create(
+          elementRange.startLine(),
+          elementRange.startCharacter(),
+          elementRange.endLine(),
+          elementRange.endCharacter()
+        );
+        documentLinks.add(new DocumentLink(range, symbolTarget(symbol)));
+      });
+  }
+
+  /**
+   * Читает текст элемента описания (имя типа) из исходного текста описания по диапазону элемента.
+   * <p>
+   * Диапазон элемента абсолютный; первая строка описания начинается со столбца
+   * {@code range.startCharacter()}, остальные — со столбца 0.
+   */
+  private static Optional<String> elementText(
+    DescriptionElement element,
+    SourceDefinedSymbolDescription description
+  ) {
+    var lines = description.getDescription().split("\n", -1);
+    var descriptionRange = description.getRange();
+    var elementRange = element.range();
+
+    int lineIdx = elementRange.startLine() - descriptionRange.startLine();
+    if (lineIdx < 0 || lineIdx >= lines.length) {
+      return Optional.empty();
+    }
+
+    var lineText = lines[lineIdx];
+    int start = elementRange.startCharacter() - (lineIdx == 0 ? descriptionRange.startCharacter() : 0);
+    int end = start + elementRange.length();
+    if (start < 0 || end > lineText.length() || start >= end) {
+      return Optional.empty();
+    }
+
+    return Optional.of(lineText.substring(start, end));
+  }
+
+  private static String symbolTarget(SourceDefinedSymbol symbol) {
+    var start = symbol.getSelectionRange().getStart();
+    return "%s#L%d,%d".formatted(symbol.getOwner().getUri(), start.getLine() + 1, start.getCharacter() + 1);
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/documentlink/TypeDefinitionDocumentLinkSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/documentlink/TypeDefinitionDocumentLinkSupplier.java
@@ -25,31 +25,32 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Describable;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.utils.DescriptionTypes;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.parser.description.SourceDefinedSymbolDescription;
+import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import com.github._1c_syntax.bsl.parser.description.VariableDescription;
-import com.github._1c_syntax.bsl.parser.description.support.DescriptionElement;
+import com.github._1c_syntax.bsl.parser.description.support.SimpleRange;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.DocumentLink;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
 import java.util.List;
-import java.util.Optional;
 import java.util.stream.Stream;
 
 /**
  * Сапплаер кликабельных ссылок на тип в описаниях символов (методов и переменных).
  * <p>
- * В doc-комментарии типы упоминаются в структурных позициях (типы параметров/возвращаемого
- * значения метода, тип переменной по нотации «тип в начале»). Сапплаер разрешает каждое такое
- * имя типа через {@link TypeService} и, если у типа есть объявляющий исходный символ
- * ({@link TypeService#definingSymbol}), формирует {@link DocumentLink} на его местоположение.
+ * В doc-комментарии типы упоминаются как типы параметров/возвращаемого значения метода и как
+ * тип переменной (нотация «тип в начале», в т.ч. в висячем комментарии). Идентичность типа берётся
+ * из семантических аксессоров парсера ({@link DescriptionTypes#typesOf}), а не из координат текста.
+ * Каждое имя типа разрешается через {@link TypeService}; если у типа есть объявляющий исходный символ
+ * ({@link TypeService#definingSymbol}), формируется {@link DocumentLink} на его местоположение.
  * <p>
  * Ссылки создаются только для типов с источниковым символом ({@code USER}/{@code CONFIGURATION}):
- * платформенные/примитивные типы объявляющего символа не имеют и пропускаются. Это же служит
- * гвардом для описаний переменных — произвольный текст в висячем комментарии не резолвится
- * в тип и ссылку не порождает.
+ * платформенные/примитивные типы объявляющего символа не имеют и пропускаются. Это же служит гвардом
+ * для описаний переменных — произвольный текст в висячем комментарии не резолвится в тип.
  */
 @Component
 @RequiredArgsConstructor
@@ -79,12 +80,8 @@ public class TypeDefinitionDocumentLinkSupplier implements DocumentLinkSupplier 
     SourceDefinedSymbolDescription description,
     List<DocumentLink> documentLinks
   ) {
-    for (var element : description.getElements()) {
-      if (element.type() != DescriptionElement.Type.TYPE_NAME) {
-        continue;
-      }
-      addTypeLink(documentContext, description, element, documentLinks);
-    }
+    DescriptionTypes.typesOf(description)
+      .forEach(type -> addTypeLink(documentContext, type, documentLinks));
 
     if (description instanceof VariableDescription variableDescription) {
       variableDescription.getTrailingDescription().ifPresent(trailingDescription ->
@@ -95,15 +92,18 @@ public class TypeDefinitionDocumentLinkSupplier implements DocumentLinkSupplier 
 
   private void addTypeLink(
     DocumentContext documentContext,
-    SourceDefinedSymbolDescription description,
-    DescriptionElement element,
+    TypeDescription type,
     List<DocumentLink> documentLinks
   ) {
-    elementText(element, description)
-      .flatMap(typeName -> typeService.resolve(typeName, documentContext.getFileType()))
+    var name = DescriptionTypes.resolveName(type);
+    if (name.isBlank()) {
+      return;
+    }
+
+    typeService.resolve(name, documentContext.getFileType())
       .flatMap(typeRef -> typeService.definingSymbol(typeRef, documentContext))
       .ifPresent(symbol -> {
-        var elementRange = element.range();
+        SimpleRange elementRange = type.element().range();
         var range = Ranges.create(
           elementRange.startLine(),
           elementRange.startCharacter(),
@@ -112,35 +112,6 @@ public class TypeDefinitionDocumentLinkSupplier implements DocumentLinkSupplier 
         );
         documentLinks.add(new DocumentLink(range, symbolTarget(symbol)));
       });
-  }
-
-  /**
-   * Читает текст элемента описания (имя типа) из исходного текста описания по диапазону элемента.
-   * <p>
-   * Диапазон элемента абсолютный; первая строка описания начинается со столбца
-   * {@code range.startCharacter()}, остальные — со столбца 0.
-   */
-  private static Optional<String> elementText(
-    DescriptionElement element,
-    SourceDefinedSymbolDescription description
-  ) {
-    var lines = description.getDescription().split("\n", -1);
-    var descriptionRange = description.getRange();
-    var elementRange = element.range();
-
-    int lineIdx = elementRange.startLine() - descriptionRange.startLine();
-    if (lineIdx < 0 || lineIdx >= lines.length) {
-      return Optional.empty();
-    }
-
-    var lineText = lines[lineIdx];
-    int start = elementRange.startCharacter() - (lineIdx == 0 ? descriptionRange.startCharacter() : 0);
-    int end = start + elementRange.length();
-    if (start < 0 || end > lineText.length() || start >= end) {
-      return Optional.empty();
-    }
-
-    return Optional.of(lineText.substring(start, end));
   }
 
   private static String symbolTarget(SourceDefinedSymbol symbol) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplier.java
@@ -231,8 +231,14 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
     List<SemanticTokenEntry> elements,
     int charOffset
   ) {
-    int lineEnd = lineText.length();
-    int currentPos = 0;
+    // Позиции элементов приходят от парсера в абсолютных координатах файла, а charOffset —
+    // это абсолютный столбец начала строки описания (ненулевой для висячих/trailing комментариев,
+    // которые начинаются не с начала строки). Поэтому работаем в абсолютных координатах:
+    // прибавлять charOffset к позиции элемента нельзя — это приводило к двойному смещению
+    // и «съезжавшей» подсветке типов в висячих (trailing) комментариях.
+    int lineStart = charOffset;
+    int lineEnd = charOffset + lineText.length();
+    int currentPos = lineStart;
 
     for (var element : elements) {
       int elementStart = element.start();
@@ -240,13 +246,12 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
       int elementEnd = elementStart + elementLength;
 
       if (currentPos < elementStart) {
-        addDocCommentRange(entries, fileLine, charOffset + currentPos, elementStart - currentPos);
+        addDocCommentRange(entries, fileLine, currentPos, elementStart - currentPos);
       }
 
-      // Add the element with adjusted position
       entries.add(new SemanticTokenEntry(
         fileLine,
-        charOffset + elementStart,
+        elementStart,
         elementLength,
         element.type(),
         element.modifiers()
@@ -256,7 +261,7 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
     }
 
     if (currentPos < lineEnd) {
-      addDocCommentRange(entries, fileLine, charOffset + currentPos, lineEnd - currentPos);
+      addDocCommentRange(entries, fileLine, currentPos, lineEnd - currentPos);
     }
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplier.java
@@ -23,7 +23,9 @@ package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
+import com.github._1c_syntax.bsl.languageserver.types.TypeService;
 import com.github._1c_syntax.bsl.parser.description.SourceDefinedSymbolDescription;
+import com.github._1c_syntax.bsl.parser.description.support.DescriptionElement;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -52,6 +54,7 @@ import java.util.Optional;
 public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
 
   private final SemanticTokensHelper helper;
+  private final TypeService typeService;
 
   @Setter
   private boolean multilineTokenSupport;
@@ -72,19 +75,23 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
     List<SemanticTokenEntry> entries = new ArrayList<>();
     var symbolTree = documentContext.getSymbolTree();
 
-    // Process method descriptions
+    // Process method descriptions. Типы параметров/возврата в описаниях методов задаются
+    // структурно (после «Параметры:»/«Возвращаемое значение:»), поэтому подсвечиваются без
+    // проверки резолва — чтобы не терять подсветку конфигурационных типов без загруженных метаданных.
     for (var method : symbolTree.getMethods()) {
       method.getDescription().ifPresent(description ->
-        addBslDocDescriptionTokens(entries, description, multilineTokenSupport)
+        addBslDocDescriptionTokens(entries, description, multilineTokenSupport, documentContext, false)
       );
     }
 
-    // Process variable descriptions
+    // Process variable descriptions. Тип переменной берётся из первого токена описания
+    // (нотация «тип в начале»), что для свободного текста даёт ложные срабатывания. Поэтому
+    // подсвечиваем как тип только то, что резолвится в реальный тип.
     for (var variable : symbolTree.getVariables()) {
       variable.getDescription().ifPresent(description -> {
-        addBslDocDescriptionTokens(entries, description, multilineTokenSupport);
+        addBslDocDescriptionTokens(entries, description, multilineTokenSupport, documentContext, true);
         description.getTrailingDescription().ifPresent(trailing ->
-          addBslDocDescriptionTokens(entries, trailing, multilineTokenSupport)
+          addBslDocDescriptionTokens(entries, trailing, multilineTokenSupport, documentContext, true)
         );
       });
     }
@@ -95,7 +102,9 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
   private void addBslDocDescriptionTokens(
     List<SemanticTokenEntry> entries,
     SourceDefinedSymbolDescription description,
-    boolean multilineTokenSupport
+    boolean multilineTokenSupport,
+    DocumentContext documentContext,
+    boolean validateTypeResolution
   ) {
     var range = description.getRange();
     if (range.isEmpty()) {
@@ -111,12 +120,20 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
     int fileStartLine = range.startLine();
     int fileStartChar = range.startCharacter();
 
+    // Split the description text into lines to get line lengths (also used to read element texts)
+    var lines = descriptionText.split("\n", -1);
+
+    var fileType = documentContext.getFileType();
+
     // Collect semantic elements from AST (parameter names, types, and keywords in structural positions)
     var semanticElements = new ArrayList<SemanticTokenEntry>();
 
     for (var element : description.getElements()) {
       var semanticType = switch (element.type()) {
-        case TYPE_NAME -> SemanticTokenTypes.Type;
+        case TYPE_NAME -> typeName(element, lines, fileStartLine, fileStartChar)
+          .filter(name -> !validateTypeResolution || typeService.resolve(name, fileType).isPresent())
+          .map(name -> SemanticTokenTypes.Type)
+          .orElse("");
         case PARAMETER_NAME -> SemanticTokenTypes.Parameter;
         case RETURNS_KEYWORD, EXAMPLE_KEYWORD, PARAMETERS_KEYWORD, DEPRECATE_KEYWORD,
              CALL_OPTIONS_KEYWORD -> SemanticTokenTypes.Macro;
@@ -134,9 +151,6 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
     for (var element : semanticElements) {
       elementsByLine.computeIfAbsent(element.line(), k -> new ArrayList<>()).add(element);
     }
-
-    // Split the description text into lines to get line lengths
-    var lines = descriptionText.split("\n", -1);
 
     if (multilineTokenSupport) {
       addBslDocTokensWithMultilineSupport(entries, lines, elementsByLine, fileStartLine, fileStartChar);
@@ -263,6 +277,36 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
     if (currentPos < lineEnd) {
       addDocCommentRange(entries, fileLine, currentPos, lineEnd - currentPos);
     }
+  }
+
+  /**
+   * Читает текст элемента описания (например, имя типа) из строк описания по его диапазону.
+   * <p>
+   * Диапазон элемента — абсолютный (координаты файла); первая строка описания начинается
+   * со столбца {@code fileStartChar}, остальные — со столбца 0.
+   *
+   * @return текст элемента, либо {@link Optional#empty()}, если диапазон выходит за пределы строк.
+   */
+  private static Optional<String> typeName(
+    DescriptionElement element,
+    String[] lines,
+    int fileStartLine,
+    int fileStartChar
+  ) {
+    var elementRange = element.range();
+    int lineIdx = elementRange.startLine() - fileStartLine;
+    if (lineIdx < 0 || lineIdx >= lines.length) {
+      return Optional.empty();
+    }
+
+    var lineText = lines[lineIdx];
+    int start = elementRange.startCharacter() - (lineIdx == 0 ? fileStartChar : 0);
+    int end = start + elementRange.length();
+    if (start < 0 || end > lineText.length() || start >= end) {
+      return Optional.empty();
+    }
+
+    return Optional.of(lineText.substring(start, end));
   }
 
   private void addDocCommentRange(List<SemanticTokenEntry> entries, int line, int start, int length) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplier.java
@@ -24,8 +24,9 @@ package com.github._1c_syntax.bsl.languageserver.semantictokens;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializeRequestReceivedEvent;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.utils.DescriptionTypes;
 import com.github._1c_syntax.bsl.parser.description.SourceDefinedSymbolDescription;
-import com.github._1c_syntax.bsl.parser.description.support.DescriptionElement;
+import com.github._1c_syntax.bsl.parser.description.support.SimpleRange;
 import lombok.RequiredArgsConstructor;
 import lombok.Setter;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -43,6 +44,8 @@ import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.Set;
+import java.util.stream.Collectors;
 
 /**
  * Сапплаер семантических токенов для BSL документации (описаний методов и переменных).
@@ -120,20 +123,23 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
     int fileStartLine = range.startLine();
     int fileStartChar = range.startCharacter();
 
-    // Split the description text into lines to get line lengths (also used to read element texts)
+    // Split the description text into lines to get line lengths
     var lines = descriptionText.split("\n", -1);
 
-    var fileType = documentContext.getFileType();
+    // Диапазоны типов, резолвящихся в реальный тип. Для описаний переменных это гвард: нотация
+    // «тип в начале» иначе подсветила бы любой первый токен висячего комментария. Для описаний
+    // методов проверка не нужна (validateTypeResolution = false) — типы заданы структурно.
+    var resolvableTypeRanges = validateTypeResolution
+      ? resolvableTypeRanges(description, documentContext)
+      : Set.<SimpleRange>of();
 
     // Collect semantic elements from AST (parameter names, types, and keywords in structural positions)
     var semanticElements = new ArrayList<SemanticTokenEntry>();
 
     for (var element : description.getElements()) {
       var semanticType = switch (element.type()) {
-        case TYPE_NAME -> typeName(element, lines, fileStartLine, fileStartChar)
-          .filter(name -> !validateTypeResolution || typeService.resolve(name, fileType).isPresent())
-          .map(name -> SemanticTokenTypes.Type)
-          .orElse("");
+        case TYPE_NAME -> !validateTypeResolution || resolvableTypeRanges.contains(element.range())
+          ? SemanticTokenTypes.Type : "";
         case PARAMETER_NAME -> SemanticTokenTypes.Parameter;
         case RETURNS_KEYWORD, EXAMPLE_KEYWORD, PARAMETERS_KEYWORD, DEPRECATE_KEYWORD,
              CALL_OPTIONS_KEYWORD -> SemanticTokenTypes.Macro;
@@ -280,33 +286,24 @@ public class BslDocSemanticTokensSupplier implements SemanticTokensSupplier {
   }
 
   /**
-   * Читает текст элемента описания (например, имя типа) из строк описания по его диапазону.
+   * Диапазоны типов описания, которые резолвятся в реальный тип через {@link TypeService}.
    * <p>
-   * Диапазон элемента — абсолютный (координаты файла); первая строка описания начинается
-   * со столбца {@code fileStartChar}, остальные — со столбца 0.
-   *
-   * @return текст элемента, либо {@link Optional#empty()}, если диапазон выходит за пределы строк.
+   * Идентичность типа берётся из семантических аксессоров парсера ({@link DescriptionTypes#typesOf}),
+   * а не восстанавливается из текста по координатам; для сопоставления с подсвечиваемыми
+   * {@code TYPE_NAME}-элементами используется диапазон {@code element().range()}.
    */
-  private static Optional<String> typeName(
-    DescriptionElement element,
-    String[] lines,
-    int fileStartLine,
-    int fileStartChar
+  private Set<SimpleRange> resolvableTypeRanges(
+    SourceDefinedSymbolDescription description,
+    DocumentContext documentContext
   ) {
-    var elementRange = element.range();
-    int lineIdx = elementRange.startLine() - fileStartLine;
-    if (lineIdx < 0 || lineIdx >= lines.length) {
-      return Optional.empty();
-    }
-
-    var lineText = lines[lineIdx];
-    int start = elementRange.startCharacter() - (lineIdx == 0 ? fileStartChar : 0);
-    int end = start + elementRange.length();
-    if (start < 0 || end > lineText.length() || start >= end) {
-      return Optional.empty();
-    }
-
-    return Optional.of(lineText.substring(start, end));
+    var fileType = documentContext.getFileType();
+    return DescriptionTypes.typesOf(description)
+      .filter(type -> {
+        var name = DescriptionTypes.resolveName(type);
+        return !name.isBlank() && typeService.resolve(name, fileType).isPresent();
+      })
+      .map(type -> type.element().range())
+      .collect(Collectors.toSet());
   }
 
   private void addDocCommentRange(List<SemanticTokenEntry> entries, int line, int start, int length) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/DescriptionTypes.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/DescriptionTypes.java
@@ -1,0 +1,93 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.utils;
+
+import com.github._1c_syntax.bsl.parser.description.CollectionTypeDescription;
+import com.github._1c_syntax.bsl.parser.description.MethodDescription;
+import com.github._1c_syntax.bsl.parser.description.SourceDefinedSymbolDescription;
+import com.github._1c_syntax.bsl.parser.description.TypeDescription;
+import com.github._1c_syntax.bsl.parser.description.VariableDescription;
+import lombok.experimental.UtilityClass;
+
+import java.util.stream.Stream;
+
+/**
+ * Утилиты для работы с типами, упомянутыми в описаниях символов (doc-комментариях).
+ * <p>
+ * Используются семантические аксессоры парсера ({@link MethodDescription#getParameters()},
+ * {@link MethodDescription#getReturnedValue()}, {@link VariableDescription#getTypes()}), которые
+ * дают идентичность типа ({@link TypeDescription#name()} / {@link CollectionTypeDescription#collectionName()})
+ * без восстановления текста по координатам.
+ */
+@UtilityClass
+public class DescriptionTypes {
+
+  /**
+   * Все типы, упомянутые в описании (типы параметров и возвращаемого значения метода либо
+   * типы переменной), включая вложенные типы полей. Описание висячего комментария переменной
+   * сюда не включается — его обходят отдельно через {@link VariableDescription#getTrailingDescription()}.
+   *
+   * @param description описание символа.
+   *
+   * @return поток описаний типов.
+   */
+  public Stream<TypeDescription> typesOf(SourceDefinedSymbolDescription description) {
+    Stream<TypeDescription> topLevel;
+    if (description instanceof MethodDescription methodDescription) {
+      topLevel = Stream.concat(
+        methodDescription.getParameters().stream().flatMap(parameter -> parameter.types().stream()),
+        methodDescription.getReturnedValue().stream()
+      );
+    } else if (description instanceof VariableDescription variableDescription) {
+      topLevel = variableDescription.getTypes().stream();
+    } else {
+      topLevel = Stream.empty();
+    }
+    return topLevel.flatMap(DescriptionTypes::flatten);
+  }
+
+  /**
+   * Имя типа для резолва в реестре типов: для простого типа — само имя, для коллекции — имя
+   * типа-головы ({@code Массив} из {@code Массив<Число>}), для гиперссылки — пустая строка
+   * (ссылки {@code См.} обрабатываются отдельно).
+   *
+   * @param type описание типа.
+   *
+   * @return имя типа для резолва либо пустая строка, если тип резолвить не нужно.
+   */
+  public String resolveName(TypeDescription type) {
+    return switch (type.variant()) {
+      case SIMPLE -> type.name();
+      case COLLECTION -> type instanceof CollectionTypeDescription collection ? collection.collectionName() : type.name();
+      case HYPERLINK -> "";
+    };
+  }
+
+  private Stream<TypeDescription> flatten(TypeDescription type) {
+    return Stream.concat(
+      Stream.of(type),
+      type.fields().stream()
+        .flatMap(field -> field.types().stream())
+        .flatMap(DescriptionTypes::flatten)
+    );
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/documentlink/SeeReferenceDocumentLinkSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/documentlink/SeeReferenceDocumentLinkSupplierTest.java
@@ -121,6 +121,36 @@ class SeeReferenceDocumentLinkSupplierTest extends AbstractServerContextAwareTes
   }
 
   @Test
+  void testTrailingVariableDescriptionReferenceProducesLink() {
+    // given - висячий (trailing) комментарий после объявления переменной со ссылкой «См.».
+    // Переменная объявлена последним оператором процедуры, чтобы комментарий не «прилип»
+    // как ведущее описание к следующему символу.
+    var content = """
+      Процедура Тест()
+          Перем ОписаннаяПеременная; // См. ДругойМетод
+      КонецПроцедуры
+
+      Процедура ДругойМетод() Экспорт
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(content);
+    var targetMethod = documentContext.getSymbolTree().getMethodSymbol("ДругойМетод").orElseThrow();
+
+    // when
+    var documentLinks = supplier.getDocumentLinks(documentContext);
+
+    // then
+    assertThat(documentLinks)
+      .hasSize(1)
+      .first()
+      .satisfies(documentLink -> {
+        assertThat(documentLink.getRange()).isEqualTo(Ranges.create(1, 38, 49));
+        assertThat(documentLink.getTarget())
+          .isEqualTo(targetTarget(documentContext.getUri().toString(), targetMethod.getSelectionRange()));
+      });
+  }
+
+  @Test
   void testUnresolvedReferenceProducesNothing() {
     // given
     var content = """

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/documentlink/TypeDefinitionDocumentLinkSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/documentlink/TypeDefinitionDocumentLinkSupplierTest.java
@@ -1,0 +1,137 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.documentlink;
+
+import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
+import com.github._1c_syntax.bsl.languageserver.types.TypeService;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import org.eclipse.lsp4j.Range;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+@SpringBootTest
+@CleanupContextBeforeClassAndAfterEachTestMethod
+class TypeDefinitionDocumentLinkSupplierTest {
+
+  @Test
+  void methodParameterTypeWithSourceSymbolProducesLink() {
+    // given
+    var typeService = mock(TypeService.class);
+    var supplier = new TypeDefinitionDocumentLinkSupplier(typeService);
+
+    var content = """
+      // Параметры:
+      //  П - МойТип - описание
+      Процедура Тест(П)
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(content);
+    SourceDefinedSymbol targetSymbol = documentContext.getSymbolTree().getMethodSymbol("Тест").orElseThrow();
+
+    when(typeService.resolve(eq("МойТип"), any())).thenReturn(Optional.of(TypeRef.ANY));
+    when(typeService.definingSymbol(eq(TypeRef.ANY), any())).thenReturn(Optional.of(targetSymbol));
+
+    // when
+    var documentLinks = supplier.getDocumentLinks(documentContext);
+
+    // then - ссылка покрывает имя типа «МойТип» и ведёт к объявляющему символу
+    assertThat(documentLinks)
+      .hasSize(1)
+      .first()
+      .satisfies(documentLink -> {
+        assertThat(documentLink.getRange()).isEqualTo(Ranges.create(1, 8, 14));
+        assertThat(documentLink.getTarget()).isEqualTo(symbolTarget(documentContext, targetSymbol.getSelectionRange()));
+      });
+  }
+
+  @Test
+  void trailingVariableTypeWithSourceSymbolProducesLink() {
+    // given - тип переменной из висячего комментария (нотация «тип в начале»)
+    var typeService = mock(TypeService.class);
+    var supplier = new TypeDefinitionDocumentLinkSupplier(typeService);
+
+    var content = """
+      Процедура Тест()
+          Перем Л; // МойТип - описание
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(content);
+    SourceDefinedSymbol targetSymbol = documentContext.getSymbolTree().getMethodSymbol("Тест").orElseThrow();
+
+    when(typeService.resolve(eq("МойТип"), any())).thenReturn(Optional.of(TypeRef.ANY));
+    when(typeService.definingSymbol(eq(TypeRef.ANY), any())).thenReturn(Optional.of(targetSymbol));
+
+    // when
+    var documentLinks = supplier.getDocumentLinks(documentContext);
+
+    // then
+    assertThat(documentLinks)
+      .hasSize(1)
+      .first()
+      .satisfies(documentLink ->
+        assertThat(documentLink.getTarget()).isEqualTo(symbolTarget(documentContext, targetSymbol.getSelectionRange()))
+      );
+  }
+
+  @Test
+  void typeWithoutSourceSymbolProducesNoLink() {
+    // given - тип резолвится, но не имеет объявляющего исходного символа (платформенный тип)
+    var typeService = mock(TypeService.class);
+    var supplier = new TypeDefinitionDocumentLinkSupplier(typeService);
+
+    var content = """
+      // Параметры:
+      //  П - Строка - описание
+      Процедура Тест(П)
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(content);
+
+    when(typeService.resolve(eq("Строка"), any())).thenReturn(Optional.of(TypeRef.ANY));
+    when(typeService.definingSymbol(eq(TypeRef.ANY), any())).thenReturn(Optional.empty());
+
+    // when
+    var documentLinks = supplier.getDocumentLinks(documentContext);
+
+    // then
+    assertThat(documentLinks).isEmpty();
+  }
+
+  private static String symbolTarget(
+    com.github._1c_syntax.bsl.languageserver.context.DocumentContext documentContext,
+    Range selectionRange
+  ) {
+    var start = selectionRange.getStart();
+    return "%s#L%d,%d".formatted(documentContext.getUri(), start.getLine() + 1, start.getCharacter() + 1);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/documentlink/TypeDefinitionDocumentLinkSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/documentlink/TypeDefinitionDocumentLinkSupplierTest.java
@@ -98,9 +98,10 @@ class TypeDefinitionDocumentLinkSupplierTest {
     assertThat(documentLinks)
       .hasSize(1)
       .first()
-      .satisfies(documentLink ->
-        assertThat(documentLink.getTarget()).isEqualTo(symbolTarget(documentContext, targetSymbol.getSelectionRange()))
-      );
+      .satisfies(documentLink -> {
+        assertThat(documentLink.getRange()).isEqualTo(Ranges.create(1, 16, 22));
+        assertThat(documentLink.getTarget()).isEqualTo(symbolTarget(documentContext, targetSymbol.getSelectionRange()));
+      });
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
@@ -489,8 +489,10 @@ class SemanticTokensProviderTest {
       new ExpectedToken(1, 6, 6, SemanticTokenTypes.Variable, SemanticTokenModifiers.Definition, "Перем1"),
       // Line 1: ; operator
       new ExpectedToken(1, 12, 1, SemanticTokenTypes.Operator, ";"),
-      // Line 1: trailing comment as Comment+Documentation
-      new ExpectedToken(1, 14, 8, SemanticTokenTypes.Comment, SemanticTokenModifiers.Documentation, "// трейл")
+      // Line 1: trailing comment "// " prefix as Comment+Documentation
+      new ExpectedToken(1, 14, 3, SemanticTokenTypes.Comment, SemanticTokenModifiers.Documentation, "// "),
+      // Line 1: первый токен висячего описания трактуется как тип переменной (нотация «тип в начале»)
+      new ExpectedToken(1, 17, 5, SemanticTokenTypes.Type, SemanticTokenModifiers.Documentation, "трейл")
     );
 
     assertTokensMatch(decoded, expected);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
@@ -489,10 +489,9 @@ class SemanticTokensProviderTest {
       new ExpectedToken(1, 6, 6, SemanticTokenTypes.Variable, SemanticTokenModifiers.Definition, "Перем1"),
       // Line 1: ; operator
       new ExpectedToken(1, 12, 1, SemanticTokenTypes.Operator, ";"),
-      // Line 1: trailing comment "// " prefix as Comment+Documentation
-      new ExpectedToken(1, 14, 3, SemanticTokenTypes.Comment, SemanticTokenModifiers.Documentation, "// "),
-      // Line 1: первый токен висячего описания трактуется как тип переменной (нотация «тип в начале»)
-      new ExpectedToken(1, 17, 5, SemanticTokenTypes.Type, SemanticTokenModifiers.Documentation, "трейл")
+      // Line 1: trailing comment as Comment+Documentation. Первый токен «трейл» не резолвится
+      // в реальный тип, поэтому остаётся частью комментария, а не подсвечивается как тип.
+      new ExpectedToken(1, 14, 8, SemanticTokenTypes.Comment, SemanticTokenModifiers.Documentation, "// трейл")
     );
 
     assertTokensMatch(decoded, expected);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
@@ -254,6 +254,28 @@ class BslDocSemanticTokensSupplierTest {
   }
 
   @Test
+  void testTrailingVariableDescriptionTypeHighlighting() {
+    // given - висячий (trailing) комментарий переменной с типом в начале (нотация «тип в начале»).
+    // Описание начинается не со столбца 0, поэтому проверяем сквозную работу:
+    // bsl-parser отдаёт TYPE_NAME-элемент в абсолютных координатах, а сапплаер подсвечивает его
+    // как тип ровно на позиции типа, без «съезжания» из-за отступа описания.
+    String bsl = """
+      Процедура Тест()
+          Перем Стр; // Строка - описание переменной
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then - "Строка" подсвечивается как тип на позиции 18 (а не со смещением на отступ описания).
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(1, 18, 6, SemanticTokenTypes.Type,
+        Set.of(SemanticTokenModifiers.Documentation), "Строка")
+    ));
+  }
+
+  @Test
   void testMultilineSupport() {
     // given
     String bsl = """

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
@@ -228,6 +228,32 @@ class BslDocSemanticTokensSupplierTest {
   }
 
   @Test
+  void testElementsInDescriptionStartingAtNonZeroColumn() {
+    // given - описание, начинающееся не с начала строки (висячий/trailing комментарий после Перем),
+    // который к тому же становится описанием следующего метода. Элементы (ключевые слова, типы)
+    // в первой строке такого описания должны подсвечиваться по своим реальным позициям,
+    // а не «съезжать» на величину отступа описания.
+    String bsl = """
+      Перем П; // Параметры:
+      //  Парам - Строка - описание
+      Процедура Тест(Парам)
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then - "Параметры:" подсвечивается на позиции 12 (а не 21 из-за двойного смещения),
+    // "Строка" на второй строке (со столбца 0) не затронута и остаётся на позиции 12.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(0, 12, 10, SemanticTokenTypes.Macro,
+        Set.of(SemanticTokenModifiers.Documentation), "Параметры:"),
+      new ExpectedToken(1, 12, 6, SemanticTokenTypes.Type,
+        Set.of(SemanticTokenModifiers.Documentation), "Строка")
+    ));
+  }
+
+  @Test
   void testMultilineSupport() {
     // given
     String bsl = """

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
@@ -276,6 +276,27 @@ class BslDocSemanticTokensSupplierTest {
   }
 
   @Test
+  void testTrailingVariableDescriptionUnresolvedTypeNotHighlighted() {
+    // given - висячий комментарий, у которого первый токен (по нотации «тип в начале») — свободный
+    // текст, не резолвящийся в реальный тип.
+    String bsl = """
+      Процедура Тест()
+          Перем П; // привет - это не тип
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then - «привет» не подсвечивается как тип: весь висячий комментарий остаётся
+    // одним комментарием-документацией (не разрезается Type-токеном).
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(1, 13, 22, SemanticTokenTypes.Comment,
+        Set.of(SemanticTokenModifiers.Documentation), "// привет - это не тип")
+    ));
+  }
+
+  @Test
   void testMultilineSupport() {
     // given
     String bsl = """


### PR DESCRIPTION
## Описание

Исправлены два связанных бага при обработке висячих (trailing) комментариев после объявления переменных:

1. **Ссылки в висячих комментариях переменных не обрабатывались**: Висячий комментарий (например, `Перем П; // См. ДругойМетод`) хранится в отдельном `VariableDescription` через метод `getTrailingDescription()`, но эти ссылки не попадали в обработку. Добавлена рекурсивная обработка висячих описаний в методе `addLinksFromDescription()`.

2. **Неправильное позиционирование семантических токенов в висячих комментариях**: При обработке элементов описания, начинающегося не с начала строки, происходило двойное смещение позиций (прибавление `charOffset` к уже абсолютным координатам от парсера). Исправлена логика в `addBslDocTokensForLine()` для работы с абсолютными координатами файла.

### Изменения:

- **SeeReferenceDocumentLinkSupplier.java**: Извлечена логика обработки ссылок в новый метод `addLinksFromDescription()`, который рекурсивно обрабатывает висячие описания переменных
- **BslDocSemanticTokensSupplier.java**: Исправлена логика позиционирования токенов для корректной работы с висячими комментариями, начинающимися не с начала строки
- **Тесты**: Добавлены тесты для проверки обработки ссылок в висячих комментариях и корректного позиционирования семантических токенов

## Связанные задачи

Closes 

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены

## Дополнительно

Добавлены два новых теста:
- `testTrailingVariableDescriptionReferenceProducesLink()` — проверяет, что ссылки в висячих комментариях переменных корректно обрабатываются
- `testElementsInDescriptionStartingAtNonZeroColumn()` — проверяет корректное позиционирование семантических токенов в описаниях, начинающихся не с начала строки

https://claude.ai/code/session_016DL8j9ZCc6WCiKeL4uMBFs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added document links from documentation “type name” references to their defining type locations, including references inside trailing variable descriptions.
* **Bug Fixes**
  * Restored missing “См.” document links in trailing variable documentation comments.
  * Improved semantic token generation for documentation elements: correct absolute positioning, more consistent line splitting, and type-resolution validation (unresolved types are no longer highlighted).
* **Tests**
  * Added/updated coverage for trailing-variable links, non-zero-column description layouts, and unresolved type highlighting behavior.
* **Chores**
  * Updated the BSL parser dependency.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->