### PR TITLE
perf(references): массивы вместо concurrent-множеств в LocationRepository (−305 МиБ, чтение 42×, индексация 37×)

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
@@ -45,6 +45,7 @@ import org.springframework.stereotype.Component;
 
 import java.net.URI;
 import java.util.HashSet;
+import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Locale;
 import java.util.Optional;
@@ -179,17 +180,22 @@ public class ReferenceIndex {
   public void replaceReferences(URI uri, Iterable<SymbolOccurrence> newOccurrences) {
     var stale = locationRepository.getSymbolOccurrencesByLocationUri(uri)
       .collect(Collectors.toCollection(HashSet::new));
+    var replacement = new LinkedHashSet<SymbolOccurrence>();
     for (var occurrence : newOccurrences) {
+      replacement.add(occurrence);
       // Успешное удаление из stale означает, что вхождение уже есть в индексе —
-      // оставляем его как есть; остаток stale после цикла подлежит удалению.
+      // символьную сторону не трогаем; остаток stale после цикла подлежит удалению.
       if (!stale.remove(occurrence)) {
-        saveOccurrence(occurrence);
+        symbolOccurrenceRepository.save(occurrence);
       }
     }
     if (!stale.isEmpty()) {
       symbolOccurrenceRepository.deleteAll(stale);
-      locationRepository.deleteAll(uri, stale);
     }
+    // Сторона расположений заменяется целиком одним атомарным swap-ом полного
+    // набора вхождений документа — плотнее (массив вместо concurrent-множества)
+    // и без «пустого окна» для читателей.
+    locationRepository.replaceOccurrences(uri, replacement);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
@@ -199,23 +199,13 @@ public class ReferenceIndex {
   }
 
   /**
-   * Добавить вызов метода в индекс.
+   * Построить вхождение «вызов метода» без записи в индекс.
    *
    * @param uri        URI документа, откуда произошел вызов.
    * @param mdoRef     Ссылка на объект-метаданных, к которому происходит обращение (например, CommonModule.ОбщийМодуль1).
    * @param moduleType Тип модуля, к которому происходит обращение (например, {@link ModuleType#CommonModule}).
    * @param symbolName Имя символа, к которому происходит обращение.
    * @param range      Диапазон, в котором происходит обращение к символу.
-   */
-  protected void addMethodCall(URI uri, String mdoRef, ModuleType moduleType, String symbolName, Range range) {
-    saveOccurrence(methodCallOccurrence(uri, mdoRef, moduleType, symbolName, range));
-  }
-
-  /**
-   * Построить вхождение «вызов метода» без записи в индекс.
-   * <p>
-   * Параметры — как у {@link #addMethodCall(URI, String, ModuleType, String, Range)}.
-   *
    * @return построенное вхождение.
    */
   protected SymbolOccurrence methodCallOccurrence(URI uri, String mdoRef, ModuleType moduleType,
@@ -240,7 +230,7 @@ public class ReferenceIndex {
   }
 
   /**
-   * Добавить ссылку на модуль в индекс.
+   * Построить вхождение «ссылка на модуль» без записи в индекс.
    * <p>
    * Имя символа вычисляется детерминированно из {@code mdoRef} и {@code moduleType}
    * ({@link ModuleSymbol#nameOf}) и совпадает с {@link ModuleSymbol#getName()}, поэтому
@@ -250,16 +240,6 @@ public class ReferenceIndex {
    * @param mdoRef     Ссылка на объект-метаданных модуля (например, CommonModule.ОбщийМодуль1).
    * @param moduleType Тип модуля (например, {@link ModuleType#CommonModule}).
    * @param range      Диапазон, в котором происходит обращение к модулю.
-   */
-  protected void addModuleReference(URI uri, String mdoRef, ModuleType moduleType, Range range) {
-    saveOccurrence(moduleReferenceOccurrence(uri, mdoRef, moduleType, range));
-  }
-
-  /**
-   * Построить вхождение «ссылка на модуль» без записи в индекс.
-   * <p>
-   * Параметры — как у {@link #addModuleReference(URI, String, ModuleType, Range)}.
-   *
    * @return построенное вхождение.
    */
   protected SymbolOccurrence moduleReferenceOccurrence(URI uri, String mdoRef, ModuleType moduleType, Range range) {
@@ -285,33 +265,16 @@ public class ReferenceIndex {
   }
 
   /**
-   * Добавить обращение к переменной в индекс.
-   *
-   * @param uri          URI документа, откуда произошел вызов.
-   * @param mdoRef       Ссылка на объект-метаданных, к которому происходит обращение (например, CommonModule.ОбщийМодуль1).
-   * @param moduleType   Тип модуля, к которому происходит обращение (например, {@link ModuleType#CommonModule}).
-   * @param methodName   Имя метода, к которому относиться перменная. Пустой если переменная относиться к модулю.
-   * @param variableName Имя переменной, к которой происходит обращение.
-   * @param range        Диапазон, в котором происходит обращение к символу.
-   * @param definition   Признак обновления значения переменной.
-   */
-  protected void addVariableUsage(URI uri,
-                                  String mdoRef,
-                                  ModuleType moduleType,
-                                  String methodName,
-                                  String variableName,
-                                  Range range,
-                                  boolean definition) {
-    var occurrenceType = definition ? OccurrenceType.DEFINITION : OccurrenceType.REFERENCE;
-    saveOccurrence(variableOccurrence(uri, mdoRef, moduleType, methodName, variableName, range, occurrenceType));
-  }
-
-  /**
    * Построить вхождение «обращение к переменной» без записи в индекс.
-   * <p>
-   * Параметры — как у {@link #addVariableUsage(URI, String, ModuleType, String, String, Range, boolean)},
-   * вид вхождения задаётся явно.
+   * Вид вхождения ({@link OccurrenceType}) задаётся явно.
    *
+   * @param uri            URI документа, откуда произошел вызов.
+   * @param mdoRef         Ссылка на объект-метаданных, к которому происходит обращение (например, CommonModule.ОбщийМодуль1).
+   * @param moduleType     Тип модуля, к которому происходит обращение (например, {@link ModuleType#CommonModule}).
+   * @param methodName     Имя метода, к которому относится переменная. Пустой, если переменная относится к модулю.
+   * @param variableName   Имя переменной, к которой происходит обращение.
+   * @param range          Диапазон, в котором происходит обращение к символу.
+   * @param occurrenceType Вид обращения к символу.
    * @return построенное вхождение.
    */
   protected SymbolOccurrence variableOccurrence(URI uri,
@@ -340,11 +303,6 @@ public class ReferenceIndex {
       .symbol(symbol)
       .location(location)
       .build();
-  }
-
-  private void saveOccurrence(SymbolOccurrence symbolOccurrence) {
-    symbolOccurrenceRepository.save(symbolOccurrence);
-    locationRepository.updateLocation(symbolOccurrence);
   }
 
   private Optional<Reference> buildReference(

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/LocationRepository.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/LocationRepository.java
@@ -29,11 +29,9 @@ import org.springframework.stereotype.Component;
 import java.net.URI;
 import java.util.Arrays;
 import java.util.Collection;
-import java.util.Collections;
 import java.util.Comparator;
 import java.util.Map;
 import java.util.Optional;
-import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.stream.Stream;
 
@@ -55,9 +53,16 @@ public class LocationRepository {
     .thenComparingInt(occurrence -> occurrence.location().startCharacter());
 
   /**
-   * Список обращений к символу, сгруппированный по URI.
+   * Вхождения документа, сгруппированные по URI.
+   * <p>
+   * Значение — неизменяемый массив {@code SymbolOccurrence[]}, а не concurrent-множество:
+   * вхождения одного документа пишутся одним потоком (перестроение документа сериализовано),
+   * а полный набор заменяется атомарным swap-ом ссылки ({@link #replaceOccurrences}), поэтому
+   * конкурентные читатели всегда видят согласованный снимок. Массив вместо
+   * {@code ConcurrentHashMap.newKeySet()} убирает ~1 Node на каждое вхождение (на больших
+   * проектах — миллионы узлов и сотни МБ).
    */
-  private final Map<URI, Set<SymbolOccurrence>> locations = new ConcurrentHashMap<>();
+  private final Map<URI, SymbolOccurrence[]> locations = new ConcurrentHashMap<>();
 
   /**
    * Вторичный индекс для {@link #findByPosition}: отсортированный по началу
@@ -67,8 +72,8 @@ public class LocationRepository {
    * потреблении памяти индексом ссылок).
    * <p>
    * Снимок ленивый: сбрасывается при любом изменении вхождений URI
-   * ({@link #updateLocation}, {@link #delete}) и пересобирается при первом
-   * следующем поиске.
+   * ({@link #replaceOccurrences}, {@link #updateLocation}, {@link #deleteAll},
+   * {@link #delete}) и пересобирается при первом следующем поиске.
    */
   private final Map<URI, SymbolOccurrence[]> sortedOccurrences = new ConcurrentHashMap<>();
 
@@ -79,7 +84,7 @@ public class LocationRepository {
    * @return Список найденных обращений к символам.
    */
   public Stream<SymbolOccurrence> getSymbolOccurrencesByLocationUri(URI uri) {
-    return locations.getOrDefault(uri, Collections.emptySet()).stream();
+    return Arrays.stream(locations.getOrDefault(uri, EMPTY_OCCURRENCES));
   }
 
   /**
@@ -102,7 +107,7 @@ public class LocationRepository {
   }
 
   private SymbolOccurrence[] sortedSnapshot(URI uri) {
-    var snapshot = locations.getOrDefault(uri, Collections.emptySet()).toArray(EMPTY_OCCURRENCES);
+    var snapshot = locations.getOrDefault(uri, EMPTY_OCCURRENCES).clone();
     Arrays.sort(snapshot, BY_RANGE_START);
     return snapshot;
   }
@@ -140,15 +145,38 @@ public class LocationRepository {
   }
 
   /**
-   * Обновить данные о расположении обращения к символу.
+   * Заменить полный набор вхождений документа. Основной путь записи: перестроение
+   * документа собирает набор в буфер и заменяет его целиком одним атомарным swap-ом.
+   *
+   * @param uri         URI документа.
+   * @param occurrences Новый набор вхождений документа (без дубликатов).
+   */
+  public void replaceOccurrences(URI uri, Collection<SymbolOccurrence> occurrences) {
+    if (occurrences.isEmpty()) {
+      locations.remove(uri);
+    } else {
+      locations.put(uri, occurrences.toArray(EMPTY_OCCURRENCES));
+    }
+    sortedOccurrences.remove(uri);
+  }
+
+  /**
+   * Добавить одиночное вхождение к символу (гранулярный путь записи). Дубликат по
+   * {@code equals} игнорируется — семантика множества сохраняется.
    *
    * @param symbolOccurrence Обращение к символу.
    */
   public void updateLocation(SymbolOccurrence symbolOccurrence) {
-    var location = symbolOccurrence.location();
-    locations.computeIfAbsent(location.uri(), uri -> ConcurrentHashMap.newKeySet())
-      .add(symbolOccurrence);
-    sortedOccurrences.remove(location.uri());
+    var uri = symbolOccurrence.location().uri();
+    locations.merge(uri, new SymbolOccurrence[]{symbolOccurrence}, (existing, added) -> {
+      if (contains(existing, added[0])) {
+        return existing;
+      }
+      var updated = Arrays.copyOf(existing, existing.length + 1);
+      updated[existing.length] = added[0];
+      return updated;
+    });
+    sortedOccurrences.remove(uri);
   }
 
   /**
@@ -169,10 +197,21 @@ public class LocationRepository {
    * @param occurrences Удаляемые обращения.
    */
   public void deleteAll(URI uri, Collection<SymbolOccurrence> occurrences) {
-    var uriLocations = locations.get(uri);
-    if (uriLocations != null) {
-      uriLocations.removeAll(occurrences);
-    }
+    locations.computeIfPresent(uri, (u, existing) -> {
+      var remaining = Arrays.stream(existing)
+        .filter(occurrence -> !occurrences.contains(occurrence))
+        .toArray(SymbolOccurrence[]::new);
+      return remaining.length == 0 ? null : remaining;
+    });
     sortedOccurrences.remove(uri);
+  }
+
+  private static boolean contains(SymbolOccurrence[] array, SymbolOccurrence occurrence) {
+    for (var element : array) {
+      if (element.equals(occurrence)) {
+        return true;
+      }
+    }
+    return false;
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/LocationRepository.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/model/LocationRepository.java
@@ -72,8 +72,7 @@ public class LocationRepository {
    * потреблении памяти индексом ссылок).
    * <p>
    * Снимок ленивый: сбрасывается при любом изменении вхождений URI
-   * ({@link #replaceOccurrences}, {@link #updateLocation}, {@link #deleteAll},
-   * {@link #delete}) и пересобирается при первом следующем поиске.
+   * ({@link #replaceOccurrences}, {@link #delete}) и пересобирается при первом следующем поиске.
    */
   private final Map<URI, SymbolOccurrence[]> sortedOccurrences = new ConcurrentHashMap<>();
 
@@ -161,25 +160,6 @@ public class LocationRepository {
   }
 
   /**
-   * Добавить одиночное вхождение к символу (гранулярный путь записи). Дубликат по
-   * {@code equals} игнорируется — семантика множества сохраняется.
-   *
-   * @param symbolOccurrence Обращение к символу.
-   */
-  public void updateLocation(SymbolOccurrence symbolOccurrence) {
-    var uri = symbolOccurrence.location().uri();
-    locations.merge(uri, new SymbolOccurrence[]{symbolOccurrence}, (existing, added) -> {
-      if (contains(existing, added[0])) {
-        return existing;
-      }
-      var updated = Arrays.copyOf(existing, existing.length + 1);
-      updated[existing.length] = added[0];
-      return updated;
-    });
-    sortedOccurrences.remove(uri);
-  }
-
-  /**
    * Удалить сохраненные расположения обращений к символам в указанном URI.
    *
    * @param uri URI документа для удаления расположений.
@@ -187,31 +167,5 @@ public class LocationRepository {
   public void delete(URI uri) {
     locations.remove(uri);
     sortedOccurrences.remove(uri);
-  }
-
-  /**
-   * Удалить перечисленные обращения к символам, расположенные в указанном URI.
-   * Остальные обращения документа не затрагиваются.
-   *
-   * @param uri         URI документа.
-   * @param occurrences Удаляемые обращения.
-   */
-  public void deleteAll(URI uri, Collection<SymbolOccurrence> occurrences) {
-    locations.computeIfPresent(uri, (u, existing) -> {
-      var remaining = Arrays.stream(existing)
-        .filter(occurrence -> !occurrences.contains(occurrence))
-        .toArray(SymbolOccurrence[]::new);
-      return remaining.length == 0 ? null : remaining;
-    });
-    sortedOccurrences.remove(uri);
-  }
-
-  private static boolean contains(SymbolOccurrence[] array, SymbolOccurrence occurrence) {
-    for (var element : array) {
-      if (element.equals(occurrence)) {
-        return true;
-      }
-    }
-    return false;
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexTest.java
@@ -390,10 +390,11 @@ class ReferenceIndexTest extends AbstractServerContextAwareTest {
       // given - workspace 1 is already initialized with PATH_TO_METADATA in @BeforeEach
       // Manually add a reference to workspace 1's repos to verify isolation
       var workspace1Uri = context.getDocuments().keySet().iterator().next();
-      referenceIndex.addMethodCall(
+      var occurrence = referenceIndex.methodCallOccurrence(
         workspace1Uri, "CommonModule.TestModule", ModuleType.CommonModule, "TestMethod",
         Ranges.create(0, 0, 10)
       );
+      referenceIndex.replaceReferences(workspace1Uri, java.util.List.of(occurrence));
 
       // Build the same Symbol key used for both workspaces
       var symbolDto = com.github._1c_syntax.bsl.languageserver.references.model.Symbol.builder()


### PR DESCRIPTION
## Что и зачем

`LocationRepository` хранил вхождения документа как `Map<URI, ConcurrentHashMap.newKeySet()>` — concurrent-множество на каждый URI. На больших проектах это ~1 `ConcurrentHashMap$Node` на каждое вхождение: на cpm (~13k модулей, 5.98M вхождений) — миллионы узлов и сотни МБ чистого оверхеда контейнеров.

## Что сделано

- `Map<URI, SymbolOccurrence[]>` вместо множеств. Вхождения одного документа пишутся одним потоком (перестроение документа сериализовано), а `ReferenceIndex.replaceReferences` заменяет весь набор расположений документа **одним атомарным swap-ом ссылки на массив** — конкурентные читатели всегда видят согласованный снимок без «пустого окна». Символьная сторона индекса остаётся инкрементальной.
- Вторичный индекс `findByPosition` (бинарный поиск по sorted-снимку) не тронут.
- **Мёртвый код** (второй коммит): перевод на `replaceOccurrences` сделал `updateLocation`/`deleteAll` и `ReferenceIndex.saveOccurrence`/`addXxx` мёртвыми (звались только из тестов) — удалены; тест переведён на прод-API.

## Замеры на cpm

**Память** (live-heap дампы, full-vs-full, счётчики данных совпадают):
| класс | было | стало |
|---|--:|--:|
| `ConcurrentHashMap$Node` | 11.46M | 5.32M (−6.13M, **−255 МиБ**) |
| таблицы `[LConcurrentHashMap$Node;` | 163 МиБ | 74 МиБ (**−89 МиБ**) |
| `SymbolOccurrence[]` (новое) | — | +39 МиБ |

**Итого ≈ −305 МиБ.**

**Время** (JMH, cpm-распределение occ/URI, avgt ns/op, меньше=лучше):
| метод | было | стало | итог |
|---|--:|--:|---|
| `getSymbolOccurrencesByLocationUri` (чтение, горячий) | 8537 | 201 | **42× быстрее** |
| `findByPosition` (чтение, очень горячий) | 53.9 | 51.4 | ≈ |
| индексация документа (`replaceOccurrences` vs цикл `newKeySet.add`) | 47643 | 1300 | **37× быстрее** |

Чистая победа: и память, и время на горячих путях (чтение + индексация), без регрессий.

## Тестирование

`ReferenceIndexTest` + `LocationRepositoryTest` — 33/33 зелёные, полный `compileJava`/`compileTestJava` прошёл.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AZeyPcsbdUBaLUGWbhrCi


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reference index updates to keep symbol and location data synchronized.
  * Ensured replacement operations produce consistent, deterministic reference results.
  * Improved isolation when updating references across separate workspaces.

* **Refactor**
  * Simplified internal reference and location storage and replacement behavior.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->