### PR TITLE
perf(types): идемпотентная регистрация member-source в MetadataCollectionSpecializer

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializer.java
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Component;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashMap;
+import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Locale;
@@ -312,6 +313,15 @@ public class MetadataCollectionSpecializer {
   private final BslContextHolder bslContextHolder;
   private final ServerContextProvider serverContextProvider;
 
+  /**
+   * Уже обработанные per-owner synthetic-типы в рамках одного {@link #specialize()}.
+   * Обход дерева метаданных приходит к одному и тому же synthetic-типу многократно
+   * (общие имена табличных частей, общий element-type), а
+   * {@link TypeRegistry#registerMemberSource} добавляет источник без дедупликации.
+   * Защита гарантирует ровно одну регистрацию источников на тип.
+   */
+  private final Set<TypeRef> registeredOwners = new HashSet<>();
+
   private static Map<String, CollectionSpec> buildCollectionIndex() {
     var m = new HashMap<String, CollectionSpec>();
     for (var spec : COLLECTIONS) {
@@ -345,6 +355,7 @@ public class MetadataCollectionSpecializer {
       return;
     }
 
+    registeredOwners.clear();
     var mdosByGroup = collectMdosByGroup(configuration.getChildrenByMdoRef().values());
     var counters = new SpecializationCounters();
     for (var context : providerOpt.get().getContexts()) {
@@ -530,6 +541,9 @@ public class MetadataCollectionSpecializer {
   private TypeRef registerPerOwner(TypeRef elementTypeRef, String ownerSuffix, MD owner) {
     var perOwnerName = elementTypeRef.qualifiedName() + "." + ownerSuffix;
     var perOwnerRef = typeRegistry.intern(TypeKind.PLATFORM, perOwnerName);
+    if (!registeredOwners.add(perOwnerRef)) {
+      return perOwnerRef;
+    }
     var overrides = buildPerOwnerOverrides(perOwnerName, owner);
     var capturedElement = elementTypeRef;
     typeRegistry.registerMemberSource(perOwnerRef,


### PR DESCRIPTION
## Что и зачем

Обход дерева метаданных в `MetadataCollectionSpecializer` приходит к одному и тому же per-owner synthetic-типу многократно (общие имена табличных частей, общий element-type), а `TypeRegistry.registerMemberSource` добавляет источник **без дедупликации** (`computeIfAbsent(...).add(...)`). В итоге ~429K списков member-source держат ~6.7M лямбд (**~14 дублей на тип**), а `getMembers` материализует ~14-кратно избыточный граф членов, удерживаемый в `membersCache`.

Профилирование (JFR + heap dump + Eclipse MAT) показало, что `TypeRegistry` удерживает ~52% живого хипа, а весь 6-млн кластер `MemberDescriptor`/`TypeSet`/`BilingualString`/лямбд — это и есть эта дублирующая материализация.

## Изменение

`registerPerOwner` помечает уже обработанные `ref` в рамках одного `specialize()` и не регистрирует источники повторно. Регистрация детерминирована по path-кодированному имени `ref`, поэтому повторная обработка была чисто избыточной — выход `getMembers` и так дедуплицируется `putIfAbsent` по имени.

## Замер (analyze на `nixel2007/cpm`)

| структура (было ~6M) | baseline | этот PR |
|---|---:|---:|
| MemberDescriptor | 6.01M | **442K** |
| TypeSet | 6.04M | 475K |
| BilingualString | 6.19M | 617K |
| member-source лямбды | ~6.7M | ~450K |

| метрика | baseline | этот PR |
|---|---:|---:|
| live heap | 5.04 ГБ | **2.95 ГБ (−41.5%)** |
| `LambdaForm.invokeExact` (CPU на дублях) | 7.6% | исчезает из топа |
| `Object[]` allocation pressure | 74% | 49% |

Соотношение 6.01M/442K ≈ **13.6×** — ровно фактор дублирования. JSON-отчёт `analyze` **побайтно идентичен** baseline.

## ✅ Валидация

`MetadataCollectionSpecializerTest` (12 тестов, HBK-gated через `BSL_LANGUAGE_SERVER_RUN_HBK_TESTS=true`) прогнан локально на реальном HBK — **12/12 PASS** на этой ветке и в комбинации A+B+C. Тесты покрывают per-MDO/per-collection специализацию, табличные части и **рекурсию по под-владельцам** (`tabularSectionGetsRecursivePerSectionType`) — ровно там, где работает гард дедупа. Плюс JSON-отчёт `analyze` побайтно идентичен baseline.

> Крупнейший из трёх независимых перф-патчей; #A и #C складываются поверх.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
