### PR TITLE
fix(lsp): анализ одиночного файла и untitled-документов без workspace

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -206,6 +206,9 @@ public class ServerContextProvider {
    */
   public void removeWorkspace(WorkspaceFolder workspaceFolder) {
     var uri = Absolute.uri(workspaceFolder.getUri());
+    // Переставляем главный контекст на другой ДО удаления из карты, чтобы primary никогда не
+    // указывал на уже удалённый контекст (иначе getPrimaryContext упал бы в гонке с маршрутизацией).
+    repointPrimaryBeforeRemoval(uri);
     var serverContext = contexts.remove(uri);
     workspaceRoots.remove(uri);
 
@@ -224,7 +227,6 @@ public class ServerContextProvider {
 
     workspaceScope.removeWorkspace(uri);
     WorkspaceContextHolder.unregisterWorkspace(uri);
-    repointPrimaryIfRemoved(uri);
   }
 
   /**
@@ -276,8 +278,9 @@ public class ServerContextProvider {
    * ({@link #getPrimaryContext()}). URI нормализуется через {@link Absolute#uri(URI)}.
    *
    * @param documentUri URI документа (будет нормализован)
-   * @return контекст сервера для документа или пустой Optional,
-   *         если не зарегистрирован ни один контекст
+   * @return контекст сервера для документа (Optional всегда непустой после {@code initialize()})
+   * @throws IllegalStateException если не зарегистрирован ни один контекст
+   *         (провайдер используется до {@code initialize()} или после {@code shutdown()})
    */
   public Optional<ServerContext> resolveContextForDocument(URI documentUri) {
     var normalizedUri = Absolute.uri(documentUri);
@@ -292,16 +295,28 @@ public class ServerContextProvider {
    * Получить главный контекст — первый зарегистрированный workspace (или дефолтный контекст
    * в режиме одиночного файла). Package-private: используется внутри
    * {@link #resolveContextForDocument(URI)} и в тестах пакета.
+   * <p>
+   * После {@code initialize()} главный контекст всегда выбран ({@code setConfigurationRoot}
+   * регистрирует либо реальные папки, либо дефолт), поэтому его отсутствие — нарушение
+   * инварианта, а не штатная ситуация: провайдер используется до {@code initialize()} или
+   * после {@code shutdown()}. Такое падаем громко, а не глотаем пустым результатом.
    *
-   * @return главный контекст сервера или пустой Optional,
-   *         если не зарегистрирован ни один контекст
+   * @return главный контекст сервера (Optional всегда непустой)
+   * @throws IllegalStateException если главный контекст не выбран или отсутствует в карте
    */
   Optional<ServerContext> getPrimaryContext() {
     var uri = primaryWorkspaceUri.get();
     if (uri == null) {
-      return Optional.empty();
+      throw new IllegalStateException(
+        "Главный workspace-контекст не выбран: ServerContextProvider используется до initialize() "
+          + "или после shutdown()."
+      );
     }
-    return Optional.ofNullable(contexts.get(uri));
+    var context = contexts.get(uri);
+    if (context == null) {
+      throw new IllegalStateException("Главный workspace-контекст отсутствует для URI: " + uri);
+    }
+    return Optional.of(context);
   }
 
   /**
@@ -435,14 +450,20 @@ public class ServerContextProvider {
    * Переназначить главный контекст при удалении текущего главного: предпочитаем оставшийся
    * реальный workspace синтетическому дефолту, дефолт — как последний вариант.
    */
-  private void repointPrimaryIfRemoved(URI removedUri) {
+  private void repointPrimaryBeforeRemoval(URI removedUri) {
     if (!removedUri.equals(primaryWorkspaceUri.get())) {
       return;
     }
+    // contexts ещё содержит removedUri (вызов до удаления) — исключаем его явно;
+    // предпочитаем оставшийся реальный workspace синтетическому дефолту.
     var next = contexts.keySet().stream()
+      .filter(uri -> !uri.equals(removedUri))
       .filter(uri -> !DEFAULT_WORKSPACE_URI.equals(uri))
       .findFirst()
-      .orElseGet(() -> contexts.containsKey(DEFAULT_WORKSPACE_URI) ? DEFAULT_WORKSPACE_URI : null);
+      .orElseGet(() ->
+        !DEFAULT_WORKSPACE_URI.equals(removedUri) && contexts.containsKey(DEFAULT_WORKSPACE_URI)
+          ? DEFAULT_WORKSPACE_URI : null
+      );
     primaryWorkspaceUri.set(next);
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -288,12 +288,13 @@ public class ServerContextProvider {
 
   /**
    * Получить главный контекст — первый зарегистрированный workspace (или дефолтный контекст
-   * в режиме одиночного файла).
+   * в режиме одиночного файла). Package-private: используется внутри
+   * {@link #resolveContextForDocument(URI)} и в тестах пакета.
    *
    * @return главный контекст сервера или пустой Optional,
    *         если не зарегистрирован ни один контекст
    */
-  public Optional<ServerContext> getPrimaryContext() {
+  Optional<ServerContext> getPrimaryContext() {
     var uri = primaryWorkspaceUri.get();
     if (uri == null) {
       return Optional.empty();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -454,8 +454,8 @@ public class ServerContextProvider {
     if (!removedUri.equals(primaryWorkspaceUri.get())) {
       return;
     }
-    // contexts ещё содержит removedUri (вызов до удаления) — исключаем его явно;
-    // предпочитаем оставшийся реальный workspace синтетическому дефолту.
+    // Карта ещё содержит удаляемый workspace (вызов идёт до удаления) — исключаем его явно
+    // и предпочитаем оставшийся реальный workspace синтетическому дефолту
     var next = contexts.keySet().stream()
       .filter(uri -> !uri.equals(removedUri))
       .filter(uri -> !DEFAULT_WORKSPACE_URI.equals(uri))

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -278,17 +278,13 @@ public class ServerContextProvider {
    * ({@link #getPrimaryContext()}). URI нормализуется через {@link Absolute#uri(URI)}.
    *
    * @param documentUri URI документа (будет нормализован)
-   * @return контекст сервера для документа (Optional всегда непустой после {@code initialize()})
+   * @return контекст сервера для документа (никогда не {@code null})
    * @throws IllegalStateException если не зарегистрирован ни один контекст
    *         (провайдер используется до {@code initialize()} или после {@code shutdown()})
    */
-  public Optional<ServerContext> resolveContextForDocument(URI documentUri) {
+  public ServerContext resolveContextForDocument(URI documentUri) {
     var normalizedUri = Absolute.uri(documentUri);
-    var direct = getServerContext(normalizedUri);
-    if (direct.isPresent()) {
-      return direct;
-    }
-    return getPrimaryContext();
+    return getServerContext(normalizedUri).orElseGet(this::getPrimaryContext);
   }
 
   /**
@@ -301,10 +297,10 @@ public class ServerContextProvider {
    * инварианта, а не штатная ситуация: провайдер используется до {@code initialize()} или
    * после {@code shutdown()}. Такое падаем громко, а не глотаем пустым результатом.
    *
-   * @return главный контекст сервера (Optional всегда непустой)
+   * @return главный контекст сервера (никогда не {@code null})
    * @throws IllegalStateException если главный контекст не выбран или отсутствует в карте
    */
-  Optional<ServerContext> getPrimaryContext() {
+  ServerContext getPrimaryContext() {
     var uri = primaryWorkspaceUri.get();
     if (uri == null) {
       throw new IllegalStateException(
@@ -316,7 +312,7 @@ public class ServerContextProvider {
     if (context == null) {
       throw new IllegalStateException("Главный workspace-контекст отсутствует для URI: " + uri);
     }
-    return Optional.of(context);
+    return context;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -73,9 +73,11 @@ public class ServerContextProvider {
   private final Map<URI, ServerContext> documentIndex = new ConcurrentHashMap<>();
 
   /**
-   * URI «главного» workspace — первого зарегистрированного контекста. Сюда маршрутизируются
-   * документы, не относящиеся ни к одному корню (untitled-буферы, файлы вне папок проекта,
-   * одиночный файл). Хранит {@code null}, пока не зарегистрирован ни один контекст.
+   * URI «главного» workspace, в который маршрутизируются документы вне всех корней
+   * (untitled-буферы, файлы вне папок проекта, одиночный файл). Предпочтение — первому
+   * реальному workspace: синтетический дефолт становится главным лишь при отсутствии реальных
+   * папок и вытесняется, как только реальная папка добавляется (в т.ч. в рантайме через
+   * {@code didChangeWorkspaceFolders}). Хранит {@code null}, пока не зарегистрирован ни один контекст.
    */
   private final AtomicReference<@Nullable URI> primaryWorkspaceUri = new AtomicReference<>();
 
@@ -154,7 +156,7 @@ public class ServerContextProvider {
 
       contexts.put(workspaceUri, serverContext);
       workspaceRoots.put(workspaceUri, rootPath);
-      markPrimaryIfAbsent(workspaceUri);
+      promoteToPrimary(workspaceUri);
 
       return serverContext;
     }
@@ -410,14 +412,39 @@ public class ServerContextProvider {
     documentIndex.remove(event.getUri());
   }
 
+  /**
+   * Назначить главным дефолтный контекст, только если главный ещё не выбран
+   * (реальные папки при инициализации не пришли).
+   */
   private void markPrimaryIfAbsent(URI workspaceUri) {
     primaryWorkspaceUri.compareAndSet(null, workspaceUri);
   }
 
+  /**
+   * Назначить реальный workspace главным, если главного нет либо им сейчас является
+   * синтетический дефолт. Так первая реальная папка (в т.ч. добавленная в рантайме) вытесняет
+   * дефолт, а последующие реальные папки главного не меняют.
+   */
+  private void promoteToPrimary(URI workspaceUri) {
+    primaryWorkspaceUri.updateAndGet(current ->
+      (current == null || DEFAULT_WORKSPACE_URI.equals(current)) ? workspaceUri : current
+    );
+  }
+
+  /**
+   * Переназначить главный контекст при удалении текущего главного: предпочитаем оставшийся
+   * реальный workspace синтетическому дефолту, дефолт — как последний вариант.
+   */
   private void repointPrimaryIfRemoved(URI removedUri) {
-    if (removedUri.equals(primaryWorkspaceUri.get())) {
-      primaryWorkspaceUri.set(contexts.keySet().stream().findFirst().orElse(null));
-    }
+    primaryWorkspaceUri.updateAndGet(current -> {
+      if (!removedUri.equals(current)) {
+        return current;
+      }
+      return contexts.keySet().stream()
+        .filter(uri -> !DEFAULT_WORKSPACE_URI.equals(uri))
+        .findFirst()
+        .orElseGet(() -> contexts.containsKey(DEFAULT_WORKSPACE_URI) ? DEFAULT_WORKSPACE_URI : null);
+    });
   }
 
   private static String extractWorkspaceName(URI workspaceUri) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -42,6 +42,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicReference;
 
 /**
  * Провайдер контекстов сервера для мульти-workspace окружения.
@@ -74,10 +75,9 @@ public class ServerContextProvider {
   /**
    * URI «главного» workspace — первого зарегистрированного контекста. Сюда маршрутизируются
    * документы, не относящиеся ни к одному корню (untitled-буферы, файлы вне папок проекта,
-   * одиночный файл). {@code null}, пока не зарегистрирован ни один контекст.
+   * одиночный файл). Хранит {@code null}, пока не зарегистрирован ни один контекст.
    */
-  @Nullable
-  private volatile URI primaryWorkspaceUri;
+  private final AtomicReference<@Nullable URI> primaryWorkspaceUri = new AtomicReference<>();
 
   public ServerContextProvider(
     ObjectProvider<ServerContext> serverContextObjectProvider,
@@ -294,7 +294,7 @@ public class ServerContextProvider {
    *         если не зарегистрирован ни один контекст
    */
   public Optional<ServerContext> getPrimaryContext() {
-    var uri = primaryWorkspaceUri;
+    var uri = primaryWorkspaceUri.get();
     if (uri == null) {
       return Optional.empty();
     }
@@ -387,7 +387,7 @@ public class ServerContextProvider {
       removeWorkspace(new WorkspaceFolder(uri.toString(), uri.toString()))
     );
     documentIndex.clear();
-    primaryWorkspaceUri = null;
+    primaryWorkspaceUri.set(null);
     LOGGER.debug("Cleared all workspaces");
   }
 
@@ -409,15 +409,13 @@ public class ServerContextProvider {
     documentIndex.remove(event.getUri());
   }
 
-  private synchronized void markPrimaryIfAbsent(URI workspaceUri) {
-    if (primaryWorkspaceUri == null) {
-      primaryWorkspaceUri = workspaceUri;
-    }
+  private void markPrimaryIfAbsent(URI workspaceUri) {
+    primaryWorkspaceUri.compareAndSet(null, workspaceUri);
   }
 
-  private synchronized void repointPrimaryIfRemoved(URI removedUri) {
-    if (removedUri.equals(primaryWorkspaceUri)) {
-      primaryWorkspaceUri = contexts.keySet().stream().findFirst().orElse(null);
+  private void repointPrimaryIfRemoved(URI removedUri) {
+    if (removedUri.equals(primaryWorkspaceUri.get())) {
+      primaryWorkspaceUri.set(contexts.keySet().stream().findFirst().orElse(null));
     }
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -53,6 +53,16 @@ import java.util.concurrent.ConcurrentHashMap;
 @Component
 public class ServerContextProvider {
 
+  /**
+   * Синтетический URI дефолтного («безворкспейсного») контекста. Создаётся, когда клиент
+   * при инициализации не прислал ни одной workspace folder, ни {@code rootUri}/{@code rootPath}
+   * (режим открытия одиночного файла или untitled-буфера). Схема не {@code file} — этот URI
+   * не должен попадать в код, приводящий URI к файловому пути ({@code Absolute.path},
+   * {@code Path.of}).
+   */
+  public static final URI DEFAULT_WORKSPACE_URI = URI.create("bsl-language-server:/default-workspace");
+  private static final String DEFAULT_WORKSPACE_NAME = "default";
+
   private final ObjectProvider<ServerContext> serverContextObjectProvider;
   private final LanguageServerConfiguration languageServerConfiguration;
   private final WorkspaceBeanScope workspaceScope;
@@ -60,6 +70,14 @@ public class ServerContextProvider {
   private final Map<URI, ServerContext> contexts = new ConcurrentHashMap<>();
   private final Map<URI, Path> workspaceRoots = new ConcurrentHashMap<>();
   private final Map<URI, ServerContext> documentIndex = new ConcurrentHashMap<>();
+
+  /**
+   * URI «главного» workspace — первого зарегистрированного контекста. Сюда маршрутизируются
+   * документы, не относящиеся ни к одному корню (untitled-буферы, файлы вне папок проекта,
+   * одиночный файл). {@code null}, пока не зарегистрирован ни один контекст.
+   */
+  @Nullable
+  private volatile URI primaryWorkspaceUri;
 
   public ServerContextProvider(
     ObjectProvider<ServerContext> serverContextObjectProvider,
@@ -136,6 +154,44 @@ public class ServerContextProvider {
 
       contexts.put(workspaceUri, serverContext);
       workspaceRoots.put(workspaceUri, rootPath);
+      markPrimaryIfAbsent(workspaceUri);
+
+      return serverContext;
+    }
+  }
+
+  /**
+   * Создать дефолтный («безворкспейсный») контекст сервера.
+   * <p>
+   * Используется, когда при инициализации не переданы ни workspace folders, ни
+   * {@code rootUri}/{@code rootPath} (открыт одиночный файл или untitled-буфер). Контекст
+   * создаётся с {@code configurationRoot == null}, поэтому {@link ServerContext#populateContext()}
+   * ничего не сканирует. Документы, не попавшие ни в один workspace, маршрутизируются в него
+   * (или в первый добавленный workspace) — см. {@link #resolveContextForDocument(URI)}.
+   * <p>
+   * В отличие от {@link #addWorkspace(URI, String)}, метод намеренно не публикует
+   * {@code WorkspaceAddedEvent}: синтетический URI не является файловым, и подписчики,
+   * приводящие URI к пути (наблюдатели файлов конфигурации/библиотек), на нём падали бы.
+   *
+   * @return дефолтный контекст сервера (идемпотентно: повторные вызовы возвращают существующий)
+   */
+  public ServerContext registerDefaultWorkspace() {
+    var existing = contexts.get(DEFAULT_WORKSPACE_URI);
+    if (existing != null) {
+      return existing;
+    }
+
+    WorkspaceContextHolder.registerWorkspace(DEFAULT_WORKSPACE_URI, DEFAULT_WORKSPACE_NAME);
+
+    try (var ctx = WorkspaceContextHolder.forUri(DEFAULT_WORKSPACE_URI)) {
+      var serverContext = serverContextObjectProvider.getObject();
+
+      serverContext.setWorkspaceUri(DEFAULT_WORKSPACE_URI);
+      serverContext.setLanguageServerConfiguration(languageServerConfiguration);
+      // configurationRoot остаётся null: сканировать нечего, populateContext() выйдет сразу.
+
+      contexts.put(DEFAULT_WORKSPACE_URI, serverContext);
+      markPrimaryIfAbsent(DEFAULT_WORKSPACE_URI);
 
       return serverContext;
     }
@@ -166,6 +222,7 @@ public class ServerContextProvider {
 
     workspaceScope.removeWorkspace(uri);
     WorkspaceContextHolder.unregisterWorkspace(uri);
+    repointPrimaryIfRemoved(uri);
   }
 
   /**
@@ -206,6 +263,42 @@ public class ServerContextProvider {
       .filter(workspaceUri -> documentUriString.startsWith(workspaceUri.toString()))
       .findFirst()
       .map(contexts::get);
+  }
+
+  /**
+   * Определить контекст сервера для документа с фолбэком на главный workspace.
+   * <p>
+   * Сначала ищет владеющий контекст по правилам {@link #getServerContext(URI)} (индекс, затем
+   * префикс URI workspace). Если документ не относится ни к одному корню (untitled-буфер, файл
+   * вне папок проекта, одиночный файл), маршрутизирует его в главный контекст
+   * ({@link #getPrimaryContext()}). URI нормализуется через {@link Absolute#uri(URI)}.
+   *
+   * @param documentUri URI документа (будет нормализован)
+   * @return контекст сервера для документа или пустой Optional,
+   *         если не зарегистрирован ни один контекст
+   */
+  public Optional<ServerContext> resolveContextForDocument(URI documentUri) {
+    var normalizedUri = Absolute.uri(documentUri);
+    var direct = getServerContext(normalizedUri);
+    if (direct.isPresent()) {
+      return direct;
+    }
+    return getPrimaryContext();
+  }
+
+  /**
+   * Получить главный контекст — первый зарегистрированный workspace (или дефолтный контекст
+   * в режиме одиночного файла).
+   *
+   * @return главный контекст сервера или пустой Optional,
+   *         если не зарегистрирован ни один контекст
+   */
+  public Optional<ServerContext> getPrimaryContext() {
+    var uri = primaryWorkspaceUri;
+    if (uri == null) {
+      return Optional.empty();
+    }
+    return Optional.ofNullable(contexts.get(uri));
   }
 
   /**
@@ -294,6 +387,7 @@ public class ServerContextProvider {
       removeWorkspace(new WorkspaceFolder(uri.toString(), uri.toString()))
     );
     documentIndex.clear();
+    primaryWorkspaceUri = null;
     LOGGER.debug("Cleared all workspaces");
   }
 
@@ -313,6 +407,18 @@ public class ServerContextProvider {
   @EventListener
   public void onDocumentRemoved(ServerContextDocumentRemovedEvent event) {
     documentIndex.remove(event.getUri());
+  }
+
+  private synchronized void markPrimaryIfAbsent(URI workspaceUri) {
+    if (primaryWorkspaceUri == null) {
+      primaryWorkspaceUri = workspaceUri;
+    }
+  }
+
+  private synchronized void repointPrimaryIfRemoved(URI removedUri) {
+    if (removedUri.equals(primaryWorkspaceUri)) {
+      primaryWorkspaceUri = contexts.keySet().stream().findFirst().orElse(null);
+    }
   }
 
   private static String extractWorkspaceName(URI workspaceUri) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProvider.java
@@ -436,15 +436,14 @@ public class ServerContextProvider {
    * реальный workspace синтетическому дефолту, дефолт — как последний вариант.
    */
   private void repointPrimaryIfRemoved(URI removedUri) {
-    primaryWorkspaceUri.updateAndGet(current -> {
-      if (!removedUri.equals(current)) {
-        return current;
-      }
-      return contexts.keySet().stream()
-        .filter(uri -> !DEFAULT_WORKSPACE_URI.equals(uri))
-        .findFirst()
-        .orElseGet(() -> contexts.containsKey(DEFAULT_WORKSPACE_URI) ? DEFAULT_WORKSPACE_URI : null);
-    });
+    if (!removedUri.equals(primaryWorkspaceUri.get())) {
+      return;
+    }
+    var next = contexts.keySet().stream()
+      .filter(uri -> !DEFAULT_WORKSPACE_URI.equals(uri))
+      .findFirst()
+      .orElseGet(() -> contexts.containsKey(DEFAULT_WORKSPACE_URI) ? DEFAULT_WORKSPACE_URI : null);
+    primaryWorkspaceUri.set(next);
   }
 
   private static String extractWorkspaceName(URI workspaceUri) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServer.java
@@ -231,6 +231,10 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
     if (workspaceFolders == null || workspaceFolders.isEmpty()) {
       var rootUri = resolveRootUri(params);
       if (rootUri == null) {
+        // Клиент не прислал ни folders, ни rootUri/rootPath — открыт одиночный файл или
+        // untitled-буфер. Заводим дефолтный контекст, чтобы такие документы можно было
+        // анализировать; иначе они не привяжутся ни к одному workspace и диагностики не пойдут.
+        serverContextProvider.registerDefaultWorkspace();
         return;
       }
       workspaceFolders = List.of(new WorkspaceFolder(rootUri, "root"));
@@ -338,7 +342,11 @@ public class BSLLanguageServer implements LanguageServer, ProtocolExtension {
    * @return список наблюдателей за файлами для регистрации у клиента
    */
   private List<FileSystemWatcher> buildFileSystemWatchers(int watchKind) {
-    var workspaceRoots = serverContextProvider.getAllContexts().keySet();
+    // Только файловые корни: дефолтный («безворкспейсный») контекст имеет синтетический
+    // не-file URI, для которого относительный шаблон наблюдения не имеет смысла.
+    var workspaceRoots = serverContextProvider.getAllContexts().keySet().stream()
+      .filter(uri -> "file".equalsIgnoreCase(uri.getScheme()))
+      .toList();
 
     if (!hasDidChangeWatchedFilesRelativePatternSupport() || workspaceRoots.isEmpty()) {
       return WATCHED_FILE_PATTERNS.stream()

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLTextDocumentService.java
@@ -1149,6 +1149,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
    */
   private @Nullable ServerContext getContextForDocument(String uriString) {
     var uri = Absolute.uri(uriString);
-    return serverContextProvider.getServerContext(uri).orElse(null);
+    return serverContextProvider.resolveContextForDocument(uri).orElse(null);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLTextDocumentService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLTextDocumentService.java
@@ -163,7 +163,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
   private static final long AWAIT_CLOSE = 30;
   private static final long AWAIT_FORCE_TERMINATION = 1;
-  private static final String NO_WORKSPACE_FOUND_MESSAGE = "No workspace found for document: {}";
 
   private final ServerContextProvider serverContextProvider;
   private final DiagnosticProvider diagnosticProvider;
@@ -704,10 +703,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
     var textDocumentItem = params.getTextDocument();
     var uri = Absolute.uri(textDocumentItem.getUri());
     var serverContext = getContextForDocument(textDocumentItem.getUri());
-    if (serverContext == null) {
-      LOGGER.warn(NO_WORKSPACE_FOUND_MESSAGE, uri);
-      return;
-    }
     var lock = serverContext.getDocumentLock(uri);
     lock.writeLock().lock();
 
@@ -748,10 +743,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
     var uri = documentContext.getUri();
     var serverContext = getContextForDocument(params.getTextDocument().getUri());
-    if (serverContext == null) {
-      LOGGER.warn(NO_WORKSPACE_FOUND_MESSAGE, uri);
-      return;
-    }
 
     // Acquire read lock to ensure document is not being modified by addDocument/removeDocument
     var lock = serverContext.getDocumentLock(uri);
@@ -789,10 +780,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
 
     var uri = documentContext.getUri();
     var serverContext = getContextForDocument(params.getTextDocument().getUri());
-    if (serverContext == null) {
-      LOGGER.warn(NO_WORKSPACE_FOUND_MESSAGE, uri);
-      return;
-    }
 
     // Remove and shutdown the executor for this document, waiting for all pending changes
     var docExecutor = documentExecutors.remove(uri);
@@ -1078,10 +1065,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
     Integer version
   ) {
     var serverContext = getContextForDocument(documentContext.getUri().toString());
-    if (serverContext == null) {
-      LOGGER.warn(NO_WORKSPACE_FOUND_MESSAGE, documentContext.getUri());
-      return;
-    }
     serverContext.rebuildDocument(
       documentContext,
       newContent,
@@ -1125,10 +1108,6 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
         cancelChecker -> {
           cancelChecker.checkCanceled();
           var serverContext = getContextForDocument(documentContext.getUri().toString());
-          if (serverContext == null) {
-            LOGGER.warn(NO_WORKSPACE_FOUND_MESSAGE, documentContext.getUri());
-            return null;
-          }
           var lock = serverContext.getDocumentLock(documentContext.getUri());
           lock.readLock().lock();
           try (var workspaceContext = WorkspaceContextHolder.forUri(serverContext.getWorkspaceUri())) {
@@ -1147,8 +1126,8 @@ public class BSLTextDocumentService implements TextDocumentService, ProtocolExte
    * @param uriString строковое представление URI документа
    * @return контекст сервера
    */
-  private @Nullable ServerContext getContextForDocument(String uriString) {
+  private ServerContext getContextForDocument(String uriString) {
     var uri = Absolute.uri(uriString);
-    return serverContextProvider.resolveContextForDocument(uri).orElse(null);
+    return serverContextProvider.resolveContextForDocument(uri);
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
@@ -211,8 +211,8 @@ class ServerContextProviderTest {
     var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "runtime");
     var workspaceContext = serverContextProvider.addWorkspace(workspaceFolder);
 
-    // then — primary «переезжает» с синтетического дефолта на реальную папку;
-    // untitled-буферы теперь маршрутизируются в неё (с конфигурацией), а не в пустой дефолт
+    // then — primary переезжает с синтетического дефолта на реальную папку, и untitled-буферы
+    // теперь маршрутизируются в неё (с конфигурацией), а не в пустой дефолт
     assertThat(serverContextProvider.getPrimaryContext()).contains(workspaceContext);
     assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
       .contains(workspaceContext);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
@@ -33,6 +33,7 @@ import java.net.URI;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
 @SpringBootTest
 class ServerContextProviderTest {
@@ -249,5 +250,16 @@ class ServerContextProviderTest {
 
     // cleanup
     serverContextProvider.clear();
+  }
+
+  @Test
+  void testResolveContextForDocumentWithoutWorkspacesFailsLoudly() {
+    // given — ни одного контекста (обращение до initialize() или после shutdown())
+    serverContextProvider.clear();
+
+    // then — маршрутизация без главного контекста падает громко, а не молча возвращает пустоту
+    assertThatThrownBy(() ->
+      serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
+      .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
@@ -27,6 +27,8 @@ import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
+import java.net.URI;
+
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -123,5 +125,70 @@ class ServerContextProviderTest {
 
     // then
     assertThat(serverContextProvider.getAllContexts()).isEmpty();
+  }
+
+  @Test
+  void testRegisterDefaultWorkspace() {
+    // when
+    var defaultContext = serverContextProvider.registerDefaultWorkspace();
+
+    // then — контекст создан без корня: populateContext ничего не сканирует
+    assertThat(defaultContext).isNotNull();
+    assertThat(defaultContext.getConfigurationRoot()).isNull();
+    assertThat(serverContextProvider.getAllContexts())
+      .containsKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
+    assertThat(serverContextProvider.getPrimaryContext()).contains(defaultContext);
+
+    // идемпотентность: повторный вызов возвращает тот же контекст
+    assertThat(serverContextProvider.registerDefaultWorkspace()).isSameAs(defaultContext);
+
+    // cleanup
+    serverContextProvider.clear();
+  }
+
+  @Test
+  void testResolveUntitledDocumentRoutesToDefaultWorkspace() {
+    // given — режим одиночного файла: зарегистрирован только дефолтный контекст
+    var defaultContext = serverContextProvider.registerDefaultWorkspace();
+
+    // when
+    var resolved = serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1"));
+
+    // then — untitled-документ маршрутизируется в дефолтный контекст
+    assertThat(resolved).contains(defaultContext);
+    // строгий поиск владельца документа фолбэка не делает
+    assertThat(serverContextProvider.getServerContext(Absolute.uri("untitled:Untitled-1"))).isEmpty();
+
+    // cleanup
+    serverContextProvider.clear();
+  }
+
+  @Test
+  void testResolveUntitledDocumentRoutesToFirstWorkspace() {
+    // given — есть реальный workspace, дефолтный контекст не создаётся
+    var workspaceUri = Absolute.path(PATH_TO_METADATA).toUri().toString();
+    var workspaceFolder = new WorkspaceFolder(workspaceUri, "test-workspace");
+    var workspaceContext = serverContextProvider.addWorkspace(workspaceFolder);
+
+    // when — untitled-буфер не относится ни к одному корню
+    var resolved = serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1"));
+
+    // then — маршрутизируется в главный (первый) workspace, а не теряется
+    assertThat(resolved).contains(workspaceContext);
+
+    // cleanup
+    serverContextProvider.removeWorkspace(workspaceFolder);
+  }
+
+  @Test
+  void testResolveContextForDocumentWithoutWorkspacesIsEmpty() {
+    // given — ни одного контекста
+    serverContextProvider.clear();
+
+    // when
+    var resolved = serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1"));
+
+    // then
+    assertThat(resolved).isEmpty();
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
@@ -147,7 +147,7 @@ class ServerContextProviderTest {
     assertThat(defaultContext.getConfigurationRoot()).isNull();
     assertThat(serverContextProvider.getAllContexts())
       .containsKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
-    assertThat(serverContextProvider.getPrimaryContext()).contains(defaultContext);
+    assertThat(serverContextProvider.getPrimaryContext()).isSameAs(defaultContext);
 
     // идемпотентность: повторный вызов возвращает тот же контекст
     assertThat(serverContextProvider.registerDefaultWorkspace()).isSameAs(defaultContext);
@@ -165,7 +165,7 @@ class ServerContextProviderTest {
     var resolved = serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1"));
 
     // then — untitled-документ маршрутизируется в дефолтный контекст
-    assertThat(resolved).contains(defaultContext);
+    assertThat(resolved).isSameAs(defaultContext);
     // строгий поиск владельца документа фолбэка не делает
     assertThat(serverContextProvider.getServerContext(Absolute.uri("untitled:Untitled-1"))).isEmpty();
 
@@ -184,7 +184,7 @@ class ServerContextProviderTest {
     var resolved = serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1"));
 
     // then — маршрутизируется в главный (первый) workspace, а не теряется
-    assertThat(resolved).contains(workspaceContext);
+    assertThat(resolved).isSameAs(workspaceContext);
 
     // cleanup
     serverContextProvider.removeWorkspace(workspaceFolder);
@@ -194,7 +194,7 @@ class ServerContextProviderTest {
   void testAddingWorkspaceAtRuntimePromotesPrimaryFromDefault() {
     // given — initialize(null): открыт одиночный файл, есть только дефолтный контекст, он же primary
     var defaultContext = serverContextProvider.registerDefaultWorkspace();
-    assertThat(serverContextProvider.getPrimaryContext()).contains(defaultContext);
+    assertThat(serverContextProvider.getPrimaryContext()).isSameAs(defaultContext);
 
     // when — в рантайме добавили реальную папку (didChangeWorkspaceFolders → addWorkspace)
     var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "runtime");
@@ -202,9 +202,9 @@ class ServerContextProviderTest {
 
     // then — primary переезжает с синтетического дефолта на реальную папку, и untitled-буферы
     // теперь маршрутизируются в неё (с конфигурацией), а не в пустой дефолт
-    assertThat(serverContextProvider.getPrimaryContext()).contains(workspaceContext);
+    assertThat(serverContextProvider.getPrimaryContext()).isSameAs(workspaceContext);
     assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
-      .contains(workspaceContext);
+      .isSameAs(workspaceContext);
     // дефолтный контекст остаётся — в нём мог остаться ранее открытый одиночный файл
     assertThat(serverContextProvider.getAllContexts())
       .containsKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
@@ -219,15 +219,15 @@ class ServerContextProviderTest {
     var defaultContext = serverContextProvider.registerDefaultWorkspace();
     var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "runtime");
     var workspaceContext = serverContextProvider.addWorkspace(workspaceFolder);
-    assertThat(serverContextProvider.getPrimaryContext()).contains(workspaceContext);
+    assertThat(serverContextProvider.getPrimaryContext()).isSameAs(workspaceContext);
 
     // when — папку убрали из рабочего пространства в рантайме
     serverContextProvider.removeWorkspace(workspaceFolder);
 
     // then — primary откатывается на оставшийся дефолтный контекст; untitled снова уходит в него
-    assertThat(serverContextProvider.getPrimaryContext()).contains(defaultContext);
+    assertThat(serverContextProvider.getPrimaryContext()).isSameAs(defaultContext);
     assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
-      .contains(defaultContext);
+      .isSameAs(defaultContext);
 
     // cleanup
     serverContextProvider.clear();
@@ -239,14 +239,14 @@ class ServerContextProviderTest {
     serverContextProvider.registerDefaultWorkspace();
     var folderX = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "X");
     var contextX = serverContextProvider.addWorkspace(folderX);
-    assertThat(serverContextProvider.getPrimaryContext()).contains(contextX);
+    assertThat(serverContextProvider.getPrimaryContext()).isSameAs(contextX);
 
     // when — добавили вторую папку Y
     var folderY = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).getParent().toUri().toString(), "Y");
     serverContextProvider.addWorkspace(folderY);
 
     // then — primary остаётся на первой реальной папке, не «прыгает» на вторую
-    assertThat(serverContextProvider.getPrimaryContext()).contains(contextX);
+    assertThat(serverContextProvider.getPrimaryContext()).isSameAs(contextX);
 
     // cleanup
     serverContextProvider.clear();

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
@@ -200,4 +200,66 @@ class ServerContextProviderTest {
     // then
     assertThat(resolved).isEmpty();
   }
+
+  @Test
+  void testAddingWorkspaceAtRuntimePromotesPrimaryFromDefault() {
+    // given — initialize(null): открыт одиночный файл, есть только дефолтный контекст, он же primary
+    var defaultContext = serverContextProvider.registerDefaultWorkspace();
+    assertThat(serverContextProvider.getPrimaryContext()).contains(defaultContext);
+
+    // when — в рантайме добавили реальную папку (didChangeWorkspaceFolders → addWorkspace)
+    var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "runtime");
+    var workspaceContext = serverContextProvider.addWorkspace(workspaceFolder);
+
+    // then — primary «переезжает» с синтетического дефолта на реальную папку;
+    // untitled-буферы теперь маршрутизируются в неё (с конфигурацией), а не в пустой дефолт
+    assertThat(serverContextProvider.getPrimaryContext()).contains(workspaceContext);
+    assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
+      .contains(workspaceContext);
+    // дефолтный контекст остаётся — в нём мог остаться ранее открытый одиночный файл
+    assertThat(serverContextProvider.getAllContexts())
+      .containsKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
+
+    // cleanup
+    serverContextProvider.clear();
+  }
+
+  @Test
+  void testRemovingRuntimeWorkspaceRepointsPrimaryBackToDefault() {
+    // given — дефолт + реальная папка; primary промоутнут на реальную
+    var defaultContext = serverContextProvider.registerDefaultWorkspace();
+    var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "runtime");
+    var workspaceContext = serverContextProvider.addWorkspace(workspaceFolder);
+    assertThat(serverContextProvider.getPrimaryContext()).contains(workspaceContext);
+
+    // when — папку убрали из рабочего пространства в рантайме
+    serverContextProvider.removeWorkspace(workspaceFolder);
+
+    // then — primary откатывается на оставшийся дефолтный контекст; untitled снова уходит в него
+    assertThat(serverContextProvider.getPrimaryContext()).contains(defaultContext);
+    assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
+      .contains(defaultContext);
+
+    // cleanup
+    serverContextProvider.clear();
+  }
+
+  @Test
+  void testFirstRuntimeWorkspaceStaysPrimaryWhenSecondAdded() {
+    // given — дефолт, затем в рантайме добавили папку X (primary → X)
+    serverContextProvider.registerDefaultWorkspace();
+    var folderX = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "X");
+    var contextX = serverContextProvider.addWorkspace(folderX);
+    assertThat(serverContextProvider.getPrimaryContext()).contains(contextX);
+
+    // when — добавили вторую папку Y
+    var folderY = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).getParent().toUri().toString(), "Y");
+    serverContextProvider.addWorkspace(folderY);
+
+    // then — primary остаётся на первой реальной папке, не «прыгает» на вторую
+    assertThat(serverContextProvider.getPrimaryContext()).contains(contextX);
+
+    // cleanup
+    serverContextProvider.clear();
+  }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
@@ -190,18 +190,6 @@ class ServerContextProviderTest {
   }
 
   @Test
-  void testResolveContextForDocumentWithoutWorkspacesIsEmpty() {
-    // given — ни одного контекста
-    serverContextProvider.clear();
-
-    // when
-    var resolved = serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1"));
-
-    // then
-    assertThat(resolved).isEmpty();
-  }
-
-  @Test
   void testAddingWorkspaceAtRuntimePromotesPrimaryFromDefault() {
     // given — initialize(null): открыт одиночный файл, есть только дефолтный контекст, он же primary
     var defaultContext = serverContextProvider.registerDefaultWorkspace();

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
@@ -258,8 +258,8 @@ class ServerContextProviderTest {
     serverContextProvider.clear();
 
     // then — маршрутизация без главного контекста падает громко, а не молча возвращает пустоту
-    assertThatThrownBy(() ->
-      serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
+    var documentUri = URI.create("untitled:Untitled-1");
+    assertThatThrownBy(() -> serverContextProvider.resolveContextForDocument(documentUri))
       .isInstanceOf(IllegalStateException.class);
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/ServerContextProviderTest.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.context;
 
 import com.github._1c_syntax.utils.Absolute;
 import org.eclipse.lsp4j.WorkspaceFolder;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -38,6 +39,14 @@ class ServerContextProviderTest {
 
   @Autowired
   private ServerContextProvider serverContextProvider;
+
+  @BeforeEach
+  void setUp() {
+    // Изоляция: serverContextProvider — общий синглтон, состояние (в т.ч. дефолтный контекст)
+    // может протечь из предыдущего теста, если его cleanup не отработал из-за упавшего ассерта.
+    // Начинаем каждый тест с чистого листа.
+    serverContextProvider.clear();
+  }
 
   @Test
   void testAddWorkspace() {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
@@ -158,11 +158,6 @@ class BSLLanguageServerTest {
     assertThat(serverContextProvider.getAllContexts())
       .doesNotContainKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
   }
-  // Сценарий «добавление реальной папки в рантайме после initialize(null)» (в т.ч. вытеснение
-  // дефолта из primary и переезд маршрутизации untitled) покрыт на уровне провайдера —
-  // ServerContextProviderTest#testAddingWorkspaceAtRuntimePromotesPrimaryFromDefault и др.;
-  // здесь LSP-специфику (initialize без корней заводит дефолт) проверяет
-  // initializeWithoutWorkspaceRegistersDefaultWorkspace.
 
   @ParameterizedTest
   @EnumSource(value = TextDocumentSyncKind.class, names = {"Full", "None"})

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.lsp;
 
 import com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.client.LanguageClientHolder;
+import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import com.github._1c_syntax.utils.Absolute;
 import mockit.Mock;
@@ -56,6 +57,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import java.io.IOException;
+import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.util.List;
@@ -84,6 +86,9 @@ class BSLLanguageServerTest {
 
   @Autowired
   private LanguageClientHolder languageClientHolder;
+
+  @Autowired
+  private ServerContextProvider serverContextProvider;
 
   @BeforeEach
   void setUp() {
@@ -118,6 +123,40 @@ class BSLLanguageServerTest {
     assertThat(initialize.getCapabilities().getTypeHierarchyProvider()).isNotNull();
     assertThat(initialize.getCapabilities().getImplementationProvider()).isNotNull();
     assertThat(initialize.getCapabilities().getLinkedEditingRangeProvider()).isNotNull();
+  }
+
+  @Test
+  void initializeWithoutWorkspaceRegistersDefaultWorkspace() throws ExecutionException, InterruptedException {
+    // given — клиент открыл одиночный файл: ни workspaceFolders, ни rootUri/rootPath
+    InitializeParams params = new InitializeParams();
+
+    // when
+    server.initialize(params).get();
+
+    // then — заведён дефолтный контекст, и untitled-документ в него маршрутизируется
+    assertThat(serverContextProvider.getAllContexts())
+      .containsKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
+    assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
+      .isPresent();
+  }
+
+  @Test
+  void untitledDocumentRoutesToWorkspaceContext() throws ExecutionException, InterruptedException {
+    // given — открыта папка проекта
+    InitializeParams params = new InitializeParams();
+    var workspaceFolder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "test");
+    params.setWorkspaceFolders(List.of(workspaceFolder));
+    server.initialize(params).get();
+
+    // when — untitled-буфер не относится ни к одному корню
+    var context = serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1"));
+
+    // then — маршрутизируется в главный (первый) workspace, а не теряется;
+    // дефолтный контекст при наличии папок не создаётся
+    assertThat(context).isPresent();
+    assertThat(context.get().getConfigurationRoot()).isNotNull();
+    assertThat(serverContextProvider.getAllContexts())
+      .doesNotContainKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
   }
 
   @ParameterizedTest

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
@@ -137,7 +137,7 @@ class BSLLanguageServerTest {
     var defaultContext = serverContextProvider.getAllContexts().get(ServerContextProvider.DEFAULT_WORKSPACE_URI);
     assertThat(defaultContext).isNotNull();
     assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
-      .contains(defaultContext);
+      .isSameAs(defaultContext);
   }
 
   @Test
@@ -153,8 +153,7 @@ class BSLLanguageServerTest {
 
     // then — маршрутизируется в главный (первый) workspace, а не теряется;
     // дефолтный контекст при наличии папок не создаётся
-    assertThat(context).isPresent();
-    assertThat(context.get().getConfigurationRoot()).isNotNull();
+    assertThat(context.getConfigurationRoot()).isNotNull();
     assertThat(serverContextProvider.getAllContexts())
       .doesNotContainKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
@@ -158,23 +158,11 @@ class BSLLanguageServerTest {
     assertThat(serverContextProvider.getAllContexts())
       .doesNotContainKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
   }
-
-  @Test
-  void addingWorkspaceFolderAfterEmptyInitializeRoutesUntitledToIt()
-    throws ExecutionException, InterruptedException {
-    // given — initialize без корней (одиночный файл): заведён дефолтный контекст
-    server.initialize(new InitializeParams()).get();
-    assertThat(serverContextProvider.getAllContexts())
-      .containsKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
-
-    // when — папку добавили в рабочее пространство в рантайме (workspace/didChangeWorkspaceFolders)
-    var folder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "runtime");
-    var workspaceContext = serverContextProvider.addWorkspace(folder);
-
-    // then — untitled-документы уходят в реальную папку с конфигурацией, а не в пустой дефолт
-    assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
-      .contains(workspaceContext);
-  }
+  // Сценарий «добавление реальной папки в рантайме после initialize(null)» (в т.ч. вытеснение
+  // дефолта из primary и переезд маршрутизации untitled) покрыт на уровне провайдера —
+  // ServerContextProviderTest#testAddingWorkspaceAtRuntimePromotesPrimaryFromDefault и др.;
+  // здесь LSP-специфику (initialize без корней заводит дефолт) проверяет
+  // initializeWithoutWorkspaceRegistersDefaultWorkspace.
 
   @ParameterizedTest
   @EnumSource(value = TextDocumentSyncKind.class, names = {"Full", "None"})

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
@@ -159,6 +159,23 @@ class BSLLanguageServerTest {
       .doesNotContainKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
   }
 
+  @Test
+  void addingWorkspaceFolderAfterEmptyInitializeRoutesUntitledToIt()
+    throws ExecutionException, InterruptedException {
+    // given — initialize без корней (одиночный файл): заведён дефолтный контекст
+    server.initialize(new InitializeParams()).get();
+    assertThat(serverContextProvider.getAllContexts())
+      .containsKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
+
+    // when — папку добавили в рабочее пространство в рантайме (workspace/didChangeWorkspaceFolders)
+    var folder = new WorkspaceFolder(Absolute.path(PATH_TO_METADATA).toUri().toString(), "runtime");
+    var workspaceContext = serverContextProvider.addWorkspace(folder);
+
+    // then — untitled-документы уходят в реальную папку с конфигурацией, а не в пустой дефолт
+    assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
+      .contains(workspaceContext);
+  }
+
   @ParameterizedTest
   @EnumSource(value = TextDocumentSyncKind.class, names = {"Full", "None"})
   void initializeUsesTextDocumentSyncKindFromConfiguration(TextDocumentSyncKind syncKind, @TempDir Path tempDir)

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/lsp/BSLLanguageServerTest.java
@@ -133,11 +133,11 @@ class BSLLanguageServerTest {
     // when
     server.initialize(params).get();
 
-    // then — заведён дефолтный контекст, и untitled-документ в него маршрутизируется
-    assertThat(serverContextProvider.getAllContexts())
-      .containsKey(ServerContextProvider.DEFAULT_WORKSPACE_URI);
+    // then — заведён дефолтный контекст, и untitled-документ маршрутизируется именно в него
+    var defaultContext = serverContextProvider.getAllContexts().get(ServerContextProvider.DEFAULT_WORKSPACE_URI);
+    assertThat(defaultContext).isNotNull();
     assertThat(serverContextProvider.resolveContextForDocument(URI.create("untitled:Untitled-1")))
-      .isPresent();
+      .contains(defaultContext);
   }
 
   @Test


### PR DESCRIPTION
## Описание

При открытии **одиночного файла** (а не папки) VS Code присылает в `initialize` все три «корневых» поля пустыми: `workspaceFolders`, `rootUri` и `rootPath` = `null`. После перехода на мульти-workspace `setConfigurationRoot` в этом случае выходил рано и **не создавал ни одного `ServerContext`**. В результате `didOpen` не мог смаршрутизировать документ (`No workspace found`), и диагностики не публиковались ни в push-, ни в pull-модели. То же самое происходило с `untitled:`-буферами даже при открытой папке — их URI никогда не совпадает по префиксу с `file://`-корнем workspace.

Что сделано:

- **`ServerContextProvider`**
  - `registerDefaultWorkspace()` — создаёт дефолтный («безворкспейсный») `ServerContext` с `configurationRoot == null`, поэтому `populateContext()` сразу выходит и ничего не сканирует. Синтетический не-`file` URI (`DEFAULT_WORKSPACE_URI`); метод намеренно **не** публикует `WorkspaceAddedEvent`, чтобы наблюдатели файлов (конфигурации/библиотек) не получали не-файловый URI и не падали на `Path.of`.
  - Отслеживание «главного» (`primary`) контекста — первого зарегистрированного workspace (или дефолтного в режиме одиночного файла); перенацеливается при удалении, сбрасывается в `clear()`.
  - `resolveContextForDocument(uri)` — индекс → префикс URI workspace → **фолбэк на primary** для документов вне всех корней (untitled-буферы, файлы вне папок проекта, одиночный файл). Строгий `getServerContext(uri)` оставлен без изменений (семантика «владелец документа»), чтобы не затронуть остальных вызывающих.
- **`BSLLanguageServer`**
  - `setConfigurationRoot`: при отсутствии folders/rootUri/rootPath заводит дефолтный контекст вместо раннего выхода.
  - `buildFileSystemWatchers`: относительные наблюдатели строятся только по `file`-корням (синтетический URI отфильтрован).
- **`BSLTextDocumentService`**
  - маршрутизация документов (`getContextForDocument`) использует новый фолбэк; pull-`diagnostic` находит документ через индекс уже после `didOpen`.

## Связанные задачи

Closes 1c-syntax/vsc-language-1c-bsl#375

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно

**Тесты:** `ServerContextProviderTest` (регистрация дефолтного контекста и идемпотентность, роутинг untitled в дефолтный/в первый workspace, пустой результат без контекстов, отсутствие фолбэка у строгого `getServerContext`) и `BSLLanguageServerTest` (`initialize` без корней заводит дефолтный контекст; untitled при открытой папке уходит в неё, дефолтный контекст не создаётся).

⚠️ **`gradlew precommit`/тесты локально прогнать не удалось** — для сборки нужен Gradle 9.6.1 (build-скрипт использует Kotlin multi-dollar interpolation), а в среде разработки его дистрибутив недоступен для скачивания, системный Gradle 8.14.3 этот синтаксис не парсит. Изменения выверены по коду; компиляцию и тесты должен подтвердить CI — прошу обратить на это внимание при ревью.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_011chMESFUX9VKy4oCuTNcWB)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Added a synthetic “default” workspace context for sessions without workspace folders or a resolvable root, with primary routing for `untitled`/single-file documents.
* **Bug Fixes**
  * Improved document-to-context resolution by routing unmatched documents to the active primary context, with correct primary promotion/reversion as real workspaces are added or removed.
  * Refined filesystem watcher generation to only consider `file`-scheme workspace roots.
* **Tests**
  * Added/expanded coverage for default workspace creation, primary behavior, and `untitled` routing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->