### PR TITLE
perf(cli): ограничить число живых документов в analyze обычным пулом

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
@@ -36,6 +36,7 @@ import lombok.extern.slf4j.Slf4j;
 import me.tongfei.progressbar.ProgressBar;
 import me.tongfei.progressbar.ProgressBarBuilder;
 import me.tongfei.progressbar.ProgressBarStyle;
+import org.jspecify.annotations.Nullable;
 import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.stereotype.Component;
 import picocli.CommandLine.Command;
@@ -143,8 +144,8 @@ public class AnalyzeCommand implements Callable<Integer> {
   private final GlobalLanguageServerConfiguration globalConfiguration;
   private final ServerContextProvider serverContextProvider;
   private final LanguageServerConfiguration configuration;
-  @Qualifier("cliExecutor")
-  private final ExecutorService cliExecutor;
+  @Qualifier("analyzeExecutor")
+  private final ExecutorService analyzeExecutor;
 
   private ServerContext serverContext;
 
@@ -184,25 +185,14 @@ public class AnalyzeCommand implements Callable<Integer> {
 
       List<FileInfo> fileInfos;
       if (silentMode) {
-        fileInfos = cliExecutor.submit(() ->
-          files.parallelStream()
-            .map((File file) -> getFileInfoFromFile(workspaceDir, file))
-            .toList()
-        ).get();
+        fileInfos = analyzeFiles(files, workspaceDir, null);
       } else {
         try (ProgressBar pb = new ProgressBarBuilder()
           .setTaskName("Analyzing files...")
           .setInitialMax(files.size())
           .setStyle(ProgressBarStyle.ASCII)
           .build()) {
-          fileInfos = cliExecutor.submit(() ->
-            files.parallelStream()
-              .map((File file) -> {
-                pb.step();
-                return getFileInfoFromFile(workspaceDir, file);
-              })
-              .toList()
-          ).get();
+          fileInfos = analyzeFiles(files, workspaceDir, pb);
         }
       }
 
@@ -220,6 +210,28 @@ public class AnalyzeCommand implements Callable<Integer> {
 
   public String[] getReportersOptions() {
     return reportersOptions.clone();
+  }
+
+  private List<FileInfo> analyzeFiles(List<File> files, Path workspaceDir, @Nullable ProgressBar progressBar)
+    throws InterruptedException, ExecutionException {
+    // Каждый документ — отдельная задача на bounded analyzeExecutor: число одновременно
+    // материализованных DocumentContext ограничено размером пула (см. ExecutorConfiguration),
+    // а не «плывёт» из-за компенсации потоков ForkJoinPool на блокирующем join диагностик.
+    var futures = files.stream()
+      .map((File file) -> analyzeExecutor.submit(() -> {
+        var fileInfo = getFileInfoFromFile(workspaceDir, file);
+        if (progressBar != null) {
+          progressBar.step();
+        }
+        return fileInfo;
+      }))
+      .toList();
+
+    var fileInfos = new ArrayList<FileInfo>(futures.size());
+    for (var future : futures) {
+      fileInfos.add(future.get());
+    }
+    return fileInfos;
   }
 
   private FileInfo getFileInfoFromFile(Path srcDir, File file) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/cli/AnalyzeCommand.java
@@ -228,8 +228,16 @@ public class AnalyzeCommand implements Callable<Integer> {
       .toList();
 
     var fileInfos = new ArrayList<FileInfo>(futures.size());
-    for (var future : futures) {
-      fileInfos.add(future.get());
+    try {
+      for (var future : futures) {
+        fileInfos.add(future.get());
+      }
+    } catch (InterruptedException | ExecutionException e) {
+      // Отменяем ещё не стартовавшие задачи (running не прерываем — обработка
+      // документа не гарантированно interruption-safe), чтобы после решения об
+      // ошибке batch не продолжал материализовать документы.
+      futures.forEach(future -> future.cancel(false));
+      throw e;
     }
     return fileInfos;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration.java
@@ -158,26 +158,16 @@ public class ExecutorConfiguration {
   }
 
   private static ExecutorService createWorkspaceForkJoinPool(String prefix) {
-    var workspaceUri = WorkspaceContextHolder.get();
-    if (workspaceUri == null) {
-      throw new IllegalStateException("Workspace context is not set when creating ForkJoinPool");
-    }
-    var workspaceName = Optional.ofNullable(WorkspaceContextHolder.getName())
-      .orElse("default");
-    var factory = new WorkspaceAwareFJWTFactory(workspaceUri, workspaceName, prefix);
+    var workspace = resolveWorkspaceContext();
+    var factory = new WorkspaceAwareFJWTFactory(workspace.uri(), workspace.name(), prefix);
     var pool = new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(), factory, null, true);
     return new ContextPropagatingExecutorService(pool);
   }
 
   private static ExecutorService createWorkspaceBoundedPool(String prefix) {
-    var workspaceUri = WorkspaceContextHolder.get();
-    if (workspaceUri == null) {
-      throw new IllegalStateException("Workspace context is not set when creating executor");
-    }
-    var workspaceName = Optional.ofNullable(WorkspaceContextHolder.getName())
-      .orElse("default");
+    var workspace = resolveWorkspaceContext();
     var parallelism = ForkJoinPool.getCommonPoolParallelism();
-    var factory = new NamedThreadFactory(prefix + workspaceName + "-");
+    var factory = new NamedThreadFactory(prefix + workspace.name() + "-");
     var pool = new ThreadPoolExecutor(
       parallelism, parallelism,
       0L, TimeUnit.MILLISECONDS,
@@ -185,6 +175,19 @@ public class ExecutorConfiguration {
       factory
     );
     return new ContextPropagatingExecutorService(pool);
+  }
+
+  private static WorkspaceContext resolveWorkspaceContext() {
+    var workspaceUri = WorkspaceContextHolder.get();
+    if (workspaceUri == null) {
+      throw new IllegalStateException("Workspace context is not set when creating executor");
+    }
+    var workspaceName = Optional.ofNullable(WorkspaceContextHolder.getName())
+      .orElse("default");
+    return new WorkspaceContext(workspaceUri, workspaceName);
+  }
+
+  private record WorkspaceContext(URI uri, String name) {
   }
 
   private static ExecutorService createSharedForkJoinExecutorService(String threadNamePrefix) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/infrastructure/ExecutorConfiguration.java
@@ -35,6 +35,11 @@ import java.util.Optional;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.ForkJoinPool;
 import java.util.concurrent.ForkJoinWorkerThread;
+import java.util.concurrent.LinkedBlockingQueue;
+import java.util.concurrent.ThreadFactory;
+import java.util.concurrent.ThreadPoolExecutor;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 
 /**
  * Конфигурация исполнителей для обработки асинхронных задач.
@@ -130,6 +135,20 @@ public class ExecutorConfiguration {
     return createWorkspaceForkJoinPool("cli-");
   }
 
+  // analyzeExecutor — внешняя ось batch-анализа (по документам). В отличие от cliExecutor
+  // это обычный ThreadPoolExecutor, а не ForkJoinPool: внутри getFileInfoFromFile идёт
+  // блокирующий join к diagnosticComputerExecutor, и на ForkJoinPool это триггерит
+  // managed-blocking компенсацию (пул плодит потоки сверх номинала → живых DocumentContext
+  // больше, чем ядер). На обычном пуле блокировка воркера потоков не плодит, поэтому число
+  // одновременно материализованных документов жёстко ограничено размером пула. Задачи
+  // сабмитятся по одной (не parallelStream), контекст workspace несёт
+  // ContextPropagatingExecutorService.
+  @Bean(destroyMethod = "shutdown")
+  @WorkspaceScope(proxyMode = ScopedProxyMode.INTERFACES)
+  public ExecutorService analyzeExecutor() {
+    return createWorkspaceBoundedPool("analyze-");
+  }
+
   private static AsyncTaskExecutor createVirtualThreadExecutor(
     TaskDecorator taskDecorator, String threadNamePrefix) {
     var executor = new SimpleAsyncTaskExecutor(threadNamePrefix);
@@ -150,10 +169,41 @@ public class ExecutorConfiguration {
     return new ContextPropagatingExecutorService(pool);
   }
 
+  private static ExecutorService createWorkspaceBoundedPool(String prefix) {
+    var workspaceUri = WorkspaceContextHolder.get();
+    if (workspaceUri == null) {
+      throw new IllegalStateException("Workspace context is not set when creating executor");
+    }
+    var workspaceName = Optional.ofNullable(WorkspaceContextHolder.getName())
+      .orElse("default");
+    var parallelism = ForkJoinPool.getCommonPoolParallelism();
+    var factory = new NamedThreadFactory(prefix + workspaceName + "-");
+    var pool = new ThreadPoolExecutor(
+      parallelism, parallelism,
+      0L, TimeUnit.MILLISECONDS,
+      new LinkedBlockingQueue<>(),
+      factory
+    );
+    return new ContextPropagatingExecutorService(pool);
+  }
+
   private static ExecutorService createSharedForkJoinExecutorService(String threadNamePrefix) {
     var factory = new NamedForkJoinWorkerThreadFactory(threadNamePrefix);
     var pool = new ForkJoinPool(ForkJoinPool.getCommonPoolParallelism(), factory, null, true);
     return new ContextPropagatingExecutorService(pool);
+  }
+
+  private record NamedThreadFactory(String prefix, AtomicInteger index) implements ThreadFactory {
+    NamedThreadFactory(String prefix) {
+      this(prefix, new AtomicInteger());
+    }
+
+    @Override
+    public Thread newThread(Runnable runnable) {
+      var thread = new Thread(runnable, prefix + index.getAndIncrement());
+      thread.setDaemon(true);
+      return thread;
+    }
   }
 
   private record NamedForkJoinWorkerThreadFactory(String prefix) implements ForkJoinPool.ForkJoinWorkerThreadFactory {


### PR DESCRIPTION
## Описание

Batch-`analyze` гоняет файлы через `cliExecutor` (**`ForkJoinPool`**) внутри `parallelStream`, а `getDiagnostics` каждого файла блокируется на `CompletableFuture.join()` к `diagnosticComputerExecutor`. `join()` внутри воркера `ForkJoinPool` — это **managed blocking**: пул, чтобы держать номинальный параллелизм, поднимает **компенсирующие потоки**, и каждый лишний воркер материализует ещё один `DocumentContext`. Естественный потолок «≈ число ядер» теряется — живых документов (и потоков) становится сильно больше, чем ядер.

Это ровно претензия §4.2 из #4248 (в дампе — `65` cli-потоков при `13` номинала и `16–22 ГиБ` RSS). До ввода отдельных пулов (`ExecutorConfiguration`) `analyze` использовал общий `ForkJoinPool` без вложенного блокирующего `submit`, и потолок «≈ ядра» держался сам собой.

### Фикс

Дать `analyze` собственный ограниченный исполнитель: фиксированный `ThreadPoolExecutor` (`analyzeExecutor`) в обёртке `ContextPropagatingExecutorService`, и сабмитить **по задаче на файл** вместо `parallelStream`. На обычном пуле заблокированный воркер потоки **не** плодит, поэтому число одновременно материализованных `DocumentContext` жёстко ограничено размером пула.

- `cliExecutor` (используется `FormatCommand`, без блокирующего `join`) и `diagnosticComputerExecutor` остаются `ForkJoinPool`.
- Контекст workspace для сабмиченных задач несёт `ContextPropagatingExecutorService` (per-task snapshot через micrometer `ThreadLocalAccessor`), поэтому per-thread `onStart`-хук `ForkJoinPool` тут не нужен.

## Замеры (JFR)

SSL 3.2 (2184 файла, 4 ядра, тёплый кэш), `analyze --reporter sarif`, вывод идентичен (**72160** диагностик до и после):

| | было (`ForkJoinPool`) | стало (bounded) |
| --- | --- | --- |
| пик потоков | 62 | **49** |
| потоков создано за прогон (JFR `jdk.ThreadStart`) | 89 | **74** |
| пик RSS | 3081 MB | **2607 MB** (−15%) |
| wall | 98 s | 98 s (без изменений) |
| SARIF | 72160 | 72160 |

Wall без изменений (первый «183→98s» был целиком эффектом прогрева page-cache — привожу честно). Эффект тем больше, чем больше ядер/степень блокировок: на многоядерном ARA2 из #4248 (`65` потоков, `22 ГиБ`) разница между «≈ ядра» и «65 живых документов» кратно крупнее.

## Связанные задачи

Пункт §4.2 архитектурного разбора #4248. Продолжение серии #4249–#4258.

Closes 

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами (`AnalyzeCommandTest`, `FormatCommandTest` — зелёные; вывод SARIF идентичен на реальном прогоне SSL)

## Дополнительно

Освобождение AST per-document уже делается (`getFileInfoFromFile` → `tryClearDocument`), поэтому bounded-пул автоматически ограничивает и живой AST размером пула — доп. действий не требуется. Размер пула сейчас = `commonPoolParallelism`; при желании легко вынести в CLI-опцию/конфиг.

---
_Generated by [Claude Code](https://claude.ai/code/session_01BSiRGLm633B4EmvG3vkk4V)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Performance**
  * Improved analysis of multiple files using a dedicated, workspace-bounded execution approach.
* **Bug Fixes**
  * Progress indicators now update more reliably during ongoing multi-file analysis.
* **Improvements**
  * Analysis results are now gathered more consistently after all submitted work finishes.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->