### PR TITLE
fix(aop): keep EventPublisherAspect registration eager under lazy-init

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/EventPublisherAspectRegistration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/aop/EventPublisherAspectRegistration.java
@@ -25,6 +25,7 @@ import jakarta.annotation.PreDestroy;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.ApplicationContext;
 import org.springframework.context.ApplicationContextAware;
+import org.springframework.context.annotation.Lazy;
 import org.springframework.stereotype.Component;
 
 /**
@@ -37,8 +38,14 @@ import org.springframework.stereotype.Component;
  * с тем контекстом, которому принадлежит бин (строгий контракт Spring). Бин регистрирует свой контекст
  * в аспекте. При уничтожении контекста {@link PreDestroy} гарантированно отменяет регистрацию,
  * не затрагивая остальные живые контексты.
+ * <p>
+ * Вся полезная работа бина — побочный эффект в {@link #setApplicationContext}, и его никто не инжектит.
+ * Поэтому при глобальной ленивой инициализации ({@code spring.main.lazy-initialization=true}) он бы не
+ * создавался и регистрация не выполнялась. {@link Lazy @Lazy(false)} гарантирует создание бина на старте
+ * контекста.
  */
 @Component
+@Lazy(false)
 @RequiredArgsConstructor
 public class EventPublisherAspectRegistration implements ApplicationContextAware {
 


### PR DESCRIPTION
## Описание
`EventPublisherAspectRegistration` (`@Component`, `ApplicationContextAware`) выполняет свою работу исключительно как побочный эффект в `setApplicationContext` (регистрирует контекст в `EventPublisherAspect`), и его никто не инжектит. Поэтому при глобальной ленивой инициализации контекста (`spring.main.lazy-initialization=true`, используется, например, при встраивании через `BSLLSBinding`) бин **никогда не создаётся**: аспект остаётся без зарегистрированного контекста и дропает все события (`Trying to send event in not active event publisher`).

Следствие: наследники `AbstractDocumentLifecycleClearableIndex` (в частности `InferredExpressionTypeIndex`, ключи — ноды `ParseTree`) не получают событий очистки, не эвиктятся по-документно и удерживают деревья разбора всех файлов → `OutOfMemoryError` при анализе больших конфигураций. Путь до GC-root по heap-dump подтверждает удержание именно через `InferredExpressionTypeIndex` (подробности в задаче).

Фикс: пометить регистратор `@Lazy(false)`, чтобы он поднимался на старте контекста даже при глобальном lazy-init — ровно так же, как это уже сделано для самих аспектов в `AspectJConfiguration`. Одна аннотация; в standalone-режиме поведение не меняется (там бин и так создавался).

## Связанные задачи
Closes #4293

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами <!-- отдельно: тест «под lazy-init аспект зарегистрирован» имеет смысл добавить, но требует поднятия контекста с lazy-init; готов дополнить, если нужно -->
- [ ] Обязательные действия перед коммитом выполнены (`gradlew precommit`) <!-- локально не гонял; рассчитываю на CI -->

## Дополнительно
Найдено при поддержке BSLLS 1.0.5 в 1c-syntax/sonar-bsl-plugin-community#445 — там же полный разбор (heap-dump, path-to-GC-root).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrK14XEjQFUCwP4j94ZChv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Ensured event publishing registration is initialized during application startup, even when global lazy initialization is enabled.
  * Improved reliability of event-related processing that depends on startup registration.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->