### PR TITLE
feat(oscript): выводить тип property-члена из См.-ссылки висячего комментария

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptModuleMembersProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptModuleMembersProvider.java
@@ -230,11 +230,15 @@ public class OScriptModuleMembersProvider {
 
   /**
    * Типы экспортной переменной-свойства из типизирующего висячего комментария
-   * её декларации ({@code Перем Контейнер Экспорт; // Массив из Число}). Источник —
-   * структурно разобранные парсером типы {@code VariableDescription.trailingDescription.getTypes()}:
-   * для коллекционной нотации {@code Массив из Число} парсер возвращает один тип-голову
-   * {@code Массив} (элемент {@code Число} — внутри него), а имя для резолва извлекает
-   * {@link DescriptionTypes#resolveName(com.github._1c_syntax.bsl.parser.description.TypeDescription)}.
+   * её декларации ({@code Перем Контейнер Экспорт; // Массив из Число}). Источники:
+   * <ul>
+   *   <li>структурно разобранные парсером типы {@code trailingDescription.getTypes()}
+   *       (для {@code Массив из Число} — один тип-голова {@code Массив}, имя берёт
+   *       {@link DescriptionTypes#resolveName(com.github._1c_syntax.bsl.parser.description.TypeDescription)});</li>
+   *   <li>если прямых типов нет — {@code См.}-ссылки {@code trailingDescription.getLinks()}
+   *       ({@code Перем Сложно Экспорт; // см. НовыйСложно}): тип берётся из возвращаемого
+   *       значения одноимённой функции этого же модуля, либо ссылка трактуется как имя типа.</li>
+   * </ul>
    * Без комментария/типа возвращает {@link TypeSet#EMPTY}.
    */
   private TypeSet propertyTypesFromComment(VariableSymbol variable) {
@@ -246,18 +250,50 @@ public class OScriptModuleMembersProvider {
     if (trailing == null) {
       return TypeSet.EMPTY;
     }
+    var refs = new ArrayList<TypeRef>();
     var types = trailing.getTypes();
-    if (types == null || types.isEmpty()) {
-      return TypeSet.EMPTY;
+    if (types != null) {
+      for (var td : types) {
+        var name = DescriptionTypes.resolveName(td);
+        if (!name.isBlank()) {
+          typeRegistry.resolve(name, FileType.OS).ifPresent(refs::add);
+        }
+      }
     }
-    var refs = new ArrayList<TypeRef>(types.size());
-    for (var td : types) {
-      var name = DescriptionTypes.resolveName(td);
-      if (!name.isBlank()) {
-        typeRegistry.resolve(name, FileType.OS).ifPresent(refs::add);
+    // Прямые типы приоритетнее; к См.-ссылкам обращаемся, только если тип не указан явно.
+    if (refs.isEmpty()) {
+      for (var link : trailing.getLinks()) {
+        addHyperlinkTypes(variable, link, refs);
       }
     }
     return refs.isEmpty() ? TypeSet.EMPTY : TypeSet.of(refs);
+  }
+
+  /**
+   * Тип из {@code См.}-ссылки висячего комментария. Если ссылка указывает на
+   * функцию того же модуля — берём её возвращаемый тип ({@code // см. НовыйСложно}
+   * → возвращаемое значение {@code НовыйСложно()}); иначе пробуем трактовать
+   * ссылку как имя типа. Cross-module ссылки ({@code Модуль.Метод}) не поддержаны.
+   */
+  private void addHyperlinkTypes(VariableSymbol variable,
+                                 com.github._1c_syntax.bsl.parser.description.support.Hyperlink link,
+                                 List<TypeRef> refs) {
+    var target = link.link();
+    if (target == null || target.isBlank() || target.contains(".")) {
+      return;
+    }
+    var localFunction = variable.getOwner().getSymbolTree().getMethods().stream()
+      .filter(method -> method.isFunction() && method.getName().equalsIgnoreCase(target))
+      .findFirst()
+      .orElse(null);
+    if (localFunction != null) {
+      var returnTypes = localFunction.getDescription()
+        .map(com.github._1c_syntax.bsl.parser.description.MethodDescription::getReturnedValue)
+        .orElse(List.of());
+      refs.addAll(resolveTypes(returnTypes).refs());
+      return;
+    }
+    typeRegistry.resolve(target, FileType.OS).ifPresent(refs::add);
   }
 
   private List<SignatureDescriptor> collectConstructors(DocumentContext documentContext, TypeRef classRef) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/ArchiveReproDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/ArchiveReproDiagnosticTest.java
@@ -165,4 +165,25 @@ class ArchiveReproDiagnosticTest extends AbstractServerContextAwareTest {
       .extracting(CompletionItem::getLabel)
       .contains("Контейнер", "Сложно");
   }
+
+  @Test
+  void hoverOnPropertyInfersTypeFromSeeReference() {
+    initWorkspace();
+
+    // Перем Сложно Экспорт; // см. НовыйСложно — тип члена выводится из
+    // возвращаемого значения функции НовыйСложно() (Структура).
+    var content = "#Использовать \"lib\"\nКлас = Новый МойКласс();\nСообщить(Клас.Сложно);\n";
+    var dc = TestUtils.getDocumentContext(TestUtils.FAKE_OSCRIPT_DOCUMENT_URI, content, context);
+
+    int col = content.split("\n")[2].indexOf("Сложно") + 2;
+    var params = new HoverParams();
+    params.setPosition(new Position(2, col));
+
+    var hover = hoverProvider.getHover(dc, params);
+
+    assertThat(hover).as("hover на члене Сложно должен быть").isPresent();
+    assertThat(hover.get().getContents().getRight().getValue())
+      .as("тип Сложно выводится из `// см. НовыйСложно` → возврат функции (Структура)")
+      .contains("Сложно: Структура");
+  }
 }


### PR DESCRIPTION
## Что

Тип экспортного property-члена OScript-класса теперь выводится из `См.`-ссылки в типизирующем висячем комментарии его декларации.

Пример (из архива пользователя):
```bsl
Перем Сложно Экспорт; // см. НовыйСложно
...
Функция НовыйСложно()
    Возврат Новый Структура("СЧислом, СТекстом", 0, "");
КонецФункции
```
`Клас.Сложно` теперь резолвится в `Структура` (раньше — `Unknown`).

## Почему не работало

У комментария `// см. НовыйСложно` парсер не кладёт тип в `trailingDescription.getTypes()` (это `HYPERLINK`-вариант) — ссылка лежит в `getTypes()`-пустом описании, а в `getLinks()`. Метод `propertyTypesFromComment` смотрел только `getTypes()`, поэтому тип не выводился.

## Что сделано

В `OScriptModuleMembersProvider.propertyTypesFromComment`: если прямых типов нет, разбираем `trailingDescription.getLinks()`:
- ссылка на **функцию того же модуля** → её возвращаемый тип (`НовыйСложно()` → `Структура`);
- иначе ссылка трактуется как имя типа (`typeRegistry.resolve`);
- cross-module ссылки (`Модуль.Метод`) пока не поддержаны (как и в инференсере для параметров).

Прямые типы остаются приоритетнее `См.`-ссылок (`Контейнер` по-прежнему `Массив` из `// Массив из Число`).

## Проверка

- Новый тест `ArchiveReproDiagnosticTest#hoverOnPropertyInfersTypeFromSeeReference`: `Клас.Сложно` → `Сложно: Структура`.
- Прежние тесты `ArchiveReproDiagnosticTest` и весь пакет `types.*` + `spotlessJavaCheck` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01GxykJ84i92KBM8JcjEt2Me)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for properties when direct type information is unavailable by utilizing reference comments as fallback sources
* **Tests**
  * Added test coverage for type inference behavior in hover information

<!-- end of auto-generated comment: release notes by coderabbit.ai -->