### PR TITLE
perf(diagnostics): резолв типа конструктора через терминальный путь ReferenceFinder

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MissedRequiredParameterDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MissedRequiredParameterDiagnostic.java
@@ -36,7 +36,6 @@ import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.eclipse.lsp4j.Position;
 import org.eclipse.lsp4j.Range;
 import org.eclipse.lsp4j.SymbolKind;
 import org.jspecify.annotations.Nullable;
@@ -109,7 +108,9 @@ public class MissedRequiredParameterDiagnostic extends AbstractVisitorDiagnostic
       return;
     }
 
-    var signatures = referenceResolver.findReference(documentContext.getUri(), typeNamePosition(typeName))
+    // typeName.IDENTIFIER() уже проверен на null выше; терминальный путь резолвера
+    // поднимается от терминала до newExpression, а не спускается от корня по позиции.
+    var signatures = referenceResolver.findReference(documentContext.getUri(), typeName.IDENTIFIER())
       .map(reference -> parameterSignatures(reference.symbol()))
       .orElseGet(List::of);
     if (signatures.isEmpty()) {
@@ -189,12 +190,6 @@ public class MissedRequiredParameterDiagnostic extends AbstractVisitorDiagnostic
       arguments[i] = parameters.get(i).expression() != null;
     }
     return arguments;
-  }
-
-  private static Position typeNamePosition(BSLParser.TypeNameContext typeName) {
-    var token = typeName.IDENTIFIER().getSymbol();
-    // Token start is sufficient: the resolver looks for a position within the identifier.
-    return new Position(token.getLine() - 1, token.getCharPositionInLine());
   }
 
   private static class MethodCall {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MissedRequiredParameterDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MissedRequiredParameterDiagnostic.java
@@ -104,13 +104,15 @@ public class MissedRequiredParameterDiagnostic extends AbstractVisitorDiagnostic
 
   private void checkConstructorCall(BSLParser.NewExpressionContext ctx) {
     var typeName = ctx.typeName();
-    if (typeName == null || typeName.IDENTIFIER() == null) {
+    if (typeName == null) {
+      return;
+    }
+    var typeNameIdentifier = typeName.IDENTIFIER();
+    if (typeNameIdentifier == null) {
       return;
     }
 
-    // typeName.IDENTIFIER() уже проверен на null выше; терминальный путь резолвера
-    // поднимается от терминала до newExpression, а не спускается от корня по позиции.
-    var signatures = referenceResolver.findReference(documentContext.getUri(), typeName.IDENTIFIER())
+    var signatures = referenceResolver.findReference(documentContext.getUri(), typeNameIdentifier)
       .map(reference -> parameterSignatures(reference.symbol()))
       .orElseGet(List::of);
     if (signatures.isEmpty()) {


### PR DESCRIPTION
## Описание

`MissedRequiredParameterDiagnostic.checkConstructorCall` резолвил тип конструктора, вычисляя `Position` из идентификатора `typeName` и вызывая `ReferenceResolver.findReference(uri, Position)`. Позиционный путь резолвера **спускается по AST от корня файла** к этой позиции — на каждом выражении `Новый Тип(...)`.

Идентификатор-терминал `typeName.IDENTIFIER()` уже под рукой (и проверен на `null` выше), поэтому переключаемся на терминальный оверлоуд `findReference(uri, TerminalNode)`, который **поднимается по AST от самого терминала**, а не спускается от корня к вычисленной позиции. Удалён ставший ненужным хелпер `typeNamePosition` и импорт `Position`; идентификатор вынесен в локальную переменную (снимает повторный вызов `IDENTIFIER()` и SonarCloud `java:S4449`).

### Замеры

Модуль SSL `УправлениеДоступомСлужебный` (~48k строк), один и тот же харнесс, best-of-10 после прогрева:

| | best | avg |
| --- | --- | --- |
| develop (спуск по позиции) | 594.5 ms | 632.6 ms |
| **после (подъём от терминала)** | **163.2 ms** | **169.8 ms** |

Ускорение ×3.6. Вывод диагностики идентичен (parity, diags=0 на модуле).

## Связанные задачи

Продолжение серии перф-оптимизаций движка резолюции типов/ссылок (#4249–#4254, #4255). Использует терминальный оверлоуд `ReferenceFinder`, добавленный в #4253.

Closes 

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами (изменённый путь `checkConstructorCall` покрыт существующими тестами конструкторов: `testConstructorCallResolvedToOScriptMethod`, `…OScriptModule`, платформенный `РегулярноеВыражение`)

## Дополнительно

Затронут только один метод; семантика (первое совпадение резолвера, тот же порядок finder'ов) сохранена — терминальный и позиционный пути дают один результат. Прогнан зелёным `MissedRequiredParameterDiagnosticTest` (6/6).