### PR TITLE
fix(diagnostics): UnusedLocalMethod FP на английских именах стандартных обработчиков

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalMethodDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalMethodDiagnostic.java
@@ -33,7 +33,6 @@ import com.github._1c_syntax.bsl.languageserver.references.ReferenceIndex;
 import com.github._1c_syntax.bsl.languageserver.types.index.EventContractsIndex;
 import com.github._1c_syntax.bsl.languageserver.types.registry.BslContextHolder;
 import com.github._1c_syntax.bsl.types.ModuleType;
-import com.github._1c_syntax.utils.CaseInsensitivePattern;
 
 import java.util.EnumSet;
 import java.util.Map;
@@ -51,10 +50,6 @@ import java.util.regex.Pattern;
   }
 )
 public class UnusedLocalMethodDiagnostic extends AbstractDiagnostic {
-
-  private static final Pattern HANDLER_PATTERN = CaseInsensitivePattern.compile(
-    "(ПриСозданииОбъекта|OnObjectCreate)"
-  );
 
   /**
    * Префиксы подключаемых методов
@@ -135,7 +130,6 @@ public class UnusedLocalMethodDiagnostic extends AbstractDiagnostic {
       .filter(method -> !method.isExport())
       .filter(method -> !isOverride(method))
       .filter(method -> !isAttachable(method))
-      .filter(method -> !isHandler(method))
       // Платформенный обработчик события (резолвится EventHandlerResolver'ом
       // по имени метода в object/manager/recordset/global/OScript-модулях).
       // Он вызывается платформой по триггеру события, в теле модуля никаких
@@ -147,10 +141,6 @@ public class UnusedLocalMethodDiagnostic extends AbstractDiagnostic {
 
   private boolean isAttachable(MethodSymbol methodSymbol) {
     return attachableMethodPrefixes.matcher(methodSymbol.getName()).matches();
-  }
-
-  private static boolean isHandler(MethodSymbol methodSymbol) {
-    return HANDLER_PATTERN.matcher(methodSymbol.getName()).matches();
   }
 
   private static boolean isOverride(MethodSymbol method) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
@@ -193,13 +193,12 @@ public class EventHandlerResolver {
     if (ownerTypeRef.isEmpty()) {
       return Optional.empty();
     }
-    var key = methodName.toLowerCase(Locale.ROOT);
     // events наследуются от generic-типа (например, ДокументОбъект.<Имя документа>)
     // автоматически через MemberSource, который TypeRegistry.registerSpecialization
     // регистрирует на специализированный TypeRef.
     return typeRegistry.getMembers(ownerTypeRef.get(), documentContext.getFileType()).stream()
       .filter(m -> m.kind() == MemberKind.EVENT)
-      .filter(m -> m.name().toLowerCase(Locale.ROOT).equals(key))
+      .filter(m -> m.matches(methodName))
       .findFirst();
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalMethodDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/UnusedLocalMethodDiagnosticTest.java
@@ -68,9 +68,12 @@ class UnusedLocalMethodDiagnosticTest extends AbstractDiagnosticTest<UnusedLocal
   }
 
   private static void checkByDefault(List<Diagnostic> diagnostics) {
-    assertThat(diagnostics).hasSize(2);
+    // ПриСозданииОбъекта (66, 10, 28) — здесь не событие: это имя события OScript-класса,
+    // а не CommonModule/ObjectModule, поэтому метод действительно неиспользуемый.
+    assertThat(diagnostics).hasSize(3);
     assertThat(diagnostics, true)
       .hasRange(1, 10, 24)
+      .hasRange(66, 10, 28)
       .hasRange(70, 10, 41)
     ;
   }
@@ -97,11 +100,12 @@ class UnusedLocalMethodDiagnosticTest extends AbstractDiagnosticTest<UnusedLocal
     List<Diagnostic> diagnostics = getDiagnostics(dc);
 
     // then
-    assertThat(diagnostics).hasSize(3);
+    assertThat(diagnostics).hasSize(4);
     assertThat(diagnostics, true)
       .hasRange(1, 10, 24)
       .hasRange(60, 10, 40)
       .hasRange(63, 10, 39)
+      .hasRange(66, 10, 28)
     ;
   }
 
@@ -119,6 +123,34 @@ class UnusedLocalMethodDiagnosticTest extends AbstractDiagnosticTest<UnusedLocal
 
     // then
     checkByDefault(diagnostics);
+  }
+
+  @Test
+  void testOScriptClassConstructorEventNotFlaggedByRuName() {
+    var content = """
+      Процедура ПриСозданииОбъекта(Знач Параметр)
+      КонецПроцедуры
+      """;
+    var dc = spy(TestUtils.getDocumentContext(content));
+    when(dc.getModuleType()).thenReturn(ModuleType.OScriptClass);
+
+    List<Diagnostic> diagnostics = getDiagnostics(dc);
+
+    assertThat(diagnostics).isEmpty();
+  }
+
+  @Test
+  void testOScriptClassConstructorEventNotFlaggedByEnName() {
+    var content = """
+      Процедура OnObjectCreate(Знач Параметр)
+      КонецПроцедуры
+      """;
+    var dc = spy(TestUtils.getDocumentContext(content));
+    when(dc.getModuleType()).thenReturn(ModuleType.OScriptClass);
+
+    List<Diagnostic> diagnostics = getDiagnostics(dc);
+
+    assertThat(diagnostics).isEmpty();
   }
 
   private void getObjectModuleDocumentContext() {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
@@ -28,6 +28,7 @@ import com.github._1c_syntax.bsl.context.api.ContextProvider;
 import com.github._1c_syntax.bsl.context.platform.PlatformGlobalContext;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.types.model.BilingualString;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
@@ -180,6 +181,29 @@ class EventHandlerResolverTest {
 
     assertThat(resolver.lookupContract(doc, "ОбработкаКоманды")).isPresent();
     assertThat(resolver.lookupContract(doc, "ЧтоТоЕщё")).isEmpty();
+  }
+
+  @Test
+  void ownerTypeEventResolvesByEnglishAliasNotJustRuPrimaryName() {
+    var objectRef = new TypeRef(TypeKind.CONFIGURATION, "ДокументОбъект.Заказ");
+    Mockito.when(typeRegistry.resolve("ДокументОбъект.Заказ")).thenReturn(Optional.of(objectRef));
+    var eventDescriptor = MemberDescriptor.event(
+        "ПередЗаписью", "",
+        List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")))
+      .withBilingualName(BilingualString.of("ПередЗаписью", "BeforeWrite"));
+    Mockito.when(typeRegistry.getMembers(Mockito.eq(objectRef), Mockito.any()))
+      .thenReturn(List.of(eventDescriptor));
+
+    var document = com.github._1c_syntax.bsl.mdo.Document.builder().name("Заказ").build();
+    var doc = Mockito.mock(DocumentContext.class);
+    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.ObjectModule);
+    Mockito.when(doc.getMdObject()).thenReturn(Optional.of(document));
+    Mockito.when(doc.getFileType()).thenReturn(FileType.BSL);
+
+    assertThat(resolver.lookupContract(doc, "ПередЗаписью")).isPresent();
+    assertThat(resolver.lookupContract(doc, "BeforeWrite")).isPresent();
+    assertThat(resolver.lookupContract(doc, "beforewrite")).isPresent();
+    assertThat(resolver.lookupContract(doc, "СлучайноеИмя")).isEmpty();
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
@@ -37,17 +37,22 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import org.junit.jupiter.api.Test;
-import org.mockito.Mockito;
 
 import java.util.List;
 import java.util.Optional;
 
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.any;
+import static org.mockito.Mockito.anyString;
+import static org.mockito.Mockito.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.when;
 
 class EventHandlerResolverTest {
 
-  private final TypeRegistry typeRegistry = Mockito.mock(TypeRegistry.class);
-  private final BslContextHolder bslContextHolder = Mockito.mock(BslContextHolder.class);
+  private final TypeRegistry typeRegistry = mock(TypeRegistry.class);
+  private final BslContextHolder bslContextHolder = mock(BslContextHolder.class);
   private final EventHandlerResolver resolver = new EventHandlerResolver(typeRegistry, bslContextHolder);
 
   @Test
@@ -105,14 +110,14 @@ class EventHandlerResolverTest {
 
     resolver.lookupContract(doc, "ПриСозданииОбъекта");
 
-    Mockito.verifyNoInteractions(typeRegistry);
+    verifyNoInteractions(typeRegistry);
   }
 
   @Test
   void globalModuleWithoutHbkReturnsEmpty() {
-    Mockito.when(bslContextHolder.get()).thenReturn(Optional.empty());
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.SessionModule);
+    when(bslContextHolder.get()).thenReturn(Optional.empty());
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.SessionModule);
 
     var contract = resolver.lookupContract(doc, "УстановкаПараметровСеанса");
 
@@ -120,25 +125,25 @@ class EventHandlerResolverTest {
   }
 
   private static DocumentContext oscriptClassDoc() {
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.OScriptClass);
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.OScriptClass);
     return doc;
   }
 
   @Test
   void globalModuleWithHbkResolvesEventByName() {
     var event = stubEvent("ПередНачаломРаботыСистемы", "BeforeStart");
-    var globalContext = Mockito.mock(PlatformGlobalContext.class);
-    Mockito.when(globalContext.applicationEvents()).thenReturn(List.of(event));
-    Mockito.when(globalContext.ordinaryApplicationEvents()).thenReturn(List.of());
-    Mockito.when(globalContext.sessionModuleEvents()).thenReturn(List.of());
-    Mockito.when(globalContext.externalConnectionModuleEvents()).thenReturn(List.of());
-    var provider = Mockito.mock(ContextProvider.class);
-    Mockito.when(provider.getGlobalContext()).thenReturn(globalContext);
-    Mockito.when(bslContextHolder.get()).thenReturn(Optional.of(provider));
+    var globalContext = mock(PlatformGlobalContext.class);
+    when(globalContext.applicationEvents()).thenReturn(List.of(event));
+    when(globalContext.ordinaryApplicationEvents()).thenReturn(List.of());
+    when(globalContext.sessionModuleEvents()).thenReturn(List.of());
+    when(globalContext.externalConnectionModuleEvents()).thenReturn(List.of());
+    var provider = mock(ContextProvider.class);
+    when(provider.getGlobalContext()).thenReturn(globalContext);
+    when(bslContextHolder.get()).thenReturn(Optional.of(provider));
 
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.ManagedApplicationModule);
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.ManagedApplicationModule);
 
     // По ru-имени и по en-алиасу должны находить один и тот же контракт.
     assertThat(resolver.lookupContract(doc, "ПередНачаломРаботыСистемы")).isPresent();
@@ -149,17 +154,17 @@ class EventHandlerResolverTest {
 
   @Test
   void globalModuleEmptyEventListReturnsEmpty() {
-    var globalContext = Mockito.mock(PlatformGlobalContext.class);
-    Mockito.when(globalContext.applicationEvents()).thenReturn(List.of());
-    Mockito.when(globalContext.ordinaryApplicationEvents()).thenReturn(List.of());
-    Mockito.when(globalContext.sessionModuleEvents()).thenReturn(List.of());
-    Mockito.when(globalContext.externalConnectionModuleEvents()).thenReturn(List.of());
-    var provider = Mockito.mock(ContextProvider.class);
-    Mockito.when(provider.getGlobalContext()).thenReturn(globalContext);
-    Mockito.when(bslContextHolder.get()).thenReturn(Optional.of(provider));
+    var globalContext = mock(PlatformGlobalContext.class);
+    when(globalContext.applicationEvents()).thenReturn(List.of());
+    when(globalContext.ordinaryApplicationEvents()).thenReturn(List.of());
+    when(globalContext.sessionModuleEvents()).thenReturn(List.of());
+    when(globalContext.externalConnectionModuleEvents()).thenReturn(List.of());
+    var provider = mock(ContextProvider.class);
+    when(provider.getGlobalContext()).thenReturn(globalContext);
+    when(bslContextHolder.get()).thenReturn(Optional.of(provider));
 
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.OrdinaryApplicationModule);
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.OrdinaryApplicationModule);
 
     assertThat(resolver.lookupContract(doc, "Что-то")).isEmpty();
   }
@@ -168,16 +173,16 @@ class EventHandlerResolverTest {
   void commandModuleResolvesViaFixedOwnerType() {
     // CommandModule идёт через MODULE_TYPE_TO_FIXED_OWNER_RU = "Модуль команды".
     var commandRef = new TypeRef(TypeKind.PLATFORM, "Модуль команды");
-    Mockito.when(typeRegistry.resolve("Модуль команды")).thenReturn(Optional.of(commandRef));
+    when(typeRegistry.resolve("Модуль команды")).thenReturn(Optional.of(commandRef));
     var eventDescriptor = MemberDescriptor.event(
       "ОбработкаКоманды", "",
       List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")));
-    Mockito.when(typeRegistry.getMembers(Mockito.eq(commandRef), Mockito.any()))
+    when(typeRegistry.getMembers(eq(commandRef), any()))
       .thenReturn(List.of(eventDescriptor));
 
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.CommandModule);
-    Mockito.when(doc.getFileType()).thenReturn(FileType.BSL);
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.CommandModule);
+    when(doc.getFileType()).thenReturn(FileType.BSL);
 
     assertThat(resolver.lookupContract(doc, "ОбработкаКоманды")).isPresent();
     assertThat(resolver.lookupContract(doc, "ЧтоТоЕщё")).isEmpty();
@@ -186,19 +191,19 @@ class EventHandlerResolverTest {
   @Test
   void ownerTypeEventResolvesByEnglishAliasNotJustRuPrimaryName() {
     var objectRef = new TypeRef(TypeKind.CONFIGURATION, "ДокументОбъект.Заказ");
-    Mockito.when(typeRegistry.resolve("ДокументОбъект.Заказ")).thenReturn(Optional.of(objectRef));
+    when(typeRegistry.resolve("ДокументОбъект.Заказ")).thenReturn(Optional.of(objectRef));
     var eventDescriptor = MemberDescriptor.event(
         "ПередЗаписью", "",
         List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")))
       .withBilingualName(BilingualString.of("ПередЗаписью", "BeforeWrite"));
-    Mockito.when(typeRegistry.getMembers(Mockito.eq(objectRef), Mockito.any()))
+    when(typeRegistry.getMembers(eq(objectRef), any()))
       .thenReturn(List.of(eventDescriptor));
 
     var document = com.github._1c_syntax.bsl.mdo.Document.builder().name("Заказ").build();
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.ObjectModule);
-    Mockito.when(doc.getMdObject()).thenReturn(Optional.of(document));
-    Mockito.when(doc.getFileType()).thenReturn(FileType.BSL);
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.ObjectModule);
+    when(doc.getMdObject()).thenReturn(Optional.of(document));
+    when(doc.getFileType()).thenReturn(FileType.BSL);
 
     assertThat(resolver.lookupContract(doc, "ПередЗаписью")).isPresent();
     assertThat(resolver.lookupContract(doc, "BeforeWrite")).isPresent();
@@ -208,9 +213,9 @@ class EventHandlerResolverTest {
 
   @Test
   void fixedOwnerTypeAbsentInRegistryReturnsEmpty() {
-    Mockito.when(typeRegistry.resolve(Mockito.anyString())).thenReturn(Optional.empty());
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.HTTPServiceModule);
+    when(typeRegistry.resolve(anyString())).thenReturn(Optional.empty());
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.HTTPServiceModule);
 
     assertThat(resolver.lookupContract(doc, "ЛюбоеИмя")).isEmpty();
   }
@@ -220,9 +225,9 @@ class EventHandlerResolverTest {
     // mdoSpecificQualifiedName возвращает empty при пустом name MDO —
     // строим реальный Catalog с пустым именем.
     var catalog = com.github._1c_syntax.bsl.mdo.Catalog.builder().name("").build();
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.ObjectModule);
-    Mockito.when(doc.getMdObject()).thenReturn(Optional.of(catalog));
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.ObjectModule);
+    when(doc.getMdObject()).thenReturn(Optional.of(catalog));
 
     assertThat(resolver.lookupContract(doc, "ПриЗаписи")).isEmpty();
   }
@@ -230,31 +235,31 @@ class EventHandlerResolverTest {
   @Test
   void mdoSpecificOwnerWithoutMdObjectReturnsEmpty() {
     // ObjectModule → ищем mdObject; если его нет — empty.
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.ObjectModule);
-    Mockito.when(doc.getMdObject()).thenReturn(Optional.empty());
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.ObjectModule);
+    when(doc.getMdObject()).thenReturn(Optional.empty());
 
     assertThat(resolver.lookupContract(doc, "ПриЗаписи")).isEmpty();
   }
 
   @Test
   void unsupportedModuleTypeReturnsEmpty() {
-    var doc = Mockito.mock(DocumentContext.class);
-    Mockito.when(doc.getModuleType()).thenReturn(ModuleType.CommonModule);
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.CommonModule);
 
     assertThat(resolver.lookupContract(doc, "ПриЗаписи")).isEmpty();
   }
 
   private static ContextEvent stubEvent(String ru, String en) {
-    var event = Mockito.mock(ContextEvent.class);
+    var event = mock(ContextEvent.class);
     var name = new ContextName(ru, en);
-    Mockito.when(event.name()).thenReturn(name);
-    Mockito.when(event.signatures()).thenReturn(List.of());
-    Mockito.when(event.description()).thenReturn("");
-    Mockito.when(event.availabilities()).thenReturn(List.<Availability>of());
-    Mockito.when(event.sinceVersion()).thenReturn("");
-    Mockito.when(event.deprecatedSinceVersion()).thenReturn("");
-    Mockito.when(event.recommendedReplacements()).thenReturn(List.of());
+    when(event.name()).thenReturn(name);
+    when(event.signatures()).thenReturn(List.of());
+    when(event.description()).thenReturn("");
+    when(event.availabilities()).thenReturn(List.<Availability>of());
+    when(event.sinceVersion()).thenReturn("");
+    when(event.deprecatedSinceVersion()).thenReturn("");
+    when(event.recommendedReplacements()).thenReturn(List.of());
     return event;
   }
 }


### PR DESCRIPTION
## Проблема

Closes #4286.

`UnusedLocalMethod` ложно срабатывал на стандартных обработчиках объектных
модулей (`BeforeWrite` и т.п.), если модуль написан на английском синтаксисе.

## Причина

`EventHandlerResolver.lookupContract` для событий owner-типа модуля
(object/manager/recordset) сравнивал имя метода только с
`MemberDescriptor.name()` — compat-геттером, который всегда возвращает
primary (русское) написание. Английский алиас события никогда не
участвовал в сравнении, поэтому `BeforeWrite` не распознавался как
`ПередЗаписью`, и метод считался «забытым».

## Фикс

Сравнение переведено на `MemberDescriptor.matches(String)` — тот же
case-insensitive матчинг по обеим локалям, что уже использовался в других
ветках резолвера (`buildGlobalEvents`, OScript-класс).

## Заодно

В `UnusedLocalMethodDiagnostic` убраны `HANDLER_PATTERN`/`isHandler()` —
блокет-regex по имени `ПриСозданииОбъекта`/`OnObjectCreate`, применявшийся
ко всем типам модулей без разбора. Эта роль сейчас полностью покрывается
`EventContractsIndex`: для `OScriptClass` конструктор резолвится
`EventHandlerResolver`'ом (события OneScript-класса захардкожены в
резолвере), а для прочих модулей (например, `CommonModule`) такого
события нет вовсе — метод с таким именем без обращений теперь
заслуженно считается неиспользуемым.

## Test plan

- [x] `EventHandlerResolverTest.ownerTypeEventResolvesByEnglishAliasNotJustRuPrimaryName` —
      регрессионный тест на #4286: событие owner-типа резолвится и по ru-,
      и по en-имени.
- [x] `UnusedLocalMethodDiagnosticTest.testOScriptClassConstructorEventNotFlaggedByRuName` /
      `...ByEnName` — подтверждают, что конструктор OScript-класса
      по-прежнему не считается неиспользуемым без блокет-regex.
- [x] Обновлены ожидания `checkByDefault()`/`testConfigure()` — общая
      фикстура диагностики содержала `ПриСозданииОбъекта` в `CommonModule`,
      где это не событие; теперь корректно флагуется.
- [x] `./gradlew test --tests "*UnusedLocalMethodDiagnosticTest*" --tests "*EventHandlerResolverTest*" --tests "*EventContractsIndexTest*"` — зелено.
- [x] `./gradlew spotlessCheck` — чисто.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved unused local method detection by removing special handling for handler-like method names; methods are now only considered valid when an event contract exists.
  * Event handler contract resolution is now consistent for both Russian and English (case-insensitive) names.
  * Prevented valid OScript class constructor events from being incorrectly reported as unused.

* **Tests**
  * Updated diagnostic expectations for unused-method scenarios.
  * Added coverage for OScript class constructor events and bilingual event-handler name resolution.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->