### PR TITLE
refactor(mcp): inject the ServerInfo interface to decouple mcp from lsp

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/CLAUDE.md
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/CLAUDE.md
@@ -26,7 +26,7 @@ Workspaces приходят от клиента через **MCP roots** (`McpRo
 folders; при `--mcp` оба источника (LSP folders + MCP roots) питают общий `ServerContextProvider`.
 Методы-инструменты помечены `@McpTool`.
 
-Инфраструктура: `McpServerInfoConfigurer` (имя/версия из `AutoServerInfo`),
+Инфраструктура: `McpServerInfoConfigurer` (имя/версия из бина `ServerInfo`),
 `McpWorkspaceBootstrap`/`McpWorkspaceResolver` (MCP roots → workspace), `McpRootsBootstrapper`/
 `McpRootsChangeConsumer` (запрос/синхронизация `roots/list`), `McpDocumentReader` (единый доступ к
 документу: `read()` — из кэша, `analyze()` — свежий AST + диагностики).

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpServerInfoConfigurer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpServerInfoConfigurer.java
@@ -21,8 +21,8 @@
  */
 package com.github._1c_syntax.bsl.languageserver.mcp;
 
-import com.github._1c_syntax.bsl.languageserver.lsp.AutoServerInfo;
 import lombok.RequiredArgsConstructor;
+import org.eclipse.lsp4j.ServerInfo;
 import org.springframework.ai.mcp.server.common.autoconfigure.properties.McpServerProperties;
 import org.springframework.beans.factory.ObjectProvider;
 import org.springframework.beans.factory.config.BeanPostProcessor;
@@ -30,8 +30,8 @@ import org.springframework.context.annotation.Profile;
 import org.springframework.stereotype.Component;
 
 /**
- * Заполняет имя и версию MCP-сервера из {@link AutoServerInfo} — единого источника истины
- * (имя из {@code spring.application.name}, версия из манифеста JAR), вместо хардкода в properties.
+ * Заполняет имя и версию MCP-сервера из бина {@link ServerInfo} — единого источника идентичности
+ * сервера, вместо хардкода в properties.
  * <p>
  * Реализовано как пост-обработка {@link McpServerProperties} (а не через {@code McpSyncServerCustomizer}),
  * потому что слот кастомайзера в автоконфигурации один и уже занят servlet-транспортом.
@@ -43,7 +43,7 @@ import org.springframework.stereotype.Component;
 @RequiredArgsConstructor
 public class McpServerInfoConfigurer implements BeanPostProcessor {
 
-  private final ObjectProvider<AutoServerInfo> serverInfoProvider;
+  private final ObjectProvider<ServerInfo> serverInfoProvider;
 
   @Override
   public Object postProcessAfterInitialization(Object bean, String beanName) {


### PR DESCRIPTION
## Зачем

`mcp` и `lsp` — параллельные «головы» (режимы запуска, выбираемые соседними cli-подкомандами), ни одна не над другой. Но в графе оставалось единственное ребро `mcp → lsp`, из-за которого головы выглядели «этажеркой».

## Корень

`McpServerInfoConfigurer` инжектил конкретный бин `lsp.AutoServerInfo` по классу, хотя нужны ему только `getName()`/`getVersion()` — оба объявлены на базовом `org.eclipse.lsp4j.ServerInfo`. Сама `lsp` при этом ссылается на `AutoServerInfo` не по имени (`BSLLanguageServer` инжектит интерфейс `ServerInfo`), так что конкретный класс по имени тянул только mcp.

## Что сделано

Инжект сменён на `ObjectProvider<ServerInfo>` (супертип lsp4j). Тот же бин `AutoServerInfo` резолвится полиморфно — поведение не меняется. `mcp` больше не импортирует `lsp`.

`AutoServerInfo` остаётся в `lsp` как реализация бина (минимальный путь; нейтральный дом для общего «server identity» — отдельный возможный шаг).

## Эффект на граф

Ребро `mcp → lsp` исчезает; `mcp` и `lsp` встают на одну высоту — равноправные головы.

## Проверки

`compileJava`/`compileTestJava` — OK; 17 `@ArchTest` без падений; mcp-тесты и `spotlessCheck` зелёные. Изменения — 2 файла (+ правка `mcp/CLAUDE.md`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkYRgB6NZZRRNZmBrdL54M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Server identity metadata now comes from the standard application info source, improving consistency for MCP server name and version reporting.
  * Version is only applied when available, avoiding blank version values.

* **Documentation**
  * Updated documentation to reflect the new source of server name and version information.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->