### PR TITLE
perf(context): мемоизировать ServerContext.findCommonModule

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -29,6 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.utils.Resources;
 import com.github._1c_syntax.bsl.mdclasses.CF;
 import com.github._1c_syntax.bsl.mdclasses.MDCReadSettings;
 import com.github._1c_syntax.bsl.mdclasses.MDClasses;
+import com.github._1c_syntax.bsl.mdo.CommonModule;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import com.github._1c_syntax.utils.Absolute;
 import com.github._1c_syntax.utils.Lazy;
@@ -100,6 +101,14 @@ public class ServerContext {
   @Getter
   private Path configurationRoot;
   private final Map<URI, String> mdoRefs = new ConcurrentHashMap<>();
+  /**
+   * Мемоизация {@link CF#findCommonModule(String)}: имя → найденный общий модуль (или
+   * {@link Optional#empty()} — кэшируются и промахи). Резолв общего модуля по имени
+   * зависит только от конфигурации, которая инвариантна на время жизни контекста, поэтому
+   * результат можно кэшировать до её перезагрузки. Вызывается на каждый идентификатор при
+   * заполнении индекса ссылок (на каждый keystroke-ребилд), а имена сильно повторяются.
+   */
+  private final Map<String, Optional<CommonModule>> commonModulesByName = new ConcurrentHashMap<>();
   /**
    * Внутренний EnumMap не потокобезопасен; создаётся обёрнутый в
    * {@link Collections#synchronizedMap(Map)} (см. {@link #addMdoRefByUri(URI, DocumentContext)}).
@@ -321,6 +330,7 @@ public class ServerContext {
     documentsByMDORef.clear();
     mdoRefs.clear();
     documentLocks.clear();
+    commonModulesByName.clear();
     configurationMetadata.clear();
   }
 
@@ -438,6 +448,18 @@ public class ServerContext {
 
   public CF getConfiguration() {
     return configurationMetadata.getOrCompute();
+  }
+
+  /**
+   * Найти общий модуль по имени с мемоизацией результата (см. {@link #commonModulesByName}).
+   * Эквивалентно {@code getConfiguration().findCommonModule(name)}, но без повторного
+   * прохода по case-insensitive карте конфигурации на каждый вызов.
+   *
+   * @param name имя общего модуля
+   * @return общий модуль или {@link Optional#empty()}, если такого нет
+   */
+  public Optional<CommonModule> findCommonModule(String name) {
+    return commonModulesByName.computeIfAbsent(name, key -> getConfiguration().findCommonModule(key));
   }
 
   private DocumentContext createDocumentContext(URI uri) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
@@ -360,7 +360,6 @@ public class ReferenceIndexFiller {
       var identifierText = identifier.getText();
 
       documentContext.getServerContext()
-        .getConfiguration()
         .findCommonModule(identifierText)
         .ifPresent(commonModule ->
           index.addModuleReference(
@@ -393,7 +392,6 @@ public class ReferenceIndexFiller {
       ModuleReference.extractMethodCallOnGetterModule(
           baseIdentifier, baseGlobalCall, modifiers, trailingCall, parsedAccessors)
         .ifPresent(call -> documentContext.getServerContext()
-          .getConfiguration()
           .findCommonModule(call.moduleName())
           .ifPresent(commonModule -> addMethodCall(
             commonModule.getMdoReference().getMdoRef(),
@@ -440,12 +438,12 @@ public class ReferenceIndexFiller {
       if (paramList == null) {
         return Collections.emptySet();
       }
-      final var mdoConfiguration = documentContext.getServerContext().getConfiguration();
+      final var serverContext = documentContext.getServerContext();
       return paramList.param().stream()
         .map(BSLParser.ParamContext::IDENTIFIER)
         .filter(Objects::nonNull)
         .map(ParseTree::getText)
-        .map(mdoConfiguration::findCommonModule)
+        .map(serverContext::findCommonModule)
         .filter(Optional::isPresent)
         .flatMap(Optional::stream)
         .map(MD::getMdoRef)
@@ -546,7 +544,6 @@ public class ReferenceIndexFiller {
         } else if (ModuleReference.isCommonModuleExpression(expression, parsedAccessors)) {
           var commonModuleOpt = ModuleReference.extractCommonModuleName(expression, parsedAccessors)
             .flatMap(moduleName -> documentContext.getServerContext()
-              .getConfiguration()
               .findCommonModule(moduleName));
           if (commonModuleOpt.isPresent()) {
             var mdoRef = commonModuleOpt.get().getMdoReference().getMdoRef();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/MdoRefBuilder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/MdoRefBuilder.java
@@ -107,7 +107,7 @@ public class MdoRefBuilder {
     }
 
     // предполагаем, что это вызов метода общего модуля
-    var commonModule = documentContext.getServerContext().getConfiguration().findCommonModule(identifier.getText());
+    var commonModule = documentContext.getServerContext().findCommonModule(identifier.getText());
     if (commonModule.isPresent()) {
       return commonModule.get().getMdoRef();
     }


### PR DESCRIPTION
## Описание

`CF.findCommonModule(name)` при заполнении индекса ссылок вызывается на каждый идентификатор (call-site, комплексный идентификатор, параметр процедуры) — десятки тысяч раз на каждый keystroke-ребилд — и каждый раз заново проходит по case-insensitive карте конфигурации (case-folding: `CharacterData.getProperties`, `StringLatin1.compareToCI`).

Резолв общего модуля по имени зависит только от конфигурации, инвариантной на время жизни `ServerContext` (её перезагрузка идёт через `ServerContext.clear()`). Добавлен мемоизирующий `ServerContext.findCommonModule` (`ConcurrentHashMap` имя → `Optional<CommonModule>`, кэшируются и промахи), сбрасывается в `clear()` рядом с `configurationMetadata`. Горячие вызывающие в `ReferenceIndexFiller` и `MdoRefBuilder` переведены на него.

Не Spring Cache (накладные расходы AOP-прокси/SpEL на ультра-горячем пути) и не Caffeine — обычный `ConcurrentHashMap.computeIfAbsent`: множество имён ограничено словарём конфигурации.

## Замер

JFR sampling, рабочий сценарий набора текста в общем модуле `УправлениеДоступомСлужебный` (SSL 3.2, 48 399 строк), antlr 0.4.0, baseline = текущий `develop` (с уже влитыми #4180 и #4181), 8 прогревов + 40 итераций, n=680 keystroke-ребилдов:

| метрика (inclusive) | baseline | fix | Δ |
|---|---|---|---|
| `CF.findCommonModule` | 1.97% (5 587) | **0.00%** (0) | исчез из профиля |
| `MdoRefBuilder.getMdoRef` self-time | 3.68% | **1.87%** | −49% |
| `CharacterData00.getProperties` | 4.68% | 3.90% | −0.78 пп |
| `StringLatin1.compareToCI` | 2.57% | 1.76% | −0.81 пп |
| rebuild p50 | 683.4 ms | 680.9 ms | −2.5 ms |

`findCommonModule` полностью ушёл из профиля ребилда, вместе с ним просела его доля в case-folding `CaseInsensitiveMap`. Попадание в кэш — дешёвый `ConcurrentHashMap.get`. Сдвиг wall-clock небольшой (ребилд доминируют лексинг+парсинг), надёжный сигнал — доля self-time в JFR.

Diagnostics/documentlink (cold-пути) оставлены на прямом `getConfiguration().findCommonModule` — их можно перевести отдельно.

## Чеклист

### Общие

- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами (поведение не меняется; покрыто существующими `ReferenceIndexFillerTest` / `ReferenceIndexTest` / `ReferenceIndexReferenceFinderTest` и диагностиками общих модулей)
- [x] Обязательные действия перед коммитом выполнены

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HcK3qVwTH91rXtgprGmoWr)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Enhanced efficiency of common module reference resolution through improved caching mechanisms.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->