### PR TITLE
Use 1c-syntax.github.io javadoc link for antlr4

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -353,7 +353,7 @@ tasks.javadoc {
         links(
             "https://1c-syntax.github.io/bsl-parser/dev/javadoc",
             "https://1c-syntax.github.io/mdclasses/dev/javadoc",
-            "https://1c-syntax.github.io/antlr/"
+            "https://1c-syntax.github.io/antlr/javadoc/"
         )
         // Проверяем корректность javadoc (битые ссылки, синтаксис, html),
         // но не требуем наличия комментариев у каждого элемента (группа missing).

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -348,20 +348,12 @@ tasks.generateDiagnosticDocs {
 }
 
 tasks.javadoc {
-    // Версия antlr4 приходит транзитивно (через bsl-parser), поэтому берём её
-    // из разрешённого runtimeClasspath, чтобы ссылка на javadoc.io указывала
-    // ровно на используемую версию (иначе .../latest даёт redirect-warning).
-    val antlr4Version = configurations.runtimeClasspath.get()
-        .resolvedConfiguration.resolvedArtifacts
-        .map { it.moduleVersion.id }
-        .first { it.group == "io.github.1c-syntax" && it.name == "antlr4" }
-        .version
     options {
         this as StandardJavadocDocletOptions
         links(
             "https://1c-syntax.github.io/bsl-parser/dev/javadoc",
             "https://1c-syntax.github.io/mdclasses/dev/javadoc",
-            "https://javadoc.io/doc/io.github.1c-syntax/antlr4/$antlr4Version"
+            "https://1c-syntax.github.io/antlr/"
         )
         // Проверяем корректность javadoc (битые ссылки, синтаксис, html),
         // но не требуем наличия комментариев у каждого элемента (группа missing).


### PR DESCRIPTION
Switch the antlr4 javadoc cross-reference from javadoc.io to the
project's GitHub Pages site at https://1c-syntax.github.io/antlr/.
This makes it consistent with the bsl-parser and mdclasses links and
removes the need to resolve the antlr4 version from the classpath.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01E8oy335AVE7ihi7yG33iwZ