### PR TITLE
fix(semanticTokens): подсвечивать тип-значение коллекции в описаниях

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/DescriptionTypes.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/DescriptionTypes.java
@@ -83,11 +83,15 @@ public class DescriptionTypes {
   }
 
   private Stream<TypeDescription> flatten(TypeDescription type) {
+    // Вложенные типы: типы-значения коллекции (Массив из Число → Число) и типы полей структуры.
+    var valueTypes = type instanceof CollectionTypeDescription collection
+      ? collection.valueTypes().stream()
+      : Stream.<TypeDescription>empty();
+    var fieldTypes = type.fields().stream()
+      .flatMap(field -> field.types().stream());
     return Stream.concat(
       Stream.of(type),
-      type.fields().stream()
-        .flatMap(field -> field.types().stream())
-        .flatMap(DescriptionTypes::flatten)
+      Stream.concat(valueTypes, fieldTypes).flatMap(DescriptionTypes::flatten)
     );
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
@@ -297,6 +297,28 @@ class BslDocSemanticTokensSupplierTest {
   }
 
   @Test
+  void testTrailingVariableCollectionTypeHighlighting() {
+    // given - висячий комментарий с типом-коллекцией «Массив из Число»: подсвечиваться должны
+    // и тип-голова (Массив), и тип-значение коллекции (Число), а не только голова.
+    String bsl = """
+      Процедура Тест()
+          Перем Контейнер Экспорт; // Массив из Число
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then - и «Массив», и «Число» подсвечены как тип («из» — разделитель, остаётся комментарием).
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(1, 32, 6, SemanticTokenTypes.Type,
+        Set.of(SemanticTokenModifiers.Documentation), "Массив"),
+      new ExpectedToken(1, 42, 5, SemanticTokenTypes.Type,
+        Set.of(SemanticTokenModifiers.Documentation), "Число")
+    ));
+  }
+
+  @Test
   void testMultilineSupport() {
     // given
     String bsl = """


### PR DESCRIPTION
Для типа-коллекции в висячем комментарии переменной («Массив из Число») подсвечивалась только голова (Массив): DescriptionTypes.flatten спускался лишь в поля структуры (fields()), но не в типы-значения коллекции (CollectionTypeDescription.valueTypes()), где лежит элемент «Число».

Теперь flatten обходит и valueTypes(), поэтому подсвечиваются и голова, и тип элемента; то же исправление даёт document link на вложенный тип. Затрагивает только потребителей typesOf (подсветка и ссылки на тип); вывод типа для автокомплита использует resolveName на top-level getTypes() и не меняется.


Claude-Session: https://claude.ai/code/session_016DL8j9ZCc6WCiKeL4uMBFs

## Описание
<!--- ОБЯЗАТЕЛЬНО опишите внесенные изменения -->

## Связанные задачи
<!--- Для каждого PR обязательно наличие связанной задачи (issue). -->
<!--- Необходимо указать ключи задач, предваряя их символом #, например -->
<!---Closes #123 -->
<!--  -->
<!-- ВНИМАНИЕ: Без ссылки на задачу пулл-реквест не будет принят! -->
<!--  -->
Closes 

## Чеклист
<!--- Перед отправкой пройдите по списку и поставьте отметку для каждого выполненного действия -->
<!--- Если не понятно, что подразумевается - спросите в чате проекта -->

### Общие

- [ ] Ветка PR обновлена из develop
- [ ] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
<!--- Различная дополнительная информация, скриншоты и т.д. -->


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed semantic highlighting for collection element types in documentation comments, ensuring both collection and element types are properly highlighted.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->