### PR TITLE
perf(diagnostics): ограничение пула JLanguageTool

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/typo/JLanguageToolPool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/typo/JLanguageToolPool.java
@@ -22,17 +22,31 @@
 package com.github._1c_syntax.bsl.languageserver.diagnostics.typo;
 
 import com.github._1c_syntax.bsl.languageserver.utils.AbstractObjectPool;
-import lombok.AllArgsConstructor;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Language;
 import org.languagetool.rules.Rule;
 
 import java.util.function.Predicate;
 
-@AllArgsConstructor
+/**
+ * Пул экземпляров {@link JLanguageTool} для одного языка.
+ * <p>
+ * Пул ограничен: каждый экземпляр при создании загружает собственную копию
+ * полного набора правил языка (десятки мегабайт на инстанс, отключение правил
+ * память не освобождает), поэтому рост пула до числа потоков анализа
+ * недопустим по памяти. При исчерпании лимита {@link #checkOut()} ждёт
+ * возврата экземпляра.
+ */
 public class JLanguageToolPool extends AbstractObjectPool<JLanguageTool> {
 
+  private static final int MAX_POOL_SIZE = 4;
+
   private final Language language;
+
+  public JLanguageToolPool(Language language) {
+    super(Math.min(MAX_POOL_SIZE, Runtime.getRuntime().availableProcessors()));
+    this.language = language;
+  }
 
   @Override
   protected JLanguageTool create() {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
@@ -82,19 +82,17 @@ public abstract class AbstractObjectPool<T> {
    * <p>
    * Если пул пуст и лимит объектов исчерпан — ждёт возврата объекта.
    * Прерывание потока во время ожидания не прерывает выдачу: флаг прерывания
-   * восстанавливается перед возвратом.
+   * восстанавливается, а прерванный поток получает объект сверх лимита
+   * (пул может временно превысить {@code maxSize} на число прерванных ожидающих).
    */
   public synchronized T checkOut() {
-    var interrupted = false;
     while (available.isEmpty() && inUse.size() >= maxSize) {
       try {
         wait();
       } catch (InterruptedException e) {
-        interrupted = true;
+        Thread.currentThread().interrupt();
+        break;
       }
-    }
-    if (interrupted) {
-      Thread.currentThread().interrupt();
     }
     if (available.isEmpty()) {
       available.add(create());
@@ -108,7 +106,7 @@ public abstract class AbstractObjectPool<T> {
   public synchronized void checkIn(T instance) {
     inUse.remove(instance);
     available.add(instance);
-    notify();
+    notifyAll();
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
@@ -50,6 +50,10 @@ import java.util.Set;
 
 /**
  * Generic object pool.
+ * <p>
+ * Может быть ограничен по количеству создаваемых объектов: при достижении
+ * лимита {@link #checkOut()} блокируется до возврата объекта через
+ * {@link #checkIn(Object)}.
  *
  * @param <T> Type T of Object in the Pool
  */
@@ -57,13 +61,41 @@ public abstract class AbstractObjectPool<T> {
 
   private final Set<T> available = new HashSet<>();
   private final Set<T> inUse = new HashSet<>();
+  private final int maxSize;
+
+  protected AbstractObjectPool() {
+    this(Integer.MAX_VALUE);
+  }
+
+  /**
+   * @param maxSize максимальное суммарное количество объектов пула
+   *                (доступных и выданных).
+   */
+  protected AbstractObjectPool(int maxSize) {
+    this.maxSize = maxSize;
+  }
 
   protected abstract T create();
 
   /**
    * Checkout object from pool.
+   * <p>
+   * Если пул пуст и лимит объектов исчерпан — ждёт возврата объекта.
+   * Прерывание потока во время ожидания не прерывает выдачу: флаг прерывания
+   * восстанавливается перед возвратом.
    */
   public synchronized T checkOut() {
+    var interrupted = false;
+    while (available.isEmpty() && inUse.size() >= maxSize) {
+      try {
+        wait();
+      } catch (InterruptedException e) {
+        interrupted = true;
+      }
+    }
+    if (interrupted) {
+      Thread.currentThread().interrupt();
+    }
     if (available.isEmpty()) {
       available.add(create());
     }
@@ -76,6 +108,7 @@ public abstract class AbstractObjectPool<T> {
   public synchronized void checkIn(T instance) {
     inUse.remove(instance);
     available.add(instance);
+    notify();
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPool.java
@@ -69,9 +69,12 @@ public abstract class AbstractObjectPool<T> {
 
   /**
    * @param maxSize максимальное суммарное количество объектов пула
-   *                (доступных и выданных).
+   *                (доступных и выданных); не меньше 1.
    */
   protected AbstractObjectPool(int maxSize) {
+    if (maxSize < 1) {
+      throw new IllegalArgumentException("maxSize must be >= 1, got: " + maxSize);
+    }
     this.maxSize = maxSize;
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPoolTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPoolTest.java
@@ -1,0 +1,143 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.utils;
+
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.Timeout;
+
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class AbstractObjectPoolTest {
+
+  private static final class CountingPool extends AbstractObjectPool<Object> {
+
+    private final AtomicInteger created = new AtomicInteger();
+
+    private CountingPool() {
+    }
+
+    private CountingPool(int maxSize) {
+      super(maxSize);
+    }
+
+    @Override
+    protected Object create() {
+      created.incrementAndGet();
+      return new Object();
+    }
+  }
+
+  @Test
+  void checkOutReusesReturnedInstance() {
+    var pool = new CountingPool();
+
+    var first = pool.checkOut();
+    pool.checkIn(first);
+    var second = pool.checkOut();
+
+    assertThat(second).isSameAs(first);
+    assertThat(pool.created.get()).isEqualTo(1);
+  }
+
+  @Test
+  void unboundedPoolCreatesInstancePerConcurrentCheckout() {
+    var pool = new CountingPool();
+
+    var first = pool.checkOut();
+    var second = pool.checkOut();
+
+    assertThat(second).isNotSameAs(first);
+    assertThat(pool.created.get()).isEqualTo(2);
+  }
+
+  @Test
+  @Timeout(10)
+  void boundedPoolBlocksUntilCheckInAndHandsOverInstance() throws InterruptedException {
+    var pool = new CountingPool(1);
+    var first = pool.checkOut();
+
+    var handedOver = new AtomicReference<>();
+    var waiterStarted = new CountDownLatch(1);
+    var waiterFinished = new CountDownLatch(1);
+    var waiter = new Thread(() -> {
+      waiterStarted.countDown();
+      handedOver.set(pool.checkOut());
+      waiterFinished.countDown();
+    });
+    waiter.start();
+
+    assertThat(waiterStarted.await(5, TimeUnit.SECONDS)).isTrue();
+    // Ожидающий поток не должен создать новый экземпляр сверх лимита
+    assertThat(waiterFinished.await(200, TimeUnit.MILLISECONDS)).isFalse();
+    assertThat(pool.created.get()).isEqualTo(1);
+
+    pool.checkIn(first);
+
+    assertThat(waiterFinished.await(5, TimeUnit.SECONDS)).isTrue();
+    assertThat(handedOver.get()).isSameAs(first);
+    assertThat(pool.created.get()).isEqualTo(1);
+  }
+
+  @Test
+  @Timeout(10)
+  void interruptedWaiterGetsInstanceOverCapAndKeepsInterruptFlag() throws InterruptedException {
+    var pool = new CountingPool(1);
+    pool.checkOut();
+
+    var wasInterrupted = new AtomicReference<Boolean>();
+    var received = new AtomicReference<>();
+    var waiter = new Thread(() -> {
+      received.set(pool.checkOut());
+      wasInterrupted.set(Thread.currentThread().isInterrupted());
+    });
+    waiter.start();
+
+    // Дождаться входа в ожидание и прервать
+    while (waiter.getState() != Thread.State.WAITING) {
+      TimeUnit.MILLISECONDS.sleep(10);
+    }
+    waiter.interrupt();
+    waiter.join(TimeUnit.SECONDS.toMillis(5));
+
+    assertThat(waiter.isAlive()).isFalse();
+    assertThat(received.get()).isNotNull();
+    assertThat(pool.created.get()).isEqualTo(2);
+    assertThat(wasInterrupted.get()).isTrue();
+  }
+
+  @Test
+  void toStringReportsPoolState() {
+    var pool = new CountingPool();
+    var instance = pool.checkOut();
+
+    assertThat(pool).hasToString("Pool available=0 inUse=1");
+
+    pool.checkIn(instance);
+
+    assertThat(pool).hasToString("Pool available=1 inUse=0");
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPoolTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPoolTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatThrownBy;
 import static org.awaitility.Awaitility.await;
 
 class AbstractObjectPoolTest {
@@ -126,6 +127,12 @@ class AbstractObjectPoolTest {
     assertThat(received.get()).isNotNull();
     assertThat(pool.created.get()).isEqualTo(2);
     assertThat(wasInterrupted.get()).isTrue();
+  }
+
+  @Test
+  void nonPositiveMaxSizeIsRejected() {
+    assertThatThrownBy(() -> new CountingPool(0))
+      .isInstanceOf(IllegalArgumentException.class);
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPoolTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/utils/AbstractObjectPoolTest.java
@@ -30,6 +30,7 @@ import java.util.concurrent.atomic.AtomicInteger;
 import java.util.concurrent.atomic.AtomicReference;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.awaitility.Awaitility.await;
 
 class AbstractObjectPoolTest {
 
@@ -117,9 +118,7 @@ class AbstractObjectPoolTest {
     waiter.start();
 
     // Дождаться входа в ожидание и прервать
-    while (waiter.getState() != Thread.State.WAITING) {
-      TimeUnit.MILLISECONDS.sleep(10);
-    }
+    await().atMost(5, TimeUnit.SECONDS).until(() -> waiter.getState() == Thread.State.WAITING);
     waiter.interrupt();
     waiter.join(TimeUnit.SECONDS.toMillis(5));
 


### PR DESCRIPTION
## Суть

`JLanguageToolPool` рос неограниченно — до числа потоков анализа: при `parallelStream` на 24-ядерной машине создавалось ~20 инстансов `JLanguageTool`, каждый при создании загружает **собственную копию** полного набора правил языка (~35 МБ на инстанс; последующий `disableRule` память не освобождает). На `analyze` УПП это давало ~680 МБ live heap только под инфраструктуру диагностики Typo.

`AbstractObjectPool` получил опциональный `maxSize`: при исчерпании лимита `checkOut()` блокируется до возврата объекта через `checkIn()` (wait/notify; прерывание потока не срывает выдачу — флаг прерывания восстанавливается перед возвратом). `JLanguageToolPool` ограничен `min(4, доступных ядер)`. Конкуренция за пул низкая: статусы слов кэшируются в `CheckedWordsHolder` (персистентный EhCache), к LT уходят только ещё не проверенные слова.

## Замер

`analyze` УПП (~9 500 модулей), холодный кэш слов, `jcmd GC.class_histogram` (live-объекты):

| Метрика | До | После |
|---|---|---|
| Инстансов `JLanguageTool` | 20 | 4 |
| Прямые объекты LanguageTool | 359 МБ | 80 МБ |
| `DisambiguationPatternRule` | 974 тыс. | 217 тыс. |

С учётом шаренных структур (CHM/массивы/строки словарей) экономия — примерно **−400 МБ** на 24-ядерной машине (на машинах с меньшим числом ядер эффект меньше — пул и раньше не вырастал большим). Диагностики эквивалентны (SARIF с идентичными счётчиками правил), время анализа не выросло (2:34 → 2:21).

## Проверки

- полный `./gradlew test`: 3 582 теста, 0 упавших;
- функциональная сверка SARIF на УПП (см. выше).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Introduced bounded pooling for language-analysis resources with an explicit maximum parallelism limit to control concurrency.
  * Pooling now reuses returned instances and scales up to the configured cap based on available CPU resources.

* **Reliability**
  * When the pool is exhausted, checkout requests now wait for an available instance instead of growing unbounded.
  * Interrupts are handled correctly while waiting, and returned instances reliably wake waiting checkouts.

* **Tests**
  * Added JUnit coverage for reuse, bounded vs. unbounded behavior, interruption handling, invalid configuration, and pool state reporting.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->