### PR TITLE
fix(binding): pin thread context classloader during context startup

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/binding/BSLLSBinding.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/binding/BSLLSBinding.java
@@ -127,6 +127,18 @@ public class BSLLSBinding {
   }
 
   private static ConfigurableApplicationContext createContext() {
-    return getApplication().run();
+    // An embedder may run with a thread context classloader that does not expose this
+    // library's classes (an isolating classloader). micrometer's ContextRegistry discovers
+    // its ThreadLocalAccessor SPI via ServiceLoader on the context classloader during
+    // startup (while the context-propagating task decorator is built), so pin the context
+    // classloader to this library's own classloader for the duration of the boot.
+    var currentThread = Thread.currentThread();
+    var originalClassLoader = currentThread.getContextClassLoader();
+    currentThread.setContextClassLoader(BSLLSBinding.class.getClassLoader());
+    try {
+      return getApplication().run();
+    } finally {
+      currentThread.setContextClassLoader(originalClassLoader);
+    }
   }
 }


### PR DESCRIPTION
## Описание

При встраивании BSL LS через `BSLLSBinding` в хост с изолирующим class loader'ом (thread context classloader не видит классы библиотеки — например, `IsolatedClassloader` сканера SonarQube) Spring-контекст не поднимается на старте.

Причина: при создании eager-бина `contextPropagatingDecorator` во время `run()` инициализируется класс `io.micrometer.context.ContextRegistry`, чей `<clinit>` ищет реализации `ThreadLocalAccessor` через `ServiceLoader.load(Class)` — однопараметрический, то есть **по thread context classloader**. Под изолирующим TCCL micrometer/аксессоры не видны → `ClassNotFoundException: io.micrometer.context.ThreadLocalAccessor` → падает весь старт контекста.

Фикс: на время подъёма контекста в `BSLLSBinding.createContext()` пинить TCCL на класслоадер самой библиотеки (`BSLLSBinding.class.getClassLoader()`). `ContextRegistry` инициализируется один раз и кэшируется статически, поэтому дальнейшая работа на потоках встраивающего хоста не затрагивается. В standalone-режиме поведение не меняется (там TCCL и так видит всё). Это позволяет встраивающим убрать собственные обходы (подмену TCCL вокруг вызова).

Библиотека уже осознаёт свой класслоадер при встраивании (`resourceLoader(new DefaultResourceLoader(BSLLSBinding.class.getClassLoader()))`) — правка последовательна с этим.

## Связанные задачи

Closes #4295

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно

Обнаружено при поддержке BSL LS в 1c-syntax/sonar-bsl-plugin-community#446 — там полный разбор (лог падения под реальным сканером). После выхода релиза/снапшота с этим фиксом на стороне плагина можно будет убрать локальную подмену TCCL.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QrK14XEjQFUCwP4j94ZChv)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved application startup reliability by ensuring the correct class-loading context is used during initialization.
  * Restored the original class-loading context after startup completes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->