### PR TITLE
perf(types): компактное хранение источников членов вместо списка на тип

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -52,6 +52,7 @@ import org.jspecify.annotations.Nullable;
 import org.springframework.stereotype.Component;
 
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.Comparator;
 import java.util.LinkedHashMap;
@@ -113,8 +114,17 @@ public class TypeRegistry {
   /**
    * Источники членов типов в разрезе языка (один тип может расширяться многими
    * источниками; порядок значим — {@link #registerMemberOverride} вставляет в начало).
+   * <p>
+   * Значение хранится компактно: для типа с единственным источником (доминирующий
+   * случай — на реальной конфигурации из ~671k типов ~561k имеют ровно один источник)
+   * — сам {@link MemberSource} без обёртки-списка; для типа с несколькими источниками
+   * — неизменяемый {@code MemberSource[]}. Массив/одиночка вместо
+   * {@code CopyOnWriteArrayList} на каждый тип убирает три служебных объекта на запись
+   * (список, его lock и backing-массив). Обновления атомарны по ключу через
+   * {@link ConcurrentHashMap#merge}; опубликованное значение неизменяемо, поэтому
+   * читатели ({@link #resolveMemberSources}) видят согласованный снимок без блокировки.
    */
-  private final Map<FileType, Map<TypeRef, List<MemberSource>>> memberSources = perFileType();
+  private final Map<FileType, Map<TypeRef, Object>> memberSources = perFileType();
 
   /**
    * Мемоизация {@link #getMembers(TypeRef, FileType)}. Сборка членов
@@ -583,13 +593,55 @@ public class TypeRegistry {
   private List<MemberSource> resolveMemberSources(TypeRef ref, FileType fileType) {
     var byRef = memberSources.get(fileType);
     var sources = byRef.get(ref);
-    if (sources == null || sources.isEmpty()) {
+    if (sources == null) {
       var canonical = aliasIndex.get(ref.qualifiedName().toLowerCase(Locale.ROOT));
       if (canonical != null && !canonical.equals(ref)) {
         sources = byRef.get(canonical);
       }
     }
-    return sources == null ? List.of() : sources;
+    return asSourceList(sources);
+  }
+
+  /**
+   * Разложить компактное значение {@link #memberSources} в список источников:
+   * {@code null} → пусто, одиночный {@link MemberSource} → список из одного,
+   * {@code MemberSource[]} → неизменяемый список-обёртка. Пустого значения не бывает —
+   * {@link #appendSource}/{@link #prependSource} всегда дают ≥1 элемент, а единственное
+   * удаление ({@code memberSources...remove(ref)}) снимает ключ целиком.
+   */
+  private static List<MemberSource> asSourceList(@Nullable Object value) {
+    if (value == null) {
+      return List.of();
+    }
+    if (value instanceof MemberSource single) {
+      return List.of(single);
+    }
+    return List.of((MemberSource[]) value);
+  }
+
+  /** Дописать источник в конец компактного значения (одиночка → массив). */
+  private static Object appendSource(Object current, Object added) {
+    var add = (MemberSource) added;
+    if (current instanceof MemberSource single) {
+      return new MemberSource[]{single, add};
+    }
+    var array = (MemberSource[]) current;
+    var updated = Arrays.copyOf(array, array.length + 1);
+    updated[array.length] = add;
+    return updated;
+  }
+
+  /** Вставить источник в начало компактного значения (override выигрывает dedup по имени). */
+  private static Object prependSource(Object current, Object added) {
+    var add = (MemberSource) added;
+    if (current instanceof MemberSource single) {
+      return new MemberSource[]{add, single};
+    }
+    var array = (MemberSource[]) current;
+    var updated = new MemberSource[array.length + 1];
+    updated[0] = add;
+    System.arraycopy(array, 0, updated, 1, array.length);
+    return updated;
   }
 
   /**
@@ -621,8 +673,7 @@ public class TypeRegistry {
    * @param fileType язык файла, в котором члены источника видимы.
    */
   public void registerMemberSource(TypeRef ref, MemberSource source, FileType fileType) {
-    memberSources.get(fileType).computeIfAbsent(ref, k -> new CopyOnWriteArrayList<>())
-      .add(source);
+    memberSources.get(fileType).merge(ref, source, TypeRegistry::appendSource);
     membersEpoch.incrementAndGet();
   }
 
@@ -637,8 +688,7 @@ public class TypeRegistry {
    * в реестре — другие members (Справочники, Перечисления, …) приходят оттуда.
    */
   public void registerMemberOverride(TypeRef ref, MemberSource source, FileType fileType) {
-    memberSources.get(fileType).computeIfAbsent(ref, k -> new CopyOnWriteArrayList<>())
-      .addFirst(source);
+    memberSources.get(fileType).merge(ref, source, TypeRegistry::prependSource);
     membersEpoch.incrementAndGet();
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryScopedSourcesTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryScopedSourcesTest.java
@@ -118,6 +118,25 @@ class TypeRegistryScopedSourcesTest {
   }
 
   @Test
+  void compactStorageKeepsSourceOrderAcrossAppendAndPrepend() {
+    // given — тип проходит все переходы компактного хранения: одиночка → массив (append)
+    // → массив с вставкой в начало (prepend). Каждый источник даёт свой член,
+    // порядок обхода источников должен сохраниться.
+    var ref = typeRegistry.intern(TypeKind.PLATFORM, "ТестовыйКомпактныйПорядок");
+    typeRegistry.registerMemberSource(ref,
+      () -> List.of(MemberDescriptor.property("первый", TypeRef.UNKNOWN, "")), FileType.BSL);
+    typeRegistry.registerMemberSource(ref,
+      () -> List.of(MemberDescriptor.property("второй", TypeRef.UNKNOWN, "")), FileType.BSL);
+    typeRegistry.registerMemberOverride(ref,
+      () -> List.of(MemberDescriptor.property("вставленный", TypeRef.UNKNOWN, "")), FileType.BSL);
+
+    // then — override встал в начало, исходные источники сохранили относительный порядок
+    assertThat(typeRegistry.getMembers(ref, FileType.BSL))
+      .extracting(MemberDescriptor::name)
+      .containsExactly("вставленный", "первый", "второй");
+  }
+
+  @Test
   void invalidateMembersEvictsOnlyGivenType() {
     // given — два типа с изменяемыми источниками членов, оба прочитаны и мемоизированы
     var refA = typeRegistry.intern(TypeKind.PLATFORM, "ТестовыйТочечныйA");


### PR DESCRIPTION
`memberSources` хранил на каждый тип `CopyOnWriteArrayList`, хотя на реальной конфигурации подавляющее большинство типов имеют ровно **один** источник членов (на cpm: **561 192 из 670 869**, 84%). Список на тип — это три служебных объекта (сам список, его `lock` и backing-массив) ради одной ссылки.

## Что сделано

Значение `memberSources` теперь хранится компактно:
- тип с единственным источником — сам `MemberSource` без обёртки;
- тип с несколькими — неизменяемый `MemberSource[]`.

Обновления атомарны по ключу через `ConcurrentHashMap.merge`, опубликованное значение неизменяемо → читатели (`resolveMemberSources`) видят согласованный снимок без блокировки (та же гарантия, что давал `CopyOnWriteArrayList`). Проверка alias-fallback смягчена с `isEmpty()` до `== null`: пустого значения быть не может (`append`/`prepend` всегда дают ≥1 элемент, а единственное удаление снимает ключ целиком).

## Замер памяти

Live-heap на cpm (13090 файлов, `jmap -histo:live`, before = `CopyOnWriteArrayList`, after = компактно):

| | before | after | Δ |
|---|---|---|---|
| `CopyOnWriteArrayList` | 673 178 / 16.16 МБ | 2 309 / 0.05 МБ | **−16.1 МБ** (точно) |
| `java.lang.Object` (lock'и CoWAL) | 702 394 / 11.24 МБ | 31 860 / 0.51 МБ | **−10.7 МБ** (точно) |
| single-source backing-массивы | — | — | **≈ −13.5 МБ** |
| новые `MemberSource[]` | — | 109 677 / 3.05 МБ | +3.05 МБ |

Число удалённых `CoWAL` (670 869) в точности совпадает с числом записей `memberSources`. **Нетто ≈ 37 МБ** с живой кучи; часть по объектам-обёрткам (−26.8 МБ) — точная арифметика по счётчикам, backing-массивы — оценка по 561k single-source `Object[1]`→голая ссылка.

Компактится только `memberSources`: `constructors` (428 записей) и `constructorSources` (0 на BSL, 484 на OScript-проекте winow) на 2–3 порядка меньше — компактить их смысла нет.

## Тесты

Добавлен `compactStorageKeepsSourceOrderAcrossAppendAndPrepend` — фиксирует порядок при переходах одиночка→append→prepend (override встаёт в начало). Существующие тесты `TypeRegistryScopedSourcesTest` покрывают single/shared/override пути. Полный прогон локально не гонял (по просьбе) — оставляю CI.

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

## Дополнительно

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved reliability when registering and resolving type member sources.
  * Preserved the correct ordering of overridden and inherited member sources.

* **Tests**
  * Added coverage verifying source ordering across multiple registrations and overrides.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->