### PR TITLE
feat(context): обработчики событий как отдельный вид символа — подсветка, completion, диагностики, hover

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
@@ -24,6 +24,8 @@ package com.github._1c_syntax.bsl.languageserver.completion;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.types.ModuleType;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 import lombok.NoArgsConstructor;
@@ -120,6 +122,14 @@ public class CompletionData {
   private String eventContractName;
 
   /**
+   * Вид модуля документа (вариант event-контракта): по нему и owner-типу
+   * ({@link #typeKind}/{@link #typeQualifiedName}) в resolve восстанавливается набор событий
+   * без обращения к документу. Заполнено только для варианта event-контракта.
+   */
+  @Nullable
+  private ModuleType moduleType;
+
+  /**
    * Создаёт ключ восстановления документации члена типа (dot-completion).
    *
    * @param uri               URI документа, в контексте которого построен item.
@@ -132,7 +142,8 @@ public class CompletionData {
    */
   public static CompletionData forMember(URI uri, TypeKind typeKind, String typeQualifiedName, String memberName,
                                          FileType fileType, Language scriptVariant) {
-    return new CompletionData(uri, typeKind, typeQualifiedName, memberName, fileType, scriptVariant, null, null);
+    return new CompletionData(uri, typeKind, typeQualifiedName, memberName, fileType, scriptVariant,
+      null, null, null);
   }
 
   /**
@@ -145,21 +156,27 @@ public class CompletionData {
    * @return ключ восстановления глобальной функции.
    */
   public static CompletionData forFunction(URI uri, String functionName, FileType fileType, Language scriptVariant) {
-    return new CompletionData(uri, null, null, null, fileType, scriptVariant, functionName, null);
+    return new CompletionData(uri, null, null, null, fileType, scriptVariant, functionName, null, null);
   }
 
   /**
    * Создаёт ключ восстановления документации контракта платформенного события
-   * (no-dot completion, заглушка ещё не объявленного обработчика).
+   * (no-dot completion, заглушка ещё не объявленного обработчика). Набор событий восстанавливается
+   * по паре {@code (moduleType, ownerTypeRef)} без обращения к документу.
    *
    * @param uri               URI документа, в контексте которого построен item.
+   * @param moduleType        вид модуля документа.
+   * @param ownerTypeRef      owner-тип событий ({@code null} для .os-класса и глобальных модулей).
    * @param eventContractName каноническое имя контракта события.
    * @param fileType          тип файла-потребителя (BSL/OS).
    * @param scriptVariant     локаль скрипта (ru/en).
    * @return ключ восстановления контракта события.
    */
-  public static CompletionData forEventContract(URI uri, String eventContractName,
-                                                FileType fileType, Language scriptVariant) {
-    return new CompletionData(uri, null, null, null, fileType, scriptVariant, null, eventContractName);
+  public static CompletionData forEventContract(URI uri, ModuleType moduleType, @Nullable TypeRef ownerTypeRef,
+                                                String eventContractName, FileType fileType, Language scriptVariant) {
+    var ownerKind = ownerTypeRef == null ? null : ownerTypeRef.kind();
+    var ownerName = ownerTypeRef == null ? null : ownerTypeRef.qualifiedName();
+    return new CompletionData(uri, ownerKind, ownerName, null, fileType, scriptVariant, null,
+      eventContractName, moduleType);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/completion/CompletionData.java
@@ -45,13 +45,16 @@ import java.net.URI;
  * Сериализуется клиентом в JSON и приходит обратно как {@code JsonObject}/Map —
  * поля сделаны bean-style (Lombok {@code @Data}) для round-trip через Jackson.
  * <p>
- * Поддерживаются два вида ключа восстановления:
+ * Поддерживаются три вида ключа восстановления:
  * <ul>
  *   <li>член типа (dot-completion): заполнены {@code typeKind}/{@code typeQualifiedName}
  *       и {@code memberName}, по ним восстанавливается член типа-владельца;</li>
  *   <li>глобальная функция (no-dot completion): заполнено {@code functionName},
  *       по нему функция ищется в глобальной области видимости. Поля типа-владельца
- *       при этом не используются.</li>
+ *       при этом не используются;</li>
+ *   <li>контракт события (no-dot completion, заглушка обработчика): заполнено
+ *       {@code eventContractName}, по нему контракт ищется среди событий owner-типа
+ *       документа.</li>
  * </ul>
  */
 @Data
@@ -109,6 +112,14 @@ public class CompletionData {
   private String functionName;
 
   /**
+   * Каноническое имя контракта платформенного события, для которого нужно восстановить
+   * документацию (no-dot completion, заглушка ещё не объявленного обработчика). Заполнено
+   * только для варианта event-контракта; для члена типа и глобальной функции — {@code null}.
+   */
+  @Nullable
+  private String eventContractName;
+
+  /**
    * Создаёт ключ восстановления документации члена типа (dot-completion).
    *
    * @param uri               URI документа, в контексте которого построен item.
@@ -121,7 +132,7 @@ public class CompletionData {
    */
   public static CompletionData forMember(URI uri, TypeKind typeKind, String typeQualifiedName, String memberName,
                                          FileType fileType, Language scriptVariant) {
-    return new CompletionData(uri, typeKind, typeQualifiedName, memberName, fileType, scriptVariant, null);
+    return new CompletionData(uri, typeKind, typeQualifiedName, memberName, fileType, scriptVariant, null, null);
   }
 
   /**
@@ -134,6 +145,21 @@ public class CompletionData {
    * @return ключ восстановления глобальной функции.
    */
   public static CompletionData forFunction(URI uri, String functionName, FileType fileType, Language scriptVariant) {
-    return new CompletionData(uri, null, null, null, fileType, scriptVariant, functionName);
+    return new CompletionData(uri, null, null, null, fileType, scriptVariant, functionName, null);
+  }
+
+  /**
+   * Создаёт ключ восстановления документации контракта платформенного события
+   * (no-dot completion, заглушка ещё не объявленного обработчика).
+   *
+   * @param uri               URI документа, в контексте которого построен item.
+   * @param eventContractName каноническое имя контракта события.
+   * @param fileType          тип файла-потребителя (BSL/OS).
+   * @param scriptVariant     локаль скрипта (ru/en).
+   * @return ключ восстановления контракта события.
+   */
+  public static CompletionData forEventContract(URI uri, String eventContractName,
+                                                FileType fileType, Language scriptVariant) {
+    return new CompletionData(uri, null, null, null, fileType, scriptVariant, null, eventContractName);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -31,6 +31,7 @@ import com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticCompu
 import com.github._1c_syntax.bsl.languageserver.context.computer.DiagnosticIgnoranceComputer;
 import com.github._1c_syntax.bsl.languageserver.context.computer.QueryComputer;
 import com.github._1c_syntax.bsl.languageserver.context.computer.SymbolTreeComputer;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventHandlerClassifier;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SelfMemberClassifier;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
@@ -122,6 +123,10 @@ public class DocumentContext implements Comparable<DocumentContext> {
   @SuppressWarnings("NullAway.Init")
   @Setter(onMethod_ = {@Autowired})
   private SelfMemberClassifier selfMemberClassifier;
+
+  @SuppressWarnings("NullAway.Init")
+  @Setter(onMethod_ = {@Autowired})
+  private EventHandlerClassifier eventHandlerClassifier;
 
   @Nullable
   private BSLTokenizer tokenizer;
@@ -439,7 +444,7 @@ public class DocumentContext implements Comparable<DocumentContext> {
   }
 
   private SymbolTree computeSymbolTree() {
-    return new SymbolTreeComputer(this, selfMemberClassifier).compute();
+    return new SymbolTreeComputer(this, selfMemberClassifier, eventHandlerClassifier).compute();
   }
 
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
@@ -23,6 +23,8 @@ package com.github._1c_syntax.bsl.languageserver.context.computer;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventHandlerClassifier;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegularMethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ParameterDefinition;
@@ -69,10 +71,12 @@ public final class MethodSymbolComputer
     BSLParser.ANNOTATION_ATCLIENTATSERVER_SYMBOL);
 
   private final DocumentContext documentContext;
+  private final EventHandlerClassifier eventHandlerClassifier;
   private final Set<MethodSymbol> methods = new HashSet<>();
 
-  public MethodSymbolComputer(DocumentContext documentContext) {
+  public MethodSymbolComputer(DocumentContext documentContext, EventHandlerClassifier eventHandlerClassifier) {
     this.documentContext = documentContext;
+    this.eventHandlerClassifier = eventHandlerClassifier;
   }
 
   @Override
@@ -245,6 +249,29 @@ public final class MethodSymbolComputer
 
     if (isOscriptClassConstructor(name, function)) {
       return ConstructorSymbol.builder()
+        .name(name)
+        .owner(documentContext)
+        .range(range)
+        .subNameRange(subNameRange)
+        .function(function)
+        .export(export)
+        .async(async)
+        .description(description)
+        .deprecated(deprecated)
+        .parameters(parameters)
+        .compilerDirectiveKind(compilerDirective)
+        .annotations(annotations)
+        .build();
+    }
+
+    // Конструктор проверяется ДО события: "ПриСозданииОбъекта" у OScript-класса совпадает
+    // и с контрактом события (см. EventHandlerResolver.OSCRIPT_CLASS_EVENTS), но остаётся
+    // ConstructorSymbol — отдельный, уже устоявшийся вид символа со своей семантикой в дереве
+    // символов, hover'е и ReferenceIndex, реклассификации не подлежит. Классификация по имени
+    // не смотрит на function/procedure (как и lookupContract) — платформа вызывает обработчик
+    // по имени независимо от того, что метод по ошибке объявлен функцией.
+    if (eventHandlerClassifier.isEventHandler(documentContext, name)) {
+      return EventMethodSymbol.builder()
         .name(name)
         .owner(documentContext)
         .range(range)

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputer.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.context.computer;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventHandlerClassifier;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ModuleSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
@@ -46,17 +47,20 @@ public class SymbolTreeComputer implements Computer<SymbolTree> {
 
   private final DocumentContext documentContext;
   private final SelfMemberClassifier selfMemberClassifier;
+  private final EventHandlerClassifier eventHandlerClassifier;
 
-  public SymbolTreeComputer(DocumentContext documentContext, SelfMemberClassifier selfMemberClassifier) {
+  public SymbolTreeComputer(DocumentContext documentContext, SelfMemberClassifier selfMemberClassifier,
+                            EventHandlerClassifier eventHandlerClassifier) {
     this.documentContext = documentContext;
     this.selfMemberClassifier = selfMemberClassifier;
+    this.eventHandlerClassifier = eventHandlerClassifier;
   }
 
   @Override
   public SymbolTree compute() {
 
     ModuleSymbol moduleSymbol = new ModuleSymbolComputer(documentContext).compute();
-    List<MethodSymbol> methods = new MethodSymbolComputer(documentContext).compute();
+    List<MethodSymbol> methods = new MethodSymbolComputer(documentContext, eventHandlerClassifier).compute();
     // Переменные и регионы — за один общий обход дерева (оба обходят его вглубь).
     var regionVariableComputer =
       new RegionVariableSymbolComputer(documentContext, moduleSymbol, methods, selfMemberClassifier);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventHandlerClassifier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventHandlerClassifier.java
@@ -25,17 +25,8 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 
 /**
  * Классифицирует объявленный в коде метод как обработчик платформенного события.
- * <p>
- * Интерфейс — контракт {@code context.computer.MethodSymbolComputer}, реальная реализация живёт
- * в {@code types.registry} ({@code EventHandlerResolver}) и внедряется через Spring: та же
- * инверсия зависимости, что и у {@code context.computer.DiagnosticComputer} (реализация —
- * {@code diagnostics.DefaultDiagnosticComputer}) — так {@code context} не зависит от {@code types}
- * напрямую (см. {@code ArchitectureTest.layer_dependencies_are_respected}), хотя классификация по
- * существу требует доступа к реестру типов платформы/конфигурации.
- * <p>
- * Безопасно вызывать в любой момент жизни воркспейса: типы платформы/конфигурации регистрируются
- * ({@code types.registry.ConfigurationTypesProvider}) сразу по добавлению workspace'а — раньше,
- * чем {@code ServerContext.populateContext()} успевает построить хоть одно дерево символов.
+ * Реализация ({@code types.registry.EventHandlerResolver}) внедряется через Spring, чтобы
+ * {@code context} не зависел от {@code types} напрямую.
  */
 public interface EventHandlerClassifier {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventHandlerClassifier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventHandlerClassifier.java
@@ -25,8 +25,6 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 
 /**
  * Классифицирует объявленный в коде метод как обработчик платформенного события.
- * Реализация ({@code types.registry.EventHandlerResolver}) внедряется через Spring, чтобы
- * {@code context} не зависел от {@code types} напрямую.
  */
 public interface EventHandlerClassifier {
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventHandlerClassifier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventHandlerClassifier.java
@@ -1,0 +1,47 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.context.symbol;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+
+/**
+ * Классифицирует объявленный в коде метод как обработчик платформенного события.
+ * <p>
+ * Интерфейс — контракт {@code context.computer.MethodSymbolComputer}, реальная реализация живёт
+ * в {@code types.registry} ({@code EventHandlerResolver}) и внедряется через Spring: та же
+ * инверсия зависимости, что и у {@code context.computer.DiagnosticComputer} (реализация —
+ * {@code diagnostics.DefaultDiagnosticComputer}) — так {@code context} не зависит от {@code types}
+ * напрямую (см. {@code ArchitectureTest.layer_dependencies_are_respected}), хотя классификация по
+ * существу требует доступа к реестру типов платформы/конфигурации.
+ * <p>
+ * Безопасно вызывать в любой момент жизни воркспейса: типы платформы/конфигурации регистрируются
+ * ({@code types.registry.ConfigurationTypesProvider}) сразу по добавлению workspace'а — раньше,
+ * чем {@code ServerContext.populateContext()} успевает построить хоть одно дерево символов.
+ */
+public interface EventHandlerClassifier {
+
+  /**
+   * Является ли метод с именем {@code methodName} обработчиком платформенного события owner-типа
+   * модуля {@code documentContext}.
+   */
+  boolean isEventHandler(DocumentContext documentContext, String methodName);
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventMethodSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventMethodSymbol.java
@@ -29,17 +29,6 @@ import org.eclipse.lsp4j.SymbolKind;
 /**
  * Символ метода-обработчика платформенного события ({@code ПриЗаписи}, {@code ПередУдалением}
  * и т.п.).
- * <p>
- * Такой же полноценный {@link AbstractMethodSymbol}, как {@link RegularMethodSymbol} и {@link
- * ConstructorSymbol} — строится {@link com.github._1c_syntax.bsl.languageserver.context.computer.MethodSymbolComputer}
- * ПРИ ОБХОДЕ AST, а не пересобирается впоследствии: метод, чьё имя совпадает с контрактом события
- * owner-типа модуля, сразу регистрируется в дереве символов как {@code EventMethodSymbol}, никогда
- * не проходя через промежуточное состояние {@link RegularMethodSymbol}.
- * <p>
- * Классификацию (нужен доступ к {@code types.registry.EventHandlerResolver}/{@code TypeRegistry},
- * которых {@code context} видеть не вправе — см. {@code ArchitectureTest.layer_dependencies_are_respected})
- * выполняет {@link EventHandlerClassifier}, внедряемый в {@code MethodSymbolComputer} через
- * инверсию зависимости (тот же приём, что и у {@code context.computer.DiagnosticComputer}).
  */
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventMethodSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/EventMethodSymbol.java
@@ -1,0 +1,58 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.context.symbol;
+
+import lombok.EqualsAndHashCode;
+import lombok.ToString;
+import lombok.experimental.SuperBuilder;
+import org.eclipse.lsp4j.SymbolKind;
+
+/**
+ * Символ метода-обработчика платформенного события ({@code ПриЗаписи}, {@code ПередУдалением}
+ * и т.п.).
+ * <p>
+ * Такой же полноценный {@link AbstractMethodSymbol}, как {@link RegularMethodSymbol} и {@link
+ * ConstructorSymbol} — строится {@link com.github._1c_syntax.bsl.languageserver.context.computer.MethodSymbolComputer}
+ * ПРИ ОБХОДЕ AST, а не пересобирается впоследствии: метод, чьё имя совпадает с контрактом события
+ * owner-типа модуля, сразу регистрируется в дереве символов как {@code EventMethodSymbol}, никогда
+ * не проходя через промежуточное состояние {@link RegularMethodSymbol}.
+ * <p>
+ * Классификацию (нужен доступ к {@code types.registry.EventHandlerResolver}/{@code TypeRegistry},
+ * которых {@code context} видеть не вправе — см. {@code ArchitectureTest.layer_dependencies_are_respected})
+ * выполняет {@link EventHandlerClassifier}, внедряемый в {@code MethodSymbolComputer} через
+ * инверсию зависимости (тот же приём, что и у {@code context.computer.DiagnosticComputer}).
+ */
+@SuperBuilder
+@EqualsAndHashCode(callSuper = true)
+@ToString(callSuper = true)
+public final class EventMethodSymbol extends AbstractMethodSymbol {
+
+  @Override
+  public SymbolKind getSymbolKind() {
+    return SymbolKind.Event;
+  }
+
+  @Override
+  public void accept(SymbolTreeVisitor visitor) {
+    visitor.visitEventMethod(this);
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SymbolTreeVisitor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/SymbolTreeVisitor.java
@@ -63,4 +63,11 @@ public interface SymbolTreeVisitor {
    * @param variable Символ переменной
    */
   void visitVariable(VariableSymbol variable);
+
+  /**
+   * Посетить символ метода-обработчика платформенного события.
+   *
+   * @param event Символ обработчика события
+   */
+  void visitEventMethod(EventMethodSymbol event);
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractSymbolTreeDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/AbstractSymbolTreeDiagnostic.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ModuleSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
@@ -78,6 +79,11 @@ public abstract class AbstractSymbolTreeDiagnostic extends AbstractDiagnostic im
   @Override
   public void visitConstructor(ConstructorSymbol constructor) {
     visitMethod(constructor);
+  }
+
+  @Override
+  public void visitEventMethod(EventMethodSymbol event) {
+    visitMethod(event);
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnostic.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticMetadata;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticSeverity;
@@ -75,12 +76,13 @@ public class EventHandlerInvalidSignatureDiagnostic extends AbstractDiagnostic i
 
   @Override
   public void check() {
-    documentContext.getSymbolTree().getMethods().forEach(method ->
-      eventContractsIndex.getContract(documentContext, method.getName())
-        .map(MemberDescriptor::signatures)
-        .filter(signatures -> !signatures.isEmpty())
-        .ifPresent(signatures -> checkSignature(method, signatures))
-    );
+    documentContext.getSymbolTree().getMethods().stream()
+      .filter(EventMethodSymbol.class::isInstance)
+      .forEach(method ->
+        eventContractsIndex.getContract(documentContext, method.getName())
+          .map(MemberDescriptor::signatures)
+          .filter(signatures -> !signatures.isEmpty())
+          .ifPresent(signatures -> checkSignature(method, signatures)));
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerOutsideEventRegionDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerOutsideEventRegionDiagnostic.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticMetadata;
@@ -29,7 +30,6 @@ import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticS
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticSeverity;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticTag;
 import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticType;
-import com.github._1c_syntax.bsl.languageserver.types.index.EventContractsIndex;
 import com.github._1c_syntax.bsl.languageserver.utils.Keywords;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.types.ModuleType;
@@ -86,24 +86,14 @@ public class EventHandlerOutsideEventRegionDiagnostic extends AbstractDiagnostic
     Keywords.FORM_TABLE_ITEMS_EVENT_HANDLERS_REGION_START.getEn()
   );
 
-  private final EventContractsIndex eventContractsIndex;
-
-  public EventHandlerOutsideEventRegionDiagnostic(EventContractsIndex eventContractsIndex) {
-    this.eventContractsIndex = eventContractsIndex;
-  }
-
   @Override
   public void check() {
     var isFormModule = documentContext.getModuleType() == ModuleType.FormModule;
     documentContext.getSymbolTree().getMethods().stream()
-      .filter(this::isEventHandler)
+      .filter(EventMethodSymbol.class::isInstance)
       .filter(method -> !isInEventRegion(method, isFormModule))
       .forEach(method -> diagnosticStorage.addDiagnostic(method.getSubNameRange(),
         info.getMessage(method.getName())));
-  }
-
-  private boolean isEventHandler(MethodSymbol method) {
-    return eventContractsIndex.getContract(documentContext, method.getName()).isPresent();
   }
 
   private static boolean isInEventRegion(MethodSymbol method, boolean isFormModule) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilder.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.hover;
 
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
@@ -57,6 +58,10 @@ public class MethodSymbolMarkupContentBuilder implements MarkupContentBuilder {
     // варианты вызова
 
     var eventContract = eventContractsIndex.getContract(symbol.getOwner(), symbol.getName());
+    // Обработчик события определяем по классифицированному виду символа (EventMethodSymbol),
+    // а не только по наличию контракта: конструктор OScript-класса (ПриСозданииОбъекта) может
+    // совпасть с событием, но остаётся конструктором и в hover'е показывается как обычный метод.
+    var isEventHandler = symbol instanceof EventMethodSymbol && eventContract.isPresent();
 
     // сигнатура
     var signature = descriptionFormatter.getSignature(symbol);
@@ -72,7 +77,7 @@ public class MethodSymbolMarkupContentBuilder implements MarkupContentBuilder {
 
     // признак "обработчик события платформы" + платформенное описание события +
     // пользовательское purpose из шапки метода (если метод — обработчик)
-    if (eventContract.isPresent()) {
+    if (isEventHandler) {
       descriptionFormatter.addSectionIfNotEmpty(markupBuilder,
         descriptionFormatter.getEventHandlerSection(symbol, eventContract.get()));
     } else {
@@ -83,7 +88,7 @@ public class MethodSymbolMarkupContentBuilder implements MarkupContentBuilder {
 
     // параметры: для обработчика — контракт события (имена/типы), иначе —
     // шапка-комментарий пользователя
-    var parametersSection = eventContract.isPresent()
+    var parametersSection = isEventHandler
       ? descriptionFormatter.getParametersSection(symbol, eventContract.get())
       : descriptionFormatter.getParametersSection(symbol);
     descriptionFormatter.addSectionIfNotEmpty(markupBuilder, parametersSection);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilder.java
@@ -42,6 +42,7 @@ public class MethodSymbolMarkupContentBuilder implements MarkupContentBuilder {
 
   private final DescriptionFormatter descriptionFormatter;
   private final EventContractsIndex eventContractsIndex;
+  private final PlatformMetadataRenderer metadataRenderer;
 
   @Override
   public MarkupContent getContent(Reference reference) {
@@ -104,6 +105,15 @@ public class MethodSymbolMarkupContentBuilder implements MarkupContentBuilder {
     // варианты вызова
     var callOptionsSection = descriptionFormatter.getCallOptionsSection(symbol);
     descriptionFormatter.addSectionIfNotEmpty(markupBuilder, callOptionsSection);
+
+    // метаданные платформенного события (замечание, пример, «см. также», доступность/версии)
+    // из дескриптора контракта — так же, как их рисуют PlatformMemberHoverBuilder и
+    // ConstructorHoverBuilder для платформенных членов и конструкторов. Только у обработчика.
+    if (isEventHandler) {
+      var eventMetadata = new StringBuilder();
+      metadataRenderer.append(eventMetadata, eventContract.get().metadata());
+      descriptionFormatter.addSectionIfNotEmpty(markupBuilder, eventMetadata.toString().strip());
+    }
 
     var content = markupBuilder.toString();
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -52,7 +52,6 @@ import com.github._1c_syntax.bsl.languageserver.utils.Keywords;
 import com.github._1c_syntax.bsl.parser.description.MethodDescription;
 import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import com.github._1c_syntax.bsl.support.CompatibilityMode;
-import com.github._1c_syntax.bsl.types.ModuleType;
 import com.github._1c_syntax.bsl.types.ScriptVariant;
 import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -26,7 +26,6 @@ import com.github._1c_syntax.bsl.languageserver.client.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.completion.CompletionData;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
-import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
@@ -45,6 +44,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.languageserver.types.index.EventContractsIndex;
 import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex;
+import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
 import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
 import com.github._1c_syntax.bsl.languageserver.types.scope.UseDirectiveScanner;
 import com.github._1c_syntax.bsl.languageserver.utils.FuzzyMatcher;
@@ -52,6 +52,7 @@ import com.github._1c_syntax.bsl.languageserver.utils.Keywords;
 import com.github._1c_syntax.bsl.parser.description.MethodDescription;
 import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import com.github._1c_syntax.bsl.support.CompatibilityMode;
+import com.github._1c_syntax.bsl.types.ModuleType;
 import com.github._1c_syntax.bsl.types.ScriptVariant;
 import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;
@@ -143,7 +144,7 @@ public final class CompletionProvider {
   private final JsonMapper jsonMapper;
   private final FuzzyMatcher fuzzyMatcher;
   private final EventContractsIndex eventContractsIndex;
-  private final ServerContextProvider serverContextProvider;
+  private final EventHandlerResolver eventHandlerResolver;
 
   // Кэшируется на initialize. snippetSupport — gate для вставки `Метод($0)` сниппета и
   // прикрепления `editor.action.triggerParameterHints` к completion item.
@@ -406,21 +407,23 @@ public final class CompletionProvider {
 
   /**
    * Восстанавливает {@code documentation} контракта платформенного события по ключу
-   * {@link CompletionData} event-варианта: по {@code uri} восстанавливается документ, среди
-   * событий owner-типа его модуля контракт ищется по каноническому имени. Если ключ неполон
-   * или документ/контракт не найдены — ничего не делает.
+   * {@link CompletionData} event-варианта: набор событий берётся по паре
+   * {@code (moduleType, ownerTypeRef)} из ключа — без обращения к документу, — а контракт ищется
+   * по каноническому имени. Если ключ неполон или контракт не найден — ничего не делает.
    *
    * @param unresolved completion item, которому проставляется документация.
    * @param data       ключ восстановления контракта события.
    */
   private void resolveEventContractDocumentation(CompletionItem unresolved, CompletionData data) {
     var eventContractName = data.getEventContractName();
-    if (eventContractName == null) {
+    var moduleType = data.getModuleType();
+    if (eventContractName == null || moduleType == null) {
       return;
     }
-    serverContextProvider.getDocument(data.getUri())
-      .stream()
-      .flatMap(documentContext -> eventContractsIndex.getAllContracts(documentContext).stream())
+    var ownerTypeRef = data.getTypeKind() == null || data.getTypeQualifiedName() == null
+      ? null
+      : new TypeRef(data.getTypeKind(), data.getTypeQualifiedName());
+    eventHandlerResolver.eventsFor(moduleType, ownerTypeRef, data.getFileType()).stream()
       .filter(contract -> contract.name().equals(eventContractName))
       .findFirst()
       .ifPresent(contract -> applyDocumentation(unresolved, contract, data.getScriptVariant()));
@@ -797,7 +800,7 @@ public final class CompletionProvider {
       if (matches(method.getName(), prefix)) {
         var item = new CompletionItem(method.getName());
         var isEventHandler = method.getSymbolKind() == SymbolKind.Event;
-        item.setKind(methodCompletionKind(method, isEventHandler));
+        item.setKind(methodCompletionKind(isEventHandler));
         applyCallableInsertText(item, method.getName(), !method.getParameters().isEmpty());
         applySourceMethodDetail(item, method);
         applySourceMethodDocumentation(item, method);
@@ -874,11 +877,10 @@ public final class CompletionProvider {
     return items;
   }
 
-  private static CompletionItemKind methodCompletionKind(MethodSymbol method, boolean isEventHandler) {
-    if (isEventHandler) {
-      return CompletionItemKind.Event;
-    }
-    return method.isFunction() ? CompletionItemKind.Function : CompletionItemKind.Method;
+  private static CompletionItemKind methodCompletionKind(boolean isEventHandler) {
+    // Объявленные методы (процедуры и функции) — Method; Function только у платформенных
+    // глобальных функций. Обработчик события — Event.
+    return isEventHandler ? CompletionItemKind.Event : CompletionItemKind.Method;
   }
 
   private static Optional<MethodSymbol> enclosingMethod(DocumentContext documentContext, Position position) {
@@ -903,6 +905,9 @@ public final class CompletionProvider {
     var declaredMethods = documentContext.getSymbolTree().getMethods();
     var scriptVariant = documentContext.getScriptVariantLanguage();
     var bslVariant = scriptVariant == Language.EN ? ScriptVariant.ENGLISH : ScriptVariant.RUSSIAN;
+    // Owner-тип событий — один на модуль; считаем один раз и кладём в data-ключ каждой заглушки,
+    // чтобы completionItem/resolve восстановил контракт без обращения к документу.
+    var ownerTypeRef = eventHandlerResolver.eventOwnerTypeRef(documentContext).orElse(null);
     for (var contract : contracts) {
       var displayName = contract.displayName(scriptVariant);
       if (PlatformMemberVersions.firesUnavailable(contract.metadata().sinceVersion(), target)
@@ -911,13 +916,14 @@ public final class CompletionProvider {
         continue;
       }
       items.add(buildEventHandlerStubItem(contract, displayName, scriptVariant, bslVariant, target,
-        documentContext.getUri(), documentContext.getFileType()));
+        documentContext, ownerTypeRef));
     }
   }
 
   private CompletionItem buildEventHandlerStubItem(MemberDescriptor contract, String displayName,
                                                    Language scriptVariant, ScriptVariant bslVariant,
-                                                   CompatibilityMode target, URI uri, FileType fileType) {
+                                                   CompatibilityMode target, DocumentContext documentContext,
+                                                   @Nullable TypeRef ownerTypeRef) {
     var item = new CompletionItem(displayName);
     item.setKind(CompletionItemKind.Event);
     var signature = contract.signatures().isEmpty() ? SignatureDescriptor.EMPTY : contract.signatures().get(0);
@@ -925,7 +931,8 @@ public final class CompletionProvider {
     // Документацию (описание события + параметры) откладываем в completionItem/resolve, если
     // клиент это поддерживает, — как остальные пути completion в этом файле.
     if (documentationResolveSupport) {
-      item.setData(CompletionData.forEventContract(uri, contract.name(), fileType, scriptVariant));
+      item.setData(CompletionData.forEventContract(documentContext.getUri(), documentContext.getModuleType(),
+        ownerTypeRef, contract.name(), documentContext.getFileType(), scriptVariant));
     } else {
       applyDocumentation(item, contract, scriptVariant);
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -420,9 +420,11 @@ public final class CompletionProvider {
     if (eventContractName == null || moduleType == null) {
       return;
     }
-    var ownerTypeRef = data.getTypeKind() == null || data.getTypeQualifiedName() == null
+    var typeKind = data.getTypeKind();
+    var typeQualifiedName = data.getTypeQualifiedName();
+    var ownerTypeRef = typeKind == null || typeQualifiedName == null
       ? null
-      : new TypeRef(data.getTypeKind(), data.getTypeQualifiedName());
+      : new TypeRef(typeKind, typeQualifiedName);
     eventHandlerResolver.eventsFor(moduleType, ownerTypeRef, data.getFileType()).stream()
       .filter(contract -> contract.name().equals(eventContractName))
       .findFirst()
@@ -1500,15 +1502,31 @@ public final class CompletionProvider {
         sb.append(", ");
       }
       var p = params.get(i);
-      var paramName = p.displayName(scriptVariant);
-      sb.append(paramName);
+      sb.append(p.displayName(scriptVariant));
       if (p.optional()) {
         // Необязательный параметр помечаем «?» после имени: ИмяПараметра?.
         sb.append('?');
       }
+      var typeLabel = formatParamTypeName(p.types(), scriptVariant);
+      if (!typeLabel.isEmpty()) {
+        sb.append(": ").append(typeLabel);
+      }
     }
     sb.append(')');
     return sb.toString();
+  }
+
+  /**
+   * Читаемое имя типа параметра для {@link #formatParameterList}: имена всех типов набора через
+   * «{@code  | }», пустая строка — если тип неизвестен (у нетипизированных параметров, например
+   * локальных методов). Использует тот же {@link #formatTypeName}, что и тип возврата.
+   */
+  private String formatParamTypeName(TypeSet types, Language scriptVariant) {
+    return types.refs().stream()
+      .map(ref -> formatTypeName(ref, scriptVariant))
+      .filter(name -> !name.isEmpty())
+      .distinct()
+      .collect(Collectors.joining(" | "));
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -799,8 +799,7 @@ public final class CompletionProvider {
     for (var method : documentContext.getSymbolTree().getMethods()) {
       if (matches(method.getName(), prefix)) {
         var item = new CompletionItem(method.getName());
-        var isEventHandler = method.getSymbolKind() == SymbolKind.Event;
-        item.setKind(methodCompletionKind(isEventHandler));
+        item.setKind(methodCompletionKind(method));
         applyCallableInsertText(item, method.getName(), !method.getParameters().isEmpty());
         applySourceMethodDetail(item, method);
         applySourceMethodDocumentation(item, method);
@@ -809,7 +808,8 @@ public final class CompletionProvider {
         }
         // Обработчик платформенного события ранжируется ниже обычных локальных методов:
         // его редко вызывают вручную, он не должен теснить процедуры/функции документа.
-        applySortText(item, isEventHandler ? BUCKET_EVENT_STUB : BUCKET_LOCAL, method.isDeprecated());
+        applySortText(item, method.getSymbolKind() == SymbolKind.Event ? BUCKET_EVENT_STUB : BUCKET_LOCAL,
+          method.isDeprecated());
         applyCommitCharacters(item);
         items.add(item);
       }
@@ -877,10 +877,10 @@ public final class CompletionProvider {
     return items;
   }
 
-  private static CompletionItemKind methodCompletionKind(boolean isEventHandler) {
+  private static CompletionItemKind methodCompletionKind(MethodSymbol method) {
     // Объявленные методы (процедуры и функции) — Method; Function только у платформенных
     // глобальных функций. Обработчик события — Event.
-    return isEventHandler ? CompletionItemKind.Event : CompletionItemKind.Method;
+    return method.getSymbolKind() == SymbolKind.Event ? CompletionItemKind.Event : CompletionItemKind.Method;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.client.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.completion.CompletionData;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.context.ServerContextProvider;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
@@ -142,6 +143,7 @@ public final class CompletionProvider {
   private final JsonMapper jsonMapper;
   private final FuzzyMatcher fuzzyMatcher;
   private final EventContractsIndex eventContractsIndex;
+  private final ServerContextProvider serverContextProvider;
 
   // Кэшируется на initialize. snippetSupport — gate для вставки `Метод($0)` сниппета и
   // прикрепления `editor.action.triggerParameterHints` к completion item.
@@ -393,11 +395,35 @@ public final class CompletionProvider {
     if (functionName != null) {
       globalScopeProvider.globalFunction(functionName, data.getFileType())
         .ifPresent(function -> applyDocumentation(unresolved, function, data.getScriptVariant()));
+    } else if (data.getEventContractName() != null) {
+      resolveEventContractDocumentation(unresolved, data);
     } else {
       resolveMemberDocumentation(unresolved, data);
     }
     unresolved.setData(null);
     return unresolved;
+  }
+
+  /**
+   * Восстанавливает {@code documentation} контракта платформенного события по ключу
+   * {@link CompletionData} event-варианта: по {@code uri} восстанавливается документ, среди
+   * событий owner-типа его модуля контракт ищется по каноническому имени. Если ключ неполон
+   * или документ/контракт не найдены — ничего не делает.
+   *
+   * @param unresolved completion item, которому проставляется документация.
+   * @param data       ключ восстановления контракта события.
+   */
+  private void resolveEventContractDocumentation(CompletionItem unresolved, CompletionData data) {
+    var eventContractName = data.getEventContractName();
+    if (eventContractName == null) {
+      return;
+    }
+    serverContextProvider.getDocument(data.getUri())
+      .stream()
+      .flatMap(documentContext -> eventContractsIndex.getAllContracts(documentContext).stream())
+      .filter(contract -> contract.name().equals(eventContractName))
+      .findFirst()
+      .ifPresent(contract -> applyDocumentation(unresolved, contract, data.getScriptVariant()));
   }
 
   /**
@@ -884,26 +910,34 @@ public final class CompletionProvider {
         || declaredMethods.stream().anyMatch(m -> contract.matches(m.getName()))) {
         continue;
       }
-      items.add(buildEventHandlerStubItem(contract, displayName, scriptVariant, bslVariant, target));
+      items.add(buildEventHandlerStubItem(contract, displayName, scriptVariant, bslVariant, target,
+        documentContext.getUri(), documentContext.getFileType()));
     }
   }
 
   private CompletionItem buildEventHandlerStubItem(MemberDescriptor contract, String displayName,
                                                    Language scriptVariant, ScriptVariant bslVariant,
-                                                   CompatibilityMode target) {
+                                                   CompatibilityMode target, URI uri, FileType fileType) {
     var item = new CompletionItem(displayName);
     item.setKind(CompletionItemKind.Event);
     var signature = contract.signatures().isEmpty() ? SignatureDescriptor.EMPTY : contract.signatures().get(0);
     applyDetail(item, formatParameterList(signature, scriptVariant), "");
-    applyDocumentation(item, contract, scriptVariant);
-    if (isMemberDeprecated(contract, target)) {
+    // Документацию (описание события + параметры) откладываем в completionItem/resolve, если
+    // клиент это поддерживает, — как остальные пути completion в этом файле.
+    if (documentationResolveSupport) {
+      item.setData(CompletionData.forEventContract(uri, contract.name(), fileType, scriptVariant));
+    } else {
+      applyDocumentation(item, contract, scriptVariant);
+    }
+    var deprecated = isMemberDeprecated(contract, target);
+    if (deprecated) {
       markDeprecatedItem(item);
     }
     item.setInsertText(formatEventHandlerSnippet(signature, displayName, scriptVariant, bslVariant, snippetSupport));
     if (snippetSupport) {
       item.setInsertTextFormat(InsertTextFormat.Snippet);
     }
-    applySortText(item, BUCKET_EVENT_STUB, isMemberDeprecated(contract, target));
+    applySortText(item, BUCKET_EVENT_STUB, deprecated);
     return item;
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -26,9 +26,11 @@ import com.github._1c_syntax.bsl.languageserver.client.ClientCapabilitiesHolder;
 import com.github._1c_syntax.bsl.languageserver.completion.CompletionData;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
+import com.github._1c_syntax.bsl.languageserver.types.index.EventContractsIndex;
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.events.LanguageServerInitializedEvent;
@@ -45,9 +47,11 @@ import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryInde
 import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
 import com.github._1c_syntax.bsl.languageserver.types.scope.UseDirectiveScanner;
 import com.github._1c_syntax.bsl.languageserver.utils.FuzzyMatcher;
+import com.github._1c_syntax.bsl.languageserver.utils.Keywords;
 import com.github._1c_syntax.bsl.parser.description.MethodDescription;
 import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import com.github._1c_syntax.bsl.support.CompatibilityMode;
+import com.github._1c_syntax.bsl.types.ScriptVariant;
 import com.github._1c_syntax.utils.Absolute;
 import lombok.RequiredArgsConstructor;
 import org.eclipse.lsp4j.ClientCapabilities;
@@ -66,6 +70,7 @@ import org.eclipse.lsp4j.InsertTextFormat;
 import org.eclipse.lsp4j.MarkupContent;
 import org.eclipse.lsp4j.MarkupKind;
 import org.eclipse.lsp4j.Position;
+import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.TextDocumentClientCapabilities;
 import org.jspecify.annotations.Nullable;
 import org.springframework.context.event.EventListener;
@@ -119,6 +124,10 @@ public final class CompletionProvider {
   private static final String BUCKET_GLOBAL = "2";
   private static final String BUCKET_TYPE = "3";
   private static final String BUCKET_KEYWORD = "4";
+  // Заглушки обработчиков платформенных событий: после локальных имён, до глобальных.
+  private static final String BUCKET_EVENT_STUB = "15";
+  // Сниппет-табстопы обработчика: $1 — тело, параметры — с ${2:...} (см. formatEventHandlerSnippet).
+  private static final int SNIPPET_PARAM_TABSTOP_OFFSET = 2;
   // Корзина членов типа в dot-completion: пользовательские/декларированные поля
   // приоритетнее дефолтных членов того же типа.
   private static final String BUCKET_MEMBER_FIELD = "1";
@@ -132,6 +141,7 @@ public final class CompletionProvider {
   private final ClientCapabilitiesHolder clientCapabilitiesHolder;
   private final JsonMapper jsonMapper;
   private final FuzzyMatcher fuzzyMatcher;
+  private final EventContractsIndex eventContractsIndex;
 
   // Кэшируется на initialize. snippetSupport — gate для вставки `Метод($0)` сниппета и
   // прикрепления `editor.action.triggerParameterHints` к completion item.
@@ -760,20 +770,17 @@ public final class CompletionProvider {
     for (var method : documentContext.getSymbolTree().getMethods()) {
       if (matches(method.getName(), prefix)) {
         var item = new CompletionItem(method.getName());
-        item.setKind(method.isFunction() ? CompletionItemKind.Function : CompletionItemKind.Method);
+        var isEventHandler = method.getSymbolKind() == SymbolKind.Event;
+        item.setKind(methodCompletionKind(method, isEventHandler));
         applyCallableInsertText(item, method.getName(), !method.getParameters().isEmpty());
         applySourceMethodDetail(item, method);
         applySourceMethodDocumentation(item, method);
         if (method.isDeprecated()) {
           markDeprecatedItem(item);
         }
-        // Обработчик платформенного события ранжируется как self-член: его
-        // редко вызывают вручную, он не должен теснить обычные локальные
-        // процедуры/функции документа.
-        var bucket = eventContractsIndex.getContract(documentContext, method.getName()).isPresent()
-          ? BUCKET_SELF
-          : BUCKET_LOCAL;
-        applySortText(item, bucket, method.isDeprecated());
+        // Обработчик платформенного события ранжируется ниже обычных локальных методов:
+        // его редко вызывают вручную, он не должен теснить процедуры/функции документа.
+        applySortText(item, isEventHandler ? BUCKET_EVENT_STUB : BUCKET_LOCAL, method.isDeprecated());
         applyCommitCharacters(item);
         items.add(item);
       }
@@ -819,6 +826,13 @@ public final class CompletionProvider {
     }
 
     selfRef.ifPresent(ref -> collectSelfMembers(ref, documentContext, declaredLocalNames, target, prefix, items));
+    // Заглушки ещё не объявленных обработчиков платформенных событий owner-типа модуля —
+    // только на уровне модуля (курсор вне тела метода): внутри чужого метода вставка нового
+    // объявления процедуры/функции была бы синтаксически некорректной (аналог «override method»
+    // в других IDE, но для обработчиков платформенных событий 1С).
+    if (enclosingMethod(documentContext, position).isEmpty()) {
+      collectEventHandlerStubs(documentContext, prefix, target, items);
+    }
 
     // Keywords: ru/en-написания не дедупятся — общей идентичности у кейвордов нет
     // (в отличие от имён типов), поэтому фильтр по языку к ним не применяется.
@@ -832,6 +846,92 @@ public final class CompletionProvider {
     }
 
     return items;
+  }
+
+  private static CompletionItemKind methodCompletionKind(MethodSymbol method, boolean isEventHandler) {
+    if (isEventHandler) {
+      return CompletionItemKind.Event;
+    }
+    return method.isFunction() ? CompletionItemKind.Function : CompletionItemKind.Method;
+  }
+
+  private static Optional<MethodSymbol> enclosingMethod(DocumentContext documentContext, Position position) {
+    var symbol = documentContext.getSymbolTree().getSymbolAtPosition(position);
+    if (symbol instanceof MethodSymbol method) {
+      return Optional.of(method);
+    }
+    return symbol.getRootParent(MethodSymbol.class).map(MethodSymbol.class::cast);
+  }
+
+  /**
+   * Заглушки ещё не объявленных обработчиков платформенных событий owner-типа модуля:
+   * контракты берём из {@link EventContractsIndex}, отсеиваем уже объявленные в модуле
+   * методы и недоступные по target-совместимости. Ранжируются в {@link #BUCKET_EVENT_STUB}.
+   */
+  private void collectEventHandlerStubs(DocumentContext documentContext, String prefix,
+                                        CompatibilityMode target, List<CompletionItem> items) {
+    var contracts = eventContractsIndex.getAllContracts(documentContext);
+    if (contracts.isEmpty()) {
+      return;
+    }
+    var declaredMethods = documentContext.getSymbolTree().getMethods();
+    var scriptVariant = documentContext.getScriptVariantLanguage();
+    var bslVariant = scriptVariant == Language.EN ? ScriptVariant.ENGLISH : ScriptVariant.RUSSIAN;
+    for (var contract : contracts) {
+      var displayName = contract.displayName(scriptVariant);
+      if (PlatformMemberVersions.firesUnavailable(contract.metadata().sinceVersion(), target)
+        || !matches(displayName, prefix)
+        || declaredMethods.stream().anyMatch(m -> contract.matches(m.getName()))) {
+        continue;
+      }
+      items.add(buildEventHandlerStubItem(contract, displayName, scriptVariant, bslVariant, target));
+    }
+  }
+
+  private CompletionItem buildEventHandlerStubItem(MemberDescriptor contract, String displayName,
+                                                   Language scriptVariant, ScriptVariant bslVariant,
+                                                   CompatibilityMode target) {
+    var item = new CompletionItem(displayName);
+    item.setKind(CompletionItemKind.Event);
+    var signature = contract.signatures().isEmpty() ? SignatureDescriptor.EMPTY : contract.signatures().get(0);
+    applyDetail(item, formatParameterList(signature, scriptVariant), "");
+    applyDocumentation(item, contract, scriptVariant);
+    if (isMemberDeprecated(contract, target)) {
+      markDeprecatedItem(item);
+    }
+    item.setInsertText(formatEventHandlerSnippet(signature, displayName, scriptVariant, bslVariant, snippetSupport));
+    if (snippetSupport) {
+      item.setInsertTextFormat(InsertTextFormat.Snippet);
+    }
+    applySortText(item, BUCKET_EVENT_STUB, isMemberDeprecated(contract, target));
+    return item;
+  }
+
+  private static String formatEventHandlerSnippet(SignatureDescriptor signature, String displayName,
+                                                  Language scriptVariant, ScriptVariant bslVariant,
+                                                  boolean asSnippet) {
+    var sb = new StringBuilder();
+    sb.append(Keywords.PROCEDURE.get(bslVariant)).append(' ').append(displayName).append('(');
+    var params = signature.parameters();
+    for (var i = 0; i < params.size(); i++) {
+      if (i > 0) {
+        sb.append(", ");
+      }
+      var paramName = params.get(i).displayName(scriptVariant);
+      if (asSnippet) {
+        sb.append("${").append(i + SNIPPET_PARAM_TABSTOP_OFFSET).append(':').append(paramName).append('}');
+      } else {
+        sb.append(paramName);
+      }
+    }
+    sb.append(")\n\t")
+      .append(asSnippet ? "$1" : "")
+      .append('\n')
+      .append(Keywords.END_PROCEDURE.get(bslVariant));
+    if (asSnippet) {
+      sb.append("$0");
+    }
+    return sb.toString();
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -143,7 +143,6 @@ public final class CompletionProvider {
   private final ClientCapabilitiesHolder clientCapabilitiesHolder;
   private final JsonMapper jsonMapper;
   private final FuzzyMatcher fuzzyMatcher;
-  private final EventContractsIndex eventContractsIndex;
   private final EventHandlerResolver eventHandlerResolver;
 
   // Кэшируется на initialize. snippetSupport — gate для вставки `Метод($0)` сниппета и
@@ -883,14 +882,6 @@ public final class CompletionProvider {
     // Объявленные методы (процедуры и функции) — Method; Function только у платформенных
     // глобальных функций. Обработчик события — Event.
     return isEventHandler ? CompletionItemKind.Event : CompletionItemKind.Method;
-  }
-
-  private static Optional<MethodSymbol> enclosingMethod(DocumentContext documentContext, Position position) {
-    var symbol = documentContext.getSymbolTree().getSymbolAtPosition(position);
-    if (symbol instanceof MethodSymbol method) {
-      return Optional.of(method);
-    }
-    return symbol.getRootParent(MethodSymbol.class).map(MethodSymbol.class::cast);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
@@ -101,7 +101,7 @@ public class ReferenceIndex {
       .mdoRef(mdoRef)
       .moduleType(moduleType)
       .scopeName(scopeName)
-      .symbolKind(symbol.getSymbolKind())
+      .symbolKind(indexedKindOf(symbol.getSymbolKind()))
       .symbolName(symbolName)
       .build();
 
@@ -216,7 +216,44 @@ public class ReferenceIndex {
   }
 
   /**
+   * Канонический вид callable-символа для построения/поиска ключа индекса вхождений
+   * ({@code Symbol.symbolKind}), в отличие от display-{@link SymbolKind}, возвращаемого
+   * {@link com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol#getSymbolKind()}.
+   * <p>
+   * На месте вызова (например, {@code Новый ИмяКласса(...)}) неизвестно без резолва
+   * документа-получателя, является ли цель обычным методом или конструктором OneScript-класса
+   * ({@link com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol}) —
+   * поэтому все callable-вхождения индексируются {@link #methodCallOccurrence} под единым
+   * {@link SymbolKind#Method} независимо от истинного вида цели (см. и
+   * {@code ReferenceIndexFiller#tryRegisterLibraryClassReference}, который знает, что вызывает
+   * именно конструктор, но всё равно идёт тем же общим путём индексации). Читающая сторона
+   * ({@link #getReferencesTo}) обязана канонизировать так же — иначе ключ, построенный по
+   * настоящему {@code getSymbolKind()} символа-цели ({@code Constructor}), никогда не совпадёт с
+   * реально сохранённым ({@code Method}), и Find References/Rename/Call Hierarchy incoming
+   * молча не находят ни одной ссылки на конструктор.
+   * <p>
+   * Так же канонизируется {@link SymbolKind#Event}: объявленные обработчики платформенных
+   * событий попадают в дерево символов как {@code EventMethodSymbol} (display-вид {@code Event}),
+   * но их прямые вызовы индексируются {@link #methodCallOccurrence} под {@code Method} — без
+   * канонизации Find References/Call Hierarchy не нашли бы ни одного прямого вызова обработчика.
+   * Точка расширения при появлении новых callable-{@link SymbolKind} — сюда достаточно добавить
+   * очередной случай.
+   *
+   * @param symbolKind реальный (display) вид искомого/индексируемого символа.
+   * @return канонический вид для ключа индекса.
+   */
+  private static SymbolKind indexedKindOf(SymbolKind symbolKind) {
+    if (symbolKind == SymbolKind.Constructor || symbolKind == SymbolKind.Event) {
+      return SymbolKind.Method;
+    }
+    return symbolKind;
+  }
+
+  /**
    * Построить вхождение «вызов метода» без записи в индекс.
+   * <p>
+   * Кладётся под каноническим {@link SymbolKind#Method} независимо от истинного вида цели
+   * (обычный метод или конструктор OneScript-класса) — см. {@link #indexedKindOf}.
    *
    * @param uri        URI документа, откуда произошел вызов.
    * @param mdoRef     Ссылка на объект-метаданных, к которому происходит обращение (например, CommonModule.ОбщийМодуль1).

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensLegendConfiguration.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensLegendConfiguration.java
@@ -53,6 +53,7 @@ public class SemanticTokensLegendConfiguration {
       SemanticTokenTypes.Comment,
       SemanticTokenTypes.Function,
       SemanticTokenTypes.Method,
+      SemanticTokenTypes.Event,  // Added for platform event handler methods
       SemanticTokenTypes.Variable,
       SemanticTokenTypes.Parameter,
       SemanticTokenTypes.Macro,

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplier.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ParameterDefinition;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.variable.VariableKind;
@@ -83,7 +84,7 @@ public class SymbolsSemanticTokensSupplier implements SemanticTokensSupplier {
     // Add method symbols (functions and procedures)
     var isStatic = Modules.isStaticModule(documentContext);
     for (var method : symbolTree.getMethods()) {
-      var semanticTokenType = method.isFunction() ? SemanticTokenTypes.Function : SemanticTokenTypes.Method;
+      var semanticTokenType = methodTokenType(method);
       var modifiers = methodModifiers(isStatic, method.isAsync());
       helper.addRange(entries, method.getSubNameRange(), semanticTokenType, modifiers);
       for (ParameterDefinition parameter : method.getParameters()) {
@@ -142,6 +143,19 @@ public class SymbolsSemanticTokensSupplier implements SemanticTokensSupplier {
         var descriptor = ((PlatformMemberSymbol) reference.symbol()).getDescriptor();
         helper.addRange(entries, reference.selectionRange(), tokenType, selfMemberModifiers(descriptor, isStatic));
       });
+  }
+
+  /**
+   * Тип семантического токена имени метода: {@link SemanticTokenTypes#Event} для
+   * обработчика платформенного события ({@link SymbolKind#Event}, см. {@code
+   * context.symbol.EventMethodSymbol}) — осознанно ценой различения функция/процедура для таких
+   * методов, иначе как обычно {@link SemanticTokenTypes#Function}/{@link SemanticTokenTypes#Method}.
+   */
+  private static String methodTokenType(MethodSymbol method) {
+    if (method.getSymbolKind() == SymbolKind.Event) {
+      return SemanticTokenTypes.Event;
+    }
+    return method.isFunction() ? SemanticTokenTypes.Function : SemanticTokenTypes.Method;
   }
 
   private static String[] methodModifiers(boolean isStatic, boolean isAsync) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplier.java
@@ -146,16 +146,16 @@ public class SymbolsSemanticTokensSupplier implements SemanticTokensSupplier {
   }
 
   /**
-   * Тип семантического токена имени метода: {@link SemanticTokenTypes#Event} для
-   * обработчика платформенного события ({@link SymbolKind#Event}, см. {@code
-   * context.symbol.EventMethodSymbol}) — осознанно ценой различения функция/процедура для таких
-   * методов, иначе как обычно {@link SemanticTokenTypes#Function}/{@link SemanticTokenTypes#Method}.
+   * Тип семантического токена имени метода: {@link SemanticTokenTypes#Event} для обработчика
+   * платформенного события ({@link SymbolKind#Event}), иначе {@link SemanticTokenTypes#Method}.
+   * Объявленные в коде методы — и процедуры, и функции — семантически методы; {@link
+   * SemanticTokenTypes#Function} зарезервирован за платформенными глобальными функциями (их
+   * размечает отдельный supplier).
    */
   private static String methodTokenType(MethodSymbol method) {
-    if (method.getSymbolKind() == SymbolKind.Event) {
-      return SemanticTokenTypes.Event;
-    }
-    return method.isFunction() ? SemanticTokenTypes.Function : SemanticTokenTypes.Method;
+    return method.getSymbolKind() == SymbolKind.Event
+      ? SemanticTokenTypes.Event
+      : SemanticTokenTypes.Method;
   }
 
   private static String[] methodModifiers(boolean isStatic, boolean isAsync) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndex.java
@@ -32,6 +32,7 @@ import org.springframework.stereotype.Component;
 
 import java.net.URI;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
@@ -60,6 +61,13 @@ public class EventContractsIndex extends AbstractDocumentLifecycleClearableIndex
     = new ConcurrentHashMap<>();
 
   /**
+   * Кэш «все события owner-типа документа» (не привязанные к конкретному объявленному методу),
+   * для автодополнения заглушки ещё не объявленного обработчика. Инвалидируется теми же
+   * событиями, что и {@link #contractsByUri}.
+   */
+  private final Map<URI, List<MemberDescriptor>> allContractsByUri = new ConcurrentHashMap<>();
+
+  /**
    * Возвращает контракт платформенного события для метода с указанным именем
    * либо {@link Optional#empty()}, если метод не является обработчиком.
    */
@@ -71,14 +79,28 @@ public class EventContractsIndex extends AbstractDocumentLifecycleClearableIndex
     return contracts.getOrDefault(methodName.toLowerCase(Locale.ROOT), Optional.empty());
   }
 
+  /**
+   * Возвращает все события owner-типа модуля документа — независимо от того, объявлен ли в
+   * документе метод-обработчик для каждого из них. См.
+   * {@link EventHandlerResolver#allEvents(DocumentContext)}.
+   */
+  public List<MemberDescriptor> getAllContracts(DocumentContext documentContext) {
+    return allContractsByUri.computeIfAbsent(
+      documentContext.getUri(),
+      uri -> eventHandlerResolver.allEvents(documentContext)
+    );
+  }
+
   @Override
   public void clear(URI uri) {
     contractsByUri.remove(uri);
+    allContractsByUri.remove(uri);
   }
 
   @EventListener
   public void handleConfigurationTypesRegistered(ConfigurationTypesRegisteredEvent event) {
     contractsByUri.clear();
+    allContractsByUri.clear();
   }
 
   private Map<String, Optional<MemberDescriptor>> buildFor(DocumentContext documentContext) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndex.java
@@ -61,13 +61,6 @@ public class EventContractsIndex extends AbstractDocumentLifecycleClearableIndex
     = new ConcurrentHashMap<>();
 
   /**
-   * Кэш «все события owner-типа документа» (не привязанные к конкретному объявленному методу),
-   * для автодополнения заглушки ещё не объявленного обработчика. Инвалидируется теми же
-   * событиями, что и {@link #contractsByUri}.
-   */
-  private final Map<URI, List<MemberDescriptor>> allContractsByUri = new ConcurrentHashMap<>();
-
-  /**
    * Возвращает контракт платформенного события для метода с указанным именем
    * либо {@link Optional#empty()}, если метод не является обработчиком.
    */
@@ -81,26 +74,22 @@ public class EventContractsIndex extends AbstractDocumentLifecycleClearableIndex
 
   /**
    * Возвращает все события owner-типа модуля документа — независимо от того, объявлен ли в
-   * документе метод-обработчик для каждого из них. См.
-   * {@link EventHandlerResolver#allEvents(DocumentContext)}.
+   * документе метод-обработчик для каждого из них. Отдельно не кэшируется: делегирует в
+   * {@link EventHandlerResolver#allEvents(DocumentContext)}, чей источник уже мемоизирован, а
+   * события зависят от типа, не от содержимого документа.
    */
   public List<MemberDescriptor> getAllContracts(DocumentContext documentContext) {
-    return allContractsByUri.computeIfAbsent(
-      documentContext.getUri(),
-      uri -> eventHandlerResolver.allEvents(documentContext)
-    );
+    return eventHandlerResolver.allEvents(documentContext);
   }
 
   @Override
   public void clear(URI uri) {
     contractsByUri.remove(uri);
-    allContractsByUri.remove(uri);
   }
 
   @EventListener
   public void handleConfigurationTypesRegistered(ConfigurationTypesRegisteredEvent event) {
     contractsByUri.clear();
-    allContractsByUri.clear();
   }
 
   private Map<String, Optional<MemberDescriptor>> buildFor(DocumentContext documentContext) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndex.java
@@ -74,9 +74,7 @@ public class EventContractsIndex extends AbstractDocumentLifecycleClearableIndex
 
   /**
    * Возвращает все события owner-типа модуля документа — независимо от того, объявлен ли в
-   * документе метод-обработчик для каждого из них. Отдельно не кэшируется: делегирует в
-   * {@link EventHandlerResolver#allEvents(DocumentContext)}, чей источник уже мемоизирован, а
-   * события зависят от типа, не от содержимого документа.
+   * документе метод-обработчик для каждого из них.
    */
   public List<MemberDescriptor> getAllContracts(DocumentContext documentContext) {
     return eventHandlerResolver.allEvents(documentContext);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentClearedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopulatedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.Symbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
@@ -696,7 +697,7 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
       if (!isSupported(symbol) || symbol.getName().isEmpty()) {
         continue;
       }
-      collected.add(toEntry(uri, symbol, scriptVariant));
+      collected.add(toEntry(documentContext, symbol, scriptVariant));
     }
 
     var snapshot = List.copyOf(collected);
@@ -783,11 +784,11 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
     }
   }
 
-  private static Entry toEntry(URI uri, SourceDefinedSymbol symbol, ScriptVariant scriptVariant) {
+  private static Entry toEntry(DocumentContext documentContext, SourceDefinedSymbol symbol, ScriptVariant scriptVariant) {
     var name = symbol.getName();
     var containerName = getContainerName(symbol, scriptVariant).orElse("");
     return new Entry(
-      uri,
+      documentContext.getUri(),
       name,
       name.toLowerCase(Locale.ENGLISH),
       symbol.getSymbolKind(),
@@ -797,12 +798,20 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
     );
   }
 
+  /**
+   * Поддерживается ли символ в {@code workspace/symbol}: любой {@link MethodSymbol}
+   * (обычный метод, конструктор OneScript-класса, обработчик платформенного события {@link
+   * com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol} — и в будущем любой
+   * новый подтип) и переменные модульного/глобального уровня.
+   */
   private static boolean isSupported(Symbol symbol) {
-    return switch (symbol.getSymbolKind()) {
-      case Method, Constructor -> true;
-      case Variable -> SUPPORTED_VARIABLE_KINDS.contains(((VariableSymbol) symbol).getKind());
-      default -> false;
-    };
+    if (symbol instanceof MethodSymbol) {
+      return true;
+    }
+    if (symbol instanceof VariableSymbol variableSymbol) {
+      return SUPPORTED_VARIABLE_KINDS.contains(variableSymbol.getKind());
+    }
+    return false;
   }
 
   private static Optional<String> getContainerName(SourceDefinedSymbol symbol, ScriptVariant scriptVariant) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndex.java
@@ -697,7 +697,7 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
       if (!isSupported(symbol) || symbol.getName().isEmpty()) {
         continue;
       }
-      collected.add(toEntry(documentContext, symbol, scriptVariant));
+      collected.add(toEntry(uri, symbol, scriptVariant));
     }
 
     var snapshot = List.copyOf(collected);
@@ -784,11 +784,11 @@ public class WorkspaceSymbolIndex extends AbstractDocumentLifecycleClearableInde
     }
   }
 
-  private static Entry toEntry(DocumentContext documentContext, SourceDefinedSymbol symbol, ScriptVariant scriptVariant) {
+  private static Entry toEntry(URI uri, SourceDefinedSymbol symbol, ScriptVariant scriptVariant) {
     var name = symbol.getName();
     var containerName = getContainerName(symbol, scriptVariant).orElse("");
     return new Entry(
-      documentContext.getUri(),
+      uri,
       name,
       name.toLowerCase(Locale.ENGLISH),
       symbol.getSymbolKind(),

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinTypesJsonLoader.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/BuiltinTypesJsonLoader.java
@@ -182,6 +182,9 @@ public class BuiltinTypesJsonLoader {
         // чтобы тип возврата сохранялся и у методов без описанных параметров.
         descriptor = new MemberDescriptor(name, MemberKind.METHOD, description, returnTypes,
           signatures, null, false, PlatformMetadata.EMPTY);
+      } else if (kind == MemberKind.EVENT) {
+        // У события есть сигнатура-контракт обработчика, но нет возвращаемого значения.
+        descriptor = MemberDescriptor.event(name, description, signatures);
       } else if (generic) {
         descriptor = MemberDescriptor.genericProperty(name, returnType, description);
       } else {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.types.registry;
 import com.github._1c_syntax.bsl.context.api.ContextEvent;
 import com.github._1c_syntax.bsl.context.platform.EnAttachments;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventHandlerClassifier;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.languageserver.types.model.BilingualString;
@@ -35,8 +36,8 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.types.ModuleType;
-import com.github._1c_syntax.utils.Lazy;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 import java.util.EnumMap;
@@ -66,7 +67,7 @@ import java.util.stream.Collectors;
 @Component
 @WorkspaceScope
 @Slf4j
-public class EventHandlerResolver {
+public class EventHandlerResolver implements EventHandlerClassifier {
 
   /**
    * Модули, чей owner-тип — специализация по имени MDO:
@@ -160,13 +161,12 @@ public class EventHandlerResolver {
   private final BslContextHolder bslContextHolder;
 
   /**
-   * Лениво построенная карта глобальных событий: {@link ModuleType} →
-   * {@code lc(имя события)} → контракт. Источник —
-   * {@code ContextProvider.getGlobalContext()} с четырьмя списками
-   * (managed/ordinary/session/external). Если HBK недоступен — карта пуста.
+   * Карта глобальных событий: {@link ModuleType} → {@code lc(имя события)} → контракт. Источник —
+   * {@code ContextProvider.getGlobalContext()} (managed/ordinary/session/external). Кэшируется
+   * только при доступном провайдере (см. {@link #globalEvents()}): до загрузки HBK карта пуста и
+   * НЕ кэшируется, чтобы пересобраться при запоздалой подгрузке bsl-context.
    */
-  private final Lazy<Map<ModuleType, Map<String, MemberDescriptor>>> globalEvents
-    = new Lazy<>(this::buildGlobalEvents);
+  private volatile @Nullable Map<ModuleType, Map<String, MemberDescriptor>> globalEventsCache;
 
   public EventHandlerResolver(TypeRegistry typeRegistry, BslContextHolder bslContextHolder) {
     this.typeRegistry = typeRegistry;
@@ -202,6 +202,46 @@ public class EventHandlerResolver {
       .findFirst();
   }
 
+  /**
+   * Реализация {@link EventHandlerClassifier} для {@code
+   * context.computer.MethodSymbolComputer}: тонкая обёртка над {@link #lookupContract} —
+   * при обходе AST полный {@link MemberDescriptor} не нужен, важен только сам факт классификации.
+   */
+  @Override
+  public boolean isEventHandler(DocumentContext documentContext, String methodName) {
+    return lookupContract(documentContext, methodName).isPresent();
+  }
+
+  /**
+   * Возвращает все события платформенного owner-типа модуля документа — независимо от того,
+   * объявлен ли в документе метод-обработчик для каждого из них.
+   * <p>
+   * Используется для автодополнения заглушки ещё не объявленного обработчика (см.
+   * {@link com.github._1c_syntax.bsl.languageserver.types.index.EventContractsIndex#getAllContracts}).
+   * Безопасно вызывать когда конфигурационные типы ещё не зарегистрированы — вернёт пустой список.
+   */
+  public List<MemberDescriptor> allEvents(DocumentContext documentContext) {
+    var moduleType = documentContext.getModuleType();
+    if (moduleType == ModuleType.OScriptClass) {
+      return OSCRIPT_CLASS_EVENTS;
+    }
+    if (GLOBAL_HOST_MODULES.contains(moduleType)) {
+      var byName = globalEvents().get(moduleType);
+      if (byName == null) {
+        return List.of();
+      }
+      // Одно событие лежит в карте под ru- и en-ключом на один и тот же объект — дедуп по identity/equals.
+      return byName.values().stream().distinct().toList();
+    }
+    var ownerTypeRef = resolveOwnerType(documentContext, moduleType);
+    if (ownerTypeRef.isEmpty()) {
+      return List.of();
+    }
+    return typeRegistry.getMembers(ownerTypeRef.get(), documentContext.getFileType()).stream()
+      .filter(m -> m.kind() == MemberKind.EVENT)
+      .toList();
+  }
+
   private static Optional<MemberDescriptor> lookupOScriptClassEvent(String methodName) {
     var key = methodName.toLowerCase(Locale.ROOT);
     var ruKey = OSCRIPT_CLASS_EVENT_ALIASES_EN_TO_RU.getOrDefault(key, key);
@@ -209,11 +249,26 @@ public class EventHandlerResolver {
   }
 
   private Optional<MemberDescriptor> lookupGlobalEvent(ModuleType moduleType, String methodName) {
-    var byName = globalEvents.getOrCompute().get(moduleType);
+    var byName = globalEvents().get(moduleType);
     if (byName == null) {
       return Optional.empty();
     }
     return Optional.ofNullable(byName.get(methodName.toLowerCase(Locale.ROOT)));
+  }
+
+  private Map<ModuleType, Map<String, MemberDescriptor>> globalEvents() {
+    var cached = globalEventsCache;
+    if (cached != null) {
+      return cached;
+    }
+    // Провайдер ещё не готов (HBK/bsl-context не загружен) — возвращаем пустоту БЕЗ кэширования:
+    // следующий вызов после подгрузки контекста соберёт и закэширует полную карту.
+    if (bslContextHolder.get().isEmpty()) {
+      return Map.of();
+    }
+    var built = buildGlobalEvents();
+    globalEventsCache = built;
+    return built;
   }
 
   private Map<ModuleType, Map<String, MemberDescriptor>> buildGlobalEvents() {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
@@ -164,9 +164,10 @@ public class EventHandlerResolver implements EventHandlerClassifier {
 
   /**
    * Карта глобальных событий: {@link ModuleType} → {@code lc(имя события)} → контракт. Источник —
-   * {@code ContextProvider.getGlobalContext()} (managed/ordinary/session/external). Кэшируется
-   * только при доступном провайдере (см. {@link #globalEvents()}): до загрузки HBK карта пуста и
-   * НЕ кэшируется, чтобы пересобраться при запоздалой подгрузке bsl-context.
+   * {@code ContextProvider.getGlobalContext()} (managed/ordinary/session/external). Собирается и
+   * кэшируется однократно при первом обращении (см. {@link #globalEvents()}); {@link BslContextHolder}
+   * синхронно-мемоизирован и позже не догружается, поэтому пустой результат (HBK недоступен)
+   * кэшируется наравне с полным.
    */
   private final AtomicReference<Map<ModuleType, Map<String, MemberDescriptor>>> globalEventsCache =
     new AtomicReference<>();
@@ -288,11 +289,12 @@ public class EventHandlerResolver implements EventHandlerClassifier {
     if (cached != null) {
       return cached;
     }
-    // Провайдер ещё не готов (HBK/bsl-context не загружен) — возвращаем пустоту БЕЗ кэширования:
-    // следующий вызов после подгрузки контекста соберёт и закэширует полную карту.
-    if (bslContextHolder.get().isEmpty()) {
-      return Map.of();
-    }
+    // Собираем и кэшируем однократно, включая пустой результат. BslContextHolder — синхронный
+    // мемоизированный Lazy без повторных попыток (см. его javadoc): если HBK/bsl-context недоступен,
+    // get() остаётся пустым навсегда, поэтому «поздней подгрузки», ради которой стоило бы не
+    // кэшировать пустоту и пересобирать, не бывает. При пустом провайдере buildGlobalEvents() отдаёт
+    // Map.of(). Гонки нет: worst-case — идемпотентный двойной build с одинаковым содержимым,
+    // AtomicReference даёт безопасную публикацию.
     var built = buildGlobalEvents();
     globalEventsCache.set(built);
     return built;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.types.registry;
 import com.github._1c_syntax.bsl.context.api.ContextEvent;
 import com.github._1c_syntax.bsl.context.platform.EnAttachments;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.EventHandlerClassifier;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.mdo.MD;
@@ -37,6 +38,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import lombok.extern.slf4j.Slf4j;
+import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 import java.util.EnumMap;
@@ -222,7 +224,32 @@ public class EventHandlerResolver implements EventHandlerClassifier {
    * Безопасно вызывать когда конфигурационные типы ещё не зарегистрированы — вернёт пустой список.
    */
   public List<MemberDescriptor> allEvents(DocumentContext documentContext) {
+    return eventsFor(documentContext.getModuleType(),
+      eventOwnerTypeRef(documentContext).orElse(null),
+      documentContext.getFileType());
+  }
+
+  /**
+   * Owner-тип, чьи события предлагаются в модуле документа: платформенный тип объекта/менеджера
+   * (например, {@code СправочникОбъект.<Имя>}). Пусто для модулей-глобальных-хостов и .os-классов —
+   * их события не зависят от конфигурационного типа. Служит стабильным ключом восстановления
+   * событий в {@code completionItem/resolve} (см. {@link #eventsFor}).
+   */
+  public Optional<TypeRef> eventOwnerTypeRef(DocumentContext documentContext) {
     var moduleType = documentContext.getModuleType();
+    if (moduleType == ModuleType.OScriptClass || GLOBAL_HOST_MODULES.contains(moduleType)) {
+      return Optional.empty();
+    }
+    return resolveOwnerType(documentContext, moduleType);
+  }
+
+  /**
+   * Все события источника, заданного парой {@code (moduleType, ownerTypeRef)} — без привязки к
+   * конкретному документу, чтобы набор можно было восстановить по ключу из
+   * {@code completionItem/resolve}. Для .os-класса и модулей-глобальных-хостов события фиксированы
+   * (owner-тип не нужен), для объектных/менеджерских модулей берутся с {@code ownerTypeRef}.
+   */
+  public List<MemberDescriptor> eventsFor(ModuleType moduleType, @Nullable TypeRef ownerTypeRef, FileType fileType) {
     if (moduleType == ModuleType.OScriptClass) {
       return OSCRIPT_CLASS_EVENTS;
     }
@@ -234,11 +261,10 @@ public class EventHandlerResolver implements EventHandlerClassifier {
       // Одно событие лежит в карте под ru- и en-ключом на один и тот же объект — дедуп по identity/equals.
       return byName.values().stream().distinct().toList();
     }
-    var ownerTypeRef = resolveOwnerType(documentContext, moduleType);
-    if (ownerTypeRef.isEmpty()) {
+    if (ownerTypeRef == null) {
       return List.of();
     }
-    return typeRegistry.getMembers(ownerTypeRef.get(), documentContext.getFileType()).stream()
+    return typeRegistry.getMembers(ownerTypeRef, fileType).stream()
       .filter(m -> m.kind() == MemberKind.EVENT)
       .toList();
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
@@ -37,7 +37,6 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import lombok.extern.slf4j.Slf4j;
-import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 import java.util.EnumMap;
@@ -48,6 +47,7 @@ import java.util.Locale;
 import java.util.Map;
 import java.util.Optional;
 import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import java.util.stream.Collectors;
 
@@ -166,7 +166,8 @@ public class EventHandlerResolver implements EventHandlerClassifier {
    * только при доступном провайдере (см. {@link #globalEvents()}): до загрузки HBK карта пуста и
    * НЕ кэшируется, чтобы пересобраться при запоздалой подгрузке bsl-context.
    */
-  private volatile @Nullable Map<ModuleType, Map<String, MemberDescriptor>> globalEventsCache;
+  private final AtomicReference<Map<ModuleType, Map<String, MemberDescriptor>>> globalEventsCache =
+    new AtomicReference<>();
 
   public EventHandlerResolver(TypeRegistry typeRegistry, BslContextHolder bslContextHolder) {
     this.typeRegistry = typeRegistry;
@@ -257,7 +258,7 @@ public class EventHandlerResolver implements EventHandlerClassifier {
   }
 
   private Map<ModuleType, Map<String, MemberDescriptor>> globalEvents() {
-    var cached = globalEventsCache;
+    var cached = globalEventsCache.get();
     if (cached != null) {
       return cached;
     }
@@ -267,7 +268,7 @@ public class EventHandlerResolver implements EventHandlerClassifier {
       return Map.of();
     }
     var built = buildGlobalEvents();
-    globalEventsCache = built;
+    globalEventsCache.set(built);
     return built;
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerEventClassificationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerEventClassificationTest.java
@@ -1,0 +1,122 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.context.computer;
+
+import com.github._1c_syntax.bsl.languageserver.context.OScriptModuleTypeResolver;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.RegularMethodSymbol;
+import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.types.ModuleType;
+import org.eclipse.lsp4j.SymbolKind;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.net.URI;
+
+import static org.mockito.Mockito.when;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Метод, являющийся обработчиком платформенного события, регистрируется в дереве символов СРАЗУ
+ * как {@link EventMethodSymbol} — {@code context.computer.MethodSymbolComputer} строит его
+ * напрямую (через {@code context.symbol.EventHandlerClassifier}, реализованный {@link
+ * EventHandlerResolver}), а не как {@link RegularMethodSymbol}, впоследствии подменяемый или
+ * оборачиваемый каким-либо индексом.
+ */
+@SpringBootTest
+class MethodSymbolComputerEventClassificationTest {
+
+  @MockitoBean
+  private EventHandlerResolver eventHandlerResolver;
+
+  @Autowired
+  private OScriptModuleTypeResolver oScriptModuleTypeResolver;
+
+  @Test
+  void methodMatchingEventContractIsRegisteredAsEventMethodSymbolDirectly() {
+    // given — стаб регистрируется ДО создания документа: MethodSymbolComputer опрашивает
+    // классификатор синхронно при обходе AST, то есть уже во время TestUtils.getDocumentContext(...).
+    // Стабится именно isEventHandler (сам метод EventHandlerClassifier, который дёргает
+    // MethodSymbolComputer), а не lookupContract: eventHandlerResolver — мок, а не spy, поэтому
+    // стаб lookupContract не заставит невыстабленный isEventHandler вызвать её "по-настоящему".
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
+
+    // when
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура ПриЗаписи(Отказ)
+      КонецПроцедуры
+      """);
+    var method = documentContext.getSymbolTree().getMethodSymbol("ПриЗаписи").orElseThrow();
+
+    // then — реальный подтип дерева, а не RegularMethodSymbol с подменённым kind
+    assertThat(method).isInstanceOf(EventMethodSymbol.class);
+    assertThat(method.getSymbolKind()).isEqualTo(SymbolKind.Event);
+  }
+
+  @Test
+  void methodNotMatchingAnyEventContractIsRegularMethodSymbol() {
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenReturn(false);
+
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура ОбычнаяПроцедура()
+      КонецПроцедуры
+      """);
+    var method = documentContext.getSymbolTree().getMethodSymbol("ОбычнаяПроцедура").orElseThrow();
+
+    assertThat(method).isInstanceOf(RegularMethodSymbol.class);
+    assertThat(method.getSymbolKind()).isEqualTo(SymbolKind.Method);
+  }
+
+  @Test
+  void oscriptClassConstructorStaysConstructorSymbolEvenIfNameMatchesEvent() {
+    // given — классификатор возвращает true намеренно (как если бы "ПриСозданииОбъекта"
+    // совпало с контрактом события — см. EventHandlerResolver.OSCRIPT_CLASS_EVENTS): конструктор
+    // всё равно не должен реклассифицироваться (проверяется ДО события в
+    // MethodSymbolComputer.createMethodSymbol).
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenReturn(true);
+    // Уникальный URI (не общий FAKE_OSCRIPT_DOCUMENT_URI, которым делится множество других
+    // тестовых классов): OScriptModuleTypeResolver.register — putIfAbsent, и при переиспользовании
+    // общего URI регистрация могла бы молча оказаться no-op'ом, если тот уже зарегистрирован
+    // как OScriptModule другим тестом, делящим Spring-контекст.
+    var uri = URI.create(
+      TestUtils.FAKE_OSCRIPT_DOCUMENT_URI.toString().replace("fake-uri.os", "fake-uri-event-ctor-test.os"));
+    oScriptModuleTypeResolver.register(uri, ModuleType.OScriptClass);
+
+    var documentContext = TestUtils.getDocumentContext(uri, """
+      Процедура ПриСозданииОбъекта()
+      КонецПроцедуры
+      """);
+    var constructor = documentContext.getSymbolTree().getConstructor().orElseThrow();
+
+    assertThat(constructor).isInstanceOf(ConstructorSymbol.class);
+    assertThat(constructor.getSymbolKind()).isEqualTo(SymbolKind.Constructor);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerEventClassificationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputerEventClassificationTest.java
@@ -31,7 +31,6 @@ import com.github._1c_syntax.bsl.types.ModuleType;
 import org.eclipse.lsp4j.SymbolKind;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/SymbolTreeComputerTest.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.context.computer;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 
 import static org.assertj.core.api.Assertions.assertThat;
@@ -31,12 +32,15 @@ import static org.assertj.core.api.Assertions.assertThat;
 @SpringBootTest
 class SymbolTreeComputerTest {
 
+  @Autowired
+  private com.github._1c_syntax.bsl.languageserver.context.symbol.EventHandlerClassifier eventHandlerClassifier;
+
   @Test
   void testModule() {
     // given
     var documentContext = TestUtils.getDocumentContextFromFile("./src/test/resources/context/symbol/SymbolTreeComputer.bsl");
 
-    var symbolTreeComputer = new SymbolTreeComputer(documentContext, (doc, name) -> false);
+    var symbolTreeComputer = new SymbolTreeComputer(documentContext, (doc, name) -> false, eventHandlerClassifier);
 
     // when
     var symbolTree = symbolTreeComputer.compute();

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnosticTest.java
@@ -41,6 +41,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import java.util.List;
 import java.util.Optional;
 
+import static org.mockito.Mockito.when;
 import static com.github._1c_syntax.bsl.languageserver.util.Assertions.assertThat;
 
 class EventHandlerInvalidSignatureDiagnosticTest
@@ -55,8 +56,13 @@ class EventHandlerInvalidSignatureDiagnosticTest
 
   @BeforeEach
   void resetResolver() {
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
       .thenReturn(Optional.empty());
+    // Классификация метода в EventMethodSymbol идёт через isEventHandler; в реальном бине это
+    // lookupContract(...).isPresent(), поэтому у мок-бина делегируем так же — тесты продолжают
+    // задавать только lookupContract.
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenAnswer(inv -> eventHandlerResolver.lookupContract(inv.getArgument(0), inv.getArgument(1)).isPresent());
   }
 
   @Test
@@ -107,7 +113,7 @@ class EventHandlerInvalidSignatureDiagnosticTest
   }
 
   private void stubAsHandler(String methodName, MemberDescriptor contract) {
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq(methodName)))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq(methodName)))
       .thenReturn(Optional.of(contract));
   }
 
@@ -127,7 +133,7 @@ class EventHandlerInvalidSignatureDiagnosticTest
         new ParameterDescriptor(BilingualString.of("ПараметрыЗаписи", "WriteParameters"),
           TypeSet.EMPTY, false, BilingualString.EMPTY, "")
       ), TypeSet.EMPTY, "")));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
 
     var src = """
@@ -155,7 +161,7 @@ class EventHandlerInvalidSignatureDiagnosticTest
         new ParameterDescriptor(BilingualString.of("Отказ", "Cancel"),
           TypeSet.EMPTY, false, BilingualString.EMPTY, "")
       ), TypeSet.EMPTY, "")));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПередЗаписью")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПередЗаписью")))
       .thenReturn(Optional.of(contract));
 
     var src = """
@@ -175,7 +181,7 @@ class EventHandlerInvalidSignatureDiagnosticTest
   @Test
   void quickFixSilentWhenContractEmpty() {
     // Контракт без сигнатур — getQuickFixes должен вернуть пустой список.
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(MemberDescriptor.event("ПриЗаписи", "", List.of())));
 
     var src = "Процедура ПриЗаписи()\nКонецПроцедуры\n";
@@ -191,7 +197,7 @@ class EventHandlerInvalidSignatureDiagnosticTest
         new ParameterDescriptor(BilingualString.of("", "Cancel"),
           TypeSet.EMPTY, false, BilingualString.EMPTY, "")
       ), TypeSet.EMPTY, "")));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("Handler")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("Handler")))
       .thenReturn(Optional.of(contract));
 
     var src = "Процедура Handler()\nКонецПроцедуры\n";
@@ -211,7 +217,7 @@ class EventHandlerInvalidSignatureDiagnosticTest
       List.of(new SignatureDescriptor(List.of(
         new ParameterDescriptor(BilingualString.EMPTY, TypeSet.EMPTY, false, BilingualString.EMPTY, "")
       ), TypeSet.EMPTY, "")));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("Handler")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("Handler")))
       .thenReturn(Optional.of(contract));
 
     var src = "Процедура Handler()\nКонецПроцедуры\n";
@@ -232,7 +238,7 @@ class EventHandlerInvalidSignatureDiagnosticTest
         new ParameterDescriptor(BilingualString.of("Отказ", "Cancel"),
           TypeSet.EMPTY, false, BilingualString.EMPTY, "")
       ), TypeSet.EMPTY, "")));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
 
     var src = """
@@ -255,7 +261,7 @@ class EventHandlerInvalidSignatureDiagnosticTest
     // Диагностика с произвольным range вне метода — quickfix не должен ничего
     // создавать. Используем существующую диагностику и подменяем range.
     var contract = contractWithCancel(true);
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
     var src = "Процедура ПриЗаписи()\nКонецПроцедуры\n";
     var documentContext = TestUtils.getDocumentContext(src);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerInvalidSignatureDiagnosticTest.java
@@ -35,7 +35,6 @@ import org.eclipse.lsp4j.Range;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerOutsideEventRegionDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerOutsideEventRegionDiagnosticTest.java
@@ -22,9 +22,6 @@
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
-import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
-import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.bsl.types.ModuleType;
@@ -42,9 +39,9 @@ import org.mockito.Mockito;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
-import java.util.Optional;
 import java.util.Set;
 
+import static org.mockito.Mockito.when;
 import static com.github._1c_syntax.bsl.languageserver.util.Assertions.assertThat;
 
 /**
@@ -56,12 +53,6 @@ import static com.github._1c_syntax.bsl.languageserver.util.Assertions.assertTha
 class EventHandlerOutsideEventRegionDiagnosticTest
   extends AbstractDiagnosticTest<EventHandlerOutsideEventRegionDiagnostic> {
 
-  private static final MemberDescriptor STUB_CONTRACT = MemberDescriptor.event(
-    "<event>",
-    "",
-    List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, ""))
-  );
-
   @MockitoBean
   EventHandlerResolver eventHandlerResolver;
 
@@ -71,8 +62,8 @@ class EventHandlerOutsideEventRegionDiagnosticTest
 
   @BeforeEach
   void resetResolver() {
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
-      .thenReturn(Optional.empty());
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenReturn(false);
   }
 
   @Test
@@ -98,9 +89,9 @@ class EventHandlerOutsideEventRegionDiagnosticTest
   }
 
   private void stubAsEventHandlers(Set<String> methodNames) {
-    methodNames.forEach(name -> Mockito.when(
-        eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq(name)))
-      .thenReturn(Optional.of(STUB_CONTRACT)));
+    methodNames.forEach(name -> when(
+        eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq(name)))
+      .thenReturn(true));
   }
 
   @Test
@@ -130,8 +121,8 @@ class EventHandlerOutsideEventRegionDiagnosticTest
       Процедура ПриЗаписи(Отказ) Экспорт
       КонецПроцедуры
       """;
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
     var documentContext = TestUtils.getDocumentContext(src);
     var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
     Assertions.assertThat(diagnostics).hasSize(1);
@@ -160,10 +151,10 @@ class EventHandlerOutsideEventRegionDiagnosticTest
       Процедура ПриУдалении(Отказ) Экспорт
       КонецПроцедуры
       """;
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриУдалении")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриУдалении")))
+      .thenReturn(true);
     var documentContext = TestUtils.getDocumentContext(src);
     var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
     Assertions.assertThat(diagnostics).hasSize(2);
@@ -201,8 +192,8 @@ class EventHandlerOutsideEventRegionDiagnosticTest
       Процедура ПриЗаписи() Экспорт
       КонецПроцедуры
       """;
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
     var documentContext = TestUtils.getDocumentContext(src);
     var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
     var diagnostic = diagnostics.get(0);
@@ -223,8 +214,8 @@ class EventHandlerOutsideEventRegionDiagnosticTest
       Процедура ПриЗаписи(Отказ) Экспорт
       КонецПроцедуры
       """;
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
     var documentContext = TestUtils.getDocumentContext(src);
     var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
     Assertions.assertThat(diagnostics).hasSize(1);
@@ -251,8 +242,8 @@ class EventHandlerOutsideEventRegionDiagnosticTest
       Процедура ПриЗаписи(Отказ) Экспорт
       КонецПроцедуры
       """;
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
     var documentContext = TestUtils.getDocumentContext(src);
     var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
     var fixes = getQuickFixes(diagnostics.get(0), documentContext);
@@ -275,8 +266,8 @@ class EventHandlerOutsideEventRegionDiagnosticTest
       Процедура ПриЗаписи(Отказ) Экспорт
       КонецПроцедуры
       """;
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
     var documentContext = TestUtils.getDocumentContext(src);
     var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
 
@@ -310,12 +301,12 @@ class EventHandlerOutsideEventRegionDiagnosticTest
 
       #КонецОбласти
       """;
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ТоварыПриИзменении")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриОткрытии")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ТоварыПриИзменении")))
+      .thenReturn(true);
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриОткрытии")))
+      .thenReturn(true);
     var documentContext = Mockito.spy(TestUtils.getDocumentContext(src));
-    Mockito.when(documentContext.getModuleType()).thenReturn(ModuleType.FormModule);
+    when(documentContext.getModuleType()).thenReturn(ModuleType.FormModule);
 
     var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
     // ТоварыПриИзменении в правильной области-префиксе → не срабатывает.
@@ -333,10 +324,10 @@ class EventHandlerOutsideEventRegionDiagnosticTest
       Процедура ПриЗаписи(Отказ) Экспорт
       КонецПроцедуры
       """;
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
     var documentContext = Mockito.spy(TestUtils.getDocumentContext(src));
-    Mockito.when(documentContext.getContentList()).thenReturn(new String[0]);
+    when(documentContext.getContentList()).thenReturn(new String[0]);
 
     var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
     Assertions.assertThat(diagnostics).isNotEmpty();
@@ -354,10 +345,10 @@ class EventHandlerOutsideEventRegionDiagnosticTest
       Процедура ПриОткрытии(Отказ, СтандартнаяОбработка) Экспорт
       КонецПроцедуры
       """;
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриОткрытии")))
-      .thenReturn(Optional.of(STUB_CONTRACT));
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриОткрытии")))
+      .thenReturn(true);
     var documentContext = Mockito.spy(TestUtils.getDocumentContext(src));
-    Mockito.when(documentContext.getModuleType()).thenReturn(ModuleType.FormModule);
+    when(documentContext.getModuleType()).thenReturn(ModuleType.FormModule);
 
     var diagnostics = diagnosticInstance.getDiagnostics(documentContext);
     Assertions.assertThat(diagnostics).hasSize(1);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilderEventHandlerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilderEventHandlerTest.java
@@ -47,6 +47,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import java.util.List;
 import java.util.Optional;
 
+import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -65,8 +66,12 @@ class MethodSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerCon
 
   @BeforeEach
   void resetResolver() {
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
       .thenReturn(Optional.empty());
+    // Классификация метода в EventMethodSymbol идёт через isEventHandler; у мок-бина делегируем
+    // в lookupContract (как в реальном бине), чтобы тесты продолжали задавать только lookupContract.
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenAnswer(inv -> eventHandlerResolver.lookupContract(inv.getArgument(0), inv.getArgument(1)).isPresent());
   }
 
   @Test
@@ -77,7 +82,7 @@ class MethodSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerCon
       "Возникает при записи объекта.",
       List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, ""))
     );
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
 
     var src = """
@@ -111,7 +116,7 @@ class MethodSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerCon
       "Возникает при записи объекта.",
       List.of(new SignatureDescriptor(List.of(cancelParam), TypeSet.EMPTY, ""))
     );
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
 
     var src = """
@@ -157,7 +162,7 @@ class MethodSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerCon
       "Возникает при записи.",
       List.of()
     );
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
 
     var src = """
@@ -189,7 +194,7 @@ class MethodSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerCon
       "",
       List.of(new SignatureDescriptor(List.of(anonymous), TypeSet.EMPTY, ""))
     );
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("Handler")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("Handler")))
       .thenReturn(Optional.of(contract));
 
     var src = """

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilderEventHandlerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilderEventHandlerTest.java
@@ -29,6 +29,7 @@ import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
 import com.github._1c_syntax.bsl.languageserver.types.model.BilingualString;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.PlatformMetadata;
 import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
@@ -45,6 +46,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.List;
 import java.util.Optional;
+import java.util.Set;
 
 import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -99,6 +101,39 @@ class MethodSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerCon
       .contains("Обработчик события платформы")
       .contains("ПриЗаписи")
       .contains("Возникает при записи объекта.");
+  }
+
+  @Test
+  void hoverIncludesEventPlatformMetadata() {
+    // given — контракт события с непустыми метаданными синтакс-помощника (замечание + пример),
+    // как их приносит bsl-context после #4304
+    var metadata = new PlatformMetadata(
+      "", "", List.of(), Set.of(), null,
+      "", "Срабатывает перед сохранением объекта в информационную базу.",
+      List.of("Отказ = Истина;"), List.of()
+    );
+    var contract = MemberDescriptor.event(
+      "ПриЗаписи",
+      "Возникает при записи объекта.",
+      List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, ""))
+    ).withMetadata(metadata);
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(Optional.of(contract));
+
+    var src = """
+      Процедура ПриЗаписи(Отказ)
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(src);
+    var method = documentContext.getSymbolTree().getMethodSymbol("ПриЗаписи").orElseThrow();
+
+    // when
+    var content = markupContentBuilder.getContent(referenceTo(documentContext, method)).getValue();
+
+    // then — блок метаданных события (замечание/пример) виден в hover обработчика
+    assertThat(content)
+      .contains("Срабатывает перед сохранением объекта в информационную базу.")
+      .contains("Отказ = Истина;");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilderEventHandlerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/MethodSymbolMarkupContentBuilderEventHandlerTest.java
@@ -40,7 +40,6 @@ import org.eclipse.lsp4j.Location;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderEventHandlerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderEventHandlerTest.java
@@ -45,6 +45,7 @@ import org.springframework.test.context.bean.override.mockito.MockitoBean;
 import java.util.List;
 import java.util.Optional;
 
+import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -63,8 +64,12 @@ class VariableSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerC
 
   @BeforeEach
   void resetResolver() {
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
       .thenReturn(Optional.empty());
+    // Классификация метода в EventMethodSymbol идёт через isEventHandler; у мок-бина делегируем
+    // в lookupContract (как в реальном бине), чтобы тесты продолжали задавать только lookupContract.
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenAnswer(inv -> eventHandlerResolver.lookupContract(inv.getArgument(0), inv.getArgument(1)).isPresent());
   }
 
   @Test
@@ -75,7 +80,7 @@ class VariableSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerC
           TypeSet.EMPTY, false,
           BilingualString.of("Признак отказа от записи.", ""), "")
       ), TypeSet.EMPTY, "")));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
 
     var src = """
@@ -107,7 +112,7 @@ class VariableSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerC
     // секция не добавляется, hover собирает базовое наполнение.
     var contract = MemberDescriptor.event("ПриЗаписи", "",
       List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
 
     var src = """
@@ -124,7 +129,7 @@ class VariableSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerC
   void parameterHoverEmptyContractSignaturesGivesNoDescription() {
     // Contract с пустым signatures (parameterAt L318) — описание не добавляется.
     var contract = MemberDescriptor.event("ПриЗаписи", "", List.of());
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
 
     var src = """
@@ -147,7 +152,7 @@ class VariableSymbolMarkupContentBuilderEventHandlerTest extends AbstractServerC
           TypeSet.EMPTY, false,
           BilingualString.of("Признак отказа.", ""), "")
       ), TypeSet.EMPTY, "")));
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
       .thenReturn(Optional.of(contract));
 
     var src = """

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderEventHandlerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderEventHandlerTest.java
@@ -38,7 +38,6 @@ import org.eclipse.lsp4j.Location;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -87,8 +87,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
 
   @BeforeEach
   void resetEventHandlerResolver() {
-    when(eventHandlerResolver.lookupContract(any(), anyString()))
-      .thenReturn(Optional.empty());
+    when(eventHandlerResolver.lookupContract(any(), anyString())).thenReturn(Optional.empty());
   }
 
   private void enableSnippetSupport(boolean enabled) {
@@ -2671,5 +2670,190 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .isNotNull();
     assertThat(add.getDocumentation().getRight().getValue()).contains("Добавляет значение");
     assertThat(add.getData()).isNull();
+  }
+
+  @Test
+  void noDotCompletionRanksEventHandlerMethodBelowRegularLocalMethod() {
+    // given: локальный метод, у которого есть контракт платформенного события,
+    // ранжируется как self-член: он редко вызывается вручную и не должен
+    // теснить обычные локальные процедуры/функции документа.
+    // Имена подобраны намеренно "в лоб алфавиту" (А — первая буква, Я —
+    // последняя): если бы обработчик события ошибочно получил ту же корзину
+    // (BUCKET_LOCAL), что и обычный метод, чисто алфавитное сравнение sortText
+    // дало бы "АСобытие" < "ЯвнаяПроцедура" — и assertion ниже упал бы, поймав
+    // регресс. С прежними именами ("ПередЗаписью"/"ОбычнаяПроцедура") тест
+    // проходил бы даже при таком регрессе — по случайному совпадению
+    // алфавитного порядка (П > О и без разницы корзин).
+    // Стабится именно isEventHandler, а не lookupContract: MethodSymbolComputer классифицирует
+    // метод обработчиком СРАЗУ при построении дерева символов через этот вызов классификатора
+    // (eventHandlerResolver — мок, а не spy, поэтому стаб lookupContract не заставит
+    // невыстабленный isEventHandler отработать "по-настоящему").
+    when(eventHandlerResolver.isEventHandler(any(), eq("АСобытие")))
+      .thenReturn(true);
+
+    var src = """
+      Процедура АСобытие(Отказ)
+      КонецПроцедуры
+
+      Процедура ЯвнаяПроцедура()
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(src);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(1, 0));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    var eventHandlerItem = items.stream()
+      .filter(it -> "АСобытие".equals(it.getLabel()))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("АСобытие должен попасть в completion"));
+    var regularMethodItem = items.stream()
+      .filter(it -> "ЯвнаяПроцедура".equals(it.getLabel()))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("ЯвнаяПроцедура должна попасть в completion"));
+
+    assertThat(eventHandlerItem.getSortText())
+      .as("обработчик платформенного события должен ранжироваться ниже обычного локального метода")
+      .isGreaterThan(regularMethodItem.getSortText());
+  }
+
+  @Test
+  void declaredEventHandlerMethodGetsEventCompletionKind() {
+    // given — стабится isEventHandler, а не lookupContract: см. комментарий в
+    // noDotCompletionRanksEventHandlerMethodBelowRegularLocalMethod.
+    when(eventHandlerResolver.isEventHandler(any(), eq("ПриЗаписи")))
+      .thenReturn(true);
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура ПриЗаписи(Отказ)
+      КонецПроцедуры
+      """);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(1, 0));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    assertThat(items)
+      .filteredOn(item -> "ПриЗаписи".equals(item.getLabel()))
+      .hasSize(1)
+      .allMatch(item -> item.getKind() == CompletionItemKind.Event);
+  }
+
+  @Test
+  void undeclaredEventHandlerOffersStubCompletionAtModuleLevel() {
+    // given — ПриЗаписи ещё не объявлен в документе, но входит в события owner-типа модуля;
+    // без snippetSupport клиента (по умолчанию в этом классе) заглушка — голый текст без $-меток
+    var contract = MemberDescriptor.event("ПриЗаписи", "",
+      List.of(new SignatureDescriptor(
+        List.of(
+          new ParameterDescriptor("Отказ", TypeSet.EMPTY, false, "", ""),
+          new ParameterDescriptor("ПараметрЗаписи", TypeSet.EMPTY, false, "", "")),
+        TypeSet.EMPTY, "")));
+    when(eventHandlerResolver.allEvents(any())).thenReturn(List.of(contract));
+    var documentContext = TestUtils.getDocumentContext("");
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(0, 0));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    var stub = items.stream()
+      .filter(item -> "ПриЗаписи".equals(item.getLabel()))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Заглушка ПриЗаписи должна попасть в completion"));
+    assertThat(stub.getKind()).isEqualTo(CompletionItemKind.Event);
+    assertThat(stub.getInsertText())
+      .isEqualTo("Процедура ПриЗаписи(Отказ, ПараметрЗаписи)\n\t\nКонецПроцедуры");
+  }
+
+  @Test
+  void undeclaredEventHandlerStubSnippetPlacesCursorInBodyFirst() {
+    // given — с snippetSupport курсор сразу после вставки должен оказаться В ТЕЛЕ (первый
+    // посещаемый tab-stop — $1), а не на первом параметре: параметры остаются доступны для
+    // переименования по Tab, но ПОСЛЕ тела ($2, $3, ...), а не раньше него; $0 — точка выхода
+    // из сниппета сразу после КонецПроцедуры.
+    enableSnippetSupport(true);
+    var contract = MemberDescriptor.event("ПриЗаписи", "",
+      List.of(new SignatureDescriptor(
+        List.of(
+          new ParameterDescriptor("Отказ", TypeSet.EMPTY, false, "", ""),
+          new ParameterDescriptor("ПараметрЗаписи", TypeSet.EMPTY, false, "", "")),
+        TypeSet.EMPTY, "")));
+    when(eventHandlerResolver.allEvents(any())).thenReturn(List.of(contract));
+    var documentContext = TestUtils.getDocumentContext("");
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(0, 0));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    var stub = items.stream()
+      .filter(item -> "ПриЗаписи".equals(item.getLabel()))
+      .findFirst()
+      .orElseThrow(() -> new AssertionError("Заглушка ПриЗаписи должна попасть в completion"));
+    assertThat(stub.getInsertTextFormat()).isEqualTo(InsertTextFormat.Snippet);
+    assertThat(stub.getInsertText())
+      .isEqualTo("Процедура ПриЗаписи(${2:Отказ}, ${3:ПараметрЗаписи})\n\t$1\nКонецПроцедуры$0");
+  }
+
+  @Test
+  void declaredEventHandlerIsNotDuplicatedAsStub() {
+    // given — ПриЗаписи уже объявлен: заглушка не должна предлагаться повторно
+    var contract = MemberDescriptor.event("ПриЗаписи", "", List.of());
+    when(eventHandlerResolver.allEvents(any())).thenReturn(List.of(contract));
+    when(eventHandlerResolver.lookupContract(any(), eq("ПриЗаписи"))).thenReturn(Optional.of(contract));
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура ПриЗаписи(Отказ)
+      КонецПроцедуры
+      """);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(1, 0));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then — единственный пункт (уже объявленный обработчик), не два (объявленный + заглушка)
+    assertThat(items)
+      .filteredOn(item -> "ПриЗаписи".equals(item.getLabel()))
+      .hasSize(1);
+  }
+
+  @Test
+  void eventHandlerStubNotOfferedInsideAnotherMethodBody() {
+    // given — курсор внутри тела ДругаяПроцедура: вставка нового объявления процедуры была бы
+    // синтаксически некорректной, заглушка не должна предлагаться
+    var contract = MemberDescriptor.event("ПриЗаписи", "", List.of());
+    when(eventHandlerResolver.allEvents(any())).thenReturn(List.of(contract));
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура ДругаяПроцедура()
+
+      КонецПроцедуры
+      """);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    params.setPosition(new Position(1, 0));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    assertThat(items).noneMatch(item -> "ПриЗаписи".equals(item.getLabel()));
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -2778,6 +2778,51 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void eventHandlerStubArrivesWithoutDocumentationButWithDataWhenResolveSupported() {
+    // given — клиент умеет лениво разрешать documentation
+    enableDocumentationResolveSupport(true);
+    var contract = MemberDescriptor.event("ПриЗаписи", "Возникает при записи объекта.",
+      List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")));
+    when(eventHandlerResolver.allEvents(any())).thenReturn(List.of(contract));
+    var documentContext = TestUtils.getDocumentContext("");
+
+    // when
+    var stub = noDotCompletionItem(documentContext, new Position(0, 0), "ПриЗаписи");
+
+    // then — documentation отложена, но data-ключ приложен для resolve
+    assertThat(stub.getDocumentation())
+      .as("при resolveSupport documentation заглушки события отдаётся лениво")
+      .isNull();
+    assertThat(stub.getData())
+      .as("для отложенного resolve в заглушку события кладётся data-ключ")
+      .isNotNull();
+  }
+
+  @Test
+  void resolveCompletionItemRestoresSameEventHandlerDocumentationAsEager() {
+    // given — ленивая заглушка события
+    enableDocumentationResolveSupport(true);
+    var contract = MemberDescriptor.event("ПриЗаписи", "Возникает при записи объекта.",
+      List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")));
+    when(eventHandlerResolver.allEvents(any())).thenReturn(List.of(contract));
+    var documentContext = TestUtils.getDocumentContext("");
+    var lazy = noDotCompletionItem(documentContext, new Position(0, 0), "ПриЗаписи");
+
+    // when — клиент запрашивает resolve
+    var resolved = resolve(lazy);
+
+    // then — documentation восстановлена по контракту события, data очищена
+    assertThat(resolved.getDocumentation())
+      .as("resolve восстанавливает documentation заглушки события")
+      .isNotNull();
+    assertThat(resolved.getDocumentation().getRight().getKind()).isEqualTo(MarkupKind.MARKDOWN);
+    assertThat(resolved.getDocumentation().getRight().getValue()).contains("Возникает при записи объекта.");
+    assertThat(resolved.getData())
+      .as("после resolve data очищается")
+      .isNull();
+  }
+
+  @Test
   void undeclaredEventHandlerStubSnippetPlacesCursorInBodyFirst() {
     // given — с snippetSupport курсор сразу после вставки должен оказаться В ТЕЛЕ (первый
     // посещаемый tab-stop — $1), а не на первом параметре: параметры остаются доступны для

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -452,52 +452,6 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
-  void noDotCompletionRanksEventHandlerMethodBelowRegularLocalMethod() {
-    // given: локальный метод, у которого есть контракт платформенного события,
-    // ранжируется как self-член: он редко вызывается вручную и не должен
-    // теснить обычные локальные процедуры/функции документа.
-    // Имена подобраны намеренно "в лоб алфавиту" (А — первая буква, Я —
-    // последняя): если бы обработчик события ошибочно получил ту же корзину
-    // (BUCKET_LOCAL), что и обычный метод, чисто алфавитное сравнение sortText
-    // дало бы "АСобытие" < "ЯвнаяПроцедура" — и assertion ниже упал бы, поймав
-    // регресс. С прежними именами ("ПередЗаписью"/"ОбычнаяПроцедура") тест
-    // проходил бы даже при таком регрессе — по случайному совпадению
-    // алфавитного порядка (П > О и без разницы корзин).
-    when(eventHandlerResolver.lookupContract(any(), eq("АСобытие")))
-      .thenReturn(Optional.of(MemberDescriptor.event("АСобытие", "", List.of())));
-
-    var src = """
-      Процедура АСобытие(Отказ)
-      КонецПроцедуры
-
-      Процедура ЯвнаяПроцедура()
-      КонецПроцедуры
-      """;
-    var documentContext = TestUtils.getDocumentContext(src);
-
-    var params = new CompletionParams();
-    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
-    params.setPosition(new Position(1, 0));
-
-    // when
-    var items = completionProvider.getCompletion(documentContext, params).getItems();
-
-    // then
-    var eventHandlerItem = items.stream()
-      .filter(it -> "АСобытие".equals(it.getLabel()))
-      .findFirst()
-      .orElseThrow(() -> new AssertionError("АСобытие должен попасть в completion"));
-    var regularMethodItem = items.stream()
-      .filter(it -> "ЯвнаяПроцедура".equals(it.getLabel()))
-      .findFirst()
-      .orElseThrow(() -> new AssertionError("ЯвнаяПроцедура должна попасть в completion"));
-
-    assertThat(eventHandlerItem.getSortText())
-      .as("обработчик платформенного события должен ранжироваться ниже обычного локального метода")
-      .isGreaterThan(regularMethodItem.getSortText());
-  }
-
-  @Test
   void noDotCompletionShowsInferredTypeForEventHandlerParameter() {
     // given: тип параметра обработчика события известен из контракта события —
     // должен показываться в detail пункта completion, а не оставаться пустым

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -1627,7 +1627,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
         .contains("Добавляет значение");
       assertThat(add.getDetail())
         .as("имя параметра в сигнатуре — на русском; необязательный → со знаком «?»")
-        .isEqualTo("(Значение?)");
+        .isEqualTo("(Значение?: Произвольный)");
     } finally {
       languageServerConfiguration.setLanguage(Language.DEFAULT_LANGUAGE);
     }
@@ -1646,7 +1646,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
         .doesNotContain("Добавляет");
       assertThat(add.getDetail())
         .as("имя параметра в сигнатуре — на английском; необязательный → со знаком «?»")
-        .isEqualTo("(Value?)");
+        .isEqualTo("(Value?: Arbitrary)");
     } finally {
       languageServerConfiguration.setLanguage(Language.DEFAULT_LANGUAGE);
     }
@@ -2447,7 +2447,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .as("для отложенного resolve в item кладётся data-ключ члена")
       .isNotNull();
     // detail остаётся жадным (фильтрация/вставка не требуют resolve)
-    assertThat(add.getDetail()).isEqualTo("(Значение?)");
+    assertThat(add.getDetail()).isEqualTo("(Значение?: Произвольный)");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -715,7 +715,7 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .findFirst()
       .orElseThrow(() -> new AssertionError("локальная функция должна попасть в no-dot completion"));
 
-    assertThat(item.getKind()).isEqualTo(CompletionItemKind.Function);
+    assertThat(item.getKind()).isEqualTo(CompletionItemKind.Method);
     assertThat(item.getDetail())
       .as("сигнатура и тип возврата локального метода — как у платформенного")
       .isEqualTo("(Имя, Приветствие?): Строка");
@@ -2805,6 +2805,8 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
     var contract = MemberDescriptor.event("ПриЗаписи", "Возникает при записи объекта.",
       List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")));
     when(eventHandlerResolver.allEvents(any())).thenReturn(List.of(contract));
+    // resolve восстанавливает контракт по ключу (moduleType, ownerTypeRef) через eventsFor
+    when(eventHandlerResolver.eventsFor(any(), any(), any())).thenReturn(List.of(contract));
     var documentContext = TestUtils.getDocumentContext("");
     var lazy = noDotCompletionItem(documentContext, new Position(0, 0), "ПриЗаписи");
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -2749,8 +2749,8 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
 
   @Test
   void undeclaredEventHandlerOffersStubCompletionAtModuleLevel() {
-    // given — ПриЗаписи ещё не объявлен в документе, но входит в события owner-типа модуля;
-    // без snippetSupport клиента (по умолчанию в этом классе) заглушка — голый текст без $-меток
+    // given: ПриЗаписи ещё не объявлен в документе, но входит в события owner-типа модуля.
+    // Без snippetSupport клиента (по умолчанию в этом классе) заглушка — голый текст без меток
     var contract = MemberDescriptor.event("ПриЗаписи", "",
       List.of(new SignatureDescriptor(
         List.of(

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
@@ -21,18 +21,23 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.ArrayList;
 import java.util.List;
 
+import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
 @SpringBootTest
@@ -40,6 +45,9 @@ class DocumentSymbolProviderTest {
 
   @Autowired
   private DocumentSymbolProvider documentSymbolProvider;
+
+  @MockitoBean
+  private EventHandlerResolver eventHandlerResolver;
 
   /**
    * Регрессионный тест: незавершённое объявление переменной ({@code Перем} без имени)
@@ -132,6 +140,42 @@ class DocumentSymbolProviderTest {
       }
     });
     return result;
+  }
+
+  /**
+   * Метод-обработчик платформенного события регистрируется в дереве символов как
+   * {@link com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol}, и outline
+   * отдаёт для него {@link SymbolKind#Event} вместо {@link SymbolKind#Method}.
+   */
+  @Test
+  void testEventHandlerMethodMarkedAsEventKind() {
+    // given — резолвер стабится ДО создания документа: MethodSymbolComputer опрашивает
+    // классификатор синхронно при обходе AST, то есть уже во время TestUtils.getDocumentContext(...).
+    // Стабится именно isEventHandler, а не lookupContract: eventHandlerResolver — мок, а не spy,
+    // поэтому стаб lookupContract не заставит невыстабленный isEventHandler отработать "по-настоящему".
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ОбычнаяПроцедура")))
+      .thenReturn(false);
+
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура ПриЗаписи(Отказ)
+      КонецПроцедуры
+      Процедура ОбычнаяПроцедура()
+      КонецПроцедуры""");
+
+    // when
+    var documentSymbols = documentSymbolProvider.getDocumentSymbols(documentContext);
+
+    // then
+    assertThat(documentSymbols)
+      .filteredOn(symbol -> symbol.getName().equals("ПриЗаписи"))
+      .hasSize(1)
+      .allMatch(symbol -> symbol.getKind() == SymbolKind.Event);
+    assertThat(documentSymbols)
+      .filteredOn(symbol -> symbol.getName().equals("ОбычнаяПроцедура"))
+      .hasSize(1)
+      .allMatch(symbol -> symbol.getKind() == SymbolKind.Method);
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
@@ -29,7 +29,6 @@ import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SemanticTokensProviderTest.java
@@ -568,7 +568,7 @@ class SemanticTokensProviderTest {
       // Line 9: Функция keyword
       new ExpectedToken(9, 0, 7, SemanticTokenTypes.Keyword, "Функция"),
       // Line 9: ПроверитьДанные function name
-      new ExpectedToken(9, 8, 15, SemanticTokenTypes.Function, "ПроверитьДанные"),
+      new ExpectedToken(9, 8, 15, SemanticTokenTypes.Method, "ПроверитьДанные"),
       // Line 9: ( operator
       new ExpectedToken(9, 23, 1, SemanticTokenTypes.Operator, "("),
       // Line 9: Имя parameter definition

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderScriptVariantTest.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.configuration.GlobalLanguageServ
 import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SymbolTree;
 import com.github._1c_syntax.bsl.languageserver.types.index.WorkspaceSymbolIndex;
@@ -79,7 +80,7 @@ class SymbolProviderScriptVariantTest {
     when(documentContext.getScriptVariantLanguage()).thenReturn(scriptVariantLanguage);
     when(documentContext.getMdObject()).thenReturn(Optional.of(mdObject));
 
-    var symbol = mock(SourceDefinedSymbol.class);
+    var symbol = mock(MethodSymbol.class);
     when(symbol.getName()).thenReturn("НеУстаревшаяПроцедура");
     when(symbol.getSymbolKind()).thenReturn(SymbolKind.Method);
     when(symbol.getRange()).thenReturn(Ranges.create(0, 0, 0, 0));
@@ -87,7 +88,7 @@ class SymbolProviderScriptVariantTest {
     when(symbol.getOwner()).thenReturn(documentContext);
 
     var symbolTree = mock(SymbolTree.class);
-    when(symbolTree.getChildrenFlat()).thenReturn(List.of(symbol));
+    when(symbolTree.getChildrenFlat()).thenReturn(List.<SourceDefinedSymbol>of(symbol));
     when(documentContext.getSymbolTree()).thenReturn(symbolTree);
 
     // имя контейнера вычисляется индексом на момент индексации в варианте языка проекта

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexConstructorSymbolTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexConstructorSymbolTest.java
@@ -1,0 +1,117 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.references;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.providers.CallHierarchyProvider;
+import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.CallHierarchyIncomingCallsParams;
+import org.eclipse.lsp4j.CallHierarchyItem;
+import org.eclipse.lsp4j.SymbolKind;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.annotation.DirtiesContext;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Регрессия: {@link ReferenceIndex#methodCallOccurrence} индексирует ЛЮБОЙ вызов метода
+ * (в т.ч. {@code Новый ИмяКласса(...)}, попадающий туда же через
+ * {@code ReferenceIndexFiller#tryRegisterLibraryClassReference}) под каноническим
+ * {@link SymbolKind#Method}, тогда как
+ * {@link com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol#getSymbolKind()}
+ * возвращает {@link SymbolKind#Constructor}. До появления {@link ReferenceIndex#indexedKindOf}
+ * {@link ReferenceIndex#getReferencesTo} строило ключ поиска по настоящему {@code Constructor} —
+ * он не совпадал с сохранённым при индексации {@code Method}, и Find References / Rename /
+ * Call Hierarchy incoming calls молча не находили ни одной ссылки на конструктор OneScript-класса.
+ */
+class ReferenceIndexConstructorSymbolTest extends AbstractServerContextAwareTest {
+
+  private static final String FIXTURE_DIR = "src/test/resources/oscript-libraries/constructor-inlay-test";
+  private static final String CALLER_PATH = FIXTURE_DIR + "/src/Классы/Caller.os";
+
+  @Autowired
+  private ReferenceIndex referenceIndex;
+
+  @Autowired
+  private OScriptLibraryIndex oScriptLibraryIndex;
+
+  @Autowired
+  private CallHierarchyProvider callHierarchyProvider;
+
+  @BeforeEach
+  @DirtiesContext
+  void freshWorkspace() {
+    initServerContext(Path.of(FIXTURE_DIR).toAbsolutePath());
+    oScriptLibraryIndex.reindex(context);
+  }
+
+  @Test
+  void getReferencesToConstructorFindsNewExpressionCall() {
+    // given
+    var classUri = oScriptLibraryIndex.findClassUri("ClassWithCtorParams").orElseThrow();
+    var classDocumentContext = context.getDocument(classUri);
+    var constructor = classDocumentContext.getSymbolTree().getConstructor().orElseThrow();
+    // индексация ссылки из Caller.os требует, чтобы документ был построен/обойдён
+    TestUtils.getDocumentContextFromFile(CALLER_PATH, context);
+
+    // when
+    var references = referenceIndex.getReferencesTo(constructor);
+
+    // then
+    assertThat(references)
+      .as("Find References на конструктор OneScript-класса должен находить `Новый ClassWithCtorParams(...)`")
+      .isNotEmpty();
+  }
+
+  @Test
+  void callHierarchyIncomingCallsFindsConstructorCaller() {
+    // given
+    var classUri = oScriptLibraryIndex.findClassUri("ClassWithCtorParams").orElseThrow();
+    var classDocumentContext = context.getDocument(classUri);
+    var constructor = classDocumentContext.getSymbolTree().getConstructor().orElseThrow();
+    TestUtils.getDocumentContextFromFile(CALLER_PATH, context);
+
+    var callHierarchyItem = new CallHierarchyItem(
+      constructor.getName(),
+      SymbolKind.Constructor,
+      classUri.toString(),
+      constructor.getRange(),
+      constructor.getSelectionRange()
+    );
+
+    // when — resolveSymbol передоверяет резолв символа referenceResolver.findReference по
+    // (documentContext.getUri(), item.getSelectionRange().getStart()), поэтому documentContext
+    // здесь — документ КЛАССА (где физически расположена selectionRange конструктора), а не Caller.os
+    var incoming = callHierarchyProvider.incomingCalls(
+      classDocumentContext, new CallHierarchyIncomingCallsParams(callHierarchyItem));
+
+    // then
+    assertThat(incoming)
+      .as("Call Hierarchy incoming calls должен находить вызывающего Caller.os")
+      .isNotEmpty();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexEventHandlerSymbolTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexEventHandlerSymbolTest.java
@@ -1,0 +1,109 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.references;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.SymbolKind;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import java.util.List;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Mockito.when;
+
+/**
+ * Регрессия: объявленный обработчик платформенного события попадает в дерево символов как
+ * {@link EventMethodSymbol} (display-вид {@link SymbolKind#Event}), но его прямые вызовы
+ * {@link ReferenceIndex#methodCallOccurrence} индексирует под каноническим {@link SymbolKind#Method}.
+ * Читающая сторона {@link ReferenceIndex#getReferencesTo} строит ключ по настоящему
+ * {@code getSymbolKind()} символа ({@code Event}) и без канонизации в {@link ReferenceIndex#indexedKindOf}
+ * никогда не совпала бы с сохранённым {@code Method} — Find References / Call Hierarchy incoming молча
+ * не нашли бы ни одного прямого вызова обработчика.
+ */
+@CleanupContextBeforeClassAndAfterClass
+class ReferenceIndexEventHandlerSymbolTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private ReferenceIndexFiller referenceIndexFiller;
+  @Autowired
+  private ReferenceIndex referenceIndex;
+
+  @MockitoBean
+  EventHandlerResolver eventHandlerResolver;
+
+  @BeforeEach
+  void resetResolver() {
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenReturn(Optional.empty());
+    // Классификация метода в EventMethodSymbol идёт через isEventHandler; у мок-бина делегируем
+    // в lookupContract (как в реальном бине), чтобы тест задавал только lookupContract.
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenAnswer(inv -> eventHandlerResolver.lookupContract(inv.getArgument(0), inv.getArgument(1)).isPresent());
+  }
+
+  @Test
+  void getReferencesToEventHandlerFindsDirectCall() {
+    // given — ПриЗаписи классифицируется как обработчик события и вызывается напрямую из Вызвать()
+    var contract = MemberDescriptor.event(
+      "ПриЗаписи",
+      "Возникает при записи объекта.",
+      List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, ""))
+    );
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(Optional.of(contract));
+
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Вызвать()
+        ПриЗаписи(Ложь);
+      КонецПроцедуры
+
+      Процедура ПриЗаписи(Отказ)
+      КонецПроцедуры
+      """);
+    referenceIndexFiller.fill(documentContext);
+
+    var eventHandler = documentContext.getSymbolTree().getMethodSymbol("ПриЗаписи").orElseThrow();
+    // предусловие регрессии: символ — именно EventMethodSymbol с display-видом Event
+    assertThat(eventHandler).isInstanceOf(EventMethodSymbol.class);
+    assertThat(eventHandler.getSymbolKind()).isEqualTo(SymbolKind.Event);
+
+    // when
+    var references = referenceIndex.getReferencesTo(eventHandler);
+
+    // then — прямой вызов ПриЗаписи(Ложь) найден несмотря на рассинхрон Event (символ) и Method (вхождение)
+    assertThat(references)
+      .as("Find References на обработчик события должен находить его прямой вызов")
+      .hasSize(1);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexTest.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.references;
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.references.model.Reference;
 import com.github._1c_syntax.bsl.languageserver.references.model.SymbolOccurrenceRepository;
+import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
@@ -51,6 +52,9 @@ class ReferenceIndexTest extends AbstractServerContextAwareTest {
 
   @Autowired
   private SymbolOccurrenceRepository symbolOccurrenceRepository;
+
+  @Autowired
+  private OScriptLibraryIndex oScriptLibraryIndex;
 
   private static final String PATH_TO_FILE = "./src/test/resources/references/ReferenceIndex.bsl";
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensLegendConfigurationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SemanticTokensLegendConfigurationTest.java
@@ -1,0 +1,43 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.semantictokens;
+
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.junit.jupiter.api.Test;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+class SemanticTokensLegendConfigurationTest {
+
+  /**
+   * Легенда обязана перечислять {@link SemanticTokenTypes#Event}: иначе индекс, который
+   * {@link SemanticTokensHelper} ищет по имени типа токена через
+   * {@code legend.getTokenTypes().indexOf(...)}, окажется {@code -1}, и токен обработчика
+   * события молча потеряется при кодировании ответа {@code textDocument/semanticTokens}.
+   */
+  @Test
+  void legendContainsEventTokenType() {
+    var legend = new SemanticTokensLegendConfiguration().semanticTokensLegend();
+
+    assertThat(legend.getTokenTypes()).contains(SemanticTokenTypes.Event);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplierTest.java
@@ -94,7 +94,7 @@ class SymbolsSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
 
     // then - function name should be highlighted as Function
     helper.assertContainsTokens(decoded, List.of(
-      new ExpectedToken(0, 8, 10, SemanticTokenTypes.Function, "МояФункция")
+      new ExpectedToken(0, 8, 10, SemanticTokenTypes.Method, "МояФункция")
     ));
   }
 
@@ -188,7 +188,7 @@ class SymbolsSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
 
     // then
     helper.assertContainsTokens(decoded, List.of(
-      new ExpectedToken(0, 14, 20, SemanticTokenTypes.Function,
+      new ExpectedToken(0, 14, 20, SemanticTokenTypes.Method,
         Set.of(SemanticTokenModifiers.Async), "ОбработатьАсинхронно")
     ));
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplierTest.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.semantictokens;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.types.oscript.OScriptLibraryIndex;
+import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
 import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
@@ -31,8 +32,11 @@ import com.github._1c_syntax.bsl.types.ModuleType;
 import org.eclipse.lsp4j.SemanticTokenModifiers;
 import org.eclipse.lsp4j.SemanticTokenTypes;
 import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentMatchers;
+import static org.mockito.Mockito.when;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Import;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.nio.file.Path;
 import java.util.List;
@@ -50,6 +54,31 @@ class SymbolsSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
 
   @Autowired
   private OScriptLibraryIndex oScriptLibraryIndex;
+
+  @MockitoBean
+  private EventHandlerResolver eventHandlerResolver;
+
+  @Test
+  void testEventHandlerMethodGetsEventTokenType() {
+    // given — резолвер стабится ДО создания документа: подробности см. в аналогичном тесте
+    // DocumentSymbolProviderTest.testEventHandlerMethodMarkedAsEventKind. Стабится isEventHandler,
+    // а не lookupContract — именно её опрашивает MethodSymbolComputer при построении дерева символов.
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("ПриЗаписи")))
+      .thenReturn(true);
+
+    String bsl = """
+      Процедура ПриЗаписи(Отказ)
+      КонецПроцедуры
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokens(bsl, supplier);
+
+    // then — имя обработчика красится как Event, а не Method
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(0, 10, 9, SemanticTokenTypes.Event, "ПриЗаписи")
+    ));
+  }
 
   @Test
   void testMethodDeclaration() {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/SymbolsSemanticTokensSupplierTest.java
@@ -92,7 +92,7 @@ class SymbolsSemanticTokensSupplierTest extends AbstractServerContextAwareTest {
     // when
     var decoded = helper.getDecodedTokens(bsl, supplier);
 
-    // then - function name should be highlighted as Function
+    // then - function name should be highlighted as Method (declared functions are methods)
     helper.assertContainsTokens(decoded, List.of(
       new ExpectedToken(0, 8, 10, SemanticTokenTypes.Method, "МояФункция")
     ));

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndexTest.java
@@ -72,7 +72,7 @@ class EventContractsIndexTest extends AbstractServerContextAwareTest {
   }
 
   @Test
-  void getAllContractsDelegatesToResolverAndCachesPerUri() {
+  void getAllContractsDelegatesToResolver() {
     var documentContext = TestUtils.getDocumentContext("");
     var contracts = List.of(MemberDescriptor.event("ПриЗаписи", "", List.of()));
     when(eventHandlerResolver.allEvents(documentContext)).thenReturn(contracts);
@@ -81,13 +81,14 @@ class EventContractsIndexTest extends AbstractServerContextAwareTest {
     var second = eventContractsIndex.getAllContracts(documentContext);
 
     assertThat(first).isEqualTo(contracts);
-    // Второй вызов должен обслуживаться из кэша, а не резолвером повторно.
-    verify(eventHandlerResolver, times(1)).allEvents(documentContext);
-    assertThat(second).isSameAs(first);
+    assertThat(second).isEqualTo(contracts);
+    // Отдельного кэша нет: события зависят от типа и уже мемоизированы источником
+    // (getMembers/globalEvents), поэтому каждый вызов делегирует в резолвер.
+    verify(eventHandlerResolver, times(2)).allEvents(documentContext);
   }
 
   @Test
-  void configurationTypesRegisteredEventClearsAllContractsCache() {
+  void getAllContractsReflectsReRegisteredTypes() {
     var documentContext = TestUtils.getDocumentContext("");
     when(eventHandlerResolver.allEvents(documentContext))
       .thenReturn(List.of(MemberDescriptor.event("Первое", "", List.of())))

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndexTest.java
@@ -29,7 +29,6 @@ import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndexTest.java
@@ -88,17 +88,25 @@ class EventContractsIndexTest extends AbstractServerContextAwareTest {
   }
 
   @Test
-  void getAllContractsReflectsReRegisteredTypes() {
-    var documentContext = TestUtils.getDocumentContext("");
-    when(eventHandlerResolver.allEvents(documentContext))
-      .thenReturn(List.of(MemberDescriptor.event("Первое", "", List.of())))
-      .thenReturn(List.of(MemberDescriptor.event("Второе", "", List.of())));
+  void configurationTypesRegisteredEventInvalidatesContractCache() {
+    // getContract кэширует контракты по URI (contractsByUri); сброс — только по событию.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура ПриЗаписи()
+      КонецПроцедуры
+      """);
+    when(eventHandlerResolver.lookupContract(documentContext, "ПриЗаписи"))
+      .thenReturn(Optional.of(MemberDescriptor.event("Первое", "", List.of())))
+      .thenReturn(Optional.of(MemberDescriptor.event("Второе", "", List.of())));
 
-    var beforeReload = eventContractsIndex.getAllContracts(documentContext);
+    var before = eventContractsIndex.getContract(documentContext, "ПриЗаписи");
+    // Без события повторный запрос обслуживается из кэша — значение то же (резолвер не опрашивается).
+    var cached = eventContractsIndex.getContract(documentContext, "ПриЗаписи");
     eventPublisher.publishEvent(new ConfigurationTypesRegisteredEvent(documentContext.getServerContext()));
-    var afterReload = eventContractsIndex.getAllContracts(documentContext);
+    // После события кэш сброшен — контракт перечитывается резолвером.
+    var afterReload = eventContractsIndex.getContract(documentContext, "ПриЗаписи");
 
-    assertThat(beforeReload).extracting(MemberDescriptor::name).containsExactly("Первое");
-    assertThat(afterReload).extracting(MemberDescriptor::name).containsExactly("Второе");
+    assertThat(before.map(MemberDescriptor::name)).contains("Первое");
+    assertThat(cached.map(MemberDescriptor::name)).contains("Первое");
+    assertThat(afterReload.map(MemberDescriptor::name)).contains("Второе");
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/EventContractsIndexTest.java
@@ -22,6 +22,8 @@
 package com.github._1c_syntax.bsl.languageserver.types.index;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.events.ConfigurationTypesRegisteredEvent;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import org.junit.jupiter.api.BeforeEach;
@@ -29,10 +31,15 @@ import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.util.List;
 import java.util.Optional;
 
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.times;
 import static org.assertj.core.api.Assertions.assertThat;
 
 class EventContractsIndexTest extends AbstractServerContextAwareTest {
@@ -40,13 +47,18 @@ class EventContractsIndexTest extends AbstractServerContextAwareTest {
   @Autowired
   private EventContractsIndex eventContractsIndex;
 
+  @Autowired
+  private ApplicationEventPublisher eventPublisher;
+
   @MockitoBean
   EventHandlerResolver eventHandlerResolver;
 
   @BeforeEach
   void resetResolver() {
-    Mockito.when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
       .thenReturn(Optional.empty());
+    when(eventHandlerResolver.allEvents(ArgumentMatchers.any()))
+      .thenReturn(List.of());
   }
 
   @Test
@@ -58,5 +70,35 @@ class EventContractsIndexTest extends AbstractServerContextAwareTest {
     var contract = eventContractsIndex.getContract(documentContext, "ПриЗаписи");
 
     assertThat(contract).isEmpty();
+  }
+
+  @Test
+  void getAllContractsDelegatesToResolverAndCachesPerUri() {
+    var documentContext = TestUtils.getDocumentContext("");
+    var contracts = List.of(MemberDescriptor.event("ПриЗаписи", "", List.of()));
+    when(eventHandlerResolver.allEvents(documentContext)).thenReturn(contracts);
+
+    var first = eventContractsIndex.getAllContracts(documentContext);
+    var second = eventContractsIndex.getAllContracts(documentContext);
+
+    assertThat(first).isEqualTo(contracts);
+    // Второй вызов должен обслуживаться из кэша, а не резолвером повторно.
+    verify(eventHandlerResolver, times(1)).allEvents(documentContext);
+    assertThat(second).isSameAs(first);
+  }
+
+  @Test
+  void configurationTypesRegisteredEventClearsAllContractsCache() {
+    var documentContext = TestUtils.getDocumentContext("");
+    when(eventHandlerResolver.allEvents(documentContext))
+      .thenReturn(List.of(MemberDescriptor.event("Первое", "", List.of())))
+      .thenReturn(List.of(MemberDescriptor.event("Второе", "", List.of())));
+
+    var beforeReload = eventContractsIndex.getAllContracts(documentContext);
+    eventPublisher.publishEvent(new ConfigurationTypesRegisteredEvent(documentContext.getServerContext()));
+    var afterReload = eventContractsIndex.getAllContracts(documentContext);
+
+    assertThat(beforeReload).extracting(MemberDescriptor::name).containsExactly("Первое");
+    assertThat(afterReload).extracting(MemberDescriptor::name).containsExactly("Второе");
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndexTest.java
@@ -33,7 +33,6 @@ import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
 import org.mockito.ArgumentMatchers;
-import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndexTest.java
@@ -24,19 +24,27 @@ package com.github._1c_syntax.bsl.languageserver.types.index;
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
+import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.params.ParameterizedTest;
 import org.junit.jupiter.params.provider.CsvSource;
+import org.mockito.ArgumentMatchers;
+import org.mockito.Mockito;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.ApplicationEventPublisher;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
 import java.util.Collections;
 import java.util.IdentityHashMap;
+import java.util.Optional;
 import java.util.Set;
 import java.util.concurrent.CancellationException;
 
+import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.assertj.core.api.Assertions.assertThatThrownBy;
 
@@ -51,6 +59,15 @@ class WorkspaceSymbolIndexTest extends AbstractServerContextAwareTest {
 
   @Autowired
   private ApplicationEventPublisher eventPublisher;
+
+  @MockitoBean
+  private EventHandlerResolver eventHandlerResolver;
+
+  @BeforeEach
+  void resetEventHandlerResolver() {
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenReturn(Optional.empty());
+  }
 
   @Test
   void indexesSupportedSymbolsOnContentChangedEvent() {
@@ -72,6 +89,29 @@ class WorkspaceSymbolIndexTest extends AbstractServerContextAwareTest {
     var variables = index.search("МодульнаяПеременная", NO_CANCEL);
     assertThat(variables)
       .anyMatch(entry -> entry.name().equals("МодульнаяПеременная"));
+  }
+
+  @Test
+  void indexedEntryHasEventKindForEventHandlerMethod() {
+    // given — резолвер стабится ДО создания документа: MethodSymbolComputer опрашивает
+    // классификатор синхронно при обходе AST, то есть уже во время TestUtils.getDocumentContext(...).
+    // Стабится именно isEventHandler, а не lookupContract — см. аналогичный комментарий в
+    // MethodSymbolComputerEventClassificationTest.
+    when(eventHandlerResolver.isEventHandler(ArgumentMatchers.any(), ArgumentMatchers.eq("уникальноесобытие123")))
+      .thenReturn(true);
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура уникальноесобытие123(Отказ)
+      КонецПроцедуры
+      """);
+
+    // when
+    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
+
+    // then
+    assertThat(index.search("уникальноесобытие123", NO_CANCEL))
+      .filteredOn(entry -> entry.name().equals("уникальноесобытие123"))
+      .hasSize(1)
+      .allMatch(entry -> entry.kind() == SymbolKind.Event);
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderAutoRegistrationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderAutoRegistrationTest.java
@@ -1,0 +1,56 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Path;
+
+import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Типы конфигурации регистрируются сразу по добавлению workspace'а (см. {@link
+ * ConfigurationTypesProvider#handleEvent}) — раньше, чем {@code ServerContext.populateContext()}
+ * успевает построить хоть одно дерево символов {@code .bsl}-файла. Это гарантирует, что классификация
+ * методов-обработчиков событий (см. {@code context.symbol.EventHandlerClassifier}) верна уже при
+ * первом построении дерева, без необходимости реактивно пересчитывать его впоследствии.
+ * <p>
+ * {@code populate=false} в этом тесте намеренно: он доказывает, что регистрация НЕ зависит от
+ * заполнения контекста документами — только от {@code configurationRoot}, который {@code
+ * ServerContextProvider#addWorkspace} устанавливает ДО публикации {@code WorkspaceAddedEvent}.
+ */
+class ConfigurationTypesProviderAutoRegistrationTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private TypeRegistry typeRegistry;
+
+  @Test
+  void typesAreRegisteredWithoutPopulatingAnyDocument() {
+    initServerContext(Path.of(PATH_TO_METADATA), false);
+
+    assertThat(context.getDocuments()).isEmpty();
+    assertThat(typeRegistry.resolve("СправочникМенеджер.Справочник1")).isPresent();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
@@ -153,6 +153,31 @@ class EventHandlerResolverTest {
   }
 
   @Test
+  void globalEventsRebuiltAfterHbkBecomesAvailable() {
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.ManagedApplicationModule);
+
+    // 1) Провайдер (HBK/bsl-context) ещё не готов — событий нет.
+    when(bslContextHolder.get()).thenReturn(Optional.empty());
+    assertThat(resolver.allEvents(doc)).isEmpty();
+
+    // 2) HBK подгрузился — пустой результат не должен был закэшироваться: те же вызовы
+    // теперь находят событие (регресс на инвалидацию кэша globalEvents).
+    var event = stubEvent("ПередНачаломРаботыСистемы", "BeforeStart");
+    var globalContext = mock(PlatformGlobalContext.class);
+    when(globalContext.applicationEvents()).thenReturn(List.of(event));
+    when(globalContext.ordinaryApplicationEvents()).thenReturn(List.of());
+    when(globalContext.sessionModuleEvents()).thenReturn(List.of());
+    when(globalContext.externalConnectionModuleEvents()).thenReturn(List.of());
+    var provider = mock(ContextProvider.class);
+    when(provider.getGlobalContext()).thenReturn(globalContext);
+    when(bslContextHolder.get()).thenReturn(Optional.of(provider));
+
+    assertThat(resolver.lookupContract(doc, "ПередНачаломРаботыСистемы")).isPresent();
+    assertThat(resolver.allEvents(doc)).isNotEmpty();
+  }
+
+  @Test
   void globalModuleEmptyEventListReturnsEmpty() {
     var globalContext = mock(PlatformGlobalContext.class);
     when(globalContext.applicationEvents()).thenReturn(List.of());
@@ -248,6 +273,93 @@ class EventHandlerResolverTest {
     when(doc.getModuleType()).thenReturn(ModuleType.CommonModule);
 
     assertThat(resolver.lookupContract(doc, "ПриЗаписи")).isEmpty();
+  }
+
+  /**
+   * Осознанное ограничение (не баг): обработчики форм не резолвятся. Форма — единственный
+   * {@link ModuleType}, у которого события декларируются не по имени, а в {@code Form.xml}
+   * (блок {@code <Events>}), это отдельная, не начатая задача (см. javadoc класса). Явный тест
+   * фиксирует контракт, чтобы отсутствие резолва для форм не осталось молчаливым и не
+   * воспринималось как забытый кейс при последующих правках.
+   */
+  @Test
+  void formModuleIsNotResolvedByDesign() {
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.FormModule);
+
+    assertThat(resolver.lookupContract(doc, "ПриОткрытии")).isEmpty();
+    assertThat(resolver.allEvents(doc)).isEmpty();
+    verifyNoInteractions(typeRegistry);
+  }
+
+  @Test
+  void allEventsForOScriptClassReturnsBuiltinEvents() {
+    var doc = oscriptClassDoc();
+
+    var events = resolver.allEvents(doc);
+
+    assertThat(events)
+      .extracting(MemberDescriptor::name)
+      .containsExactlyInAnyOrder("ПриСозданииОбъекта", "ОбработкаПолученияПредставления");
+  }
+
+  @Test
+  void allEventsForGlobalModuleDedupsRuEnAliases() {
+    var event = stubEvent("ПередНачаломРаботыСистемы", "BeforeStart");
+    var globalContext = mock(PlatformGlobalContext.class);
+    when(globalContext.applicationEvents()).thenReturn(List.of(event));
+    when(globalContext.ordinaryApplicationEvents()).thenReturn(List.of());
+    when(globalContext.sessionModuleEvents()).thenReturn(List.of());
+    when(globalContext.externalConnectionModuleEvents()).thenReturn(List.of());
+    var provider = mock(ContextProvider.class);
+    when(provider.getGlobalContext()).thenReturn(globalContext);
+    when(bslContextHolder.get()).thenReturn(Optional.of(provider));
+
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.ManagedApplicationModule);
+
+    // Событие лежит в карте под ru- и en-ключом на один и тот же объект — в allEvents() должно
+    // остаться единственное вхождение, а не два дубля.
+    assertThat(resolver.allEvents(doc))
+      .hasSize(1)
+      .extracting(MemberDescriptor::name)
+      .containsExactly("ПередНачаломРаботыСистемы");
+  }
+
+  @Test
+  void allEventsForGlobalModuleWithoutHbkReturnsEmpty() {
+    when(bslContextHolder.get()).thenReturn(Optional.empty());
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.SessionModule);
+
+    assertThat(resolver.allEvents(doc)).isEmpty();
+  }
+
+  @Test
+  void allEventsForMdoSpecificOwnerFiltersByEventKind() {
+    var eventDescriptor = MemberDescriptor.event(
+      "ПриЗаписи", "", List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")));
+    var methodDescriptor = MemberDescriptor.method("Записать");
+    var commandRef = new TypeRef(TypeKind.PLATFORM, "Модуль команды");
+    when(typeRegistry.resolve("Модуль команды")).thenReturn(Optional.of(commandRef));
+    when(typeRegistry.getMembers(eq(commandRef), any()))
+      .thenReturn(List.of(eventDescriptor, methodDescriptor));
+
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.CommandModule);
+    when(doc.getFileType()).thenReturn(FileType.BSL);
+
+    assertThat(resolver.allEvents(doc))
+      .extracting(MemberDescriptor::name)
+      .containsExactly("ПриЗаписи");
+  }
+
+  @Test
+  void allEventsForUnsupportedModuleTypeReturnsEmpty() {
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.CommonModule);
+
+    assertThat(resolver.allEvents(doc)).isEmpty();
   }
 
   private static ContextEvent stubEvent(String ru, String en) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
@@ -153,16 +153,11 @@ class EventHandlerResolverTest {
   }
 
   @Test
-  void globalEventsRebuiltAfterHbkBecomesAvailable() {
+  void globalEventsCachedAfterFirstBuild() {
     var doc = mock(DocumentContext.class);
     when(doc.getModuleType()).thenReturn(ModuleType.ManagedApplicationModule);
 
-    // 1) Провайдер (HBK/bsl-context) ещё не готов — событий нет.
-    when(bslContextHolder.get()).thenReturn(Optional.empty());
-    assertThat(resolver.allEvents(doc)).isEmpty();
-
-    // 2) HBK подгрузился — пустой результат не должен был закэшироваться: те же вызовы
-    // теперь находят событие (регресс на инвалидацию кэша globalEvents).
+    // 1) Провайдер доступен — карта глобальных событий собирается и кэшируется при первом обращении.
     var event = stubEvent("ПередНачаломРаботыСистемы", "BeforeStart");
     var globalContext = mock(PlatformGlobalContext.class);
     when(globalContext.applicationEvents()).thenReturn(List.of(event));
@@ -173,6 +168,12 @@ class EventHandlerResolverTest {
     when(provider.getGlobalContext()).thenReturn(globalContext);
     when(bslContextHolder.get()).thenReturn(Optional.of(provider));
 
+    assertThat(resolver.allEvents(doc)).isNotEmpty();
+
+    // 2) Результат закэширован: даже если провайдер потом «пропадёт», ранее собранная карта
+    // остаётся (BslContextHolder в проде синхронно-мемоизирован и не меняется, поэтому кэшировать
+    // безусловно, включая пустоту, безопасно — см. EventHandlerResolver#globalEvents).
+    when(bslContextHolder.get()).thenReturn(Optional.empty());
     assertThat(resolver.lookupContract(doc, "ПередНачаломРаботыСистемы")).isPresent();
     assertThat(resolver.allEvents(doc)).isNotEmpty();
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryRegistrationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryRegistrationTest.java
@@ -505,4 +505,68 @@ class TypeRegistryRegistrationTest {
       assertThat(lower).isEqualTo(mixed);
     }
   }
+
+  /**
+   * Регресс: платформенная специализация ({@code ОтчетОбъект.<Имя>}, kind PLATFORM)
+   * несёт события; когда модуль объекта до-регистрирует свои члены через
+   * {@code registerConfigurationType} того же имени, событие НЕ должно исчезнуть
+   * (инвариант «одно имя ↔ один TypeRef»: registerConfigurationType переиспользует
+   * существующий ref, а не плодит теневой CONFIGURATION-ref). Ровно этот баг ронял
+   * классификацию {@code ПриКомпоновкеРезультата} у отчётов после populateContext.
+   */
+  @Test
+  void registerConfigurationTypeReusesExistingPlatformRefAndKeepsEvents() {
+    // given — generic ОтчетОбъект.<Имя отчёта> с событием, и его специализация (kind PLATFORM).
+    var generic = typeRegistry.intern(TypeKind.PLATFORM, "ТестОбъект.<Имя>");
+    var event = com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor.event(
+      "ПриКомпоновкеРезультата", "", java.util.List.of());
+    typeRegistry.registerMemberSource(generic, () -> java.util.List.of(event), FileType.BSL);
+    var specialized = typeRegistry.registerSpecialization(
+      "ТестОбъект.Мой", generic, java.util.Map.of(), FileType.BSL);
+    assertThat(specialized.kind()).isEqualTo(TypeKind.PLATFORM);
+
+    // when — модуль объекта до-регистрирует собственный метод на тот же тип.
+    var ref = typeRegistry.registerConfigurationType("ТестОбъект.Мой");
+    var method = com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor.method(
+      "МойМетод", "", java.util.List.of());
+    typeRegistry.registerMemberSource(ref, () -> java.util.List.of(method), FileType.BSL);
+
+    // then — тот же ref (не теневой CONFIGURATION), и событие соседствует с методом модуля.
+    assertThat(ref).isSameAs(specialized);
+    assertThat(typeRegistry.resolve("ТестОбъект.Мой")).contains(specialized);
+    var memberNames = typeRegistry.getMembers(specialized, FileType.BSL).stream()
+      .map(com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor::name)
+      .toList();
+    assertThat(memberNames).contains("ПриКомпоновкеРезультата", "МойМетод");
+  }
+
+  /**
+   * Симметрия рельс: тот же результат при обратном порядке (сначала конфигурационный
+   * тип объекта — как у справочников/документов через {@code registerObjectAndRefTypes},
+   * затем платформенная специализация досыпает события). Оба пути сходятся на один ref.
+   */
+  @Test
+  void specializationReusesExistingConfigurationRefAndKeepsBothMemberSets() {
+    // given — сначала конфигурационный тип объекта со «своим» членом (kind CONFIGURATION).
+    var ref = typeRegistry.registerConfigurationType("Тест2Объект.Мой");
+    assertThat(ref.kind()).isEqualTo(TypeKind.CONFIGURATION);
+    var method = com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor.method(
+      "МойМетод", "", java.util.List.of());
+    typeRegistry.registerMemberSource(ref, () -> java.util.List.of(method), FileType.BSL);
+
+    // when — платформенная специализация того же имени досыпает событие.
+    var generic = typeRegistry.intern(TypeKind.PLATFORM, "Тест2Объект.<Имя>");
+    var event = com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor.event(
+      "ПриКомпоновкеРезультата", "", java.util.List.of());
+    typeRegistry.registerMemberSource(generic, () -> java.util.List.of(event), FileType.BSL);
+    var specialized = typeRegistry.registerSpecialization(
+      "Тест2Объект.Мой", generic, java.util.Map.of(), FileType.BSL);
+
+    // then — специализация переиспользовала существующий CONFIGURATION-ref, члены слиты.
+    assertThat(specialized).isSameAs(ref);
+    var memberNames = typeRegistry.getMembers(ref, FileType.BSL).stream()
+      .map(com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor::name)
+      .toList();
+    assertThat(memberNames).contains("ПриКомпоновкеРезультата", "МойМетод");
+  }
 }


### PR DESCRIPTION
## Summary
Обработчики платформенных событий 1С получают честный отдельный вид символа `EventMethodSymbol`, классифицируемый при сборке дерева символов (`EventHandlerClassifier`). Это единый источник истины «метод — обработчик события» для всех потребителей LSP:

- **Семантическая подсветка** обработчиков (Event-токен) + document symbols.
- **Completion**: иконка `Event` у объявленных обработчиков, ранжирование ниже обычных локальных методов, и **стабы ещё не объявленных обработчиков** owner-типа модуля (предложение реализовать, со сниппетом тела процедуры; только на уровне модуля, вне тела метода).
- **Диагностики** `EventHandlerOutsideEventRegion` и `EventHandlerInvalidSignature` **мигрированы** на определение обработчика через вид символа (`instanceof EventMethodSymbol`) вместо переспрашивания контракта по имени.
- **Hover** метода и параметра обработчика — по виду символа.

Единая классификация: конструктор OScript-класса (`ПриСозданииОбъекта`), совпадающий по имени с событием, остаётся `ConstructorSymbol` и обработчиком не считается — консистентно во всех потребителях (раньше эвристики по имени могли расходиться).

## Стек и порядок мержа
Это **верхний PR стека** из двух, **stacked поверх #4289** (`feat/self-member-lsp-support`). Порядок слияния:
1. **Сначала #4289** («self-члены модуля в completion, hover, references…»).
2. **Потом этот PR (#4301)** — база сейчас `feat/self-member-lsp-support`; после мержа #4289 GitHub перенацелит его на `develop` (дифф очистится сам), либо базу вернём вручную.

Пока #4289 не смёржен, дифф корректнее ревьюить относительно ветки #4289 — GitHub уже показывает только дельту обработчиков событий (не self-member).

## Не входит (осознанно)
Автоподстановка типа параметра в detail из **сигнатуры события** здесь есть (список параметров стаба/метода показывается как `Имя: Тип`). А вот **инференс типа обычной локальной переменной/параметра** при автодополнении её имени (`TypeService.typesOfSymbol`) — это self-member фича #4289: сам тип берётся из сигнатуры события и уже есть в develop (`ExpressionTypeInferencer`), поэтому этот путь заработает автоматически при мерже #4289.

## Test plan
- [x] Точечные тесты по всем слоям зелёные: `EventContractsIndex`, `EventHandlerResolver`, `MethodSymbolComputerEventClassification`, `SymbolsSemanticTokensSupplier`, `CompletionProvider`, `EventHandlerOutsideEventRegionDiagnostic`, `EventHandlerInvalidSignatureDiagnostic`, `MethodSymbolMarkupContentBuilderEventHandler`, `VariableSymbolMarkupContentBuilderEventHandler`, `HoverProvider`.
- [x] `compileJava` + `compileTestJava` + `spotlessCheck` — зелёные.
- [ ] Полный `./gradlew check` — в рамках сессии не гонялся.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Platform event handlers are now exposed as a dedicated **Event** symbol kind, with matching semantic token typing and hover/markup details.
  * Module-level completion can suggest undeclared platform event handlers, including snippet-mode insertion; completion item resolve now supports event-contract documentation.
* **Bug Fixes**
  * Event-handler diagnostics now target event-handler methods specifically and improve “outside event region” detection.
  * Reference/workspace symbol indexing and reference lookups better align callable-kind handling for event handlers.
* **Tests**
  * Added/updated regression coverage for event-handler classification, completion (including resolve/snippets), diagnostics, semantic tokens/legend, and indexing.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->
