### PR TITLE
perf(references): хелпер Positions и отказ от лишних Range при взятии позиции

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/ExtractStructureConstructorSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/ExtractStructureConstructorSupplier.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.codeactions;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.DiagnosticHelper;
+import com.github._1c_syntax.bsl.languageserver.utils.Positions;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.configuration.Resources;
 import com.github._1c_syntax.bsl.languageserver.utils.Strings;
@@ -127,7 +128,7 @@ public class ExtractStructureConstructorSupplier implements CodeActionSupplier {
     var constructorEdit = new TextEdit(Ranges.create(doCall), "()");
     changes.add(constructorEdit);
 
-    var indentSize = Ranges.create(lValue).getStart().getCharacter();
+    var indentSize = Positions.create(lValue).getCharacter();
 
     var rparenRange = Ranges.create(doCall.RPAREN());
     var constructorLine = rparenRange.getEnd().getLine();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallHintRenderer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallHintRenderer.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.Resources;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
+import com.github._1c_syntax.bsl.languageserver.utils.Positions;
 import com.github._1c_syntax.bsl.parser.BSLParser;
 import org.apache.commons.lang3.Strings;
 import org.eclipse.lsp4j.InlayHint;
@@ -202,7 +203,7 @@ public class PlatformMethodCallHintRenderer {
 
   private static Position positionOf(BSLParser.CallParamContext callParam) {
     var token = callParam.getStart();
-    return new Position(token.getLine() - 1, token.getCharPositionInLine());
+    return Positions.create(token);
   }
 
   private boolean showDefaultValues() {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintCollector.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/PlatformMethodCallInlayHintCollector.java
@@ -29,6 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.languageserver.types.util.SignatureSelection;
+import com.github._1c_syntax.bsl.languageserver.utils.Positions;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
@@ -180,7 +181,7 @@ public class PlatformMethodCallInlayHintCollector {
         continue;
       }
       var start = arg.getStart();
-      var position = new Position(start.getLine() - 1, start.getCharPositionInLine());
+      var position = Positions.create(start);
       result.add(typeService.expressionTypesAt(documentContext, position));
     }
     return result;
@@ -267,7 +268,7 @@ public class PlatformMethodCallInlayHintCollector {
   }
 
   private static Position positionOf(Token token) {
-    return new Position(token.getLine() - 1, token.getCharPositionInLine());
+    return Positions.create(token);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplier.java
@@ -25,6 +25,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConf
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.types.TypeService;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.utils.Positions;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
@@ -119,7 +120,7 @@ public class VariableTypeInlayHintSupplier implements InlayHintSupplier<Variable
     }
     var identifier = maybeIdentifier.get();
 
-    var namePosition = Ranges.create(identifier).getEnd();
+    var namePosition = Positions.createEnd(identifier);
     if (!Ranges.containsPosition(range, namePosition)) {
       return Optional.empty();
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/LinkedEditingRangeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/LinkedEditingRangeProvider.java
@@ -27,7 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
 import com.github._1c_syntax.bsl.languageserver.references.ReferenceResolver;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
-import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.languageserver.utils.Positions;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import lombok.RequiredArgsConstructor;
 import org.antlr.v4.runtime.ParserRuleContext;
@@ -177,8 +177,8 @@ public class LinkedEditingRangeProvider {
     ParserRuleContext ast = documentContext.getAst();
     var positionInsideToken = new Position(position.getLine(), position.getCharacter() - 1);
     return Trees.findTerminalNodeContainsPosition(ast, positionInsideToken)
-      .filter(terminalNode -> Ranges.create(terminalNode).getEnd().equals(position))
-      .map(terminalNode -> Ranges.create(terminalNode).getStart());
+      .filter(terminalNode -> Positions.createEnd(terminalNode).equals(position))
+      .map(terminalNode -> Positions.create(terminalNode));
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/LinkedEditingRangeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/LinkedEditingRangeProvider.java
@@ -178,7 +178,7 @@ public class LinkedEditingRangeProvider {
     var positionInsideToken = new Position(position.getLine(), position.getCharacter() - 1);
     return Trees.findTerminalNodeContainsPosition(ast, positionInsideToken)
       .filter(terminalNode -> Positions.createEnd(terminalNode).equals(position))
-      .map(terminalNode -> Positions.create(terminalNode));
+      .map(Positions::create);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SelectionRangeProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SelectionRangeProvider.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.providers;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.utils.Positions;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
 import com.github._1c_syntax.bsl.parser.BSLParser;
@@ -94,7 +95,7 @@ public class SelectionRangeProvider {
   @Nullable
   private static TerminalNode findTerminalNodeAtPosition(ParserRuleContext ast, Position position) {
     var node = Trees.findTerminalNodeContainsPosition(ast, position).orElse(null);
-    if (node != null && !Ranges.create(node).getStart().equals(position)) {
+    if (node != null && !Positions.create(node).equals(position)) {
       return node;
     }
 
@@ -111,7 +112,7 @@ public class SelectionRangeProvider {
 
     var positionInsideToken = new Position(position.getLine(), position.getCharacter() - 1);
     return Trees.findTerminalNodeContainsPosition(ast, positionInsideToken)
-      .filter(terminalNode -> Ranges.create(terminalNode).getEnd().equals(position));
+      .filter(terminalNode -> Positions.createEnd(terminalNode).equals(position));
   }
 
   @Nullable

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/SignatureHelpProvider.java
@@ -35,6 +35,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
 import com.github._1c_syntax.bsl.languageserver.types.util.SignatureSelection;
+import com.github._1c_syntax.bsl.languageserver.utils.Positions;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.parser.BSLParser;
 import lombok.RequiredArgsConstructor;
@@ -281,7 +282,7 @@ public final class SignatureHelpProvider {
         continue;
       }
       var start = arg.getStart();
-      var position = new Position(start.getLine() - 1, start.getCharPositionInLine());
+      var position = Positions.create(start);
       result.add(typeService.expressionTypesAt(documentContext, position));
     }
     return result;
@@ -425,7 +426,7 @@ public final class SignatureHelpProvider {
     }
     // тип ресивера — по позиции имени метода
     var memberToken = mc.methodName().IDENTIFIER().getSymbol();
-    var memberPos = new Position(memberToken.getLine() - 1, memberToken.getCharPositionInLine());
+    var memberPos = Positions.create(memberToken);
     var typeSet = typeService.receiverTypesAt(documentContext, memberPos);
     for (TypeRef ref : typeSet.refs()) {
       for (var member : typeService.getMembers(ref, documentContext.getFileType())) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceFinder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceFinder.java
@@ -22,7 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.references;
 
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
-import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.languageserver.utils.Positions;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
 
@@ -55,6 +55,6 @@ public interface ReferenceFinder {
    * @return данные ссылки.
    */
   default Optional<Reference> findReference(URI uri, TerminalNode terminal) {
-    return findReference(uri, Ranges.create(terminal).getStart());
+    return findReference(uri, Positions.create(terminal));
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/Positions.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/Positions.java
@@ -1,0 +1,70 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.utils;
+
+import lombok.experimental.UtilityClass;
+import org.antlr.v4.runtime.Token;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.eclipse.lsp4j.Position;
+import org.jspecify.annotations.Nullable;
+
+/**
+ * Набор методов для удобства работы с позициями (LSP {@link Position}).
+ * <p>
+ * ANTLR-координаты токена ({@code line} 1-based, {@code charPositionInLine})
+ * приводятся к LSP-модели ({@code line} 0-based) в одном месте, без промежуточного
+ * {@link org.eclipse.lsp4j.Range}.
+ */
+@UtilityClass
+public final class Positions {
+
+  /**
+   * Создать позицию по координатам LSP.
+   *
+   * @param line      строка (0-based)
+   * @param character символ
+   * @return созданная позиция
+   */
+  public Position create(int line, int character) {
+    return new Position(line, character);
+  }
+
+  /**
+   * Начальная позиция токена.
+   *
+   * @param token токен
+   * @return позиция начала токена
+   */
+  public Position create(Token token) {
+    return create(token.getLine() - 1, token.getCharPositionInLine());
+  }
+
+  /**
+   * Начальная позиция терминального узла.
+   *
+   * @param terminalNode терминальный узел; {@code null} трактуется как пустая позиция (0,0)
+   * @return позиция начала узла
+   */
+  public Position create(@Nullable TerminalNode terminalNode) {
+    return terminalNode == null ? create(0, 0) : create(terminalNode.getSymbol());
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/Positions.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/Positions.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.utils;
 
 import lombok.experimental.UtilityClass;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.Token;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.eclipse.lsp4j.Position;
@@ -66,5 +67,36 @@ public final class Positions {
    */
   public Position create(@Nullable TerminalNode terminalNode) {
     return terminalNode == null ? create(0, 0) : create(terminalNode.getSymbol());
+  }
+
+  /**
+   * Начальная позиция контекста правила парсера (по стартовому токену).
+   *
+   * @param ruleContext контекст правила
+   * @return позиция начала контекста
+   */
+  public Position create(ParserRuleContext ruleContext) {
+    return create(ruleContext.getStart());
+  }
+
+  /**
+   * Конечная позиция токена. Соответствует концу {@link Ranges#create(Token)}:
+   * {@code charPositionInLine + длина текста токена}.
+   *
+   * @param token токен
+   * @return позиция конца токена
+   */
+  public Position createEnd(Token token) {
+    return create(token.getLine() - 1, token.getCharPositionInLine() + token.getText().length());
+  }
+
+  /**
+   * Конечная позиция терминального узла.
+   *
+   * @param terminalNode терминальный узел; {@code null} трактуется как пустая позиция (0,0)
+   * @return позиция конца узла
+   */
+  public Position createEnd(@Nullable TerminalNode terminalNode) {
+    return terminalNode == null ? create(0, 0) : createEnd(terminalNode.getSymbol());
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/PositionsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/PositionsTest.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.utils;
 
 import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.ParserRuleContext;
 import org.antlr.v4.runtime.tree.TerminalNode;
 import org.antlr.v4.runtime.tree.TerminalNodeImpl;
 import org.eclipse.lsp4j.Position;
@@ -63,6 +64,37 @@ class PositionsTest {
   @Test
   void createFromNullTerminalNodeIsEmpty() {
     assertThat(Positions.create((TerminalNode) null)).isEqualTo(new Position(0, 0));
+  }
+
+  @Test
+  void createFromRuleContext() {
+    var ctx = new ParserRuleContext(null, -1);
+    ctx.start = token();
+    ctx.stop = token();
+
+    assertThat(Positions.create(ctx)).isEqualTo(new Position(4, 6));
+    assertThat(Positions.create(ctx)).isEqualTo(Ranges.create(ctx).getStart());
+  }
+
+  @Test
+  void createEndFromToken() {
+    var token = token();
+
+    // Парити с прежним Ranges.create(token).getEnd(): колонка + длина текста.
+    assertThat(Positions.createEnd(token)).isEqualTo(new Position(4, 6 + "Идентификатор".length()));
+    assertThat(Positions.createEnd(token)).isEqualTo(Ranges.create(token).getEnd());
+  }
+
+  @Test
+  void createEndFromTerminalNode() {
+    TerminalNode terminal = new TerminalNodeImpl(token());
+
+    assertThat(Positions.createEnd(terminal)).isEqualTo(Ranges.create(terminal).getEnd());
+  }
+
+  @Test
+  void createEndFromNullTerminalNodeIsEmpty() {
+    assertThat(Positions.createEnd((TerminalNode) null)).isEqualTo(new Position(0, 0));
   }
 
   private static CommonToken token() {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/PositionsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/PositionsTest.java
@@ -1,0 +1,74 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.utils;
+
+import org.antlr.v4.runtime.CommonToken;
+import org.antlr.v4.runtime.tree.TerminalNode;
+import org.antlr.v4.runtime.tree.TerminalNodeImpl;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class PositionsTest {
+
+  @Test
+  void createFromCoordinates() {
+    assertThat(Positions.create(3, 7)).isEqualTo(new Position(3, 7));
+  }
+
+  @Test
+  void createFromToken() {
+    var token = token();
+
+    // ANTLR line 1-based -> LSP line 0-based; колонка без изменений.
+    assertThat(Positions.create(token)).isEqualTo(new Position(4, 6));
+  }
+
+  @Test
+  void createFromTokenMatchesRangeStart() {
+    var token = token();
+
+    // Парити с прежним Ranges.create(terminal).getStart().
+    assertThat(Positions.create(token)).isEqualTo(Ranges.create(token).getStart());
+  }
+
+  @Test
+  void createFromTerminalNode() {
+    TerminalNode terminal = new TerminalNodeImpl(token());
+
+    assertThat(Positions.create(terminal)).isEqualTo(new Position(4, 6));
+    assertThat(Positions.create(terminal)).isEqualTo(Ranges.create(terminal).getStart());
+  }
+
+  @Test
+  void createFromNullTerminalNodeIsEmpty() {
+    assertThat(Positions.create((TerminalNode) null)).isEqualTo(new Position(0, 0));
+  }
+
+  private static CommonToken token() {
+    var token = new CommonToken(1, "Идентификатор");
+    token.setLine(5);
+    token.setCharPositionInLine(6);
+    return token;
+  }
+}


### PR DESCRIPTION
## Описание

Часть общей оптимизации из #4248 (раздел «Лишние Position/Range в новом terminal SPI»): убираем аллокацию `Range` там, где нужна всего одна `Position`.

### 1. Терминальный `ReferenceFinder`

Дефолтный `ReferenceFinder.findReference(uri, TerminalNode)` вычислял стартовую позицию через `Ranges.create(terminal).getStart()` — создавал `Range` (**две** `Position`), брал одну и выбрасывал остальное. Оверлоуд **не переопределён** у самых частых finder'ов (`ReferenceIndexReferenceFinder` `@Order(40)`, `SourceDefinedSymbolDeclarationReferenceFinder`, `AnnotationReferenceFinder`), поэтому каждый терминальный lookup сорсового символа (горячий путь инференсера и диагностик) аллоцировал на ровном месте — в конфигурации, чей heap и так доминируется `Position`/`Range`.

### 2. Утилити-класс `Positions`

Добавлен `utils/Positions` (по образцу `Ranges`) — сборка **одной** `Position` из координат / `Token` / `TerminalNode` / `ParserRuleContext`, плюс `createEnd(Token/TerminalNode)`. Конвертация ANTLR→LSP (`line - 1`, `charPositionInLine`) теперь в одном месте.

### 3. Переезд остальных мест на `Positions`

Переведены все места, где `Range` строился только ради одного конца, и inline-конструирование позиции из токена:

- `Ranges.create(x).getStart()/.getEnd()` → `Positions.create/createEnd`: `SelectionRangeProvider`, `LinkedEditingRangeProvider`, `ExtractStructureConstructorSupplier`, `VariableTypeInlayHintSupplier`;
- inline `new Position(token.getLine()-1, token.getCharPositionInLine())`: `SignatureHelpProvider`, `PlatformMethodCallHintRenderer`, `PlatformMethodCallInlayHintCollector`.

Поведение не меняется: `createEnd` повторяет арифметику конца из `Ranges`, а `PositionsTest` проверяет парити против `Ranges.create(...).getStart()/.getEnd()`.

> Границы эффекта: это снижение **скорости аллокаций / нагрузки на GC** (объекты транзиентные), а не пикового удержанного heap. Удержанные `Position`/`Range` из #4248 — это модель индекса ссылок, отдельная тема.

## Связанные задачи

Пункт из архитектурного разбора #4248. Продолжение серии #4249–#4257.

Closes 

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами (`PositionsTest`; парити подтверждён 119 тестами затронутых провайдеров/inlay-hint/code-action, а также `ReferenceIndexTest`/`ReferencesProviderTest`/`DefinitionProviderTest`/`RenameProviderTest`)

## Дополнительно

`Ranges` не тронут (у него уже есть импорт `org.eclipse.lsp4j.util.Positions` — не стал смешивать имена внутри него). Место с нестандартной колонкой (`PlatformMethodCallInlayHintCollector`, центрирование по токену) намеренно оставлено на `new Position`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved accuracy and consistency of cursor-to-language-element positioning across reference finding, selection/linked editing ranges, signature help, and inlay hints.
  * Standardized edit and hint alignment by using shared LSP position conversion (including proper start/end handling).
* **Tests**
  * Added unit tests covering position conversion utilities for tokens, terminal nodes (including null-safe `(0, 0)`), parser contexts, and end-position calculation.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->