### PR TITLE
feat(diagnostics): параметры-списки принимают строку или массив (тип List)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
@@ -26,10 +26,10 @@ import com.github._1c_syntax.utils.CaseInsensitivePattern;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.tree.ParseTree;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jspecify.annotations.Nullable;
 
 import java.lang.reflect.Field;
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -125,7 +125,7 @@ public final class DiagnosticHelper {
     types.add(Boolean.class);
     types.add(Float.class);
     types.add(String.class);
-    types.add(Either.class);
+    types.add(List.class);
 
     diagnostic.getInfo().getParameters().stream()
       .filter(diagnosticParameterInfo -> configuration.containsKey(diagnosticParameterInfo.getName())
@@ -145,21 +145,21 @@ public final class DiagnosticHelper {
   /**
    * Приводит значение параметра из конфигурации к типу целевого поля диагностики.
    * <p>
-   * Для полей типа {@link Either}{@code <String, List<String>>} значение может прийти
-   * как строка (список через разделитель — например, из SonarQube UI) либо как JSON-массив
-   * (десериализуется Jackson в {@link List}). Строка оборачивается в левую ветвь,
-   * массив — в правую. Для остальных полей значение возвращается без изменений.
+   * Для полей типа {@link List} значение может прийти как строка (элементы через запятую —
+   * например, из SonarQube UI) либо как JSON-массив (десериализуется Jackson в {@link List}).
+   * В обоих случаях возвращается {@code List<String>}. Для остальных полей значение
+   * возвращается без изменений.
    *
    * @param field Целевое поле диагностики
    * @param value Значение из конфигурации ({@code String}, {@code List} и т.п.)
    * @return Значение, пригодное для присвоения полю
    */
   private static Object castParameterValue(Field field, Object value) {
-    if (Either.class.isAssignableFrom(field.getType())) {
+    if (List.class.isAssignableFrom(field.getType())) {
       if (value instanceof List<?> list) {
-        return Either.forRight(list.stream().map(String::valueOf).toList());
+        return list.stream().map(String::valueOf).toList();
       }
-      return Either.forLeft(String.valueOf(value));
+      return asStringList(String.valueOf(value));
     }
     return value;
   }
@@ -185,24 +185,17 @@ public final class DiagnosticHelper {
   }
 
   /**
-   * Разворачивает значение параметра-списка в список строк.
+   * Разбирает строку с элементами через запятую в список строк.
    * <p>
-   * Левая ветвь {@link Either} — строка с элементами через запятую (форма, приходящая из SonarQube UI
-   * и из «старых» конфигов); правая ветвь — уже готовый список (из JSON-массива). Элементы обрезаются
-   * по краям от пробелов; пустые элементы отбрасываются.
+   * Используется как для значения параметра-списка из конфигурации в строковой форме
+   * (SonarQube UI, «старые» конфиги), так и для инициализации поля значением по умолчанию.
+   * Элементы обрезаются по краям от пробелов; пустые элементы отбрасываются.
    *
-   * @param value Значение параметра: строка через запятую либо список строк
+   * @param value Строка с элементами через запятую
    * @return Список строк без пустых элементов
    */
-  public static List<String> asStringList(Either<String, List<String>> value) {
-    List<String> source;
-    if (value.isRight()) {
-      source = value.getRight();
-    } else {
-      source = List.of(value.getLeft().split(","));
-    }
-
-    return source.stream()
+  public static List<String> asStringList(String value) {
+    return Arrays.stream(value.split(","))
       .map(String::trim)
       .filter(element -> !element.isEmpty())
       .toList();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
@@ -154,7 +154,7 @@ public final class DiagnosticHelper {
    * @param value Значение из конфигурации ({@code String}, {@code List} и т.п.)
    * @return Значение, пригодное для присвоения полю
    */
-  private static Object castParameterValue(Field field, @Nullable Object value) {
+  private static @Nullable Object castParameterValue(Field field, @Nullable Object value) {
     if (value == null) {
       return null;
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
@@ -26,10 +26,13 @@ import com.github._1c_syntax.utils.CaseInsensitivePattern;
 import lombok.experimental.UtilityClass;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.tree.ParseTree;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.jspecify.annotations.Nullable;
 
+import java.lang.reflect.Field;
 import java.util.HashMap;
 import java.util.HashSet;
+import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.StringJoiner;
@@ -130,12 +133,34 @@ public final class DiagnosticHelper {
         try {
           var field = diagnostic.getClass().getDeclaredField(diagnosticParameterInfo.getName());
           if (field.trySetAccessible()) {
-            field.set(diagnostic, configuration.get(field.getName()));
+            field.set(diagnostic, castParameterValue(field, configuration.get(field.getName())));
           }
-        } catch (NoSuchFieldException | IllegalAccessException e) {
+        } catch (NoSuchFieldException | IllegalAccessException | IllegalArgumentException e) {
           LOGGER.error("Can't set param.", e);
         }
       });
+  }
+
+  /**
+   * Приводит значение параметра из конфигурации к типу целевого поля диагностики.
+   * <p>
+   * Для полей типа {@link Either}{@code <String, List<String>>} значение может прийти
+   * как строка (список через разделитель — например, из SonarQube UI) либо как JSON-массив
+   * (десериализуется Jackson в {@link List}). Строка оборачивается в левую ветвь,
+   * массив — в правую. Для остальных полей значение возвращается без изменений.
+   *
+   * @param field Целевое поле диагностики
+   * @param value Значение из конфигурации ({@code String}, {@code List} и т.п.)
+   * @return Значение, пригодное для присвоения полю
+   */
+  private static Object castParameterValue(Field field, Object value) {
+    if (Either.class.isAssignableFrom(field.getType())) {
+      if (value instanceof List<?> list) {
+        return Either.forRight(list.stream().map(String::valueOf).toList());
+      }
+      return Either.forLeft(String.valueOf(value));
+    }
+    return value;
   }
 
   /**
@@ -156,6 +181,30 @@ public final class DiagnosticHelper {
     }
 
     configureDiagnostic(diagnostic, newConfiguration);
+  }
+
+  /**
+   * Разворачивает значение параметра-списка в список строк.
+   * <p>
+   * Левая ветвь {@link Either} — строка с элементами через запятую (форма, приходящая из SonarQube UI
+   * и из «старых» конфигов); правая ветвь — уже готовый список (из JSON-массива). Элементы обрезаются
+   * по краям от пробелов; пустые элементы отбрасываются.
+   *
+   * @param value Значение параметра: строка через запятую либо список строк
+   * @return Список строк без пустых элементов
+   */
+  public static List<String> asStringList(Either<String, List<String>> value) {
+    List<String> source;
+    if (value.isRight()) {
+      source = value.getRight();
+    } else {
+      source = List.of(value.getLeft().split(","));
+    }
+
+    return source.stream()
+      .map(String::trim)
+      .filter(element -> !element.isEmpty())
+      .toList();
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
@@ -125,6 +125,7 @@ public final class DiagnosticHelper {
     types.add(Boolean.class);
     types.add(Float.class);
     types.add(String.class);
+    types.add(Either.class);
 
     diagnostic.getInfo().getParameters().stream()
       .filter(diagnosticParameterInfo -> configuration.containsKey(diagnosticParameterInfo.getName())

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/DiagnosticHelper.java
@@ -154,12 +154,15 @@ public final class DiagnosticHelper {
    * @param value Значение из конфигурации ({@code String}, {@code List} и т.п.)
    * @return Значение, пригодное для присвоения полю
    */
-  private static Object castParameterValue(Field field, Object value) {
+  private static Object castParameterValue(Field field, @Nullable Object value) {
+    if (value == null) {
+      return null;
+    }
     if (List.class.isAssignableFrom(field.getType())) {
       if (value instanceof List<?> list) {
         return list.stream().map(String::valueOf).toList();
       }
-      return asStringList(String.valueOf(value));
+      return asStringList(value.toString());
     }
     return value;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnostic.java
@@ -40,6 +40,7 @@ import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.Token;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Languages;
 import org.languagetool.rules.RuleMatch;
@@ -108,7 +109,7 @@ public class TypoDiagnostic extends AbstractDiagnostic {
   @DiagnosticParameter(
     type = String.class
   )
-  private String userWordsToIgnore = DEFAULT_USER_WORDS_TO_IGNORE;
+  private Either<String, List<String>> userWordsToIgnore = Either.forLeft(DEFAULT_USER_WORDS_TO_IGNORE);
 
   /**
    * Готовый список слов для игнорирования
@@ -130,8 +131,9 @@ public class TypoDiagnostic extends AbstractDiagnostic {
   private Set<String> makeWordsToIgnore() {
     var delimiter = ',';
     var exceptions = SPACES_PATTERN.matcher(info.getResourceString("diagnosticExceptions")).replaceAll("");
-    if (!userWordsToIgnore.isEmpty()) {
-      exceptions += delimiter + SPACES_PATTERN.matcher(userWordsToIgnore).replaceAll("");
+    var userWords = String.join(String.valueOf(delimiter), DiagnosticHelper.asStringList(userWordsToIgnore));
+    if (!userWords.isEmpty()) {
+      exceptions += delimiter + SPACES_PATTERN.matcher(userWords).replaceAll("");
     }
 
     // добавим к переданным строки в разных регистрах

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnostic.java
@@ -107,7 +107,7 @@ public class TypoDiagnostic extends AbstractDiagnostic {
   private int minWordLength = DEFAULT_MIN_WORD_LENGTH;
 
   @DiagnosticParameter(
-    type = String.class
+    type = Either.class
   )
   private Either<String, List<String>> userWordsToIgnore = Either.forLeft(DEFAULT_USER_WORDS_TO_IGNORE);
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnostic.java
@@ -40,7 +40,6 @@ import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.Token;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.text.WordUtils;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 import org.languagetool.JLanguageTool;
 import org.languagetool.Languages;
 import org.languagetool.rules.RuleMatch;
@@ -107,9 +106,9 @@ public class TypoDiagnostic extends AbstractDiagnostic {
   private int minWordLength = DEFAULT_MIN_WORD_LENGTH;
 
   @DiagnosticParameter(
-    type = Either.class
+    type = List.class
   )
-  private Either<String, List<String>> userWordsToIgnore = Either.forLeft(DEFAULT_USER_WORDS_TO_IGNORE);
+  private List<String> userWordsToIgnore = DiagnosticHelper.asStringList(DEFAULT_USER_WORDS_TO_IGNORE);
 
   /**
    * Готовый список слов для игнорирования
@@ -131,7 +130,7 @@ public class TypoDiagnostic extends AbstractDiagnostic {
   private Set<String> makeWordsToIgnore() {
     var delimiter = ',';
     var exceptions = SPACES_PATTERN.matcher(info.getResourceString("diagnosticExceptions")).replaceAll("");
-    var userWords = String.join(String.valueOf(delimiter), DiagnosticHelper.asStringList(userWordsToIgnore));
+    var userWords = String.join(String.valueOf(delimiter), userWordsToIgnore);
     if (!userWords.isEmpty()) {
       exceptions += delimiter + SPACES_PATTERN.matcher(userWords).replaceAll("");
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/info/DiagnosticParameterInfo.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/info/DiagnosticParameterInfo.java
@@ -23,7 +23,6 @@ package com.github._1c_syntax.bsl.languageserver.diagnostics.info;
 
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticParameter;
 import lombok.Getter;
-import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -59,9 +58,9 @@ public final class DiagnosticParameterInfo {
       value = Float.parseFloat(valueToCast);
     } else if (type == String.class) {
       value = valueToCast;
-    } else if (type == Either.class) {
+    } else if (type == List.class) {
       // Параметр-список: внешнее (config/SonarQube) представление по умолчанию — строка через запятую.
-      // В Either значение оборачивается при применении конфигурации (см. DiagnosticHelper).
+      // В List значение разбирается при применении конфигурации (см. DiagnosticHelper).
       value = valueToCast;
     } else {
       throw new IllegalArgumentException("Unsupported diagnostic parameter type " + type);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/info/DiagnosticParameterInfo.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/info/DiagnosticParameterInfo.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.diagnostics.info;
 
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticParameter;
 import lombok.Getter;
+import org.eclipse.lsp4j.jsonrpc.messages.Either;
 
 import java.lang.reflect.Field;
 import java.util.Arrays;
@@ -57,6 +58,10 @@ public final class DiagnosticParameterInfo {
     } else if (type == Float.class) {
       value = Float.parseFloat(valueToCast);
     } else if (type == String.class) {
+      value = valueToCast;
+    } else if (type == Either.class) {
+      // Параметр-список: внешнее (config/SonarQube) представление по умолчанию — строка через запятую.
+      // В Either значение оборачивается при применении конфигурации (см. DiagnosticHelper).
       value = valueToCast;
     } else {
       throw new IllegalArgumentException("Unsupported diagnostic parameter type " + type);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/TypoDiagnosticTest.java
@@ -112,4 +112,18 @@ class TypoDiagnosticTest extends AbstractDiagnosticTest<TypoDiagnostic> {
     assertThat(diagnostics, true)
       .hasRange(8, 13, 8, 18);
   }
+
+  @Test
+  void testConfigureUserWordsToIgnoreAsList() {
+
+    Map<String, Object> configuration = diagnosticInstance.getInfo().getDefaultConfiguration();
+    configuration.put("userWordsToIgnore", List.of("Варинаты", "Атмена"));
+    diagnosticInstance.configure(configuration);
+
+    List<Diagnostic> diagnostics = getDiagnostics();
+
+    assertThat(diagnostics).hasSize(1);
+    assertThat(diagnostics, true)
+      .hasRange(8, 13, 8, 18);
+  }
 }


### PR DESCRIPTION
## Описание

Параметры-списки диагностик (значения через запятую) получили первоклассный тип **`List`** и теперь принимают два входных представления:

- **строку через запятую** — как раньше, в т.ч. из SonarQube UI и «старых» конфигов;
- **JSON-массив строк** в `.bsl-language-server.json` (`"userWordsToIgnore": ["Слово1", "Слово2"]`).

Реализация:

- `@DiagnosticParameter(type = List.class)` + поле `List<String>` вместо строки.
- `DiagnosticHelper.castParameterValue` приводит значение из конфигурации к `List<String>`: строка → `split` по запятой (с trim/отбросом пустых), JSON-массив (Jackson → `ArrayList`) → список.
- `DiagnosticHelper.asStringList(String)` — разбор CSV, переиспользуется для инициализации полей значением по умолчанию.
- `DiagnosticParameterInfo` и `DiagnosticHelper.configureDiagnostic` знают про `List.class`; внешнее представление значения по умолчанию остаётся строкой (для SonarQube UI и JSON-схемы).
- Первая переведённая диагностика — **`Typo`** (`userWordsToIgnore`).

Обратная совместимость полная: старые CSV-строки в конфигах и любые значения из SonarQube продолжают работать; массив — новая опциональная возможность JSON-конфига.

### Схема параметров

`parameters-schema.json` **не правился руками** — он генерируется `gradlew precommit` через плагин `bslls-dev-tools`. Поддержка `"type": ["string","array"]` добавлена в 1c-syntax/bslls-dev-tools#PR (см. связанные PR ниже). После релиза плагина и бампа его версии здесь схема перегенерится автоматически. В рантайме массив уже принимается независимо от схемы.

## Связанные PR

- 1c-syntax/bslls-dev-tools — генерация схемы для типа `List` (ветка `claude/diagnostic-params-string-list-28j3v4`)
- 1c-syntax/sonar-bsl-plugin-community — проброс параметров-списков (ветка `claude/diagnostic-params-string-list-28j3v4`)

## Связанные задачи
<!-- ВНИМАНИЕ: без ссылки на задачу PR не будет принят — добавьте ключ issue. -->
Closes 

## Чеклист

### Общие

- [ ] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами (`TypoDiagnosticTest`, в т.ч. новый кейс с массивом)
- [ ] Обязательные действия перед коммитом выполнены (`gradlew precommit`) — регенерация схемы зависит от релиза `bslls-dev-tools`, см. выше

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (в этом PR меняется только тип параметра, тексты не затрагивались)

## Дополнительно

Дальнейший план — раскатать тип `List` на остальные списочные параметры (`LatinAndCyrillicSymbolInWord`, `MagicNumber`/`MagicDate`, `CommentedCode` и др.; `UsingServiceTag` — отдельно, там `|`-разделитель/regex).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01W86iNs3Sj9wTS6NFFHvVbv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Diagnostic settings now support list-based parameters.
  * Comma-separated values are automatically parsed into trimmed lists, with empty entries ignored.
  * Typo checking now supports configuring multiple words to ignore.

* **Bug Fixes**
  * Improved handling of ignored-word settings when provided as lists or text values.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->