### PR TITLE
refactor(infrastructure): decouple ehcache wiring from diagnostics

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/typo/CheckedWordsHolder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/typo/CheckedWordsHolder.java
@@ -39,7 +39,7 @@ public class CheckedWordsHolder {
    * @param word слово, статус которого запрашивается
    * @return WordStatus, указывающий, есть ли у слова ошибка, отсутствует ли ошибка, или слово отсутствует в кэше
    */
-  @Cacheable(value = "typoCache", key = "#lang + ':' + #word", cacheManager = "typoCacheManager")
+  @Cacheable(value = "typoCache", key = "#lang + ':' + #word", cacheManager = "ehcacheCacheManager")
   public WordStatus getWordStatus(String lang, String word) {
     return WordStatus.MISSING;
   }
@@ -51,7 +51,7 @@ public class CheckedWordsHolder {
    * @param word слово, которое помечается как содержащее ошибку
    * @return сохранённый WordStatus, указывающий на наличие ошибки
    */
-  @CachePut(value = "typoCache", key = "#lang + ':' + #word", cacheManager = "typoCacheManager")
+  @CachePut(value = "typoCache", key = "#lang + ':' + #word", cacheManager = "ehcacheCacheManager")
   public WordStatus markWordAsError(String lang, String word) {
     return WordStatus.HAS_ERROR;
   }
@@ -63,7 +63,7 @@ public class CheckedWordsHolder {
    * @param word слово, которое помечается как не содержащее ошибку
    * @return сохранённый WordStatus, указывающий на отсутствие ошибки
    */
-  @CachePut(value = "typoCache", key = "#lang + ':' + #word", cacheManager = "typoCacheManager")
+  @CachePut(value = "typoCache", key = "#lang + ':' + #word", cacheManager = "ehcacheCacheManager")
   public WordStatus markWordAsNoError(String lang, String word) {
     return WordStatus.NO_ERROR;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/typo/TypoCacheRegistrar.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/typo/TypoCacheRegistrar.java
@@ -1,0 +1,60 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.diagnostics.typo;
+
+import com.github._1c_syntax.bsl.languageserver.infrastructure.EhcacheRegistrar;
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+import org.springframework.stereotype.Component;
+
+/**
+ * Регистрирует персистентный кэш орфографии {@code typoCache} в общем EhCache-менеджере: ключ —
+ * {@code язык:слово}, значение — {@link WordStatus}.
+ */
+@Component
+public class TypoCacheRegistrar implements EhcacheRegistrar {
+
+  static final String CACHE_NAME = "typoCache";
+
+  @Override
+  public String cacheName() {
+    return CACHE_NAME;
+  }
+
+  @Override
+  public Class<?> keyType() {
+    return String.class;
+  }
+
+  @Override
+  public Class<?> valueType() {
+    return WordStatus.class;
+  }
+
+  @Override
+  public CacheConfiguration<String, WordStatus> configuration(ResourcePoolsBuilder resourcePools) {
+    return CacheConfigurationBuilder
+      .newCacheConfigurationBuilder(String.class, WordStatus.class, resourcePools)
+      .build();
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/CacheConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/CacheConfiguration.java
@@ -21,11 +21,9 @@
  */
 package com.github._1c_syntax.bsl.languageserver.infrastructure;
 
-import com.github._1c_syntax.bsl.languageserver.diagnostics.typo.WordStatus;
 import com.github._1c_syntax.bsl.mdo.CommonModule;
 import com.github.benmanes.caffeine.cache.Cache;
 import com.github.benmanes.caffeine.cache.Caffeine;
-import org.ehcache.config.builders.CacheConfigurationBuilder;
 import org.ehcache.config.builders.CacheManagerBuilder;
 import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.ehcache.config.units.EntryUnit;
@@ -46,13 +44,14 @@ import java.util.Optional;
 /**
  * Spring-конфигурация кэширования.
  * <p>
- * Для typoCache используется EhCache с персистентным хранилищем на диске.
- * Для остальных кэшей (например, code lens) используется Caffeine с хранением в памяти.
+ * EhCache-менеджер ({@code ehcacheManager}) — общий и cache-agnostic: каждый модуль регистрирует
+ * свой персистентный кэш через {@link EhcacheRegistrar}, а {@code ehcacheCacheManager} оборачивает
+ * их в Spring-{@link CacheManager}. Для остальных кэшей (например, code lens) используется Caffeine
+ * с хранением в памяти.
  */
 @Configuration
 @EnableCaching
 public class CacheConfiguration {
-  private static final String TYPO_CACHE_NAME = "typoCache";
   private static final int MAX_CACHE_INSTANCES = 10;
   /**
    * Потолок кэша резолва общих модулей. Кэшируются и промахи, поэтому размер считается по словарю
@@ -67,7 +66,7 @@ public class CacheConfiguration {
    * Основной менеджер кэша, использующий Caffeine для кэширования в памяти.
    * <p>
    * Помечен как {@code @Primary}, поэтому используется для всех кэшей по умолчанию,
-   * если не указан явно другой менеджер кэша (например, {@code typoCacheManager} для typoCache).
+   * если не указан явно другой менеджер кэша (например, {@code ehcacheCacheManager} для typoCache).
    */
   @Bean
   @Primary
@@ -98,133 +97,109 @@ public class CacheConfiguration {
   }
 
   /**
-   * Выделенный менеджер EhCache для typoCache с персистентным хранением на диске.
+   * Общий менеджер EhCache с персистентным хранением на диске.
    * <p>
-   * Настроен программно, без использования XML-конфигурации.
-   * При закрытии Spring-контекста вызывается метод {@code close()} для корректного завершения работы кэша.
-   * <p>
-   * Кэш размещается в каталоге пользователя, что позволяет избежать захламления git-репозиториев.
-   * Путь можно переопределить через свойство {@code app.cache.fullPath}.
-   * <p>
-   * При запуске нескольких экземпляров в одной директории автоматически используются
-   * отдельные каталоги кэша с суффиксами @1, @2 и т.д. Если все каталоги заблокированы
-   * (более 10 экземпляров), автоматически используется кэш в памяти без персистентности.
+   * Cache-agnostic: каждый кэш объявляется отдельным {@link EhcacheRegistrar}. Настроен программно,
+   * без XML; при закрытии Spring-контекста вызывается {@code close()}. Кэш размещается в каталоге
+   * пользователя (путь переопределяется свойством {@code app.cache.fullPath}). При запуске
+   * нескольких экземпляров используются каталоги с суффиксами @1, @2 и т.д.; если все заблокированы
+   * (более 10 экземпляров), используется кэш в памяти без персистентности.
    */
   @Bean(destroyMethod = "close")
   public org.ehcache.CacheManager ehcacheManager(
     CachePathProvider cachePathProvider,
     @Value("${app.cache.basePath}") String basePath,
-    @Value("${app.cache.fullPath}") String fullPath
+    @Value("${app.cache.fullPath}") String fullPath,
+    List<EhcacheRegistrar> registrars
   ) {
-    // Try to create cache manager with instance-numbered directories
-    // if the primary directory is locked
-    return createEhcacheManagerWithRetry(cachePathProvider, basePath, fullPath);
+    return createEhcacheManagerWithRetry(cachePathProvider, basePath, fullPath, registrars);
   }
 
   /**
-   * Создаёт менеджер EhCache, пробуя пути с разными номерами экземпляров при блокировке.
+   * Spring-{@link CacheManager} поверх кэшей общего EhCache-менеджера.
    * <p>
-   * Пытается использовать основной путь (без суффикса), затем пути с суффиксами @1, @2 и т.д.
-   * до максимального количества попыток.
+   * На него ссылаются потребители через {@code @Cacheable(cacheManager = "ehcacheCacheManager")},
+   * когда нужен персистентный кэш, а не {@code @Primary} Caffeine.
+   */
+  @Bean
+  public CacheManager ehcacheCacheManager(
+    org.ehcache.CacheManager ehcacheManager,
+    List<EhcacheRegistrar> registrars
+  ) {
+    var simpleCacheManager = new SimpleCacheManager();
+    simpleCacheManager.setCaches(
+      registrars.stream()
+        .map(registrar -> toSpringCache(ehcacheManager, registrar))
+        .toList()
+    );
+    simpleCacheManager.afterPropertiesSet();
+    return simpleCacheManager;
+  }
+
+  private static org.springframework.cache.Cache toSpringCache(
+    org.ehcache.CacheManager ehcacheManager,
+    EhcacheRegistrar registrar
+  ) {
+    var nativeCache = ehcacheManager.getCache(
+      registrar.cacheName(), registrar.keyType(), registrar.valueType());
+    return new EhCacheAdapter<>(nativeCache, registrar.cacheName());
+  }
+
+  /**
+   * Создаёт общий менеджер EhCache, пробуя каталоги с разными номерами экземпляров при блокировке.
    * <p>
-   * Если все попытки исчерпаны (все каталоги заблокированы), автоматически создаётся
-   * кэш-менеджер с хранением только в памяти (без персистентности на диске).
+   * Пытается использовать основной путь (без суффикса), затем пути с суффиксами @1, @2 и т.д. до
+   * максимального количества попыток. Если все каталоги заблокированы, создаётся менеджер с
+   * хранением только в памяти (без персистентности на диске).
    *
    * @param cachePathProvider провайдер путей к кэшу
-   * @param basePath базовый путь
-   * @param fullPath полный путь (если задан)
+   * @param basePath          базовый путь
+   * @param fullPath          полный путь (если задан)
+   * @param registrars        декларации кэшей, которые нужно зарегистрировать в менеджере
    * @return менеджер EhCache
    */
   private static org.ehcache.CacheManager createEhcacheManagerWithRetry(
     CachePathProvider cachePathProvider,
     String basePath,
-    String fullPath
+    String fullPath,
+    List<EhcacheRegistrar> registrars
   ) {
     for (var instanceNumber = 0; instanceNumber < MAX_CACHE_INSTANCES; instanceNumber++) {
       try {
         var cacheDir = cachePathProvider.getCachePath(basePath, fullPath, instanceNumber);
-        return createEhcacheManager(cacheDir);
+        return createPersistentEhcacheManager(cacheDir, registrars);
       } catch (org.ehcache.StateTransitionException e) {
-        // This exception indicates the directory is locked by another process
-        // Continue to try next instance number
+        // The directory is locked by another process, try the next instance number.
       }
     }
-    
-    // If we exhausted all attempts, fall back to in-memory cache
-    return createInMemoryEhcacheManager();
+
+    return createInMemoryEhcacheManager(registrars);
   }
 
-  /**
-   * Создаёт менеджер EhCache для указанного каталога.
-   *
-   * @param cacheDir каталог для персистентного хранилища
-   * @return менеджер EhCache
-   */
-  private static org.ehcache.CacheManager createEhcacheManager(java.nio.file.Path cacheDir) {
-    // Build resource pools with disk persistence
+  private static org.ehcache.CacheManager createPersistentEhcacheManager(
+    java.nio.file.Path cacheDir,
+    List<EhcacheRegistrar> registrars
+  ) {
     var resourcePools = ResourcePoolsBuilder.newResourcePoolsBuilder()
       .heap(HEAP_ENTRIES_COUNT, EntryUnit.ENTRIES)
       .disk(DISK_SIZE_MB, MemoryUnit.MB, true);
-    
-    var cacheConfig = createTypoCacheConfig(resourcePools);
 
-    // Build native EhCache manager with persistence
-    return CacheManagerBuilder.newCacheManagerBuilder()
-      .with(CacheManagerBuilder.persistence(cacheDir.toFile()))
-      .withCache(TYPO_CACHE_NAME, cacheConfig)
-      .build(true);
+    var builder = CacheManagerBuilder.newCacheManagerBuilder()
+      .with(CacheManagerBuilder.persistence(cacheDir.toFile()));
+    for (var registrar : registrars) {
+      builder = builder.withCache(registrar.cacheName(), registrar.configuration(resourcePools));
+    }
+    return builder.build(true);
   }
 
-  /**
-   * Создаёт менеджер EhCache с хранением только в памяти (без персистентности).
-   * <p>
-   * Используется как fallback, когда все доступные каталоги кэша заблокированы.
-   * Кэш будет очищен при перезапуске приложения.
-   *
-   * @return менеджер EhCache с in-memory хранилищем
-   */
-  private static org.ehcache.CacheManager createInMemoryEhcacheManager() {
-    // Build resource pools with heap-only storage
+  private static org.ehcache.CacheManager createInMemoryEhcacheManager(List<EhcacheRegistrar> registrars) {
     var resourcePools = ResourcePoolsBuilder.newResourcePoolsBuilder()
       .heap(HEAP_ENTRIES_COUNT, EntryUnit.ENTRIES);
-    
-    var cacheConfig = createTypoCacheConfig(resourcePools);
 
-    // Build native EhCache manager without persistence
-    return CacheManagerBuilder.newCacheManagerBuilder()
-      .withCache(TYPO_CACHE_NAME, cacheConfig)
-      .build(true);
-  }
-
-  /**
-   * Создаёт конфигурацию кэша для typoCache.
-   *
-   * @param resourcePoolsBuilder построитель пулов ресурсов (heap, disk и т.д.)
-   * @return конфигурация кэша
-   */
-  private static org.ehcache.config.CacheConfiguration<String, WordStatus> createTypoCacheConfig(
-    ResourcePoolsBuilder resourcePoolsBuilder
-  ) {
-    return CacheConfigurationBuilder
-      .newCacheConfigurationBuilder(
-        String.class,
-        WordStatus.class,
-        resourcePoolsBuilder
-      )
-      .build();
-  }
-
-  @Bean
-  public CacheManager typoCacheManager(org.ehcache.CacheManager ehcacheManager) {
-    var nativeCache = ehcacheManager.getCache(TYPO_CACHE_NAME, String.class, WordStatus.class);
-    
-    // Wrap the native cache with EhCacheAdapter
-    var simpleCacheManager = new SimpleCacheManager();
-    simpleCacheManager.setCaches(List.of(
-      new EhCacheAdapter<>(nativeCache, TYPO_CACHE_NAME)
-    ));
-    simpleCacheManager.afterPropertiesSet();
-    
-    return simpleCacheManager;
+    var builder = CacheManagerBuilder.newCacheManagerBuilder();
+    for (var registrar : registrars) {
+      builder = builder.withCache(registrar.cacheName(), registrar.configuration(resourcePools));
+    }
+    return builder.build(true);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/EhcacheRegistrar.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/EhcacheRegistrar.java
@@ -1,0 +1,57 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.infrastructure;
+
+import org.ehcache.config.CacheConfiguration;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
+
+/**
+ * Декларация кэша EhCache, который модуль регистрирует в общем менеджере {@code ehcacheManager}.
+ * <p>
+ * Сам менеджер, его персистентность и retry по каталогам принадлежат инфраструктуре; модуль лишь
+ * объявляет имя кэша, типы ключа/значения и конфигурацию поверх переданных пулов ресурсов (heap
+ * либо heap+disk — в зависимости от доступности персистентного хранилища). Бин-реализация этого
+ * интерфейса автоматически подхватывается при сборке менеджера.
+ */
+public interface EhcacheRegistrar {
+
+  /**
+   * @return имя (alias) кэша
+   */
+  String cacheName();
+
+  /**
+   * @return тип ключа кэша
+   */
+  Class<?> keyType();
+
+  /**
+   * @return тип значения кэша
+   */
+  Class<?> valueType();
+
+  /**
+   * @param resourcePools пулы ресурсов, согласованные с режимом менеджера (heap или heap+disk)
+   * @return конфигурация кэша
+   */
+  CacheConfiguration<?, ?> configuration(ResourcePoolsBuilder resourcePools);
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/architecture/ArchitectureTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/architecture/ArchitectureTest.java
@@ -290,8 +290,8 @@ class ArchitectureTest {
   // weaving AspectJ, а не исходных зависимостей), он просто не попадает в назначенные срезы.
 
   static final Set<String> ACYCLIC_DOMAINS = Set.of(
-    "cfg", "cli", "client", "codelenses", "commands", "databind", "events", "jsonrpc",
-    "mcp", "recognizer", "reporters", "utils", "websocket"
+    "cfg", "cli", "client", "codelenses", "commands", "databind", "events", "infrastructure",
+    "jsonrpc", "mcp", "recognizer", "reporters", "utils", "websocket"
   );
 
   static final SliceAssignment ACYCLIC_DOMAIN_SLICES = new SliceAssignment() {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/CacheConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/CacheConfigurationTest.java
@@ -21,10 +21,11 @@
  */
 package com.github._1c_syntax.bsl.languageserver.infrastructure;
 
-import com.github._1c_syntax.bsl.languageserver.diagnostics.typo.WordStatus;
 import org.ehcache.Cache;
 import org.ehcache.CacheManager;
 import org.ehcache.Status;
+import org.ehcache.config.builders.CacheConfigurationBuilder;
+import org.ehcache.config.builders.ResourcePoolsBuilder;
 import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.io.CleanupMode;
@@ -45,6 +46,9 @@ import static org.assertj.core.api.Assertions.assertThat;
 
 class CacheConfigurationTest {
 
+  private static final String CACHE_NAME = "testCache";
+  private static final List<EhcacheRegistrar> REGISTRARS = List.of(new TestRegistrar());
+
   private CacheConfiguration cacheConfiguration;
   private CacheManager ehcacheManager;
   private final List<CacheManager> additionalManagers = new ArrayList<>();
@@ -58,18 +62,18 @@ class CacheConfigurationTest {
       .toArray(CompletableFuture[]::new);
     CompletableFuture.allOf(closeFutures).join();
     additionalManagers.clear();
-    
+
     // Close main manager
     closeManager(ehcacheManager);
     ehcacheManager = null;
-    
+
     // Clean up temporary directories after closing all managers
     for (Path tempDir : tempDirectories) {
       deleteDirectorySilently(tempDir);
     }
     tempDirectories.clear();
   }
-  
+
   private void closeManager(CacheManager manager) {
     if (manager != null && manager.getStatus() != Status.UNINITIALIZED) {
       try {
@@ -80,7 +84,7 @@ class CacheConfigurationTest {
       }
     }
   }
-  
+
   /**
    * Рекурсивно удаляет директорию, игнорируя ошибки доступа к файлам.
    * Используется для очистки временных директорий после закрытия EhCache менеджеров.
@@ -89,7 +93,7 @@ class CacheConfigurationTest {
     if (directory == null || !Files.exists(directory)) {
       return;
     }
-    
+
     try {
       Files.walkFileTree(directory, new SimpleFileVisitor<>() {
         @Override
@@ -125,7 +129,8 @@ class CacheConfigurationTest {
     // when
     ehcacheManager = (CacheManager) ReflectionTestUtils.invokeMethod(
       cacheConfiguration,
-      "createInMemoryEhcacheManager"
+      "createInMemoryEhcacheManager",
+      REGISTRARS
     );
 
     // then
@@ -133,12 +138,12 @@ class CacheConfigurationTest {
     assertThat(ehcacheManager.getStatus()).isEqualTo(Status.AVAILABLE);
 
     // Verify cache is created and accessible
-    Cache<String, WordStatus> cache = ehcacheManager.getCache("typoCache", String.class, WordStatus.class);
+    Cache<String, String> cache = ehcacheManager.getCache(CACHE_NAME, String.class, String.class);
     assertThat(cache).isNotNull();
 
     // Verify cache works
-    cache.put("test", WordStatus.NO_ERROR);
-    assertThat(cache.get("test")).isEqualTo(WordStatus.NO_ERROR);
+    cache.put("test", "noError");
+    assertThat(cache.get("test")).isEqualTo("noError");
   }
 
   @Test
@@ -157,7 +162,8 @@ class CacheConfigurationTest {
       "createEhcacheManagerWithRetry",
       cachePathProvider,
       basePath,
-      fullPath
+      fullPath,
+      REGISTRARS
     );
 
     // then
@@ -165,7 +171,7 @@ class CacheConfigurationTest {
     assertThat(ehcacheManager.getStatus()).isEqualTo(Status.AVAILABLE);
 
     // Verify cache is created
-    Cache<String, WordStatus> cache = ehcacheManager.getCache("typoCache", String.class, WordStatus.class);
+    Cache<String, String> cache = ehcacheManager.getCache(CACHE_NAME, String.class, String.class);
     assertThat(cache).isNotNull();
   }
 
@@ -183,11 +189,12 @@ class CacheConfigurationTest {
     for (int i = 0; i < 10; i++) {
       var cachePath = cachePathProvider.getCachePath(basePath, fullPath, i);
       Files.createDirectories(cachePath);
-      
+
       CacheManager lockedManager = (CacheManager) ReflectionTestUtils.invokeMethod(
         cacheConfiguration,
-        "createEhcacheManager",
-        cachePath
+        "createPersistentEhcacheManager",
+        cachePath,
+        REGISTRARS
       );
       additionalManagers.add(lockedManager);
     }
@@ -198,7 +205,8 @@ class CacheConfigurationTest {
       "createEhcacheManagerWithRetry",
       cachePathProvider,
       basePath,
-      fullPath
+      fullPath,
+      REGISTRARS
     );
 
     // then
@@ -206,11 +214,11 @@ class CacheConfigurationTest {
     assertThat(ehcacheManager.getStatus()).isEqualTo(Status.AVAILABLE);
 
     // Verify cache is created and works
-    Cache<String, WordStatus> cache = ehcacheManager.getCache("typoCache", String.class, WordStatus.class);
+    Cache<String, String> cache = ehcacheManager.getCache(CACHE_NAME, String.class, String.class);
     assertThat(cache).isNotNull();
-    
-    cache.put("test", WordStatus.NO_ERROR);
-    assertThat(cache.get("test")).isEqualTo(WordStatus.NO_ERROR);
+
+    cache.put("test", "noError");
+    assertThat(cache.get("test")).isEqualTo("noError");
   }
 
   @Test
@@ -225,8 +233,9 @@ class CacheConfigurationTest {
     // when
     ehcacheManager = (CacheManager) ReflectionTestUtils.invokeMethod(
       cacheConfiguration,
-      "createEhcacheManager",
-      cachePath
+      "createPersistentEhcacheManager",
+      cachePath,
+      REGISTRARS
     );
 
     // then
@@ -234,12 +243,12 @@ class CacheConfigurationTest {
     assertThat(ehcacheManager.getStatus()).isEqualTo(Status.AVAILABLE);
 
     // Verify cache is created with persistence
-    Cache<String, WordStatus> cache = ehcacheManager.getCache("typoCache", String.class, WordStatus.class);
+    Cache<String, String> cache = ehcacheManager.getCache(CACHE_NAME, String.class, String.class);
     assertThat(cache).isNotNull();
 
     // Verify cache works
-    cache.put("persistentKey", WordStatus.HAS_ERROR);
-    assertThat(cache.get("persistentKey")).isEqualTo(WordStatus.HAS_ERROR);
+    cache.put("persistentKey", "hasError");
+    assertThat(cache.get("persistentKey")).isEqualTo("hasError");
   }
 
   @Test
@@ -250,29 +259,58 @@ class CacheConfigurationTest {
     // when
     ehcacheManager = (CacheManager) ReflectionTestUtils.invokeMethod(
       cacheConfiguration,
-      "createInMemoryEhcacheManager"
+      "createInMemoryEhcacheManager",
+      REGISTRARS
     );
 
     // then
-    Cache<String, WordStatus> cache = ehcacheManager.getCache("typoCache", String.class, WordStatus.class);
-    cache.put("key1", WordStatus.NO_ERROR);
-    cache.put("key2", WordStatus.HAS_ERROR);
+    Cache<String, String> cache = ehcacheManager.getCache(CACHE_NAME, String.class, String.class);
+    cache.put("key1", "noError");
+    cache.put("key2", "hasError");
 
-    assertThat(cache.get("key1")).isEqualTo(WordStatus.NO_ERROR);
-    assertThat(cache.get("key2")).isEqualTo(WordStatus.HAS_ERROR);
+    assertThat(cache.get("key1")).isEqualTo("noError");
+    assertThat(cache.get("key2")).isEqualTo("hasError");
 
     // Close and recreate - data should be lost
     ehcacheManager.close();
 
     ehcacheManager = (CacheManager) ReflectionTestUtils.invokeMethod(
       cacheConfiguration,
-      "createInMemoryEhcacheManager"
+      "createInMemoryEhcacheManager",
+      REGISTRARS
     );
 
-    cache = ehcacheManager.getCache("typoCache", String.class, WordStatus.class);
-    
+    cache = ehcacheManager.getCache(CACHE_NAME, String.class, String.class);
+
     // Data should not persist
     assertThat(cache.get("key1")).isNull();
     assertThat(cache.get("key2")).isNull();
+  }
+
+  /**
+   * Универсальный реестр для проверки механики менеджера без привязки к конкретному домену.
+   */
+  private static final class TestRegistrar implements EhcacheRegistrar {
+    @Override
+    public String cacheName() {
+      return CACHE_NAME;
+    }
+
+    @Override
+    public Class<?> keyType() {
+      return String.class;
+    }
+
+    @Override
+    public Class<?> valueType() {
+      return String.class;
+    }
+
+    @Override
+    public org.ehcache.config.CacheConfiguration<String, String> configuration(ResourcePoolsBuilder resourcePools) {
+      return CacheConfigurationBuilder
+        .newCacheConfigurationBuilder(String.class, String.class, resourcePools)
+        .build();
+    }
   }
 }


### PR DESCRIPTION
Introduce the EhcacheRegistrar interface so the shared ehcacheManager
stays cache-agnostic in infrastructure: each module declares its own
persistent cache (name, key/value types, configuration) and infra
collects the registrars, builds the manager and wraps them into the
ehcacheCacheManager Spring CacheManager.

The typo cache moves to diagnostics.typo.TypoCacheRegistrar, removing the
infrastructure -> diagnostics import (WordStatus). This lifts the
infrastructure package out of the remaining core cycle; it is added to
the ArchitectureTest acyclic ratchet so new code keeps it cycle-free.

Co-Authored-By: Claude Opus 4.8 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01LkYRgB6NZZRRNZmBrdL54M

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for multiple persistent caches managed through a shared cache registration mechanism.
  * Introduced a new cache setup that can expose persistent caches to the application cache layer.

* **Bug Fixes**
  * Updated typo-related caching to use the new cache setup, improving cache consistency and reliability.
  * Refined cache initialization so persistent and in-memory caches are handled more robustly when cache directories are unavailable.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->