### PR TITLE
perf(diagnostics): не спускаться в простые операторы в EmptyStatement

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyStatementDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EmptyStatementDiagnostic.java
@@ -62,6 +62,13 @@ public class EmptyStatementDiagnostic extends AbstractVisitorDiagnostic implemen
       diagnosticStorage.addDiagnostic(ctx);
     }
 
+    // Вложенные операторы возможны только внутри compoundStatement (если/пока/для/попытка):
+    // codeBlock грамматики встречается лишь там. В простых операторах (присваивание, вызов,
+    // preprocessor, «;») вложенных statement'ов нет — спускаться в их выражения незачем.
+    if (ctx.compoundStatement() == null) {
+      return ctx;
+    }
+
     return super.visitStatement(ctx);
   }
 


### PR DESCRIPTION
## Описание

`EmptyStatementDiagnostic.visitStatement` вызывал `super.visitStatement(ctx)` для **каждого** оператора, спускаясь в его поддерево целиком — включая деревья выражений простых операторов (`assignment`, `callStatement`, `waitStatement`, `preprocessor`), которые по грамматике **не могут** содержать вложенный оператор.

Из грамматики BSL: `codeBlock` (а значит и вложенные `statement`) встречается только внутри `compoundStatement` (`if`/`while`/`for`/`forEach`/`try`):

```
statement : ( ( label? (assignment | callStatement | waitStatement | compoundStatement | preprocessor)? ) SEMICOLON? ) | SEMICOLON ;
codeBlock : (statement | preprocessor)* ;
```

Поэтому при `ctx.compoundStatement() == null` возвращаемся без `super` — отсекаем спуск в выражения простых операторов, но по-прежнему заходим в составные операторы, чтобы найти вложенные пустые операторы. Пустые операторы, лежащие напрямую в `codeBlock`, всё равно посещаются как соседи (их перебирает `visitChildren` охватывающего `codeBlock`).

### Замеры

Общий модуль SSL `УправлениеДоступомСлужебный` (~48k строк), один и тот же харнесс, best-of-10 после прогрева:

| | best | avg |
| --- | --- | --- |
| develop | 252.7 ms | 256.9 ms |
| **после гварда** | **239.2 ms** | **249.6 ms** |

~5%. Профиль подтверждает механику: доля спуска в выражения (`visitExpression`/`visitAssignment`/`visitCallStatement`/…) упала с ~9.9% до ~5.6% сэмплов; основную стоимость составляет неустранимый этим гвардом обход каждого оператора через цепочку `codeBlock` и диспетчеризация `visitStatement`.

Приём общий: тот же `compoundStatement`-гвард применим к любой visitor-диагностике, которой важна только структура операторов.

## Связанные задачи

Продолжение серии перф-оптимизаций (#4249–#4256). Мотивировано профилированием из #4248.

Closes 

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами (результат идентичен: 8 диагностик на модуле SSL, `EmptyStatementDiagnosticTest` 2/2 зелёный)

## Дополнительно

Результат диагностики не меняется (parity подтверждён на фикстуре и на большом модуле) — гвард только отсекает заведомо бесплодный спуск в выражения.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSiRGLm633B4EmvG3vkk4V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved empty-statement analysis for simple statements.
  * Prevented incorrect traversal into nested expressions and statements where nested operators are not supported.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->