### PR TITLE
refactor(references): разорвать цикл references↔types через унификацию OScript-резолва по mdoRef

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/MdoRefBuilder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/MdoRefBuilder.java
@@ -73,6 +73,10 @@ public class MdoRefBuilder {
     // осторожно! не менять на вызов documentContext.getMdoRef, а то зациклится
     var mdoRef = documentContext.getMdObject()
       .map(MD::getMdoRef)
+      // .os-файл library-сущности OneScript не имеет объекта метаданных: его mdoRef — каноничное
+      // имя библиотеки (зарегистрированное индексатором до добавления документа), чтобы он
+      // резолвился в documentsByMDORef единообразно с BSL-объектами.
+      .or(() -> documentContext.getServerContext().findOScriptLibraryName(documentContext.getUri()))
       .orElseGet(() -> documentContext.getUri().toString());
     return stringInterner.intern(mdoRef);
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -120,12 +120,22 @@ public class ServerContext {
   private final Map<String, Map<ModuleType, DocumentContext>> documentsByMDORef
     = new ConcurrentHashMap<>();
   /**
-   * Каталог библиотечных сущностей OneScript: {@code nameKey → (каноничное имя, тип модуля)}.
+   * Каталог библиотечных сущностей OneScript: {@code nameKey → (тип модуля, документ)}.
    * Наполняется извне (индексатором OneScript-библиотек) и служит резолву имени класса/модуля
-   * библиотеки в каноничное имя — аналогично тому, как {@link #findCommonModule(String)} резолвит
-   * общий модуль из метаданных конфигурации. Регистронезависимый (ключ — {@code nameKey}).
+   * библиотеки в документ .os-файла — аналогично тому, как {@link #findCommonModule(String)}
+   * резолвит общий модуль из метаданных конфигурации. Регистронезависимый (ключ — {@code nameKey});
+   * под несколькими именами (алиасами) может резолвиться один и тот же документ.
    */
   private final Map<String, OScriptLibrarySymbol> oscriptLibrariesByNameKey = new ConcurrentHashMap<>();
+  /**
+   * {@code URI .os-файла → каноничное имя} его library-сущности. Наполняется индексатором
+   * OneScript-библиотек <b>до</b> добавления документа в контекст, чтобы {@code mdoRef}
+   * такого документа вычислялся как имя библиотеки (см. {@link MdoRefBuilder}), а не как URI:
+   * тогда документ индексируется в {@link #documentsByMDORef} под своим именем и резолвится
+   * единообразно с BSL-объектами. Первое зарегистрированное имя выигрывает (у одного файла
+   * может быть несколько ролей — см. {@code OScriptModuleTypeResolver}).
+   */
+  private final Map<URI, String> oscriptLibraryNamesByUri = new ConcurrentHashMap<>();
   private final Map<URI, ReadWriteLock> documentLocks = new ConcurrentHashMap<>();
 
   private final Map<DocumentContext, State> states = new ConcurrentHashMap<>();
@@ -341,6 +351,7 @@ public class ServerContext {
     documentsByMDORef.clear();
     mdoRefs.clear();
     oscriptLibrariesByNameKey.clear();
+    oscriptLibraryNamesByUri.clear();
     documentLocks.clear();
     commonModuleCache.invalidateAll();
     configurationMetadata.clear();
@@ -481,67 +492,99 @@ public class ServerContext {
   }
 
   /**
-   * Зарегистрировать библиотечную сущность OneScript: занести её в каталог имён (для канонизации
-   * в {@link #findLibraryClass}/{@link #findLibraryModule}) и проиндексировать документ в
-   * {@code documentsByMDORef} под каноничным именем (чтобы он резолвился через
-   * {@link #getDocument(String, ModuleType)}). Вызывается индексатором OneScript-библиотек.
+   * Привязать {@code URI .os-файла} к каноничному имени его library-сущности <b>до</b>
+   * добавления документа в контекст. Нужно, чтобы {@code mdoRef} документа вычислился как имя
+   * библиотеки (см. {@link MdoRefBuilder}), а не как URI. Первое имя выигрывает: у одного файла
+   * может быть несколько ролей, но идентичность документа (mdoRef) должна быть стабильной.
    *
-   * @param qualifiedName    каноничное имя сущности
+   * @param uri           URI .os-файла (абсолютный, нормализованный)
+   * @param qualifiedName каноничное имя сущности
+   */
+  public void registerOScriptLibraryName(URI uri, String qualifiedName) {
+    oscriptLibraryNamesByUri.putIfAbsent(uri, qualifiedName);
+  }
+
+  /**
+   * Каноничное имя library-сущности OneScript, привязанное к URI через
+   * {@link #registerOScriptLibraryName}. Используется {@link MdoRefBuilder} при вычислении
+   * {@code mdoRef} .os-документов, у которых нет объекта метаданных.
+   *
+   * @param uri URI .os-файла
+   * @return каноничное имя либо {@code empty}
+   */
+  public Optional<String> findOScriptLibraryName(URI uri) {
+    return Optional.ofNullable(oscriptLibraryNamesByUri.get(uri));
+  }
+
+  /**
+   * Зарегистрировать библиотечную сущность OneScript: занести её в каталог имён (для резолва
+   * в {@link #findLibraryClass}/{@link #findLibraryModule}) и проиндексировать документ в
+   * {@code documentsByMDORef} под его {@code mdoRef} (= каноничным именем, см.
+   * {@link #registerOScriptLibraryName}), чтобы он резолвился через
+   * {@link #getDocument(String, ModuleType)}. Вызывается индексатором OneScript-библиотек.
+   *
+   * @param qualifiedName    каноничное имя сущности (алиас в каталоге имён)
    * @param moduleType       {@link ModuleType#OScriptClass} или {@link ModuleType#OScriptModule}
    * @param documentContext  документ .os-файла
    */
   public void registerOScriptLibrary(String qualifiedName, ModuleType moduleType, DocumentContext documentContext) {
-    oscriptLibrariesByNameKey.put(oscriptNameKey(qualifiedName), new OScriptLibrarySymbol(qualifiedName, moduleType));
+    oscriptLibrariesByNameKey.put(oscriptNameKey(qualifiedName), new OScriptLibrarySymbol(moduleType, documentContext));
     documentsByMDORef
-      .computeIfAbsent(qualifiedName, k -> Collections.synchronizedMap(new EnumMap<>(ModuleType.class)))
+      .computeIfAbsent(documentContext.getMdoRef(), k -> Collections.synchronizedMap(new EnumMap<>(ModuleType.class)))
       .put(moduleType, documentContext);
   }
 
   /**
-   * Снять регистрацию библиотечной сущности OneScript: из каталога имён и из
-   * {@code documentsByMDORef}. Вызывается индексатором при удалении файла/пере-индексации.
+   * Снять регистрацию библиотечной сущности OneScript: из каталога имён, из
+   * {@code documentsByMDORef} и из привязки {@code URI → имя}. Вызывается индексатором при
+   * удалении файла/пере-индексации.
    *
    * @param qualifiedName каноничное имя сущности
    * @param moduleType    тип модуля сущности
    */
   public void removeOScriptLibrary(String qualifiedName, ModuleType moduleType) {
-    oscriptLibrariesByNameKey.remove(oscriptNameKey(qualifiedName));
-    var group = documentsByMDORef.get(qualifiedName);
+    var symbol = oscriptLibrariesByNameKey.remove(oscriptNameKey(qualifiedName));
+    if (symbol == null) {
+      return;
+    }
+    var documentContext = symbol.documentContext();
+    var group = documentsByMDORef.get(documentContext.getMdoRef());
     if (group != null) {
       group.remove(moduleType);
       if (group.isEmpty()) {
-        documentsByMDORef.remove(qualifiedName);
+        documentsByMDORef.remove(documentContext.getMdoRef());
       }
     }
+    oscriptLibraryNamesByUri.remove(documentContext.getUri());
   }
 
   /**
-   * Найти каноничное имя зарегистрированного library-класса OneScript по имени из исходного кода.
+   * Найти документ зарегистрированного library-класса OneScript по имени из исходного кода.
    *
    * @param name имя из кода (произвольный регистр)
-   * @return каноничное имя класса либо {@code empty}
+   * @return документ .os-файла класса либо {@code empty}
    */
-  public Optional<String> findLibraryClass(String name) {
+  public Optional<DocumentContext> findLibraryClass(String name) {
     return findOScriptLibrarySymbol(name, ModuleType.OScriptClass);
   }
 
   /**
-   * Найти каноничное имя зарегистрированного library-модуля OneScript по имени из исходного кода.
+   * Найти документ зарегистрированного library-модуля OneScript по имени из исходного кода.
    *
    * @param name имя из кода (произвольный регистр)
-   * @return каноничное имя модуля либо {@code empty}
+   * @return документ .os-файла модуля либо {@code empty}
    */
-  public Optional<String> findLibraryModule(String name) {
+  public Optional<DocumentContext> findLibraryModule(String name) {
     return findOScriptLibrarySymbol(name, ModuleType.OScriptModule);
   }
 
-  private Optional<String> findOScriptLibrarySymbol(String name, ModuleType moduleType) {
+  private Optional<DocumentContext> findOScriptLibrarySymbol(String name, ModuleType moduleType) {
     if (name == null || name.isBlank()) {
       return Optional.empty();
     }
     return Optional.ofNullable(oscriptLibrariesByNameKey.get(oscriptNameKey(name)))
       .filter(symbol -> symbol.moduleType() == moduleType)
-      .map(OScriptLibrarySymbol::qualifiedName);
+      .map(OScriptLibrarySymbol::documentContext);
   }
 
   /**
@@ -554,12 +597,12 @@ public class ServerContext {
   }
 
   /**
-   * Запись каталога библиотечных сущностей OneScript (для канонизации имени).
+   * Запись каталога библиотечных сущностей OneScript.
    *
-   * @param qualifiedName каноничное имя
-   * @param moduleType    тип модуля (класс/модуль)
+   * @param moduleType       тип модуля (класс/модуль)
+   * @param documentContext  документ .os-файла сущности
    */
-  public record OScriptLibrarySymbol(String qualifiedName, ModuleType moduleType) {
+  public record OScriptLibrarySymbol(ModuleType moduleType, DocumentContext documentContext) {
   }
 
   private DocumentContext createDocumentContext(URI uri) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -120,14 +120,12 @@ public class ServerContext {
   private final Map<String, Map<ModuleType, DocumentContext>> documentsByMDORef
     = new ConcurrentHashMap<>();
   /**
-   * Каталог библиотечных сущностей OneScript: {@code nameKey → (каноничное имя, тип модуля, URI)}.
+   * Каталог библиотечных сущностей OneScript: {@code nameKey → (каноничное имя, тип модуля)}.
    * Наполняется извне (индексатором OneScript-библиотек) и служит резолву имени класса/модуля
-   * библиотеки в каноничный mdoRef — аналогично тому, как {@link #findCommonModule(String)}
-   * резолвит общий модуль из метаданных конфигурации. Регистронезависимый (ключ — {@code nameKey}).
+   * библиотеки в каноничное имя — аналогично тому, как {@link #findCommonModule(String)} резолвит
+   * общий модуль из метаданных конфигурации. Регистронезависимый (ключ — {@code nameKey}).
    */
   private final Map<String, OScriptLibrarySymbol> oscriptLibrariesByNameKey = new ConcurrentHashMap<>();
-  /** Обратный индекс {@code URI → nameKey'и записей} для снятия при удалении/пере-индексации файла. */
-  private final Map<URI, Set<String>> oscriptLibraryNameKeysByUri = new ConcurrentHashMap<>();
   private final Map<URI, ReadWriteLock> documentLocks = new ConcurrentHashMap<>();
 
   private final Map<DocumentContext, State> states = new ConcurrentHashMap<>();
@@ -312,7 +310,6 @@ public class ServerContext {
     }
 
     removeDocumentMdoRefByUri(uri);
-    removeOScriptDocumentMdoRefs(uri);
     states.remove(documentContext);
     documents.remove(uri);
     documentLocks.remove(uri);
@@ -344,7 +341,6 @@ public class ServerContext {
     documentsByMDORef.clear();
     mdoRefs.clear();
     oscriptLibrariesByNameKey.clear();
-    oscriptLibraryNameKeysByUri.clear();
     documentLocks.clear();
     commonModuleCache.invalidateAll();
     configurationMetadata.clear();
@@ -485,85 +481,36 @@ public class ServerContext {
   }
 
   /**
-   * Зарегистрировать библиотечную сущность OneScript (класс/модуль) в каталоге.
-   * Вызывается индексатором OneScript-библиотек.
+   * Зарегистрировать библиотечную сущность OneScript: занести её в каталог имён (для канонизации
+   * в {@link #findLibraryClass}/{@link #findLibraryModule}) и проиндексировать документ в
+   * {@code documentsByMDORef} под каноничным именем (чтобы он резолвился через
+   * {@link #getDocument(String, ModuleType)}). Вызывается индексатором OneScript-библиотек.
+   *
+   * @param qualifiedName    каноничное имя сущности
+   * @param moduleType       {@link ModuleType#OScriptClass} или {@link ModuleType#OScriptModule}
+   * @param documentContext  документ .os-файла
+   */
+  public void registerOScriptLibrary(String qualifiedName, ModuleType moduleType, DocumentContext documentContext) {
+    oscriptLibrariesByNameKey.put(oscriptNameKey(qualifiedName), new OScriptLibrarySymbol(qualifiedName, moduleType));
+    documentsByMDORef
+      .computeIfAbsent(qualifiedName, k -> Collections.synchronizedMap(new EnumMap<>(ModuleType.class)))
+      .put(moduleType, documentContext);
+  }
+
+  /**
+   * Снять регистрацию библиотечной сущности OneScript: из каталога имён и из
+   * {@code documentsByMDORef}. Вызывается индексатором при удалении файла/пере-индексации.
    *
    * @param qualifiedName каноничное имя сущности
-   * @param moduleType    {@link ModuleType#OScriptClass} или {@link ModuleType#OScriptModule}
-   * @param uri           URI .os-файла
+   * @param moduleType    тип модуля сущности
    */
-  public void registerOScriptLibrarySymbol(String qualifiedName, ModuleType moduleType, URI uri) {
-    var key = oscriptNameKey(qualifiedName);
-    oscriptLibrariesByNameKey.put(key, new OScriptLibrarySymbol(qualifiedName, moduleType, uri));
-    oscriptLibraryNameKeysByUri.computeIfAbsent(uri, k -> ConcurrentHashMap.newKeySet()).add(key);
-    registerOScriptDocumentMdoRefs(uri);
-  }
-
-  /**
-   * Снять все библиотечные записи OneScript, связанные с файлом (при удалении/пере-индексации).
-   */
-  public void removeOScriptLibrarySymbolsByUri(URI uri) {
-    // сначала снимаем регистрации документа в индексе по mdoRef (пока каталог ещё населён),
-    // потом чистим сам каталог.
-    removeOScriptDocumentMdoRefs(uri);
-    var keys = oscriptLibraryNameKeysByUri.remove(uri);
-    if (keys != null) {
-      keys.forEach(oscriptLibrariesByNameKey::remove);
-    }
-  }
-
-  /**
-   * Зарегистрировать .os-документ в индексе по mdoRef под каждым его каноничным lib-именем
-   * (если документ уже создан). Идемпотентно; вызывается и при создании документа, и при
-   * наполнении каталога — порядок этих событий не фиксирован.
-   */
-  private void registerOScriptDocumentMdoRefs(URI uri) {
-    var documentContext = documents.get(uri);
-    var keys = oscriptLibraryNameKeysByUri.get(uri);
-    if (documentContext == null || keys == null) {
-      return;
-    }
-    for (var key : keys) {
-      var symbol = oscriptLibrariesByNameKey.get(key);
-      if (symbol != null) {
-        documentsByMDORef
-          .computeIfAbsent(symbol.qualifiedName(),
-            k -> Collections.synchronizedMap(new EnumMap<>(ModuleType.class)))
-          .put(symbol.moduleType(), documentContext);
-      }
-    }
-  }
-
-  /**
-   * Полностью очистить каталог библиотечных сущностей OneScript и снять связанные регистрации
-   * документов в индексе по mdoRef. Вызывается перед полной пере-индексацией библиотек.
-   */
-  public void clearOScriptLibrarySymbols() {
-    for (var uri : new ArrayList<>(oscriptLibraryNameKeysByUri.keySet())) {
-      removeOScriptDocumentMdoRefs(uri);
-    }
-    oscriptLibrariesByNameKey.clear();
-    oscriptLibraryNameKeysByUri.clear();
-  }
-
-  /**
-   * Снять регистрации .os-документа в индексе по mdoRef под его lib-именами.
-   */
-  private void removeOScriptDocumentMdoRefs(URI uri) {
-    var keys = oscriptLibraryNameKeysByUri.get(uri);
-    if (keys == null) {
-      return;
-    }
-    for (var key : keys) {
-      var symbol = oscriptLibrariesByNameKey.get(key);
-      if (symbol != null) {
-        var group = documentsByMDORef.get(symbol.qualifiedName());
-        if (group != null) {
-          group.remove(symbol.moduleType());
-          if (group.isEmpty()) {
-            documentsByMDORef.remove(symbol.qualifiedName());
-          }
-        }
+  public void removeOScriptLibrary(String qualifiedName, ModuleType moduleType) {
+    oscriptLibrariesByNameKey.remove(oscriptNameKey(qualifiedName));
+    var group = documentsByMDORef.get(qualifiedName);
+    if (group != null) {
+      group.remove(moduleType);
+      if (group.isEmpty()) {
+        documentsByMDORef.remove(qualifiedName);
       }
     }
   }
@@ -607,13 +554,12 @@ public class ServerContext {
   }
 
   /**
-   * Запись каталога библиотечных сущностей OneScript.
+   * Запись каталога библиотечных сущностей OneScript (для канонизации имени).
    *
    * @param qualifiedName каноничное имя
    * @param moduleType    тип модуля (класс/модуль)
-   * @param uri           URI .os-файла
    */
-  public record OScriptLibrarySymbol(String qualifiedName, ModuleType moduleType, URI uri) {
+  public record OScriptLibrarySymbol(String qualifiedName, ModuleType moduleType) {
   }
 
   private DocumentContext createDocumentContext(URI uri) {
@@ -621,9 +567,6 @@ public class ServerContext {
 
     documents.put(uri, documentContext);
     addMdoRefByUri(uri, documentContext);
-    // .os-документы библиотек дополнительно индексируются по своим каноничным lib-именам,
-    // если каталог уже населён индексатором (порядок не фиксирован — см. метод).
-    registerOScriptDocumentMdoRefs(uri);
 
     return documentContext;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContext.java
@@ -48,10 +48,12 @@ import org.springframework.stereotype.Component;
 import java.io.File;
 import java.net.URI;
 import java.nio.file.Path;
+import java.text.Normalizer;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
@@ -117,6 +119,15 @@ public class ServerContext {
    */
   private final Map<String, Map<ModuleType, DocumentContext>> documentsByMDORef
     = new ConcurrentHashMap<>();
+  /**
+   * Каталог библиотечных сущностей OneScript: {@code nameKey → (каноничное имя, тип модуля, URI)}.
+   * Наполняется извне (индексатором OneScript-библиотек) и служит резолву имени класса/модуля
+   * библиотеки в каноничный mdoRef — аналогично тому, как {@link #findCommonModule(String)}
+   * резолвит общий модуль из метаданных конфигурации. Регистронезависимый (ключ — {@code nameKey}).
+   */
+  private final Map<String, OScriptLibrarySymbol> oscriptLibrariesByNameKey = new ConcurrentHashMap<>();
+  /** Обратный индекс {@code URI → nameKey'и записей} для снятия при удалении/пере-индексации файла. */
+  private final Map<URI, Set<String>> oscriptLibraryNameKeysByUri = new ConcurrentHashMap<>();
   private final Map<URI, ReadWriteLock> documentLocks = new ConcurrentHashMap<>();
 
   private final Map<DocumentContext, State> states = new ConcurrentHashMap<>();
@@ -301,6 +312,7 @@ public class ServerContext {
     }
 
     removeDocumentMdoRefByUri(uri);
+    removeOScriptDocumentMdoRefs(uri);
     states.remove(documentContext);
     documents.remove(uri);
     documentLocks.remove(uri);
@@ -331,6 +343,8 @@ public class ServerContext {
     states.clear();
     documentsByMDORef.clear();
     mdoRefs.clear();
+    oscriptLibrariesByNameKey.clear();
+    oscriptLibraryNameKeysByUri.clear();
     documentLocks.clear();
     commonModuleCache.invalidateAll();
     configurationMetadata.clear();
@@ -470,11 +484,146 @@ public class ServerContext {
     return commonModuleCache.get(name, key -> getConfiguration().findCommonModule(key));
   }
 
+  /**
+   * Зарегистрировать библиотечную сущность OneScript (класс/модуль) в каталоге.
+   * Вызывается индексатором OneScript-библиотек.
+   *
+   * @param qualifiedName каноничное имя сущности
+   * @param moduleType    {@link ModuleType#OScriptClass} или {@link ModuleType#OScriptModule}
+   * @param uri           URI .os-файла
+   */
+  public void registerOScriptLibrarySymbol(String qualifiedName, ModuleType moduleType, URI uri) {
+    var key = oscriptNameKey(qualifiedName);
+    oscriptLibrariesByNameKey.put(key, new OScriptLibrarySymbol(qualifiedName, moduleType, uri));
+    oscriptLibraryNameKeysByUri.computeIfAbsent(uri, k -> ConcurrentHashMap.newKeySet()).add(key);
+    registerOScriptDocumentMdoRefs(uri);
+  }
+
+  /**
+   * Снять все библиотечные записи OneScript, связанные с файлом (при удалении/пере-индексации).
+   */
+  public void removeOScriptLibrarySymbolsByUri(URI uri) {
+    // сначала снимаем регистрации документа в индексе по mdoRef (пока каталог ещё населён),
+    // потом чистим сам каталог.
+    removeOScriptDocumentMdoRefs(uri);
+    var keys = oscriptLibraryNameKeysByUri.remove(uri);
+    if (keys != null) {
+      keys.forEach(oscriptLibrariesByNameKey::remove);
+    }
+  }
+
+  /**
+   * Зарегистрировать .os-документ в индексе по mdoRef под каждым его каноничным lib-именем
+   * (если документ уже создан). Идемпотентно; вызывается и при создании документа, и при
+   * наполнении каталога — порядок этих событий не фиксирован.
+   */
+  private void registerOScriptDocumentMdoRefs(URI uri) {
+    var documentContext = documents.get(uri);
+    var keys = oscriptLibraryNameKeysByUri.get(uri);
+    if (documentContext == null || keys == null) {
+      return;
+    }
+    for (var key : keys) {
+      var symbol = oscriptLibrariesByNameKey.get(key);
+      if (symbol != null) {
+        documentsByMDORef
+          .computeIfAbsent(symbol.qualifiedName(),
+            k -> Collections.synchronizedMap(new EnumMap<>(ModuleType.class)))
+          .put(symbol.moduleType(), documentContext);
+      }
+    }
+  }
+
+  /**
+   * Полностью очистить каталог библиотечных сущностей OneScript и снять связанные регистрации
+   * документов в индексе по mdoRef. Вызывается перед полной пере-индексацией библиотек.
+   */
+  public void clearOScriptLibrarySymbols() {
+    for (var uri : new ArrayList<>(oscriptLibraryNameKeysByUri.keySet())) {
+      removeOScriptDocumentMdoRefs(uri);
+    }
+    oscriptLibrariesByNameKey.clear();
+    oscriptLibraryNameKeysByUri.clear();
+  }
+
+  /**
+   * Снять регистрации .os-документа в индексе по mdoRef под его lib-именами.
+   */
+  private void removeOScriptDocumentMdoRefs(URI uri) {
+    var keys = oscriptLibraryNameKeysByUri.get(uri);
+    if (keys == null) {
+      return;
+    }
+    for (var key : keys) {
+      var symbol = oscriptLibrariesByNameKey.get(key);
+      if (symbol != null) {
+        var group = documentsByMDORef.get(symbol.qualifiedName());
+        if (group != null) {
+          group.remove(symbol.moduleType());
+          if (group.isEmpty()) {
+            documentsByMDORef.remove(symbol.qualifiedName());
+          }
+        }
+      }
+    }
+  }
+
+  /**
+   * Найти каноничное имя зарегистрированного library-класса OneScript по имени из исходного кода.
+   *
+   * @param name имя из кода (произвольный регистр)
+   * @return каноничное имя класса либо {@code empty}
+   */
+  public Optional<String> findLibraryClass(String name) {
+    return findOScriptLibrarySymbol(name, ModuleType.OScriptClass);
+  }
+
+  /**
+   * Найти каноничное имя зарегистрированного library-модуля OneScript по имени из исходного кода.
+   *
+   * @param name имя из кода (произвольный регистр)
+   * @return каноничное имя модуля либо {@code empty}
+   */
+  public Optional<String> findLibraryModule(String name) {
+    return findOScriptLibrarySymbol(name, ModuleType.OScriptModule);
+  }
+
+  private Optional<String> findOScriptLibrarySymbol(String name, ModuleType moduleType) {
+    if (name == null || name.isBlank()) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(oscriptLibrariesByNameKey.get(oscriptNameKey(name)))
+      .filter(symbol -> symbol.moduleType() == moduleType)
+      .map(OScriptLibrarySymbol::qualifiedName);
+  }
+
+  /**
+   * Нормализация имени OneScript-сущности для регистронезависимого сравнения.
+   * Должна совпадать с {@code OScriptLibraryIndex.nameKey}: NFC + lower-case (Locale.ROOT) —
+   * имена в .os-файлах хранятся в NFD, а в коде набираются в NFC.
+   */
+  private static String oscriptNameKey(String name) {
+    return Normalizer.normalize(name, Normalizer.Form.NFC).toLowerCase(Locale.ROOT);
+  }
+
+  /**
+   * Запись каталога библиотечных сущностей OneScript.
+   *
+   * @param qualifiedName каноничное имя
+   * @param moduleType    тип модуля (класс/модуль)
+   * @param uri           URI .os-файла
+   */
+  public record OScriptLibrarySymbol(String qualifiedName, ModuleType moduleType, URI uri) {
+  }
+
   private DocumentContext createDocumentContext(URI uri) {
     var documentContext = documentContextProvider.getObject(uri, this);
 
     documents.put(uri, documentContext);
     addMdoRefByUri(uri, documentContext);
+    // .os-документы библиотек дополнительно индексируются по своим каноничным lib-именам,
+    // если каталог уже населён индексатором (порядок не фиксирован — см. метод).
+    registerOScriptDocumentMdoRefs(uri);
 
     return documentContext;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/KeywordSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/KeywordSymbol.java
@@ -28,7 +28,7 @@ import org.eclipse.lsp4j.SymbolKind;
 /**
  * Synthetic-символ BSL-keyword'а ({@code Если}, {@code Истина}, {@code Цикл}…).
  * <p>
- * Создаётся on-the-fly в {@link com.github._1c_syntax.bsl.languageserver.references.KeywordReferenceFinder}
+ * Создаётся on-the-fly в {@link com.github._1c_syntax.bsl.languageserver.types.references.KeywordReferenceFinder}
  * при попадании курсора на keyword-токен — keyword'ы не являются
  * source-defined-символами и не лежат в symbol-tree модуля, но участвуют
  * в общем reference/hover-flow на правах обычного {@link Symbol}.

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/hover/KeywordSymbolMarkupContentBuilder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/hover/KeywordSymbolMarkupContentBuilder.java
@@ -35,7 +35,7 @@ import org.springframework.stereotype.Component;
  * ({@code Если}, {@code Истина}, {@code Цикл}…).
  * <p>
  * {@link KeywordSymbol} приходит уже с локализованным описанием
- * (выбранным {@link com.github._1c_syntax.bsl.languageserver.references.KeywordReferenceFinder}
+ * (выбранным {@link com.github._1c_syntax.bsl.languageserver.types.references.KeywordReferenceFinder}
  * по текущей локали LS и AST-контексту). Билдер только оборачивает
  * keyword и описание в markdown-формат:
  * <pre>

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/HoverProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/HoverProvider.java
@@ -42,7 +42,7 @@ import java.util.Optional;
  * подбору ссылки, живёт в реализациях {@link com.github._1c_syntax.bsl.languageserver.references.ReferenceFinder}
  * (в том числе synthetic-символы для аннотаций и keyword'ов —
  * {@link com.github._1c_syntax.bsl.languageserver.references.AnnotationReferenceFinder},
- * {@link com.github._1c_syntax.bsl.languageserver.references.KeywordReferenceFinder}),
+ * {@link com.github._1c_syntax.bsl.languageserver.types.references.KeywordReferenceFinder}),
  * всё, что относится к формированию текста подсказки — в соответствующем
  * {@code MarkupContentBuilder}.
  *

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
@@ -30,7 +30,6 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
-import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex;
 import com.github._1c_syntax.bsl.languageserver.context.MdoRefBuilder;
 import com.github._1c_syntax.bsl.languageserver.utils.Methods;
 import com.github._1c_syntax.bsl.languageserver.utils.ModuleReference;
@@ -85,7 +84,6 @@ public class ReferenceIndexFiller {
 
   private final ReferenceIndex index;
   private final LanguageServerConfiguration configuration;
-  private final OScriptLibraryIndex oScriptLibraryIndex;
 
   @EventListener
   public void handleEvent(DocumentContextContentChangedEvent event) {
@@ -267,35 +265,34 @@ public class ReferenceIndexFiller {
         return;
       }
       var name = typeName.IDENTIFIER().getText();
-      var libUri = oScriptLibraryIndex.findClassUri(name);
-      if (libUri.isEmpty()) {
+      var libClass = documentContext.getServerContext().findLibraryClass(name);
+      if (libClass.isEmpty()) {
         return;
       }
-      var libMdoRef = libUri.get().toString();
-      var moduleType = actualLibraryModuleType(libUri.get(), ModuleType.OScriptClass);
+      var mdoRef = libClass.get();
       var range = Ranges.create(typeName.IDENTIFIER());
 
-      var ctor = libraryClassConstructor(libUri.get());
+      var ctor = libraryClassConstructor(mdoRef);
       if (ctor.isPresent()) {
         index.addMethodCall(
           documentContext.getUri(),
-          libMdoRef,
-          moduleType,
+          mdoRef,
+          ModuleType.OScriptClass,
           ctor.get().getName(),
           range
         );
       } else {
         index.addModuleReference(
           documentContext.getUri(),
-          libMdoRef,
-          moduleType,
+          mdoRef,
+          ModuleType.OScriptClass,
           range
         );
       }
     }
 
-    private Optional<ConstructorSymbol> libraryClassConstructor(URI libUri) {
-      return Optional.ofNullable(documentContext.getServerContext().getDocument(libUri))
+    private Optional<ConstructorSymbol> libraryClassConstructor(String mdoRef) {
+      return documentContext.getServerContext().getDocument(mdoRef, ModuleType.OScriptClass)
         .map(DocumentContext::getSymbolTree)
         .flatMap(SymbolTree::getConstructor);
     }
@@ -312,39 +309,25 @@ public class ReferenceIndexFiller {
       if (identifier == null) {
         return;
       }
-      var libUri = oScriptLibraryIndex.findModuleUri(identifier.getText());
-      if (libUri.isEmpty()) {
+      var libModule = documentContext.getServerContext().findLibraryModule(identifier.getText());
+      if (libModule.isEmpty()) {
         return;
       }
-      var libMdoRef = libUri.get().toString();
-      var moduleType = actualLibraryModuleType(libUri.get(), ModuleType.OScriptModule);
+      var mdoRef = libModule.get();
 
       // Ссылка на сам identifier модуля — нужна для go-to-definition без точки.
       index.addModuleReference(
         documentContext.getUri(),
-        libMdoRef,
-        moduleType,
+        mdoRef,
+        ModuleType.OScriptModule,
         Ranges.create(identifier)
       );
 
       if (methodName.isPresent()) {
         var methodNameToken = methodName.get();
-        addMethodCall(libMdoRef, moduleType, Strings.trimQuotes(methodNameToken.getText()),
+        addMethodCall(mdoRef, ModuleType.OScriptModule, Strings.trimQuotes(methodNameToken.getText()),
           Ranges.create(methodNameToken));
       }
-    }
-
-    /**
-     * Возвращает фактический {@link ModuleType} документа библиотечного .os-файла.
-     * Один .os может быть зарегистрирован одновременно и как класс, и как модуль
-     * (см. {@link OScriptLibraryIndex}); чтобы ссылка корректно резолвилась через
-     * {@code ServerContext.getDocument(mdoRef, moduleType)}, используем тип
-     * фактически загруженного {@link DocumentContext}, а не «теоретический»
-     * тип из роли регистрации.
-     */
-    private ModuleType actualLibraryModuleType(java.net.URI libUri, ModuleType fallback) {
-      var dc = documentContext.getServerContext().getDocument(libUri);
-      return dc != null ? dc.getModuleType() : fallback;
     }
 
     /**
@@ -585,8 +568,8 @@ public class ReferenceIndexFiller {
       if (typeName == null || typeName.IDENTIFIER() == null) {
         return null;
       }
-      return oScriptLibraryIndex.findClassUri(typeName.IDENTIFIER().getText())
-        .map(java.net.URI::toString)
+      return documentContext.getServerContext()
+        .findLibraryClass(typeName.IDENTIFIER().getText())
         .orElse(null);
     }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexFiller.java
@@ -25,10 +25,8 @@ import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConf
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.MdoRefBuilder;
 import com.github._1c_syntax.bsl.languageserver.utils.Methods;
@@ -269,10 +267,11 @@ public class ReferenceIndexFiller {
       if (libClass.isEmpty()) {
         return;
       }
-      var mdoRef = libClass.get();
+      var libDocument = libClass.get();
+      var mdoRef = libDocument.getMdoRef();
       var range = Ranges.create(typeName.IDENTIFIER());
 
-      var ctor = libraryClassConstructor(mdoRef);
+      var ctor = libDocument.getSymbolTree().getConstructor();
       if (ctor.isPresent()) {
         index.addMethodCall(
           documentContext.getUri(),
@@ -291,12 +290,6 @@ public class ReferenceIndexFiller {
       }
     }
 
-    private Optional<ConstructorSymbol> libraryClassConstructor(String mdoRef) {
-      return documentContext.getServerContext().getDocument(mdoRef, ModuleType.OScriptClass)
-        .map(DocumentContext::getSymbolTree)
-        .flatMap(SymbolTree::getConstructor);
-    }
-
     /**
      * Если идентификатор соответствует имени зарегистрированного OneScript
      * library-модуля, регистрирует:
@@ -313,7 +306,7 @@ public class ReferenceIndexFiller {
       if (libModule.isEmpty()) {
         return;
       }
-      var mdoRef = libModule.get();
+      var mdoRef = libModule.get().getMdoRef();
 
       // Ссылка на сам identifier модуля — нужна для go-to-definition без точки.
       index.addModuleReference(
@@ -570,6 +563,7 @@ public class ReferenceIndexFiller {
       }
       return documentContext.getServerContext()
         .findLibraryClass(typeName.IDENTIFIER().getText())
+        .map(DocumentContext::getMdoRef)
         .orElse(null);
     }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
@@ -138,6 +138,7 @@ public class OScriptLibraryIndex {
    */
   public List<Path> reindex(ServerContext serverContext) {
     oScriptModuleTypeResolver.clear();
+    serverContext.clearOScriptLibrarySymbols();
     entriesByUri.clear();
     entriesByName.clear();
 
@@ -172,6 +173,8 @@ public class OScriptLibraryIndex {
       return;
     }
     oScriptModuleTypeResolver.unregister(uri);
+    serverContextProvider.getServerContext(uri)
+      .ifPresent(sc -> sc.removeOScriptLibrarySymbolsByUri(uri));
     for (var entry : entries) {
       entriesByName.remove(nameKey(entry.qualifiedName()));
     }
@@ -417,6 +420,10 @@ public class OScriptLibraryIndex {
     var entry = new LibraryEntry(uri, qualifiedName, kind, libOrigin, implicit);
     entriesByUri.computeIfAbsent(uri, k -> new java.util.concurrent.CopyOnWriteArrayList<>()).add(entry);
     entriesByName.put(nameKey(qualifiedName), entry);
+
+    // Публикуем сущность в каталог ServerContext ДО добавления документа: при создании документа
+    // (createDocumentContext) он сразу проиндексируется в documentsByMDORef под своим lib-именем.
+    serverContext.registerOScriptLibrarySymbol(qualifiedName, moduleType, uri);
 
     // Добавляем .os-файл в ServerContext как обычный документ. SymbolTreeComputer,
     // ReferenceIndexFiller, OScriptModuleMembersProvider и прочие подхватят его

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
@@ -425,6 +425,11 @@ public class OScriptLibraryIndex {
     entriesByUri.computeIfAbsent(uri, k -> new java.util.concurrent.CopyOnWriteArrayList<>()).add(entry);
     entriesByName.put(nameKey(qualifiedName), entry);
 
+    // Привязываем URI → каноничное имя ДО addDocument: тогда mdoRef создаваемого документа
+    // вычислится как имя библиотеки (а не URI), и он проиндексируется в documentsByMDORef под
+    // своим именем — единообразно с BSL-объектами.
+    serverContext.registerOScriptLibraryName(uri, qualifiedName);
+
     // Добавляем .os-файл в ServerContext как обычный документ. SymbolTreeComputer,
     // ReferenceIndexFiller, OScriptModuleMembersProvider и прочие подхватят его
     // через события.
@@ -432,8 +437,8 @@ public class OScriptLibraryIndex {
       var dc = serverContext.addDocument(uri);
       serverContext.rebuildDocument(dc);
       // Регистрируем сущность в каталоге имён ServerContext и индексируем документ в
-      // documentsByMDORef под каноничным именем — чтобы ReferenceIndexFiller резолвил
-      // ссылки на эту lib-сущность через ServerContext.getDocument(имя, moduleType).
+      // documentsByMDORef под его mdoRef (= каноничным именем) — чтобы ReferenceIndexFiller
+      // резолвил ссылки на эту lib-сущность через ServerContext.getDocument(имя, moduleType).
       serverContext.registerOScriptLibrary(qualifiedName, moduleType, dc);
       // Явный вызов: гарантирует регистрацию USER-типа в актуальном
       // workspace-scope (event-listener тоже сработает, но он не

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/oscript/OScriptLibraryIndex.java
@@ -138,7 +138,9 @@ public class OScriptLibraryIndex {
    */
   public List<Path> reindex(ServerContext serverContext) {
     oScriptModuleTypeResolver.clear();
-    serverContext.clearOScriptLibrarySymbols();
+    // снимаем прежние регистрации lib-сущностей в ServerContext (каталог имён + documentsByMDORef)
+    entriesByName.values().forEach(entry ->
+      serverContext.removeOScriptLibrary(entry.qualifiedName(), moduleTypeOf(entry.kind())));
     entriesByUri.clear();
     entriesByName.clear();
 
@@ -173,10 +175,12 @@ public class OScriptLibraryIndex {
       return;
     }
     oScriptModuleTypeResolver.unregister(uri);
-    serverContextProvider.getServerContext(uri)
-      .ifPresent(sc -> sc.removeOScriptLibrarySymbolsByUri(uri));
+    var serverContext = serverContextProvider.getServerContext(uri).orElse(null);
     for (var entry : entries) {
       entriesByName.remove(nameKey(entry.qualifiedName()));
+      if (serverContext != null) {
+        serverContext.removeOScriptLibrary(entry.qualifiedName(), moduleTypeOf(entry.kind()));
+      }
     }
     oScriptModuleMembersProvider.unregister(uri);
   }
@@ -407,7 +411,7 @@ public class OScriptLibraryIndex {
     // OScriptModuleMembersProvider → TypeRegistry, и в completion-метки.
     var qualifiedName = Normalizer.normalize(rawQualifiedName, Normalizer.Form.NFC);
     var uri = Absolute.uri(osFile.toUri());
-    var moduleType = kind == EntryKind.CLASS ? ModuleType.OScriptClass : ModuleType.OScriptModule;
+    var moduleType = moduleTypeOf(kind);
     // Сначала сообщаем резолверу тип модуля — это нужно, чтобы при первом
     // событии DocumentContextContentChangedEvent документ уже знал свой
     // ModuleType (через DocumentContext.computeModuleType фолбэк).
@@ -421,16 +425,16 @@ public class OScriptLibraryIndex {
     entriesByUri.computeIfAbsent(uri, k -> new java.util.concurrent.CopyOnWriteArrayList<>()).add(entry);
     entriesByName.put(nameKey(qualifiedName), entry);
 
-    // Публикуем сущность в каталог ServerContext ДО добавления документа: при создании документа
-    // (createDocumentContext) он сразу проиндексируется в documentsByMDORef под своим lib-именем.
-    serverContext.registerOScriptLibrarySymbol(qualifiedName, moduleType, uri);
-
     // Добавляем .os-файл в ServerContext как обычный документ. SymbolTreeComputer,
     // ReferenceIndexFiller, OScriptModuleMembersProvider и прочие подхватят его
     // через события.
     try {
       var dc = serverContext.addDocument(uri);
       serverContext.rebuildDocument(dc);
+      // Регистрируем сущность в каталоге имён ServerContext и индексируем документ в
+      // documentsByMDORef под каноничным именем — чтобы ReferenceIndexFiller резолвил
+      // ссылки на эту lib-сущность через ServerContext.getDocument(имя, moduleType).
+      serverContext.registerOScriptLibrary(qualifiedName, moduleType, dc);
       // Явный вызов: гарантирует регистрацию USER-типа в актуальном
       // workspace-scope (event-listener тоже сработает, но он не
       // обязан выполняться в том же scope/потоке, что и reindex).
@@ -443,6 +447,10 @@ public class OScriptLibraryIndex {
     } catch (RuntimeException e) {
       LOGGER.warn("Failed to load oscript library file: {}", osFile, e);
     }
+  }
+
+  private static ModuleType moduleTypeOf(EntryKind kind) {
+    return kind == EntryKind.CLASS ? ModuleType.OScriptClass : ModuleType.OScriptModule;
   }
 
   @Nullable

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/references/KeywordReferenceFinder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/references/KeywordReferenceFinder.java
@@ -19,11 +19,13 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with BSL Language Server.
  */
-package com.github._1c_syntax.bsl.languageserver.references;
+package com.github._1c_syntax.bsl.languageserver.types.references;
 
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.KeywordSymbol;
+import com.github._1c_syntax.bsl.languageserver.references.AnnotationReferenceFinder;
+import com.github._1c_syntax.bsl.languageserver.references.ReferenceFinder;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
 import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/references/NewExpressionReferenceFinder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/references/NewExpressionReferenceFinder.java
@@ -19,10 +19,11 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with BSL Language Server.
  */
-package com.github._1c_syntax.bsl.languageserver.references;
+package com.github._1c_syntax.bsl.languageserver.types.references;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.bsl.languageserver.references.ReferenceFinder;
 import com.github._1c_syntax.bsl.languageserver.references.model.OccurrenceType;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/references/PlatformMemberReferenceFinder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/references/PlatformMemberReferenceFinder.java
@@ -19,9 +19,10 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with BSL Language Server.
  */
-package com.github._1c_syntax.bsl.languageserver.references;
+package com.github._1c_syntax.bsl.languageserver.types.references;
 
 import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
+import com.github._1c_syntax.bsl.languageserver.references.ReferenceFinder;
 import com.github._1c_syntax.bsl.languageserver.references.model.OccurrenceType;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/references/package-info.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/references/package-info.java
@@ -1,0 +1,34 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+
+/**
+ * Type-aware реализации порта {@link com.github._1c_syntax.bsl.languageserver.references.ReferenceFinder}.
+ * <p>
+ * Резолвят ссылки, консультируясь с системой типов (платформенные/конфигурационные члены,
+ * конструкторы, ключевые слова). Сам порт и type-agnostic finder'ы живут в пакете
+ * {@code references}; эти адаптеры вынесены сюда, к своим зависимостям из {@code types},
+ * чтобы пакет {@code references} не зависел от {@code types}.
+ */
+@NullMarked
+package com.github._1c_syntax.bsl.languageserver.types.references;
+
+import org.jspecify.annotations.NullMarked;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/architecture/ArchitectureTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/architecture/ArchitectureTest.java
@@ -201,10 +201,11 @@ class ArchitectureTest {
   // зависимости): в байткоде в него никто не входит (ссылки на него — только в Javadoc @link),
   // поэтому он не нарушает полноту. websocket — лист без внутренних зависимостей.
   //
-  // Известные циклы оставлены ОСОЗНАННО (правило их допускает, но они помечены как долг):
-  //   - References↔Types: взаимные ссылки индексов. Разрывается позже.
-  // Появление НОВЫХ циклов среди уже ацикличных пакетов ловит отдельное правило ниже
-  // (acyclic_domains_stay_free_of_cycles).
+  // Цикл References↔Types разорван: type-aware finder'ы переехали в types.references, а
+  // ReferenceIndexFiller резолвит library-сущности OneScript по mdoRef через ServerContext
+  // (каталог наполняет types), поэтому references больше не зависит от types — осталось только
+  // types→references. Появление НОВЫХ циклов среди уже ацикличных пакетов ловит отдельное правило
+  // ниже (acyclic_domains_stay_free_of_cycles).
   //
   // Замечание про inline-константы: codeactions и diagnostics ссылаются на DiagnosticProvider.SOURCE
   // (public static final String) — javac встраивает значение, ребра в байткоде нет, поэтому Providers
@@ -316,13 +317,14 @@ class ArchitectureTest {
       "Cfg", "Configuration", "Context", "DiagnosticsMetadata", "Formatting", "Infrastructure",
       "Recognizer", "References", "Types", "Utils")
 
-    // Домены-фундамент. References↔Types — известный цикл (см. комментарий выше).
+    // Домены-фундамент. references — нижний слой разрешения имён, от types НЕ зависит;
+    // types выше и зависит от references (вывод типов опирается на разрешение имён).
     .whereLayer("Configuration").mayOnlyAccessLayers(
       "DiagnosticsMetadata", "Events", "Infrastructure", "Utils")
     .whereLayer("Context").mayOnlyAccessLayers(
       "Client", "Configuration", "DiagnosticsMetadata", "Infrastructure", "Utils")
     .whereLayer("References").mayOnlyAccessLayers(
-      "Configuration", "Context", "Infrastructure", "Types", "Utils")
+      "Configuration", "Context", "Infrastructure", "Utils")
     .whereLayer("Types").mayOnlyAccessLayers(
       "Configuration", "Context", "Events", "Infrastructure", "References", "Utils")
     .whereLayer("Cfg").mayOnlyAccessLayers("Utils")


### PR DESCRIPTION
## Зачем

`references ↔ types` — последний реальный кросс-доменный цикл ядра. Естественное направление —
**`references` снизу** (type-agnostic разрешение имён), **`types` сверху** (вывод типов опирается на
разрешение имён). Значит оставляем `types → references`, убираем `references → types` целиком.

Этих рёбер было 6: пять давали три «type-aware» finder&#39;а, шестое — `ReferenceIndexFiller`,
которому нужно было сматчить имя OneScript-класса/модуля в его .os-документ.

## Что сделано

**1. Перенос type-aware finder&#39;ов (5 рёбер).** `KeywordReferenceFinder`,
`NewExpressionReferenceFinder`, `PlatformMemberReferenceFinder` резолвят ссылки, **консультируясь с
системой типов** (`TypeService`, `GlobalScopeProvider`, символы типов) — это адаптеры порта
`ReferenceFinder`, а не ядро разрешения имён. Порт и чистые finder&#39;ы остались в `references`, эти
три переехали в **`types.references`**, к своим зависимостям. Они по-прежнему реализуют
`references.ReferenceFinder` и собираются `ReferenceResolver`&#39;ом через `List`
(Spring, независимо от пакета).

**2. Унификация OScript-резолва по mdoRef (6-е ребро).** Раньше BSL-ссылки резолвились по
**логическому mdoRef** (`MdoRefBuilder`/`findCommonModule` из `context`) через
`ServerContext.getDocument(mdoRef, moduleType)`, а OScript был исключением — ключевался по URI,
потому что у .os-доков библиотек нет объекта метаданных, а значит и логического mdoRef. Привёл
OScript к BSL — теперь у library-.os-документа **`mdoRef` = его каноничное lib-имя**:
- `OScriptLibraryIndex` при `registerEntry` **до** `addDocument` сеет привязку `URI → каноничное
  имя` в `ServerContext` (`registerOScriptLibraryName`); `MdoRefBuilder` для .os-файла без
  MD-объекта берёт mdoRef из этой привязки (а не из URI). Так документ попадает в
  `documentsByMDORef` **под своим же mdoRef** — механизмом `addMdoRefByUri`, единообразно с BSL.
  **Мультиидентичность** (один файл — несколько lib-имён/ролей) схлопывается в одну стабильную
  идентичность документа (первое имя выигрывает, как и `ModuleType` в `OScriptModuleTypeResolver`);
  под каждый `ModuleType`-роль документ доступен через тот же mdoRef.
- `ServerContext` держит **каталог lib-сущностей** (`имя → (ModuleType, DocumentContext)`,
  регистронезависимый) для резолва имени класса/модуля в документ — параллельно `findCommonModule`.
  `findLibraryClass`/`findLibraryModule` теперь возвращают **`DocumentContext`** (а не строку-имя):
  вызывающему нужен именно документ (конструктор, символы), а ключ индекса он берёт из
  `doc.getMdoRef()`.
- `ReferenceIndexFiller` берёт документ через `findLibrary…`, пишет `mdoRef = doc.getMdoRef()` и
  синтаксический `ModuleType`; лишний round-trip `getDocument(mdoRef, moduleType)` и хелпер
  `libraryClassConstructor` убраны. Зависимость `references → types` из филлера ушла.

**3. Починка висячих javadoc-`@link`.** Три ссылки на `KeywordReferenceFinder` в
`context.symbol`/`hover`/`providers` остались указывать на старый пакет после переезда финдера в
`types.references` (шаг 1) — обновлены на новый FQN (из-за них CI `check` падал на `javadoc`).

## Граф

`references → types` = **0** — **цикл разорван**, `references` стал нижним слоем. Из реальных циклов
ядра не осталось ни одного (после `configuration↔context` в #4229). Модель `ArchitectureTest`
обновлена: `References` больше не обращается к `Types`, осталось только `types → references`.

## Инварианты (по ревью-замечаниям)

- `context` **не** зависит от `types`: каталог/привязки на `ServerContext` используют только
  контекст-безопасные типы (`String`/`URI`/`DocumentContext`/внешний `bsl.types.ModuleType`) —
  цикла `context↔types` не возникает.
- API поиска модулей симметричен: `findLibraryClass/Module` — в том же домене `context`, что и
  `findCommonModule` (не переведён на API типов).
- **BSL-путь регистрации** (`addMdoRefByUri`/`mdoRefs`) концептуально не тронут — .os теперь просто
  идёт по нему же, получив каноничный mdoRef.

## Проверки

Локально зелёные: **полный `./gradlew test` — `BUILD SUCCESSFUL`, 0 падений** (включая
`ArchitectureTest` с `layer_dependencies_are_respected`/`acyclic_domains_stay_free_of_cycles` и все
OScript-тесты резолюции/определения/hover/completion/signature), плюс `spotlessCheck` и `javadoc`.

## Дальше (отдельно)

Консолидация `OScriptLibraryIndex` ↔ `GlobalScopeProvider` (оба держат `имя/тип ↔ URI` в `types`) —
отложена в отдельный шаг.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


## Summary by CodeRabbit

* **New Features**
  * Enhanced navigation for OneScript library classes and modules with more robust matching (case- and Unicode-normalized).
  * Improved library resolution consistency so library-backed symbols map reliably across documents.

* **Bug Fixes**
  * Reference resolution remains correct after workspace reindexing, including when library-related files are added, updated, or removed.
  * Reduced missed and stale references for library-based code navigation, with improved handling for library documents that may lack certain internal anchors.
