### PR TITLE
fix(types): одноимённые свойство и метод типа не вытесняют друг друга

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -32,6 +32,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.AnyType;
 import com.github._1c_syntax.bsl.languageserver.types.model.BilingualString;
 import com.github._1c_syntax.bsl.languageserver.types.model.ConfigurationType;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberSource;
 import com.github._1c_syntax.bsl.languageserver.types.model.PlatformMetadata;
 import com.github._1c_syntax.bsl.languageserver.types.model.PlatformType;
@@ -373,8 +374,11 @@ public class TypeRegistry {
 
   /**
    * Получить полный набор членов типа в разрезе языка — union по всем
-   * зарегистрированным {@link MemberSource}'ам этого языка. Дубли по имени
-   * отбрасываются (побеждает первый зарегистрированный источник).
+   * зарегистрированным {@link MemberSource}'ам этого языка. Дубли по паре
+   * (вид члена {@link MemberKind}, имя без учёта регистра) отбрасываются
+   * (побеждает первый источник в порядке резолва, а не обязательно первый
+   * зарегистрированный — см. {@link #registerMemberOverride}) — член одного
+   * вида не вытесняет одноимённый член другого вида.
    * <p>
    * Fallback по имени: TypeRef в LS — это пара {@code (kind, qualifiedName)}, и
    * один и тот же тип может предъявляться с разными kind'ами в зависимости от
@@ -540,15 +544,23 @@ public class TypeRegistry {
     // registerMemberSource/registerMemberOverride (Phase B/C MetadataCollectionSpecializer
     // и др. workspace-scoped провайдеры). Список — CopyOnWriteArrayList,
     // снимок через List.copyOf дёшев и стабилен на время итерации.
-    var byName = new LinkedHashMap<String, MemberDescriptor>();
+    // Ключ дедупликации — (kind, имя): метод и свойство с одинаковым именем —
+    // разные члены (например, self-completion может видеть self-метод и
+    // одноимённую self-переменную типа), один не должен вытеснять другой.
+    var byNameAndKind = new LinkedHashMap<MemberKey, MemberDescriptor>();
     for (var source : List.copyOf(resolveMemberSources(ref, fileType))) {
       for (var member : source.getMembers()) {
-        byName.putIfAbsent(member.name().toLowerCase(Locale.ROOT), member);
+        byNameAndKind.putIfAbsent(
+          new MemberKey(member.kind(), member.name().toLowerCase(Locale.ROOT)), member);
       }
     }
     // Неизменяемый список: память шарится между вызовами, случайная мутация
     // упадёт сразу (все потребители только итерируют).
-    return List.copyOf(byName.values());
+    return List.copyOf(byNameAndKind.values());
+  }
+
+  /** Ключ дедупликации членов в {@link #computeMembers}: вид члена + имя без учёта регистра. */
+  private record MemberKey(MemberKind kind, String lowercaseName) {
   }
 
   /**
@@ -599,7 +611,7 @@ public class TypeRegistry {
   /**
    * Аналог {@link #registerMemberSource}, но вставляет источник в НАЧАЛО списка,
    * чтобы при сборе членов через {@link #getMembers(TypeRef, FileType)} он выигрывал
-   * dedup ({@code putIfAbsent} по имени). Используется для override returnType
+   * dedup ({@code putIfAbsent} по паре (вид члена, имя)). Используется для override returnType
    * у конкретного member'а уже зарегистрированного типа (например, подмена
    * {@code ОбъектМетаданныхКонфигурация.Документы} с общего
    * {@code КоллекцияОбъектовМетаданных} на специализированный

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -559,8 +559,16 @@ public class TypeRegistry {
     return List.copyOf(byNameAndKind.values());
   }
 
-  /** Ключ дедупликации членов в {@link #computeMembers}: вид члена + имя без учёта регистра. */
-  private record MemberKey(MemberKind kind, String lowercaseName) {
+  /**
+   * Ключ дедупликации членов в {@link #computeMembers}: вид члена + имя без учёта регистра.
+   * Package-private (а не private) ради прямого юнит-теста {@code compareTo}.
+   */
+  record MemberKey(MemberKind kind, String lowercaseName) implements Comparable<MemberKey> {
+    @Override
+    public int compareTo(MemberKey other) {
+      var byKind = kind.compareTo(other.kind);
+      return byKind != 0 ? byKind : lowercaseName.compareTo(other.lowercaseName);
+    }
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryMemberDedupTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryMemberDedupTest.java
@@ -1,0 +1,83 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * {@link TypeRegistry#getMembers} объединяет members из нескольких источников,
+ * дедуплицируя по паре ({@link MemberKind}, имя без учёта регистра) — метод и
+ * свойство с одинаковым именем должны сосуществовать (у каждого вида — свой
+ * "мешок" дедупликации), а не вытеснять друг друга.
+ */
+class TypeRegistryMemberDedupTest {
+
+  private TypeRegistry typeRegistry;
+
+  @BeforeEach
+  void setUp() {
+    typeRegistry = new TypeRegistry(List.of(), new MemberMetadataIndex());
+    typeRegistry.bootstrap();
+  }
+
+  @Test
+  void propertyAndMethodWithSameNameBothSurvive() {
+    var ref = typeRegistry.registerConfigurationType("ТестовыйТипСОдноимённымиЧленами");
+    var property = MemberDescriptor.property("Записать", TypeRef.UNKNOWN);
+    var method = MemberDescriptor.method("Записать");
+    typeRegistry.registerMemberSource(ref, () -> List.of(property), FileType.BSL);
+    typeRegistry.registerMemberSource(ref, () -> List.of(method), FileType.BSL);
+
+    var members = typeRegistry.getMembers(ref, FileType.BSL);
+
+    assertThat(members)
+      .as("свойство и метод с одинаковым именем — разные члены, оба должны присутствовать")
+      .extracting(MemberDescriptor::kind)
+      .contains(MemberKind.PROPERTY, MemberKind.METHOD);
+  }
+
+  @Test
+  void twoMembersOfSameKindAndNameStillDedupeToTheFirstOne() {
+    var ref = typeRegistry.registerConfigurationType("ТестовыйТипСДублемСвойства");
+    var first = MemberDescriptor.property("Х", TypeRef.UNKNOWN, "первый источник");
+    var second = MemberDescriptor.property("Х", TypeRef.UNKNOWN, "второй источник");
+    typeRegistry.registerMemberSource(ref, () -> List.of(first), FileType.BSL);
+    typeRegistry.registerMemberSource(ref, () -> List.of(second), FileType.BSL);
+
+    var members = typeRegistry.getMembers(ref, FileType.BSL);
+    var matching = members.stream().filter(m -> m.matches("Х")).toList();
+
+    assertThat(matching)
+      .as("два члена ОДНОГО вида с одинаковым именем по-прежнему дедуплицируются — выигрывает первый источник")
+      .hasSize(1);
+    assertThat(matching.getFirst().description()).isEqualTo("первый источник");
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryMemberDedupTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryMemberDedupTest.java
@@ -80,4 +80,18 @@ class TypeRegistryMemberDedupTest {
       .hasSize(1);
     assertThat(matching.getFirst().description()).isEqualTo("первый источник");
   }
+
+  @Test
+  void memberKeyOrdersByKindThenName() {
+    var propertyA = new TypeRegistry.MemberKey(MemberKind.PROPERTY, "а");
+    var propertyB = new TypeRegistry.MemberKey(MemberKind.PROPERTY, "б");
+    var methodA = new TypeRegistry.MemberKey(MemberKind.METHOD, "а");
+
+    // Одинаковый вид — сравнение по имени.
+    assertThat(propertyA).isLessThan(propertyB);
+    // Разный вид — сравнение по виду члена (имя одинаковое).
+    assertThat(propertyA.compareTo(methodA)).isNotZero();
+    // Рефлексивность.
+    assertThat(propertyA.compareTo(propertyA)).isZero();
+  }
 }


### PR DESCRIPTION
## Summary
`TypeRegistry.getMembers` дедуплицировал члены типа только по имени (без учёта вида) — одноимённые свойство и метод из разных источников вытесняли друг друга, в completion/hover оставался только первый зарегистрированный. Дедупликация теперь по паре **(вид члена, имя без учёта регистра)**: члены разных видов сосуществуют, дубли одного вида по-прежнему схлопываются в первый источник.

Независимый пред-существующий баг, выделен из #4289 по просьбе ревьюера.

## Test plan
- [x] `TypeRegistryMemberDedupTest` — одноимённые property+method сосуществуют; дубль одного вида схлопывается в первый источник.
- [x] `compileJava` + `spotlessCheck` — зелёные.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Members with the same name but different kinds (e.g., properties vs. methods) now display together.
  * Duplicate members of the same kind and name are consolidated consistently, preserving the first entry’s details. 
* **Tests**
  * Added coverage to verify member deduplication behavior for both cross-kind and same-kind cases.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->