### PR TITLE
fix(mcp): пометить MCP-инструменты как read-only

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/AnalyzeFileTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/AnalyzeFileTool.java
@@ -62,7 +62,7 @@ public class AnalyzeFileTool {
     // https://github.com/spring-projects/spring-ai/issues/4487
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/AnalyzeFileTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/AnalyzeFileTool.java
@@ -60,7 +60,14 @@ public class AnalyzeFileTool {
     // fields (here — nullable severity/code/source). Known upstream bug, open as of 2.0.0-M6:
     // https://github.com/spring-projects/spring-ai/issues/4825
     // https://github.com/spring-projects/spring-ai/issues/4487
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result analyzeFile(
     @McpToolParam(required = true, description = McpToolParams.FILE)
     String file

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/CallHierarchyTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/CallHierarchyTool.java
@@ -79,7 +79,7 @@ public class CallHierarchyTool {
     // https://github.com/spring-projects/spring-ai/issues/4487
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/CallHierarchyTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/CallHierarchyTool.java
@@ -77,7 +77,14 @@ public class CallHierarchyTool {
     // fields (here — null target / nullable detail). Known upstream bug, open as of 2.0.0-M6:
     // https://github.com/spring-projects/spring-ai/issues/4825
     // https://github.com/spring-projects/spring-ai/issues/4487
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result callHierarchy(
     @McpToolParam(required = true, description = McpToolParams.FILE)
     String file,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DefinitionTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DefinitionTool.java
@@ -66,7 +66,14 @@ public class DefinitionTool {
     // fields. Known upstream bug, open as of 2.0.0-M6:
     // https://github.com/spring-projects/spring-ai/issues/4825
     // https://github.com/spring-projects/spring-ai/issues/4487
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result definition(
     @McpToolParam(required = true, description = McpToolParams.FILE)
     String file,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DefinitionTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DefinitionTool.java
@@ -68,7 +68,7 @@ public class DefinitionTool {
     // https://github.com/spring-projects/spring-ai/issues/4487
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DocumentSymbolsTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DocumentSymbolsTool.java
@@ -64,7 +64,7 @@ public class DocumentSymbolsTool {
     // https://github.com/spring-projects/spring-ai/issues/4487
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DocumentSymbolsTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/DocumentSymbolsTool.java
@@ -62,7 +62,14 @@ public class DocumentSymbolsTool {
     // fields (here — nullable symbol detail). Known upstream bug, open as of 2.0.0-M6:
     // https://github.com/spring-projects/spring-ai/issues/4825
     // https://github.com/spring-projects/spring-ai/issues/4487
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result documentSymbols(
     @McpToolParam(required = true, description = McpToolParams.FILE)
     String file

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/FindReferencesTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/FindReferencesTool.java
@@ -66,7 +66,14 @@ public class FindReferencesTool {
     // fields. Known upstream bug, open as of 2.0.0-M6:
     // https://github.com/spring-projects/spring-ai/issues/4825
     // https://github.com/spring-projects/spring-ai/issues/4487
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result findReferences(
     @McpToolParam(required = true, description = McpToolParams.FILE)
     String file,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/FindReferencesTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/FindReferencesTool.java
@@ -68,7 +68,7 @@ public class FindReferencesTool {
     // https://github.com/spring-projects/spring-ai/issues/4487
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
@@ -85,7 +85,7 @@ public class GlobalMemberInfoTool {
     // Known upstream bug, open as of 2.0.0-M6.
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberInfoTool.java
@@ -83,7 +83,14 @@ public class GlobalMemberInfoTool {
       + "`Сообщить`/`Message`, global properties like `Метаданные`/`Metadata`, and system enums.",
     // Output schema disabled: Spring AI generates a non-nullable schema that rejects null DTO fields.
     // Known upstream bug, open as of 2.0.0-M6.
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result globalMemberInfo(
     @McpToolParam(required = true, description = McpToolParams.GLOBAL_MEMBER_NAME)
     String name,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberSearchTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberSearchTool.java
@@ -106,7 +106,7 @@ public class GlobalMemberSearchTool {
     // Known upstream bug, open as of 2.0.0-M6.
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberSearchTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/GlobalMemberSearchTool.java
@@ -104,7 +104,14 @@ public class GlobalMemberSearchTool {
       + "`global_member_info` for a single member by exact name.",
     // Output schema disabled: Spring AI generates a non-nullable schema that rejects null DTO fields.
     // Known upstream bug, open as of 2.0.0-M6.
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result globalMemberSearch(
     @McpToolParam(required = true, description = McpToolParams.FILE_TYPE)
     FileType fileType,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/HoverTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/HoverTool.java
@@ -71,7 +71,7 @@ public class HoverTool {
     // https://github.com/spring-projects/spring-ai/issues/4487
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/HoverTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/HoverTool.java
@@ -69,7 +69,14 @@ public class HoverTool {
     // fields (here — null contents/range when there is no hover). Known upstream bug, open as of 2.0.0-M6:
     // https://github.com/spring-projects/spring-ai/issues/4825
     // https://github.com/spring-projects/spring-ai/issues/4487
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result hover(
     @McpToolParam(required = true, description = McpToolParams.FILE)
     String file,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeAtPositionTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeAtPositionTool.java
@@ -73,7 +73,7 @@ public class TypeAtPositionTool {
     // Known upstream bug, open as of 2.0.0-M6.
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeAtPositionTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeAtPositionTool.java
@@ -71,7 +71,14 @@ public class TypeAtPositionTool {
       + "with the members (methods and properties) available on it.",
     // Output schema disabled: Spring AI generates a non-nullable schema that rejects null DTO fields.
     // Known upstream bug, open as of 2.0.0-M6.
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result typeAtPosition(
     @McpToolParam(required = true, description = McpToolParams.FILE)
     String file,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
@@ -92,7 +92,14 @@ public class TypeInfoTool {
       + "metadata (since/deprecated versions, execution contexts, examples, see-also).",
     // Output schema disabled: Spring AI generates a non-nullable schema that rejects null DTO fields
     // (here — nullable description/defaultValue). Known upstream bug, open as of 2.0.0-M6.
-    generateOutputSchema = false)
+    generateOutputSchema = false,
+    // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
+    // tool is not treated as destructive (#4226).
+    annotations = @McpTool.McpAnnotations(
+      readOnlyHint = true,
+      destructiveHint = false,
+      idempotentHint = true,
+      openWorldHint = false))
   public Result typeInfo(
     @McpToolParam(required = true, description = McpToolParams.TYPE_NAME)
     String typeName,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/mcp/tools/TypeInfoTool.java
@@ -94,7 +94,7 @@ public class TypeInfoTool {
     // (here — nullable description/defaultValue). Known upstream bug, open as of 2.0.0-M6.
     generateOutputSchema = false,
     // Read-only: only inspects 1C/OneScript code, never mutates anything. Hint clients so the
-    // tool is not treated as destructive (#4226).
+    // tool is not treated as destructive.
     annotations = @McpTool.McpAnnotations(
       readOnlyHint = true,
       destructiveHint = false,

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpStreamableServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpStreamableServerTest.java
@@ -70,7 +70,7 @@ class McpStreamableServerTest {
   @Test
   void allToolsAreMarkedReadOnly() {
     // Все инструменты только читают код и ничего не меняют — клиент (например, Claude) не должен
-    // считать их разрушающими и спрашивать подтверждение на каждый вызов (#4226).
+    // считать их разрушающими и спрашивать подтверждение на каждый вызов.
     var tools = mcpSyncServer.listTools();
 
     assertThat(tools).isNotEmpty();

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpStreamableServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/mcp/McpStreamableServerTest.java
@@ -68,6 +68,26 @@ class McpStreamableServerTest {
   }
 
   @Test
+  void allToolsAreMarkedReadOnly() {
+    // Все инструменты только читают код и ничего не меняют — клиент (например, Claude) не должен
+    // считать их разрушающими и спрашивать подтверждение на каждый вызов (#4226).
+    var tools = mcpSyncServer.listTools();
+
+    assertThat(tools).isNotEmpty();
+    assertThat(tools).allSatisfy(tool -> {
+      assertThat(tool.annotations())
+        .as("tool '%s' must carry read-only annotations", tool.name())
+        .isNotNull();
+      assertThat(tool.annotations().readOnlyHint())
+        .as("tool '%s' must be read-only", tool.name())
+        .isTrue();
+      assertThat(tool.annotations().destructiveHint())
+        .as("tool '%s' must not be destructive", tool.name())
+        .isFalse();
+    });
+  }
+
+  @Test
   void streamableHttpEndpointHandlesInitialize() throws Exception {
     var requestBody = """
       {"jsonrpc":"2.0","id":1,"method":"initialize","params":{"protocolVersion":"2025-03-26",\


### PR DESCRIPTION
## Описание

В режиме MCP все 10 инструментов помечались клиентом (например, Claude) как потенциально разрушающие (destructive), из-за чего при каждом вызове запрашивалось подтверждение. Причина — у `@McpTool`-методов отсутствовали аннотации, а по спецификации MCP при отсутствии `readOnlyHint` инструмент считается потенциально изменяющим данные.

Изменения:
- Добавлена аннотация `@McpTool.McpAnnotations(readOnlyHint = true, destructiveHint = false, idempotentHint = true, openWorldHint = false)` ко всем 10 инструментам (`AnalyzeFileTool`, `DocumentSymbolsTool`, `FindReferencesTool`, `CallHierarchyTool`, `HoverTool`, `DefinitionTool`, `TypeInfoTool`, `TypeAtPositionTool`, `GlobalMemberInfoTool`, `GlobalMemberSearchTool`). Все они только читают код 1С/OneScript и ничего не изменяют, детерминированы и работают в рамках анализируемого проекта.
- В `McpStreamableServerTest` добавлен тест `allToolsAreMarkedReadOnly`, который поднимает реальный MCP-сервер, получает список зарегистрированных инструментов и проверяет, что у каждого `readOnlyHint = true` и `destructiveHint = false` — то есть подсказки доходят до клиента сквозь Spring AI, а не просто присутствуют в исходниках. Тест также служит защитой для будущих инструментов.

## Связанные задачи

Closes #4226

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (изменение не связано с диагностиками)

## Дополнительно

Локально пройден `McpStreamableServerTest` (3/3), `compileJava`/`compileTestJava` без ошибок.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01XpKbajVYu4rJSimcRrQYpF)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * MCP tools now advertise clearer client-facing behavior hints, indicating they are read-only, non-destructive, idempotent, and closed-world.
* **Tests**
  * Added a test to confirm every exposed MCP tool includes these read-only and non-destructive markings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->