### PR TITLE
fix(jmh): IncrementalTextChangeBenchmark в пакет lsp (чинит compileJmhJava)

### DIFF
--- a/src/jmh/java/com/github/_1c_syntax/bsl/languageserver/lsp/IncrementalTextChangeBenchmark.java
+++ b/src/jmh/java/com/github/_1c_syntax/bsl/languageserver/lsp/IncrementalTextChangeBenchmark.java
@@ -19,7 +19,7 @@
  * You should have received a copy of the GNU Lesser General Public
  * License along with BSL Language Server.
  */
-package com.github._1c_syntax.bsl.languageserver;
+package com.github._1c_syntax.bsl.languageserver.lsp;
 
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.eclipse.lsp4j.TextDocumentContentChangeEvent;


### PR DESCRIPTION
Бенчмарк `IncrementalTextChangeBenchmark` не компилировался: он в пакете `...languageserver`, а зовёт `protected static BSLTextDocumentService.applyIncrementalChange` из пакета `...lsp` (недоступен извне пакета; и сам класс не импортирован). Из-за этого падал весь `compileJmhJava` — а jmh source set не проверяется на CI, поэтому поломка накопилась незамеченной.

Фикс: перенос бенчмарка в пакет `...lsp` (рядом с `BSLTextDocumentService`) — `protected` становится доступен как пакетный, без изменения видимости прод-кода.

`compileJmhJava` — зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017AZeyPcsbdUBaLUGWbhrCi