### PR TITLE
perf(types): интернирование TypeSet и BilingualString

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/BilingualString.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/BilingualString.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.types.model;
 
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
+import com.github._1c_syntax.utils.GenericInterner;
 
 /**
  * Двуязычная (ru + en) пара строк. Используется для всех 1С-сущностей с
@@ -48,6 +49,13 @@ public record BilingualString(String ru, String en) {
 
   public static final BilingualString EMPTY = new BilingualString("", "");
 
+  /**
+   * Кэш-интернер: одни и те же двуязычные пары (имена методов/типов, описания)
+   * повторяются миллионы раз в материализованной модели членов, поэтому
+   * фабрики {@link #of} возвращают разделяемый экземпляр на каждое уникальное значение.
+   */
+  private static final GenericInterner<BilingualString> INTERNER = new GenericInterner<>();
+
   public BilingualString {
     ru = ru == null ? "" : ru;
     en = en == null ? "" : en;
@@ -59,14 +67,14 @@ public record BilingualString(String ru, String en) {
   public static BilingualString of(String singleLocale) {
     return singleLocale == null || singleLocale.isEmpty()
       ? EMPTY
-      : new BilingualString(singleLocale, "");
+      : INTERNER.intern(new BilingualString(singleLocale, ""));
   }
 
   public static BilingualString of(String ru, String en) {
     if ((ru == null || ru.isEmpty()) && (en == null || en.isEmpty())) {
       return EMPTY;
     }
-    return new BilingualString(ru, en);
+    return INTERNER.intern(new BilingualString(ru, en));
   }
 
   public boolean isEmpty() {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSet.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSet.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.model;
 
+import com.github._1c_syntax.utils.GenericInterner;
 import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
@@ -67,6 +68,13 @@ public record TypeSet(
 
   public static final TypeSet EMPTY = new TypeSet(Collections.emptySet());
 
+  /**
+   * Кэш-интернер: одни и те же наборы типов (особенно односложные returnType'ы
+   * членов) повторяются миллионы раз в материализованной модели членов, поэтому
+   * фабрики {@link #of} возвращают разделяемый экземпляр на каждое уникальное значение.
+   */
+  private static final GenericInterner<TypeSet> INTERNER = new GenericInterner<>();
+
   public TypeSet {
     refs = compactRefs(refs);
     elementTypes = elementTypes == null || elementTypes.isEmpty()
@@ -90,16 +98,16 @@ public record TypeSet(
   public static TypeSet of(TypeRef... refs) {
     return switch (refs.length) {
       case 0 -> EMPTY;
-      case 1 -> new TypeSet(Set.of(refs[0]));
-      default -> new TypeSet(new LinkedHashSet<>(Arrays.asList(refs)));
+      case 1 -> INTERNER.intern(new TypeSet(Set.of(refs[0])));
+      default -> INTERNER.intern(new TypeSet(new LinkedHashSet<>(Arrays.asList(refs))));
     };
   }
 
   public static TypeSet of(Collection<TypeRef> refs) {
     return switch (refs.size()) {
       case 0 -> EMPTY;
-      case 1 -> new TypeSet(Set.of(refs.iterator().next()));
-      default -> new TypeSet(new LinkedHashSet<>(refs));
+      case 1 -> INTERNER.intern(new TypeSet(Set.of(refs.iterator().next())));
+      default -> INTERNER.intern(new TypeSet(new LinkedHashSet<>(refs)));
     };
   }
 


### PR DESCRIPTION
## Что и зачем

Одни и те же наборы типов (особенно односложные returnType'ы членов) и двуязычные пары имён/описаний повторяются миллионами в материализованной модели членов. Фабрики `TypeSet.of` и `BilingualString.of` теперь возвращают разделяемый экземпляр на каждое уникальное значение через `GenericInterner` (как уже сделано для `TypeRef`).

## Замер (analyze на `nixel2007/cpm`)

| структура | baseline | этот PR |
|---|---:|---:|
| TypeSet | 6.04M | **389K** |
| BilingualString | 6.19M | **105K** |

| метрика | baseline | этот PR |
|---|---:|---:|
| live heap | 5.04 ГБ | **3.51 ГБ (−30.4%)** |

JSON-отчёт `analyze` **побайтно идентичен** baseline. `TypeSetTest` 18/0/0, `BilingualStringTest` 10/0/0.

## ⚠️ Trade-offs (важно прочитать)

- Интернирование — это **дедуп после создания**: добавляет работу в горячую фазу наполнения системы типов (диагностики в замере — самые медленные из вариантов) и **не трогает 6M `MemberDescriptor`** (поэтому −30% против −41.5% у дедупа регистрации).
- Интернер **статический (на процесс)** — для language-server режима его надо сделать per-registry, иначе он удержит `TypeRef` чужих workspace (утечка между сессиями). В сценарии `analyze` (один workspace, процесс завершается) это неважно.

> Этот патч во многом **перекрывается** [#B (идемпотентная регистрация)](https://github.com/1c-syntax/bsl-language-server/pull/4189): тот убирает дубликаты в источнике (включая 6M MemberDescriptor) без интернера и без CPU-оверхеда в горячей фазе. Открыт для полноты сравнения трёх независимых рычагов — если берётся #B, этот PR можно закрыть.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Optimized internal memory management for improved efficiency and application performance. The system now intelligently reuses instances for repeated operations with identical values, reducing memory consumption and enhancing overall responsiveness.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->