### PR TITLE
perf(references): не вызывать MDOType.fromValue для идентификаторов без свойства

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/MdoRefBuilder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/MdoRefBuilder.java
@@ -112,14 +112,19 @@ public class MdoRefBuilder {
       return commonModule.get().getMdoRef();
     }
 
+    // имя объекта метаданных — второй "модификатор" (после точки). Если его нет, то и ссылку
+    // на платформенный объект построить нельзя, поэтому дорогой MDOType.fromValue даже не вызываем
+    // (на голых идентификаторах, например чтениях локальных переменных, это самый частый случай).
+    var mdoName = getMdoName(modifiers);
+    if (mdoName.isEmpty()) {
+      return "";
+    }
+
     // раз не общий модуль, то нужно определить тип метаданного и, если у него есть модуль менеджера, вызвать метод
     // todo такой подход не дает использовать ссылки на методы платформенных объектов
     var mdoType = MDOType.fromValue(identifier.getText());
     if (mdoType.isPresent()) {
-      var mdoName = getMdoName(modifiers);
-      if (!mdoName.isEmpty()) {
-        return MdoReference.create(mdoType.get(), mdoName).getMdoRef();
-      }
+      return MdoReference.create(mdoType.get(), mdoName).getMdoRef();
     }
     return "";
   }


### PR DESCRIPTION
## Описание

`MdoRefBuilder.getMdoRef(identifier, modifiers)` строит ссылку на платформенный объект, только когда есть **и** тип (`MDOType.fromValue(identifier)`), **и** имя объекта (второй «модификатор» после точки). Но `mdoName` проверялся **после** `fromValue`, поэтому для каждого голого идентификатора (чтение локальной переменной и т.п., у которого модификаторов нет) дорогой `MDOType.fromValue` вызывался впустую и всегда возвращал `""`.

Считаем `mdoName` первым и выходим до `fromValue`, если он пуст. Поведение идентично: там, где `mdoName` пуст, старый код тоже возвращал `""`.

`getMdoRef` дёргается в `ReferenceIndexFiller` на каждый call-site / комплексный идентификатор при заполнении индекса ссылок, то есть на каждый keystroke-ребилд документа, — поэтому это hot path набора текста.

## Замер

JFR sampling, рабочий сценарий набора текста в общем модуле `УправлениеДоступомСлужебный` (SSL 3.2, 48 399 строк), antlr 0.4.0, baseline vs fix, 8 прогревов + 40 итераций, n=680 keystroke-ребилдов:

| метрика | baseline | fix | Δ |
|---|---|---|---|
| `MDOType.fromValue` (inclusive) | 2.34% (6 708) | 0.59% (1 679) | **−75%** |
| `MdoRefBuilder.getMdoRef` self-time | 5.36% (15 391) | 3.68% (10 410) | **−31%** |
| `CF.findCommonModule` (inclusive) | 1.86% | 1.97% | ≈ шум (не трогали) |
| rebuild p50 | 689.2 ms | 683.4 ms | −5.8 ms |
| rebuild mean | 694.3 ms | 688.1 ms | −6.2 ms |

Остаточные 0.59% `fromValue` — легитимные случаи `Справочники.X` и т.п. с непустым именем объекта. Сдвиг wall-clock небольшой (весь ребилд доминируют лексинг+парсинг), надёжный сигнал — доля self-time в JFR.

## Чеклист

### Общие

- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами (рефакторинг без изменения поведения; покрыт существующими `ReferenceIndexFillerTest` / `ReferenceIndexTest` / `ReferenceIndexReferenceFinderTest`)
- [x] Обязательные действия перед коммитом выполнены

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcK3qVwTH91rXtgprGmoWr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved efficiency of metadata object reference resolution by optimizing the control flow to skip unnecessary processing when required name components are missing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->