### PR TITLE
perf(workspacesymbol): убрать copy-on-write бакеты и лишнюю переиндексацию

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
@@ -45,6 +45,7 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
 import java.util.EnumSet;
+import java.util.HashSet;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
@@ -266,12 +267,12 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
       if (removed == null || removed.isEmpty()) {
         return;
       }
-      var removedSet = Collections.<Entry>newSetFromMap(new IdentityHashMap<>());
-      removedSet.addAll(removed);
+      var keys = new HashSet<String>();
       for (var entry : removed) {
-        for (var key : keysOf(entry.name())) {
-          removeEntryFromKey(key, removedSet);
-        }
+        keys.addAll(keysOf(entry.name()));
+      }
+      for (var key : keys) {
+        removeEntryFromKey(key, uri);
       }
     } finally {
       lock.writeLock().unlock();
@@ -660,7 +661,6 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
 
   private void index(DocumentContext documentContext) {
     var uri = documentContext.getUri();
-    clear(uri);
 
     var scriptVariant = scriptVariantOf(documentContext);
     var collected = new ArrayList<Entry>();
@@ -672,11 +672,20 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
       collected.add(toEntry(uri, symbol, scriptVariant));
     }
 
-    if (collected.isEmpty()) {
+    var snapshot = List.copyOf(collected);
+    // Переиндексация — no-op, если набор записей не изменился. При batch-анализе один и тот же
+    // документ перестраивается дважды (populateContext, затем rebuild на этапе диагностик), но
+    // индексируемые данные (имя, kind, range, теги, containerName) не меняются. Entry — record со
+    // значимым equals, порядок детерминирован (обход дерева символов), так что снимки равны и
+    // пересборка trie (взятие глобального write-lock'а) пропускается полностью.
+    if (snapshot.equals(indexedByUri.get(uri))) {
       return;
     }
 
-    var snapshot = List.copyOf(collected);
+    clear(uri);
+    if (snapshot.isEmpty()) {
+      return;
+    }
 
     lock.writeLock().lock();
     try {
@@ -686,7 +695,12 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
       indexedByUri.put(uri, snapshot);
       for (var entry : snapshot) {
         for (var key : keysOf(entry.name())) {
-          trie.merge(key, List.of(entry), WorkspaceSymbolIndex::concat);
+          var bucket = trie.get(key);
+          if (bucket == null) {
+            bucket = new ArrayList<>();
+            trie.put(key, bucket);
+          }
+          bucket.add(entry);
         }
       }
     } finally {
@@ -724,22 +738,21 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
   }
 
   /**
-   * Удалить из {@link #trie} записи с данным ключом, попавшие в {@code toRemove};
-   * пустой после фильтрации ключ удаляется целиком. Вызывается под write-lock.
+   * Удалить из бакета данного ключа все записи документа {@code uri}; опустевший ключ удаляется
+   * из {@link #trie} целиком. Бакет мутабельный — удаление идёт на месте, без пересборки списка.
+   * Вызывается под write-lock.
    *
-   * @param key      lowercase-имя (ключ дерева)
-   * @param toRemove удаляемые записи (по идентичности)
+   * @param key lowercase-имя (ключ дерева)
+   * @param uri URI документа, чьи записи удаляются
    */
-  private void removeEntryFromKey(String key, Set<Entry> toRemove) {
+  private void removeEntryFromKey(String key, URI uri) {
     var bucket = trie.get(key);
     if (bucket == null) {
       return;
     }
-    var filtered = withoutEntries(bucket, toRemove);
-    if (filtered.isEmpty()) {
+    bucket.removeIf(entry -> entry.uri().equals(uri));
+    if (bucket.isEmpty()) {
       trie.remove(key);
-    } else {
-      trie.put(key, filtered);
     }
   }
 
@@ -777,22 +790,6 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
       : ScriptVariant.RUSSIAN;
   }
 
-  private static List<Entry> concat(List<Entry> existing, List<Entry> added) {
-    var copy = new ArrayList<Entry>(existing.size() + added.size());
-    copy.addAll(existing);
-    copy.addAll(added);
-    return List.copyOf(copy);
-  }
-
-  private static List<Entry> withoutEntries(List<Entry> source, Set<Entry> toRemove) {
-    var copy = new ArrayList<Entry>(source.size());
-    for (var entry : source) {
-      if (!toRemove.contains(entry)) {
-        copy.add(entry);
-      }
-    }
-    return List.copyOf(copy);
-  }
 
   /**
    * Счётчик просмотренных записей для периодической проверки отмены запроса.

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopulatedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
@@ -245,6 +246,32 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
   @Override
   public void handleDataCleared(ServerContextDocumentClearedEvent event) {
     // no-op: записи автономны и должны пережить освобождение AST при batch-наполнении
+  }
+
+  /**
+   * Ужать backing-массивы бакетов до фактического размера после массового наполнения
+   * ({@code populateContext}).
+   * <p>
+   * Бакеты создаются как {@link ArrayList} с ёмкостью по умолчанию (10) и растут инкрементально по
+   * мере индексации документов. Подавляющее большинство ключей дерева редкие (1–3 записи), поэтому у
+   * них остаётся запас ёмкости; в сумме по множеству ключей это заметный перерасход. Триминг после
+   * наполнения возвращает массивы к точному размеру (аналог {@code trimToSize} в
+   * {@code SymbolTreeComputer}). Последующие инкрементальные правки до-растят бакеты как обычно.
+   *
+   * @param event событие завершения наполнения контекста
+   */
+  @EventListener
+  public void handleServerContextPopulated(ServerContextPopulatedEvent event) {
+    lock.writeLock().lock();
+    try {
+      for (var bucket : trie.values()) {
+        if (bucket instanceof ArrayList<?> arrayList) {
+          arrayList.trimToSize();
+        }
+      }
+    } finally {
+      lock.writeLock().unlock();
+    }
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndexTest.java
@@ -75,6 +75,34 @@ class WorkspaceSymbolIndexTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void reindexingUnchangedContentIsNoOpAndReusesEntries() {
+    // given — документ уже проиндексирован (при batch-анализе он индексируется дважды:
+    // populateContext, затем rebuild на этапе диагностик через AnalyzeCommand.getFileInfoFromFile)
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура ОбработкаПроведения() Экспорт
+      КонецПроцедуры
+      """);
+    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
+    var first = findByName("ОбработкаПроведения");
+
+    // when — повторная индексация ТОГО ЖЕ содержимого
+    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
+    var second = findByName("ОбработкаПроведения");
+
+    // then — набор записей не изменился, поэтому переиндексация не пересобирает индекс:
+    // возвращается тот же экземпляр Entry. При повторной clear+re-add (прежнее поведение)
+    // Entry создавалась бы заново, и проверка идентичности падала бы.
+    assertThat(second).isSameAs(first);
+  }
+
+  private Entry findByName(String name) {
+    return index.search(name, NO_CANCEL).stream()
+      .filter(entry -> entry.name().equals(name))
+      .findFirst()
+      .orElseThrow();
+  }
+
+  @Test
   void findsSymbolByWordStartAndMultiWord() {
     // given
     var documentContext = TestUtils.getDocumentContext("""


### PR DESCRIPTION
## Что и зачем

`WorkspaceSymbolIndex` хранит `PatriciaTrie<List<Entry>>` с **неизменяемыми** бакетами. Обе мутации пересобирали бакет целиком через `List.copyOf` на каждую запись:
- add (`concat`): O(bucket²) на наполнение популярного ключа;
- remove (`withoutEntries`): скан всего бакета + копия на каждый удаляемый документ.

Для вездесущих 1С-имён (`ПриСозданииНаСервере` и т.п.) бакет ≈ размер воркспейса → квадратика по числу файлов и основной источник `Object[]`-мусора. Вдобавок при batch-анализе каждый документ индексируется **дважды** (`populateContext`, затем `rebuild` на этапе диагностик через `AnalyzeCommand.getFileInfoFromFile`), и второй `clear` бил по уже наполненным бакетам под **глобальным write-lock'ом**, сериализуя параллельные диагностики.

## Изменение

- **A — skip-unchanged:** `index()` собирает `snapshot` и выходит, если он равен уже проиндексированному (`snapshot.equals(indexedByUri.get(uri))`). Индексируются только имя/kind/range/теги/containerName; `Entry` — record со значимым `equals`, порядок детерминирован. Повторный проход при анализе становится no-op и **не берёт write-lock**.
- **B′ — мутабельные бакеты:** значения trie — `ArrayList`; add = `bucket.add` (O(1) без копии), remove = `bucket.removeIf(e.uri().equals(uri))` (скан на месте). Удалены `concat`, `withoutEntries`, `IdentityHashMap`-removedSet. Мутации только под write-lock, бакеты наружу не отдаются.

Diff — один файл, 31+/34−.

## Замер `analyze` на `nixel2007/cpm` (vs develop = #4188+#4189+findCommonModule)

| метрика | baseline | этот PR | Δ |
|---|---:|---:|---:|
| CPU `withoutEntries`/`concat` | #1, 13–21 % | **нет в профиле** | устранён |
| `Object[]` allocation pressure | 66 % | **8 %** | −58 пп |
| **contention на WSI write-lock** (parked, сумма по потокам) | **1858.6 с** | **0.9 с** | **−99.95 %** |
| diag-фаза | 5:42 | **0:40** | ×8.5 |
| JSON-отчёт | — | **побайтно идентичен** | без регрессий |
| live heap (A+B′) | 2.82 ГБ | 3.02 ГБ | +0.2 ГБ — слак ёмкости ArrayList |
| live heap (A+B′ + trimToSize) | 2.82 ГБ | **2.94 ГБ** | бакеты снова точного размера |

Глобальный write-lock был основной точкой сериализации параллельных populate/диагностик (события Spring синхронные → слушатель на worker-потоке → один write-lock на каждый `index()`). Профилировка `jdk.ThreadPark`: на этом замке простаивало ~1860 потоко-секунд (≈3.4 ядра весь прогон) — после фикса 0.9 с.

## Тесты
`WorkspaceSymbolIndexTest` 23/0/0, `SymbolProviderStreamingTest` 7/0/0, `SymbolProviderScriptVariantTest` 2/0/0, `BSLWorkspaceServiceTest` 26/0/0, `SymbolProviderTest` — зелёные.

## trimToSize (второй коммит)
Мутабельные бакеты — `ArrayList` с ёмкостью по умолчанию (10), большинство ключей редкие → слак. По `ServerContextPopulatedEvent` (после `populateContext`) бакеты ужимаются `trimToSize` (аналог `SymbolTreeComputer`). Замер: heap **3.02 → 2.94 ГБ (−80 МБ)** — бакеты снова точного размера, как прежние `List.copyOf`; остаток vs baseline (+0.12 ГБ) — run-to-run разброс ленивой материализации модели членов, не индекс. Скорость/аллокации не регрессируют.

## Открытые вопросы (draft)
- Нужен **red-test** перф-инварианта (повторный `index()` не пересобирает бакеты / не берёт write-lock) — добавлю перед снятием с draft.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Symbol indexing now intelligently skips reprocessing when document content remains unchanged
  * Optimized memory footprint of workspace symbol storage
  * Streamlined deletion operations to reduce unnecessary work during indexing

* **New Features**
  * Added event listener to optimize symbol index following server context initialization

<!-- end of auto-generated comment: release notes by coderabbit.ai -->