### PR TITLE
Общий резолв ValueTypeDescription в ValueTypes

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -55,8 +55,6 @@ import com.github._1c_syntax.bsl.mdo.children.PredefinedValue;
 import com.github._1c_syntax.bsl.mdo.children.StandardAttribute;
 import com.github._1c_syntax.bsl.types.MDOType;
 import com.github._1c_syntax.bsl.types.MultiName;
-import com.github._1c_syntax.bsl.types.ValueType;
-import com.github._1c_syntax.bsl.types.value.PrimitiveValueType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.jspecify.annotations.Nullable;
@@ -1053,18 +1051,7 @@ public class ConfigurationTypesProvider {
   }
 
   private TypeSet resolveCommonAttributeReturnTypes(CommonAttribute ca) {
-    var valueType = ca.getValueType();
-    if (valueType.isEmpty()) {
-      return TypeSet.EMPTY;
-    }
-    var refs = new java.util.LinkedHashSet<TypeRef>();
-    for (var vt : valueType.getTypes()) {
-      var resolved = resolveValueType(vt);
-      if (resolved != null) {
-        refs.add(resolved);
-      }
-    }
-    return refs.isEmpty() ? TypeSet.EMPTY : TypeSet.of(refs);
+    return ValueTypes.resolve(typeRegistry, ca.getValueType());
   }
 
   /**
@@ -1107,27 +1094,6 @@ public class ConfigurationTypesProvider {
    * composite-типа из нескольких {@code v8:Type}).
    */
   private TypeSet resolveAttributeReturnTypes(Attribute attribute) {
-    var valueType = attribute.getValueType();
-    if (valueType.isEmpty()) {
-      return TypeSet.EMPTY;
-    }
-    var refs = new java.util.LinkedHashSet<TypeRef>();
-    for (var vt : valueType.getTypes()) {
-      var resolved = resolveValueType(vt);
-      if (resolved != null) {
-        refs.add(resolved);
-      }
-    }
-    return refs.isEmpty() ? TypeSet.EMPTY : TypeSet.of(refs);
-  }
-
-  @Nullable
-  private TypeRef resolveValueType(ValueType vt) {
-    if (vt instanceof PrimitiveValueType primitive) {
-      return typeRegistry.resolve(primitive.fullName().getRu()).orElse(null);
-    }
-    // V8 / METADATA / UNKNOWN — пока не поддерживаем точно; resolve по имени даст
-    // частичное покрытие для V8-типов, имена которых совпадают с регистрационными.
-    return typeRegistry.resolve(vt.fullName().getRu()).orElse(null);
+    return ValueTypes.resolve(typeRegistry, attribute.getValueType());
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ValueTypes.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ValueTypes.java
@@ -1,0 +1,69 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.types.ValueType;
+import com.github._1c_syntax.bsl.types.ValueTypeDescription;
+import lombok.experimental.UtilityClass;
+import org.jspecify.annotations.Nullable;
+
+import java.util.LinkedHashSet;
+
+/**
+ * Перевод описания типа значения из mdclasses ({@link ValueTypeDescription}) в
+ * {@link TypeSet} реестра. Общий код для всех источников конфигурационных членов:
+ * реквизиты объектов, общие реквизиты, реквизиты формы.
+ */
+@UtilityClass
+public class ValueTypes {
+
+  /**
+   * Набор {@link TypeRef} для описания типа значения (union для composite-типа
+   * из нескольких {@code v8:Type}). Нерезолвящиеся типы отбрасываются;
+   * пустой результат — {@link TypeSet#EMPTY}.
+   */
+  public static TypeSet resolve(TypeRegistry typeRegistry, ValueTypeDescription valueType) {
+    if (valueType.isEmpty()) {
+      return TypeSet.EMPTY;
+    }
+    var refs = new LinkedHashSet<TypeRef>();
+    for (var type : valueType.getTypes()) {
+      var resolved = resolveOne(typeRegistry, type);
+      if (resolved != null) {
+        refs.add(resolved);
+      }
+    }
+    return refs.isEmpty() ? TypeSet.EMPTY : TypeSet.of(refs);
+  }
+
+  /**
+   * Резолв одного {@link ValueType} по его ru-имени. Примитивы и V8-типы
+   * ({@code ДинамическийСписок}, {@code ХранилищеЗначения}) и конфигурационные
+   * ссылки ({@code СправочникСсылка.X}) в реестре именованы одинаково, поэтому
+   * достаточно одного lookup'а по имени.
+   */
+  private static @Nullable TypeRef resolveOne(TypeRegistry typeRegistry, ValueType valueType) {
+    return typeRegistry.resolve(valueType.fullName().getRu()).orElse(null);
+  }
+}


### PR DESCRIPTION
## Что и зачем

Перевод `ValueTypeDescription` из mdclasses в `TypeSet` был приватным кодом `ConfigurationTypesProvider` и дублировался в двух методах — `resolveAttributeReturnTypes` (реквизиты объектов) и `resolveCommonAttributeReturnTypes` (общие реквизиты). Тела идентичны, включая сборку union'а для composite-типа и отбрасывание нерезолвящихся имён.

Вынесено в утилиту `ValueTypes`. Провайдер худеет на 36 строк, а следующему источнику конфигурационных членов не придётся копировать это в третий раз.

## Поведение

Не меняется. Прежний `resolveValueType` формально разделял `PrimitiveValueType` и остальные типы, но обе ветки резолвили по одному и тому же `fullName().getRu()`, поэтому объединение веток эквивалентно.

Покрыто существующими тестами резолва реквизитов (`ConfigurationTypesProviderTest`, `CatalogAttributeMembersTest`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type resolution for configuration and attribute metadata.
  * Enhanced support for attributes with multiple possible value types.
  * Unrecognized value types are now handled gracefully without disrupting available type information.

* **Refactor**
  * Centralized type resolution to provide more consistent behavior across supported attributes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->