### PR TITLE
fix(types): не задваивать стандартные реквизиты записи регистра

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -757,15 +757,27 @@ public class ConfigurationTypesProvider {
   static @Nullable RegisterChildren registerChildrenOf(MD md) {
     return switch (md) {
       case InformationRegister r ->
-        new RegisterChildren(r.getDimensions(), r.getResources(), r.getAttributes());
+        new RegisterChildren(r.getDimensions(), r.getResources(), customAttributesOf(r.getAttributes()));
       case AccumulationRegister r ->
-        new RegisterChildren(r.getDimensions(), r.getResources(), r.getAttributes());
+        new RegisterChildren(r.getDimensions(), r.getResources(), customAttributesOf(r.getAttributes()));
       case AccountingRegister r ->
-        new RegisterChildren(r.getDimensions(), r.getResources(), r.getAttributes());
+        new RegisterChildren(r.getDimensions(), r.getResources(), customAttributesOf(r.getAttributes()));
       case CalculationRegister r ->
-        new RegisterChildren(r.getDimensions(), r.getResources(), r.getAttributes());
+        new RegisterChildren(r.getDimensions(), r.getResources(), customAttributesOf(r.getAttributes()));
       default -> null;
     };
+  }
+
+  /**
+   * Отфильтровывает {@link StandardAttribute} (Период/Регистратор/Активность/…):
+   * {@code getAttributes()} регистра возвращает их вперемешку с собственными
+   * реквизитами, но они уже приходят как обычные bilingual-члены generic-типа
+   * записи ({@code РегистрХХХЗапись.<Имя>}) из bsl-context — без фильтра
+   * плейсхолдер {@code <Имя реквизита>} материализовал бы их второй раз,
+   * одноязычными (под английским написанием).
+   */
+  private static List<? extends Attribute> customAttributesOf(List<? extends Attribute> attributes) {
+    return attributes.stream().filter(a -> !(a instanceof StandardAttribute)).toList();
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/RegisterRecordStandardAttributesHbkTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/RegisterRecordStandardAttributesHbkTest.java
@@ -30,6 +30,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.TestPropertySource;
 
 import java.util.Locale;
+import java.util.Set;
 
 import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -65,10 +66,13 @@ class RegisterRecordStandardAttributesHbkTest extends AbstractServerContextAware
     var lowerNames = members.stream().map(m -> m.name().toLowerCase(Locale.ROOT)).toList();
 
     assertThat(lowerNames)
-      .as("Активность/Период/Регистратор/НомерСтроки должны прийти РОВНО по одному разу, "
-        + "как единственный bilingual-член (из bsl-context), а не второй раз под "
-        + "английским написанием (материализованным по ошибке из getAttributes())")
-      .doesNotContain("active", "period", "linenumber", "recorder")
-      .contains("активность", "период", "регистратор", "номерстроки");
+      .as("стандартные реквизиты не должны материализоваться второй раз под английским "
+        + "написанием (из getAttributes())")
+      .doesNotContain("active", "period", "linenumber", "recorder");
+    assertThat(lowerNames)
+      .as("Активность/Период/Регистратор/НомерСтроки должны прийти РОВНО по одному разу — "
+        + "единственным bilingual-членом из bsl-context")
+      .filteredOn(Set.of("активность", "период", "регистратор", "номерстроки")::contains)
+      .containsExactlyInAnyOrder("активность", "период", "регистратор", "номерстроки");
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/RegisterRecordStandardAttributesHbkTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/RegisterRecordStandardAttributesHbkTest.java
@@ -1,0 +1,74 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.Locale;
+
+import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Регресс: {@code getAttributes()} регистра (bsl-mdo) возвращает стандартные
+ * реквизиты записи (Период/Регистратор/Активность/…) вперемешку с
+ * собственными, но platform-типа записи ({@code РегистрХХХЗапись.<Имя>}) уже
+ * несёт их из bsl-context как обычные bilingual-члены. Без фильтра по
+ * {@code Имя реквизита} материализуются ОДНОЯЗЫЧНЫЕ дубликаты (под английским
+ * написанием) — нужен реальный HBK, дубликаты не воспроизводятся на
+ * JSON-фолбэке.
+ */
+@CleanupContextBeforeClassAndAfterClass
+@TestPropertySource(properties = "app.platform-context.enabled=true")
+@EnabledIfEnvironmentVariable(named = "BSL_LANGUAGE_SERVER_RUN_HBK_TESTS",
+  matches = "true",
+  disabledReason = "Требует HBK 1С (стандартные реквизиты записи регистра — из bsl-context)")
+class RegisterRecordStandardAttributesHbkTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private TypeRegistry typeRegistry;
+
+  @Test
+  void informationRegisterRecordHasNoDuplicateStandardAttributeMembers() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+
+    var ref = typeRegistry.resolve("РегистрСведенийЗапись.РегистрСведений1", FileType.BSL).orElse(null);
+    assertThat(ref).as("специализированный тип записи регистра сведений должен резолвиться").isNotNull();
+
+    var members = typeRegistry.getMembers(ref, FileType.BSL);
+    var lowerNames = members.stream().map(m -> m.name().toLowerCase(Locale.ROOT)).toList();
+
+    assertThat(lowerNames)
+      .as("Активность/Период/Регистратор/НомерСтроки должны прийти РОВНО по одному разу, "
+        + "как единственный bilingual-член (из bsl-context), а не второй раз под "
+        + "английским написанием (материализованным по ошибке из getAttributes())")
+      .doesNotContain("active", "period", "linenumber", "recorder")
+      .contains("активность", "период", "регистратор", "номерстроки");
+  }
+}


### PR DESCRIPTION
## Summary
`getAttributes()` регистра (bsl-mdo) возвращает стандартные реквизиты записи (Период/Регистратор/Активность/НомерСтроки) вперемешку с собственными, но platform-тип записи (`РегистрХХХЗапись.<Имя>`) уже несёт их из bsl-context как обычные bilingual-члены. Без фильтра плейсхолдер `<Имя реквизита>` материализует их второй раз — одноязычными, под английским написанием. Фикс: отфильтровываем `StandardAttribute` из `getAttributes()`.

Независимый пред-существующий баг, выделен из #4289 по просьбе ревьюера.

## Test plan
- [x] `compileJava` + `spotlessCheck` — зелёные.
- [ ] `RegisterRecordStandardAttributesHbkTest` — гейтится по `BSL_LANGUAGE_SERVER_RUN_HBK_TESTS`: дубликаты воспроизводятся только на реальном HBK 1С (не на JSON-фолбэке), в обычном CI пропускается. Проверялось вручную на реальном HBK.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
