### PR TITLE
refactor(commands): break the codelenses ↔ commands cycle

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/AbstractMethodComplexityCodeLensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codelenses/AbstractMethodComplexityCodeLensSupplier.java
@@ -78,8 +78,9 @@ public abstract class AbstractMethodComplexityCodeLensSupplier
 
       var title = Resources.getResourceString(configuration.getLanguage(), getClass(), TITLE_KEY, complexity);
       var arguments = new ToggleComplexityInlayHintsCommandArguments(
+        data.getUri(),
         commandSupplier.getId(),
-        data
+        data.getMethodName()
       );
 
       var command = commandSupplier.createCommand(title, arguments);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/commands/complexity/ToggleComplexityInlayHintsCommandArguments.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/commands/complexity/ToggleComplexityInlayHintsCommandArguments.java
@@ -21,7 +21,6 @@
  */
 package com.github._1c_syntax.bsl.languageserver.commands.complexity;
 
-import com.github._1c_syntax.bsl.languageserver.codelenses.AbstractMethodComplexityCodeLensSupplier;
 import com.github._1c_syntax.bsl.languageserver.commands.DefaultCommandArguments;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
@@ -46,12 +45,5 @@ public class ToggleComplexityInlayHintsCommandArguments extends DefaultCommandAr
   public ToggleComplexityInlayHintsCommandArguments(URI uri, String id, String methodName) {
     super(uri, id);
     this.methodName = methodName;
-  }
-
-  public ToggleComplexityInlayHintsCommandArguments(
-    String id,
-    AbstractMethodComplexityCodeLensSupplier.ComplexityCodeLensData data
-  ) {
-    this(data.getUri(), id, data.getMethodName());
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/architecture/ArchitectureTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/architecture/ArchitectureTest.java
@@ -290,8 +290,8 @@ class ArchitectureTest {
   // weaving AspectJ, а не исходных зависимостей), он просто не попадает в назначенные срезы.
 
   static final Set<String> ACYCLIC_DOMAINS = Set.of(
-    "cfg", "cli", "client", "databind", "events", "jsonrpc", "mcp",
-    "recognizer", "reporters", "utils", "websocket"
+    "cfg", "cli", "client", "codelenses", "commands", "databind", "events", "jsonrpc",
+    "mcp", "recognizer", "reporters", "utils", "websocket"
   );
 
   static final SliceAssignment ACYCLIC_DOMAIN_SLICES = new SliceAssignment() {


### PR DESCRIPTION
## Зачем

После выноса `client` в `develop` в графе остаётся два цикла: доменное ядро-7 и изолированный `codelenses ↔ commands`. Этот PR убирает второй.

## Корень

Единственное ребро `commands → codelenses` — это конструктор-удобство в `ToggleComplexityInlayHintsCommandArguments`:

```java
public ToggleComplexityInlayHintsCommandArguments(String id, ComplexityCodeLensData data) {
  this(data.getUri(), id, data.getMethodName());   // только распаковка двух полей
}
```

Он тянул вложенный DTO `AbstractMethodComplexityCodeLensSupplier.ComplexityCodeLensData` из `codelenses` лишь чтобы достать `uri` и `methodName`.

## Что сделано

Конструктор-сахар удалён. Его единственный продакшн-вызов — в `AbstractMethodComplexityCodeLensSupplier`, где объект `data` и так в руках, — теперь распаковывает поля сам и зовёт существующий 3-арг `@ConstructorProperties(uri, id, methodName)` конструктор. Тесты уже использовали 3-арг форму, так что их править не пришлось.

## Контракт LSP не затронут

Меняется только то, **где** в Java-коде распаковываются два геттера. Поля, `@ConstructorProperties`, идентичность классов и регистрация подтипов — без изменений, значит форма `codeLens.data` / `command.arguments` (`{uri, id, methodName}`) и путь десериализации те же. Тесты полного флоу линза→resolve→команда зелёные.

## Эффект на граф

`commands` больше не импортирует `codelenses`; оба пакета становятся ацикличными. Остаётся **единственный** цикл — доменное ядро-7 (`configuration, context, diagnostics, formatting, infrastructure, references, types`). `codelenses`/`commands` добавлены в `ACYCLIC_DOMAINS`, поэтому повторное появление back-edge поймает проверка.

## Проверки

`compileJava`/`compileTestJava` — OK; 17 `@ArchTest` без падений; тесты сложности/линз/команд и `CodeLensProviderTest` зелёные; `spotlessCheck` зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkYRgB6NZZRRNZmBrdL54M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of complexity-related code lens actions by passing the required document and method details directly.
  * Removed an outdated convenience path so command execution now uses the standard arguments consistently.

* **Chores**
  * Minor test formatting update with no behavior change.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->