### PR TITLE
perf(references): компактное хранение reference-индекса (−~870 МиБ на cpm)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Component;
 
 import java.net.URI;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -179,17 +180,22 @@ public class ReferenceIndex {
   public void replaceReferences(URI uri, Iterable<SymbolOccurrence> newOccurrences) {
     var stale = locationRepository.getSymbolOccurrencesByLocationUri(uri)
       .collect(Collectors.toCollection(HashSet::new));
+    var replacement = new LinkedHashSet<SymbolOccurrence>();
     for (var occurrence : newOccurrences) {
+      replacement.add(occurrence);
       // Успешное удаление из stale означает, что вхождение уже есть в индексе —
-      // оставляем его как есть; остаток stale после цикла подлежит удалению.
+      // символьную сторону не трогаем; остаток stale после цикла подлежит удалению.
       if (!stale.remove(occurrence)) {
-        saveOccurrence(occurrence);
+        symbolOccurrenceRepository.save(occurrence);
       }
     }
     if (!stale.isEmpty()) {
       symbolOccurrenceRepository.deleteAll(stale);
-      locationRepository.deleteAll(uri, stale);
     }
+    // Сторона расположений заменяется целиком одним атомарным swap-ом полного
+    // набора вхождений документа — плотнее (массив вместо concurrent-множества)
+    // и без «пустого окна» для читателей.
+    locationRepository.replaceOccurrences(uri, replacement);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/LocationRepository.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/LocationRepository.java
@@ -29,11 +29,9 @@ import org.springframework.stereotype.Component;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
@@ -55,9 +53,16 @@ public class LocationRepository {
     .thenComparingInt(occurrence -> occurrence.location().startCharacter());
 
   /**
-   * Список обращений к символу, сгруппированный по URI.
+   * Вхождения документа, сгруппированные по URI.
+   * <p>
+   * Значение — неизменяемый массив {@code SymbolOccurrence[]}, а не concurrent-множество:
+   * вхождения одного документа пишутся одним потоком (перестроение документа сериализовано),
+   * а полный набор заменяется атомарным swap-ом ссылки ({@link #replaceOccurrences}), поэтому
+   * конкурентные читатели всегда видят согласованный снимок. Массив вместо
+   * {@code ConcurrentHashMap.newKeySet()} убирает ~1 Node на каждое вхождение (на больших
+   * проектах — миллионы узлов и сотни МБ).
    */
-  private final Map<URI, Set<SymbolOccurrence>> locations = new ConcurrentHashMap<>();
+  private final Map<URI, SymbolOccurrence[]> locations = new ConcurrentHashMap<>();
 
   /**
    * Вторичный индекс для {@link #findByPosition}: отсортированный по началу
@@ -67,8 +72,8 @@ public class LocationRepository {
    * потреблении памяти индексом ссылок).
    * <p>
    * Снимок ленивый: сбрасывается при любом изменении вхождений URI
-   * ({@link #updateLocation}, {@link #delete}) и пересобирается при первом
-   * следующем поиске.
+   * ({@link #replaceOccurrences}, {@link #updateLocation}, {@link #deleteAll},
+   * {@link #delete}) и пересобирается при первом следующем поиске.
    */
   private final Map<URI, SymbolOccurrence[]> sortedOccurrences = new ConcurrentHashMap<>();
 
@@ -79,7 +84,7 @@ public class LocationRepository {
    * @return Список найденных обращений к символам.
    */
   public Stream<SymbolOccurrence> getSymbolOccurrencesByLocationUri(URI uri) {
-    return locations.getOrDefault(uri, Collections.emptySet()).stream();
+    return Arrays.stream(locations.getOrDefault(uri, EMPTY_OCCURRENCES));
   }
 
   /**
@@ -102,7 +107,7 @@ public class LocationRepository {
   }
 
   private SymbolOccurrence[] sortedSnapshot(URI uri) {
-    var snapshot = locations.getOrDefault(uri, Collections.emptySet()).toArray(EMPTY_OCCURRENCES);
+    var snapshot = locations.getOrDefault(uri, EMPTY_OCCURRENCES).clone();
     Arrays.sort(snapshot, BY_RANGE_START);
     return snapshot;
   }
@@ -140,15 +145,38 @@ public class LocationRepository {
   }
 
   /**
-   * Обновить данные о расположении обращения к символу.
+   * Заменить полный набор вхождений документа. Основной путь записи: перестроение
+   * документа собирает набор в буфер и заменяет его целиком одним атомарным swap-ом.
+   *
+   * @param uri         URI документа.
+   * @param occurrences Новый набор вхождений документа (без дубликатов).
+   */
+  public void replaceOccurrences(URI uri, Collection<SymbolOccurrence> occurrences) {
+    if (occurrences.isEmpty()) {
+      locations.remove(uri);
+    } else {
+      locations.put(uri, occurrences.toArray(EMPTY_OCCURRENCES));
+    }
+    sortedOccurrences.remove(uri);
+  }
+
+  /**
+   * Добавить одиночное вхождение к символу (гранулярный путь записи). Дубликат по
+   * {@code equals} игнорируется — семантика множества сохраняется.
    *
    * @param symbolOccurrence Обращение к символу.
    */
   public void updateLocation(SymbolOccurrence symbolOccurrence) {
-    var location = symbolOccurrence.location();
-    locations.computeIfAbsent(location.uri(), uri -> ConcurrentHashMap.newKeySet())
-      .add(symbolOccurrence);
-    sortedOccurrences.remove(location.uri());
+    var uri = symbolOccurrence.location().uri();
+    locations.merge(uri, new SymbolOccurrence[]{symbolOccurrence}, (existing, added) -> {
+      if (contains(existing, added[0])) {
+        return existing;
+      }
+      var updated = Arrays.copyOf(existing, existing.length + 1);
+      updated[existing.length] = added[0];
+      return updated;
+    });
+    sortedOccurrences.remove(uri);
   }
 
   /**
@@ -169,10 +197,21 @@ public class LocationRepository {
    * @param occurrences Удаляемые обращения.
    */
   public void deleteAll(URI uri, Collection<SymbolOccurrence> occurrences) {
-    var uriLocations = locations.get(uri);
-    if (uriLocations != null) {
-      uriLocations.removeAll(occurrences);
-    }
+    locations.computeIfPresent(uri, (u, existing) -> {
+      var remaining = Arrays.stream(existing)
+        .filter(occurrence -> !occurrences.contains(occurrence))
+        .toArray(SymbolOccurrence[]::new);
+      return remaining.length == 0 ? null : remaining;
+    });
     sortedOccurrences.remove(uri);
+  }
+
+  private static boolean contains(SymbolOccurrence[] array, SymbolOccurrence occurrence) {
+    for (var element : array) {
+      if (element.equals(occurrence)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/SymbolOccurrenceRepository.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/SymbolOccurrenceRepository.java
@@ -24,11 +24,12 @@ package com.github._1c_syntax.bsl.languageserver.references.model;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import org.springframework.stereotype.Component;
 
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.LinkedHashSet;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.concurrent.ConcurrentSkipListSet;
 
 /**
  * Хранилище обращений к символам.
@@ -38,14 +39,19 @@ import java.util.concurrent.ConcurrentSkipListSet;
 public class SymbolOccurrenceRepository {
 
   /**
-   * Список обращений к символам в разрезе символов.
+   * Обращения к символам в разрезе символов.
    * <p>
-   * Внешняя карта — {@link ConcurrentHashMap}: ключ-{@link Symbol} ищется по hashCode/equals
-   * за O(1) без вызовов {@code Symbol.compareTo} (на перестроении индекса при наборе текста это
-   * было основной не-ANTLR статьёй расхода). Внутреннее множество остаётся сортированным
-   * {@link ConcurrentSkipListSet}, поэтому порядок обращений ({@code getAllBySymbol}) сохраняется.
+   * Значение карты хранится в компактном виде: для символа с единственным обращением —
+   * сам {@link SymbolOccurrence} без обёртки-коллекции (доминирующий случай), для символа
+   * с несколькими обращениями — отсортированный по {@link SymbolOccurrence#compareTo} массив
+   * {@code SymbolOccurrence[]}. Это устраняет накладные расходы {@link java.util.concurrent.ConcurrentSkipListSet}
+   * (заголовок мапы 88Б, sentinel- и index-узлы), которые на больших проектах составляли сотни МБ.
+   * <p>
+   * Все изменения выполняются атомарно по ключу через {@link ConcurrentHashMap#compute}
+   * и {@link ConcurrentHashMap#computeIfPresent}; массив неизменяем после публикации,
+   * поэтому читатели ({@link #getAllBySymbol}) всегда видят согласованный снимок.
    */
-  private final Map<Symbol, Set<SymbolOccurrence>> occurrencesToSymbols = new ConcurrentHashMap<>();
+  private final Map<Symbol, Object> occurrencesToSymbols = new ConcurrentHashMap<>();
 
   /**
    * Сохранить обращение к символу в хранилище.
@@ -53,18 +59,27 @@ public class SymbolOccurrenceRepository {
    * @param symbolOccurrence Обращение к символу.
    */
   public void save(SymbolOccurrence symbolOccurrence) {
-    occurrencesToSymbols.computeIfAbsent(symbolOccurrence.symbol(), symbol -> new ConcurrentSkipListSet<>())
-      .add(symbolOccurrence);
+    occurrencesToSymbols.compute(symbolOccurrence.symbol(), (symbol, current) -> insert(current, symbolOccurrence));
   }
 
   /**
    * Получить все обращения к указанному символу.
    *
    * @param symbol Символ.
-   * @return Список обращений к символу.
+   * @return Список обращений к символу (в порядке сортировки {@link SymbolOccurrence}).
    */
   public Set<SymbolOccurrence> getAllBySymbol(Symbol symbol) {
-    return occurrencesToSymbols.getOrDefault(symbol, Collections.emptySet());
+    var current = occurrencesToSymbols.get(symbol);
+    if (current == null) {
+      return Collections.emptySet();
+    }
+    if (current instanceof SymbolOccurrence single) {
+      return Collections.singleton(single);
+    }
+    var array = (SymbolOccurrence[]) current;
+    var result = new LinkedHashSet<SymbolOccurrence>(array.length);
+    Collections.addAll(result, array);
+    return Collections.unmodifiableSet(result);
   }
 
   /**
@@ -74,10 +89,59 @@ public class SymbolOccurrenceRepository {
    */
   public void deleteAll(Set<SymbolOccurrence> symbolOccurrences) {
     symbolOccurrences.forEach(symbolOccurrence ->
-      occurrencesToSymbols.computeIfPresent(symbolOccurrence.symbol(), (Symbol s, Set<SymbolOccurrence> set) -> {
-        set.remove(symbolOccurrence);
-        return set.isEmpty() ? null : set; // null => remove mapping
-      })
+      occurrencesToSymbols.computeIfPresent(symbolOccurrence.symbol(), (symbol, current) -> remove(current, symbolOccurrence))
     );
+  }
+
+  /**
+   * Вставить обращение в текущее значение, сохранив сортировку и семантику множества
+   * (дубликат по {@code compareTo == 0} игнорируется).
+   */
+  private static Object insert(Object current, SymbolOccurrence occurrence) {
+    if (current == null) {
+      return occurrence;
+    }
+    if (current instanceof SymbolOccurrence single) {
+      int c = occurrence.compareTo(single);
+      if (c == 0) {
+        return single;
+      }
+      return c < 0
+        ? new SymbolOccurrence[]{occurrence, single}
+        : new SymbolOccurrence[]{single, occurrence};
+    }
+    var array = (SymbolOccurrence[]) current;
+    int idx = Arrays.binarySearch(array, occurrence);
+    if (idx >= 0) {
+      return array; // элемент с таким же ключом уже есть
+    }
+    int insertPos = -idx - 1;
+    var updated = new SymbolOccurrence[array.length + 1];
+    System.arraycopy(array, 0, updated, 0, insertPos);
+    updated[insertPos] = occurrence;
+    System.arraycopy(array, insertPos, updated, insertPos + 1, array.length - insertPos);
+    return updated;
+  }
+
+  /**
+   * Удалить обращение из текущего значения, схлопывая массив обратно к одиночному
+   * значению или {@code null} (удаление ключа) по мере уменьшения.
+   */
+  private static Object remove(Object current, SymbolOccurrence occurrence) {
+    if (current instanceof SymbolOccurrence single) {
+      return single.compareTo(occurrence) == 0 ? null : single;
+    }
+    var array = (SymbolOccurrence[]) current;
+    int idx = Arrays.binarySearch(array, occurrence);
+    if (idx < 0) {
+      return array;
+    }
+    if (array.length == 2) {
+      return array[idx == 0 ? 1 : 0]; // схлопнуть к одиночному значению
+    }
+    var updated = new SymbolOccurrence[array.length - 1];
+    System.arraycopy(array, 0, updated, 0, idx);
+    System.arraycopy(array, idx + 1, updated, idx, array.length - idx - 1);
+    return updated;
   }
 }


### PR DESCRIPTION
## Что и зачем

На больших проектах reference-индекс (`SymbolOccurrenceRepository` + `LocationRepository`) — крупнейший потребитель памяти. На конфигурации **cpm** (~13k модулей, **5 979 539** вхождений, **1 449 862** символов) он держал большую часть хипа, причём почти всё это — не данные, а накладные расходы контейнеров.

PR ничего не меняет в самих данных (`SymbolOccurrence`, `Location`, `Symbol` и внешние мапы остаются как есть) — только заменяет расточительные per-элемент контейнеры на компактные массивы. Внешние контракты `ReferenceIndex` и обоих репозиториев сохранены.

### Методика замера

Live-heap дампы (`jmap -dump:live`) снимались на cpm в фазе диагностик, когда индекс уже полностью построен (`ServerContext.populateContext` наполняет его целиком до анализа). Сравнение честное, full-vs-full: во всех трёх дампах счётчики данных совпадают до штуки — `SymbolOccurrence` 5 979 539, `Location` 5 979 539, `Symbol` 1 449 862. Значит дельты по контейнерам детерминированы. Размеры — shallow, МиБ.

---

## Коммит 1 — `SymbolOccurrenceRepository`: скип-листы → single-or-array

**Было:** `Map<Symbol, ConcurrentSkipListSet<SymbolOccurrence>>` — по одному `ConcurrentSkipListSet` на символ.

`ConcurrentSkipListSet` — самая расточительная по памяти коллекция JDK: на символ приходились заголовок `ConcurrentSkipListMap` (88 Б), sentinel-Node и вероятностные index-узлы. При 1.45M символов это давало сотни МБ на пустой инфраструктуре.

**Стало:** `Map<Symbol, Object>`, где значение — либо сам `SymbolOccurrence` (символ с единственным обращением, доминирующий случай — вообще без обёртки-коллекции), либо отсортированный `SymbolOccurrence[]` для нескольких обращений. Все изменения атомарны по ключу через `compute`/`computeIfPresent`; массив неизменяем после публикации, поэтому читатели `getAllBySymbol` видят согласованный снимок и прежний порядок сортировки.

Распределение на cpm: **40%** символов (584 456) имеют 1 обращение → хранятся без контейнера; **60%** (865 406) → `SymbolOccurrence[]` в среднем по ~6 элементов.

| класс | baseline (кол-во / МиБ) | после #1 (кол-во / МиБ) |
|---|---:|---:|
| `ConcurrentSkipListMap$Node` | 7 432 528 / 283.5 | 3 127 / 0.1 |
| `ConcurrentSkipListMap$Index` | 4 439 463 / 169.4 | 1 645 / 0.1 |
| `ConcurrentSkipListMap` | 1 450 048 / 121.7 | 186 / 0.0 |
| `ConcurrentSkipListSet` | 1 449 863 / 33.2 | 1 / 0.0 |
| `SymbolOccurrence[]` (новое) | 5 166 / 19.3 | 865 406 / 61.5 |
| **итого контейнеры** | **627.1** | **61.7** |

**Экономия ≈ 565 МиБ.** `ReferenceIndexTest` — 14/14 зелёные (включая мутирующие `clearReferences`, `crossWorkspaceIsolation`).

---

## Коммит 2 — `LocationRepository`: concurrent-множества → массивы

**Было:** `Map<URI, ConcurrentHashMap.newKeySet()>` — concurrent-множество на каждый URI. Каждое вхождение = отдельный `ConcurrentHashMap$Node` + таблицы под каждый URI.

**Стало:** `Map<URI, SymbolOccurrence[]>`. Вхождения одного документа пишутся одним потоком (перестроение документа сериализовано), а `ReferenceIndex.replaceReferences` теперь заменяет весь набор расположений документа **одним атомарным swap-ом ссылки на массив** — конкурентные читатели всегда видят согласованный снимок, без «пустого окна». Символьная сторона индекса осталась инкрементальной (добавить новые, удалить устаревшие). Вторичный индекс `findByPosition` не изменился — читает тот же массив. Гранулярный `updateLocation`/`deleteAll` (прямой `addXxx`-API, используется тестами) сохранён как copy-on-write.

| класс | после #1 (кол-во / МиБ) | после #1+#2 (кол-во / МиБ) |
|---|---:|---:|
| `ConcurrentHashMap$Node` | 11 397 432 / 478.3 | 5 324 688 / 223.4 |
| `[LConcurrentHashMap$Node;` (таблицы) | 14 463 / 162.9 | 1 840 / 73.7 |
| `SymbolOccurrence[]` | 865 406 / 61.5 | 875 668 / 100.5 |

Уходит **6.07M** `ConcurrentHashMap$Node` (−255 МиБ) и −89 МиБ таблиц, взамен +39 МиБ массивов. **Экономия ≈ 305 МиБ.** `ReferenceIndexTest` + `LocationRepositoryTest` — зелёные.

---

## Суммарно на cpm

| состояние | live-heap дамп | total live shallow |
|---|---:|---:|
| baseline (develop) | 5.0 ГБ | 4295 МиБ |
| + #1 | 4.1 ГБ | 3554 МиБ |
| + #1 + #2 | 3.3 ГБ | 2818 МиБ |

Детерминированная, атрибутируемая правкам экономия по контейнерам reference-индекса — **≈ 870 МиБ** (565 + 305). Общий спад total-хипа больше (−1477 МиБ), но остаток — это разброс транзиентных объектов фазы диагностик (`Position`, `Range`, `Diagnostic`, `ATNConfig`), т.к. дампы сняты в разные моменты; приписывать его правкам не корректно. Данные индекса (`SymbolOccurrence`/`Location`/`Symbol`) во всех дампах идентичны.

## Тестирование

Локально прогнаны `ReferenceIndexTest` и `LocationRepositoryTest` — зелёные. Полный набор (в т.ч. диагностики, зависящие от reference-индекса) — на CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AZeyPcsbdUBaLUGWbhrCi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved reference index updates to apply document changes atomically.
  - Prevented duplicate reference entries while preserving their order.
  - Improved consistency when adding, removing, or replacing symbol references.
  - Reduced the risk of stale or partially updated reference locations during indexing.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->