### PR TITLE
refactor(context): перенести OScriptModuleTypeResolver в context (разрыв context → types)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -41,7 +41,6 @@ import com.github._1c_syntax.bsl.parser.BSLTokenizer;
 import com.github._1c_syntax.bsl.parser.SDBLTokenizer;
 import com.github._1c_syntax.bsl.support.SupportVariant;
 import com.github._1c_syntax.bsl.types.ConfigurationSource;
-import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptModuleTypeResolver;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import com.github._1c_syntax.bsl.types.ScriptVariant;
 import com.github._1c_syntax.utils.Lazy;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/OScriptModuleTypeResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/OScriptModuleTypeResolver.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with BSL Language Server.
  */
-package com.github._1c_syntax.bsl.languageserver.types.oscript;
+package com.github._1c_syntax.bsl.languageserver.context;
 
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.types.ModuleType;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.types.oscript;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.OScriptModuleTypeResolver;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.WorkspaceAddedEvent;


### PR DESCRIPTION
## Зачем

`context → types` держалось на **единственном** ребре: `DocumentContext` импортировал `types.oscript.OScriptModuleTypeResolver`, чтобы определить тип модуля документа. Но сам резолвер — workspace-scoped реестр `URI → ModuleType` (84 строки) — **не зависит от `types`**: его единственный проектный импорт — лист `infrastructure.WorkspaceScope`, а `ModuleType` берётся из внешней библиотеки mdclasses (`com.github._1c_syntax.bsl.types`), а не из нашего `languageserver.types`.

То есть класс жил «не там»: будучи независимым от `types`, он своим расположением создавал ребро `context → types`.

## Что сделано

- `OScriptModuleTypeResolver`: `types.oscript` → `context` (as-is, поведение не меняется — чистая релокация бина).
- `DocumentContext` — убран импорт (сосед по пакету).
- `types.oscript.OScriptLibraryIndex` — добавлен импорт `context.OScriptModuleTypeResolver`. Он остаётся **производителем**, регистрирующим типы модулей в context-овый реестр; направление `types → context` естественное (типы и так массово зависят от контекста).

## Эффект на граф

`context → types` = **1 → 0** — прямая связка `context ↔ types` снята. Пакет `context` (корень) больше не указывает в `types`/`diagnostics` вовсе, только в свои подпакеты.

Это первая (необходимая, но не достаточная) половина по выводу фундамента `context` из ядрового цикла: большой SCC пока сохраняется через `context.computer.DiagnosticComputer → BSLDiagnostic → types → context`. Второй, осевой разрез — `DiagnosticComputer → BSLDiagnostic` — отдельным шагом.

## Проверки

`compileJava`/`compileTestJava` — OK; `ArchitectureTest` (все правила) зелёный; `*OScript*Test`, `spotlessCheck` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkYRgB6NZZRRNZmBrdL54M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved handling of OScript-related type resolution, which should make code analysis and language server behavior more reliable.
  - Resolved an import/reference mismatch that could affect project indexing or completion in some cases.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->