### PR TITLE
refactor(context): инвертировать DiagnosticComputer — убрать ребро context → diagnostics

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/CLAUDE.md
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/CLAUDE.md
@@ -49,8 +49,10 @@
 
 - **`SymbolTreeComputer`** → `SymbolTree`; делегирует `ModuleSymbolComputer`,
   `MethodSymbolComputer`, `RegionVariableSymbolComputer`/`VariableSymbolComputer`.
-- **`DiagnosticComputer`** (Spring-компонент, **не** `Computer<T>`) — прогоняет все
-  `BSLDiagnostic` (параллельно), фильтрует по конфигурации и правилам подавления.
+- **`DiagnosticComputer`** — **интерфейс** (`compute(DocumentContext) → List<Diagnostic>`), не
+  `Computer<T>`. Реализация (`DefaultDiagnosticComputer`) живёт в пакете `diagnostics` и
+  прогоняет все `BSLDiagnostic` параллельно, фильтруя по конфигурации и правилам подавления.
+  Так `context` не зависит от движка диагностик (инверсия зависимости).
 - **`DiagnosticIgnoranceComputer`** → данные о подавлении (сканирует `// BSLLS:…-off`).
 - **`CyclomaticComplexityComputer`** / **`CognitiveComplexityComputer`** → `ComplexityData`.
 - **`QueryComputer`** → токенизированные SDBL-запросы; **`GitBlameComputer`** → git blame.

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/DiagnosticComputer.java
@@ -21,78 +21,22 @@
  */
 package com.github._1c_syntax.bsl.languageserver.context.computer;
 
-import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.diagnostics.BSLDiagnostic;
-import lombok.RequiredArgsConstructor;
-import lombok.extern.slf4j.Slf4j;
 import org.eclipse.lsp4j.Diagnostic;
-import org.springframework.beans.factory.annotation.Lookup;
-import org.springframework.beans.factory.annotation.Qualifier;
-import org.springframework.stereotype.Component;
 
 import java.util.List;
-import java.util.concurrent.CompletableFuture;
-import java.util.concurrent.ExecutorService;
-import java.util.function.Predicate;
-import java.util.stream.Stream;
 
 /**
- * Вычислитель диагностик для документа.
- * <p>
- * Абстрактный класс, обеспечивающий параллельное вычисление диагностик
- * всеми зарегистрированными анализаторами с обработкой ошибок.
+ * Вычислитель диагностик документа: прогоняет зарегистрированные анализаторы и возвращает
+ * найденные проблемы в виде протокольных диагностик.
  */
-@Component
-@Slf4j
-@RequiredArgsConstructor
-public abstract class DiagnosticComputer {
-
-  private final LanguageServerConfiguration configuration;
-
-  @Qualifier("diagnosticComputerExecutor")
-  private final ExecutorService executor;
+public interface DiagnosticComputer {
 
   /**
    * Вычислить все диагностики для документа.
    *
-   * @param documentContext Контекст документа для анализа
-   * @return Список найденных диагностик
+   * @param documentContext контекст анализируемого документа
+   * @return список найденных диагностик
    */
-  public List<Diagnostic> compute(DocumentContext documentContext) {
-    return CompletableFuture
-      .supplyAsync(() -> internalCompute(documentContext), executor)
-      .join();
-  }
-
-  private List<Diagnostic> internalCompute(DocumentContext documentContext) {
-    DiagnosticIgnoranceComputer.Data diagnosticIgnorance = documentContext.getDiagnosticIgnorance();
-
-    var ignoredAuthors = configuration.getDiagnosticsOptions().getIgnoredAuthors();
-    GitBlameComputer.Data gitBlameIgnorance = ignoredAuthors.isEmpty()
-      ? GitBlameComputer.Data.empty()
-      : new GitBlameComputer(documentContext.getUri(), ignoredAuthors).compute();
-
-    return diagnostics(documentContext).parallelStream()
-      .flatMap((BSLDiagnostic diagnostic) -> {
-        try {
-          return diagnostic.getDiagnostics(documentContext).stream();
-        } catch (RuntimeException e) {
-          var message = "Diagnostic computation error.%nFile: %s%nDiagnostic: %s".formatted(
-            documentContext.getUri(),
-            diagnostic.getInfo().getCode()
-          );
-          LOGGER.error(message, e);
-
-          return Stream.empty();
-        }
-      })
-      .filter(Predicate.not(diagnosticIgnorance::diagnosticShouldBeIgnored))
-      .filter(Predicate.not(gitBlameIgnorance::diagnosticShouldBeIgnored))
-      .toList();
-
-  }
-
-  @Lookup("diagnostics")
-  protected abstract List<BSLDiagnostic> diagnostics(DocumentContext documentContext);
+  List<Diagnostic> compute(DocumentContext documentContext);
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DefaultDiagnosticComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DefaultDiagnosticComputer.java
@@ -1,0 +1,95 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.diagnostics;
+
+import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticComputer;
+import com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticIgnoranceComputer;
+import com.github._1c_syntax.bsl.languageserver.context.computer.GitBlameComputer;
+import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
+import org.eclipse.lsp4j.Diagnostic;
+import org.springframework.beans.factory.annotation.Lookup;
+import org.springframework.beans.factory.annotation.Qualifier;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.ExecutorService;
+import java.util.function.Predicate;
+import java.util.stream.Stream;
+
+/**
+ * Реализация {@link DiagnosticComputer} по умолчанию.
+ * <p>
+ * Параллельно вычисляет диагностики всеми зарегистрированными анализаторами {@link BSLDiagnostic}
+ * с обработкой ошибок и фильтрацией по правилам подавления и игнорируемым авторам.
+ */
+@Component
+@Slf4j
+@RequiredArgsConstructor
+public abstract class DefaultDiagnosticComputer implements DiagnosticComputer {
+
+  private final LanguageServerConfiguration configuration;
+
+  @Qualifier("diagnosticComputerExecutor")
+  private final ExecutorService executor;
+
+  @Override
+  public List<Diagnostic> compute(DocumentContext documentContext) {
+    return CompletableFuture
+      .supplyAsync(() -> internalCompute(documentContext), executor)
+      .join();
+  }
+
+  private List<Diagnostic> internalCompute(DocumentContext documentContext) {
+    DiagnosticIgnoranceComputer.Data diagnosticIgnorance = documentContext.getDiagnosticIgnorance();
+
+    var ignoredAuthors = configuration.getDiagnosticsOptions().getIgnoredAuthors();
+    GitBlameComputer.Data gitBlameIgnorance = ignoredAuthors.isEmpty()
+      ? GitBlameComputer.Data.empty()
+      : new GitBlameComputer(documentContext.getUri(), ignoredAuthors).compute();
+
+    return diagnostics(documentContext).parallelStream()
+      .flatMap((BSLDiagnostic diagnostic) -> {
+        try {
+          return diagnostic.getDiagnostics(documentContext).stream();
+        } catch (RuntimeException e) {
+          var message = "Diagnostic computation error.%nFile: %s%nDiagnostic: %s".formatted(
+            documentContext.getUri(),
+            diagnostic.getInfo().getCode()
+          );
+          LOGGER.error(message, e);
+
+          return Stream.empty();
+        }
+      })
+      .filter(Predicate.not(diagnosticIgnorance::diagnosticShouldBeIgnored))
+      .filter(Predicate.not(gitBlameIgnorance::diagnosticShouldBeIgnored))
+      .toList();
+
+  }
+
+  @Lookup("diagnostics")
+  protected abstract List<BSLDiagnostic> diagnostics(DocumentContext documentContext);
+}


### PR DESCRIPTION
## Зачем

Финальный разрез, выводящий фундамент `context` из ядрового цикла. Единственное цикло-образующее ребро `context → diagnostics` — это `context.computer.DiagnosticComputer`, который итерировал `BSLDiagnostic` (`getDiagnostics(ctx)` + `getInfo().getCode()` для лога). `DocumentContext` лениво считает диагностики документа, делегируя ему.

## Что сделано (инверсия зависимости)

- **`context.computer.DiagnosticComputer` → интерфейс** (`compute(DocumentContext) → List<Diagnostic>`): импортит только `DocumentContext` + lsp4j `Diagnostic`, **ни одного `diagnostics`-импорта**.
- **Реализация → `diagnostics.DefaultDiagnosticComputer`**: весь прежний прогон (параллельный стрим `BSLDiagnostic`, `@Lookup("diagnostics")`, фильтры по подавлению/авторам, обработка ошибок). Зависит от `context`/`configuration` — **естественные направления** (`diagnostics → context` уже массовое), нового цикла нет.
- **`DocumentContext` не меняется** — инжектит интерфейс по типу, Spring подставляет реализацию в рантайме. DI-проводка ребром пакета не является.

Теперь `context` объявляет контракт, а `diagnostics` его реализует: `context` **компилируется без пакета `diagnostics`** (зависимость развёрнута, не спрятана).

## Эффект на граф (per-package SCC, non-static импорты)

- `context → diagnostics`-движок исчез; осталась лишь ссылка `DiagnosticIgnoranceComputer → metadata.DiagnosticCode` — это **лист** (вне цикла).
- В паре с уже влитым переносом `OScriptModuleTypeResolver` `context` **выходит из ядра целиком**: `context.* → большой SCC = NONE`.
- **Большой SCC: 20 → 9.** `context` и `diagnostics` стали чистыми слоями; остаточное ядро — `types ↔ references` (`references` + `types.*`).

## Проверки

`compileJava`/`compileTestJava` — OK; `ArchitectureTest` зелёный; `SmokyTest` и `BSLTextDocumentServiceTest` (включая `testStandardDiagnosticKnownFile`/`didOpen`/`didSave` — реальный прогон диагностик через DI + `@Lookup`) зелёные; `spotlessCheck`, `javadoc` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01LkYRgB6NZZRRNZmBrdL54M)_