### PR TITLE
docs(context): починить сломанную javadoc-ссылку в OScriptModuleTypeResolver

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/OScriptModuleTypeResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/OScriptModuleTypeResolver.java
@@ -37,8 +37,8 @@ import java.util.concurrent.ConcurrentMap;
  * Используется как fallback для {@code DocumentContext.computeModuleType()}:
  * {@code Configuration.getModuleTypeByURI(uri)} ничего не знает о файлах
  * OneScript-библиотек и возвращает {@link ModuleType#UNKNOWN}. Этот резолвер
- * наполняется компонентом {@link OScriptLibraryIndex} в процессе индексации
- * библиотек и позволяет различать классы и модули OneScript на уровне
+ * наполняется компонентом {@link com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex}
+ * в процессе индексации библиотек и позволяет различать классы и модули OneScript на уровне
  * {@link com.github._1c_syntax.bsl.languageserver.context.DocumentContext}.
  */
 @Component


### PR DESCRIPTION
## Зачем

После #4222 (`OScriptModuleTypeResolver` переехал `types.oscript → context`) class-level javadoc содержит `{@link OScriptLibraryIndex}`. В прежнем пакете `types.oscript` это был сосед и ссылка резолвилась; в `context` импорта нет → `error: reference not found`. Из-за этого job **`build-javadoc` падает на develop** (PR #4222 смержился с этим красным job'ом).

## Что сделано

Ссылка заполнена полным именем:
```
{@link com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex}
```
— в стиле соседней FQN-`@link` в том же комментарии (на `DocumentContext`), **без добавления импорта**, чтобы не вернуть только что снятое ребро `context → types`.

## Проверки

`./gradlew javadoc` — `BUILD SUCCESSFUL`, 0 ошибок (`reference not found` исчез). Правка только в javadoc-комментарии, на код/граф не влияет.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkYRgB6NZZRRNZmBrdL54M)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated developer-facing comments for clearer type references and formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->