### PR TITLE
refactor(utils): move URITypeAdapter out of databind to break databind cycle

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/DefaultCodeLensData.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/DefaultCodeLensData.java
@@ -21,7 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.codelenses;
 
-import com.github._1c_syntax.bsl.languageserver.databind.URITypeAdapter;
+import com.github._1c_syntax.bsl.languageserver.utils.URITypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import lombok.Value;
 import lombok.experimental.NonFinal;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/commands/DefaultCommandArguments.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/commands/DefaultCommandArguments.java
@@ -21,7 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.commands;
 
-import com.github._1c_syntax.bsl.languageserver.databind.URITypeAdapter;
+import com.github._1c_syntax.bsl.languageserver.utils.URITypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import lombok.Value;
 import lombok.experimental.NonFinal;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/DefaultInlayHintData.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/DefaultInlayHintData.java
@@ -21,7 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.inlayhints;
 
-import com.github._1c_syntax.bsl.languageserver.databind.URITypeAdapter;
+import com.github._1c_syntax.bsl.languageserver.utils.URITypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import lombok.Value;
 import lombok.experimental.NonFinal;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintData.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintData.java
@@ -21,7 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.inlayhints;
 
-import com.github._1c_syntax.bsl.languageserver.databind.URITypeAdapter;
+import com.github._1c_syntax.bsl.languageserver.utils.URITypeAdapter;
 import com.google.gson.annotations.JsonAdapter;
 import lombok.Value;
 import lombok.experimental.NonFinal;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/URITypeAdapter.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/URITypeAdapter.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with BSL Language Server.
  */
-package com.github._1c_syntax.bsl.languageserver.databind;
+package com.github._1c_syntax.bsl.languageserver.utils;
 
 import com.google.gson.TypeAdapter;
 import com.google.gson.stream.JsonReader;


### PR DESCRIPTION
URITypeAdapter is a generic Gson TypeAdapter<URI> with no project dependencies.
Living in databind, it was the sole reason codelenses/commands/inlayhints data
classes imported the databind package, while databind imports those features to
register their JSON subtypes — a package cycle.

Relocating the adapter to the leaf utils package removes every inbound edge to
databind (it now only depends outward, on the features it registers), so
databind leaves the package cycle (import-level SCC shrinks 22 -> 21).

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LkYRgB6NZZRRNZmBrdL54M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Updated URI handling references across several language server features to use a single shared location.
  * Improved consistency for items such as code lenses, command arguments, and inlay hints.
  * No visible behavior changes are expected.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->