### PR TITLE
test(architecture): expand layer model and add cycle ratchet for acyclic packages

### DIFF
--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/architecture/ArchitectureTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/architecture/ArchitectureTest.java
@@ -291,8 +291,8 @@ class ArchitectureTest {
   // weaving AspectJ, а не исходных зависимостей), он просто не попадает в назначенные срезы.
 
   static final Set<String> ACYCLIC_DOMAINS = Set.of(
-    "cfg", "cli", "color", "events", "folding", "formatting",
-    "jsonrpc", "mcp", "recognizer", "reporters", "utils", "websocket"
+    "cfg", "cli", "events", "jsonrpc", "mcp",
+    "recognizer", "reporters", "utils", "websocket"
   );
 
   static final SliceAssignment ACYCLIC_DOMAIN_SLICES = new SliceAssignment() {


### PR DESCRIPTION
## Зачем

Шаг к включению ArchUnit-проверки ацикличности пакетов. Сейчас её нельзя включить глобально: 22 из ~30 top-level пакетов слиплись в один цикличный «ком». Этот PR не разрезает ком (это отдельная работа), а **фиксирует то, что уже здорово**, и расширяет слоистую модель, чтобы новый код не делал хуже.

## Что внутри

**1. `utils` зафиксирован как лист** — новое правило `utils_should_not_depend_on_project_packages`. Пакет переиспользуемых хелперов не зависит ни от одного доменного пакета проекта. Запирает ранее влитый рефакторинг (#4212).

**2. Слоистая модель расширена с 13 до 29 слоёв.** Раньше направление вызовов было закреплено только для голов и фасада `providers`. Теперь зафиксированы:
- поставщики отдельных фич — доступны только из `providers` (codeactions, color, documenthighlight, documentlink, folding, rename, semantictokens);
- презентационный кластер `codelenses/commands/databind/hover/inlayhints` — со своими реальными потребителями (включая `lsp`, который резолвит их `Data`-DTO);
- узкие предметные пакеты с единственным потребителем: `cfg`/`recognizer` — только из `diagnostics`, `jsonrpc` — только из `lsp`, `formatting` — из `diagnostics` и `providers`.

Намеренно **не** заслоены `types`/`infrastructure`/`events` (слишком много потребителей — ограничение свелось бы к перечислению почти всего) и цикличное ядро (нет фиксированного набора потребителей). `websocket` тоже не слой: его режим поднимает подкоманда `cli` через Spring, без зависимостей времени компиляции.

**3. Храповик ацикличности** — правило `acyclic_domains_stay_free_of_cycles` через кастомный `SliceAssignment`. Проверяет отсутствие циклов среди пакетов, которые **уже** ацикличны и лежат вне ядра: `cfg, cli, events, jsonrpc, mcp, recognizer, reporters, utils, websocket`. Новый код не сможет завести цикл среди них. Цикличное ядро в срезы не входит; `aop` тоже — его рёбра это артефакт compile-time weaving AspectJ, а не исходные зависимости.

## Проверки

17 `@ArchTest`, 0 failures; `spotlessCheck` зелёный. Изменения только в тестах архитектуры — на прод-код не влияют.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkYRgB6NZZRRNZmBrdL54M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated architecture checks to focus on the core application areas currently under cycle validation.
  * Removed a few packages from the acyclic coverage list, so they are no longer included in that specific cycle-check rule.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->