### PR TITLE
perf(types): компактное представление односложного TypeSet

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSet.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSet.java
@@ -68,7 +68,7 @@ public record TypeSet(
   public static final TypeSet EMPTY = new TypeSet(Collections.emptySet());
 
   public TypeSet {
-    refs = Collections.unmodifiableSet(new LinkedHashSet<>(refs));
+    refs = compactRefs(refs);
     elementTypes = elementTypes == null || elementTypes.isEmpty()
       ? Collections.emptyMap()
       : Collections.unmodifiableMap(new LinkedHashMap<>(elementTypes));
@@ -88,17 +88,36 @@ public record TypeSet(
   }
 
   public static TypeSet of(TypeRef... refs) {
-    if (refs.length == 0) {
-      return EMPTY;
-    }
-    return new TypeSet(new LinkedHashSet<>(Arrays.asList(refs)));
+    return switch (refs.length) {
+      case 0 -> EMPTY;
+      case 1 -> new TypeSet(Set.of(refs[0]));
+      default -> new TypeSet(new LinkedHashSet<>(Arrays.asList(refs)));
+    };
   }
 
   public static TypeSet of(Collection<TypeRef> refs) {
-    if (refs.isEmpty()) {
-      return EMPTY;
-    }
-    return new TypeSet(new LinkedHashSet<>(refs));
+    return switch (refs.size()) {
+      case 0 -> EMPTY;
+      case 1 -> new TypeSet(Set.of(refs.iterator().next()));
+      default -> new TypeSet(new LinkedHashSet<>(refs));
+    };
+  }
+
+  /**
+   * Компактное неизменяемое представление набора ссылок: одно- и пустые наборы
+   * (подавляющее большинство) обходятся без {@link LinkedHashSet}/обёртки, что
+   * экономит память на каждый {@code TypeSet}. Для наборов из двух и более ссылок
+   * сохраняется порядок вставки через {@link LinkedHashSet}.
+   *
+   * @param refs исходный набор ссылок на типы
+   * @return неизменяемый набор тех же ссылок, компактный для размеров 0 и 1
+   */
+  private static Set<TypeRef> compactRefs(Set<TypeRef> refs) {
+    return switch (refs.size()) {
+      case 0 -> Collections.emptySet();
+      case 1 -> Set.of(refs.iterator().next());
+      default -> Collections.unmodifiableSet(new LinkedHashSet<>(refs));
+    };
   }
 
   public boolean isEmpty() {


### PR DESCRIPTION
## Что и зачем

`TypeSet` (returnType членов, типы выражений) — один из самых массовых объектов в системе типов. Канонический конструктор оборачивал любой набор ссылок в `Collections.unmodifiableSet(new LinkedHashSet<>(...))`, а `LinkedHashSet` внутри — это `LinkedHashMap` + 16-слотовый `Node[]`-массив. На конфигурации ERP-масштаба это ~6 млн односложных `TypeSet`, каждый из которых тратит ~241 байт инфраструктуры коллекции на одну полезную (и без того интернированную) `TypeRef`.

## Изменение

- Для наборов размера **0 и 1** — компактное неизменяемое представление (`Collections.emptySet` / `Set.of`), без `LinkedHashSet` и обёртки.
- Для **2+** ссылок — порядок вставки по-прежнему сохраняется через `LinkedHashSet`.
- Фабрики `of()` больше не аллоцируют `LinkedHashSet` дважды для односложного входа.
- Контракт `refs() : Set<TypeRef>` и record-семантика `equals`/`hashCode` не меняются.

## Замер (analyze на `nixel2007/cpm`, 13 090 файлов, `-Xmx10g`)

| метрика | baseline | этот PR |
|---|---:|---:|
| live heap | 5.04 ГБ | **4.35 ГБ (−13.7%)** |
| объектов | 139.0M | 128.2M |
| TypeSet-машинерия (LinkedHashSet+Map+Entry+Node[]+Unmodifiable) | ~1.3 ГБ | → `Set12` **146 МБ** |
| `Object[]` allocation pressure | 74% | 68% |

JSON-отчёт `analyze` **побайтно идентичен** baseline (160 526 263 байт). `TypeSetTest` — 18/0/0.

> Ортогонален #B (дедуп регистрации) и #C (интернирование) — складывается с ними; вместе A+B+C дают −45.1% heap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal type reference management in TypeSet to use more efficient collection representations, reducing memory overhead for different set sizes while preserving insertion order and immutability guarantees.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->