### PR TITLE
feat(symbols): SymbolKind.Function для методов модулей без состояния

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolComputer.java
@@ -22,6 +22,7 @@
 package com.github._1c_syntax.bsl.languageserver.context.computer;
 
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ConstructorSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.EventHandlerClassifier;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol;
@@ -290,6 +291,7 @@ public final class MethodSymbolComputer
     return RegularMethodSymbol.builder()
       .name(name)
       .owner(documentContext)
+      .standaloneFunction(isStatelessModule())
       .range(range)
       .subNameRange(subNameRange)
       .function(function)
@@ -301,6 +303,29 @@ public final class MethodSymbolComputer
       .compilerDirectiveKind(compilerDirective)
       .annotations(annotations)
       .build();
+  }
+
+  /**
+   * Проверить, что модуль не хранит состояние: общий модуль BSL
+   * ({@link ModuleType#CommonModule}) либо модуль OneScript (любой {@code .os}-файл,
+   * не являющийся классом).
+   * <p>
+   * Методы таких модулей — самостоятельные функции, а не члены объекта со
+   * состоянием, поэтому для них корректнее {@link org.eclipse.lsp4j.SymbolKind#Function}.
+   * Класс OneScript ({@link ModuleType#OScriptClass}) — это инстанцируемый объект
+   * со своим состоянием, поэтому его методы остаются
+   * {@link org.eclipse.lsp4j.SymbolKind#Method}. Отдельный {@code .os}-файл вне
+   * библиотеки имеет {@link ModuleType#UNKNOWN}, но по семантике OneScript это
+   * скрипт-модуль, а не класс, поэтому он также считается модулем без состояния.
+   *
+   * @return {@code true}, если модуль не хранит состояние
+   */
+  private boolean isStatelessModule() {
+    if (documentContext.getModuleType() == ModuleType.CommonModule) {
+      return true;
+    }
+    return documentContext.getFileType() == FileType.OS
+      && documentContext.getModuleType() != ModuleType.OScriptClass;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/RegularMethodSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/RegularMethodSymbol.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.context.symbol;
 
+import lombok.Builder;
 import lombok.EqualsAndHashCode;
 import lombok.ToString;
 import lombok.experimental.SuperBuilder;
@@ -31,15 +32,34 @@ import org.eclipse.lsp4j.SymbolKind;
  * модуле BSL. Конструкторы OneScript-классов представлены отдельным
  * {@link ConstructorSymbol}, чтобы их можно было различать в symbol tree,
  * hover'е и go-to-definition. Общая структура полей — в {@link AbstractMethodSymbol}.
+ * <p>
+ * В LSP нет отдельного {@link SymbolKind} для процедуры, поэтому и процедуры, и
+ * функции BSL по умолчанию представлены как {@link SymbolKind#Method}. Но методы
+ * модулей без состояния — общих модулей BSL и модулей OneScript — это
+ * самостоятельные функции, а не члены объекта со состоянием, поэтому для них
+ * корректнее {@link SymbolKind#Function}. Признак задаётся флагом
+ * {@link #standaloneFunction}: он влияет только на {@link #getSymbolKind()} (вид
+ * символа в outline и результатах поиска по рабочей области); во всех прочих
+ * отношениях такой символ остаётся обычным {@link RegularMethodSymbol} и
+ * обрабатывается общим путём (hover, автодополнение, семантические токены).
  */
 @SuperBuilder
 @EqualsAndHashCode(callSuper = true)
 @ToString(callSuper = true)
 public final class RegularMethodSymbol extends AbstractMethodSymbol {
 
+  /**
+   * {@code true}, если метод принадлежит модулю без состояния (общий модуль BSL
+   * либо модуль OneScript) и потому является самостоятельной функцией —
+   * {@link SymbolKind#Function}. Иначе метод представлен как
+   * {@link SymbolKind#Method}. Значение по умолчанию — {@code false}.
+   */
+  @Builder.Default
+  private final boolean standaloneFunction = false;
+
   @Override
   public SymbolKind getSymbolKind() {
-    return SymbolKind.Method;
+    return standaloneFunction ? SymbolKind.Function : SymbolKind.Method;
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -799,7 +799,7 @@ public final class CompletionProvider {
     for (var method : documentContext.getSymbolTree().getMethods()) {
       if (matches(method.getName(), prefix)) {
         var item = new CompletionItem(method.getName());
-        item.setKind(methodCompletionKind(method));
+        item.setKind(methodCompletionKind(method.getSymbolKind()));
         applyCallableInsertText(item, method.getName(), !method.getParameters().isEmpty());
         applySourceMethodDetail(item, method);
         applySourceMethodDocumentation(item, method);
@@ -877,10 +877,17 @@ public final class CompletionProvider {
     return items;
   }
 
-  private static CompletionItemKind methodCompletionKind(MethodSymbol method) {
-    // Объявленные методы (процедуры и функции) — Method; Function только у платформенных
-    // глобальных функций. Обработчик события — Event.
-    return method.getSymbolKind() == SymbolKind.Event ? CompletionItemKind.Event : CompletionItemKind.Method;
+  /**
+   * Вид иконки объявленного метода по его {@link SymbolKind}: обработчик события — Event;
+   * метод модуля без состояния (общий модуль BSL, модуль OneScript) — самостоятельная функция
+   * (Function); прочие процедуры и функции — Method.
+   */
+  private static CompletionItemKind methodCompletionKind(SymbolKind symbolKind) {
+    return switch (symbolKind) {
+      case Event -> CompletionItemKind.Event;
+      case Function -> CompletionItemKind.Function;
+      default -> CompletionItemKind.Method;
+    };
   }
 
   /**
@@ -1180,7 +1187,11 @@ public final class CompletionProvider {
     var displayName = member.displayName(scriptVariant);
     var item = new CompletionItem(displayName);
     if (member.kind() == MemberKind.METHOD) {
-      item.setKind(methodKind);
+      // Для source-defined членов (например, экспортных методов общего модуля) вид берётся
+      // прямо из символа-источника, чтобы иконка совпадала со структурой документа; для
+      // платформенных членов без символа — переданный methodKind.
+      var sourceSymbol = member.sourceSymbol();
+      item.setKind(sourceSymbol == null ? methodKind : methodCompletionKind(sourceSymbol.getSymbolKind()));
       applyCallableInsertText(item, displayName, memberHasParameters(member));
       applyMethodDetail(item, member, scriptVariant);
     } else {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProvider.java
@@ -879,12 +879,13 @@ public final class CompletionProvider {
 
   /**
    * Вид иконки объявленного метода по его {@link SymbolKind}: обработчик события — Event;
-   * метод модуля без состояния (общий модуль BSL, модуль OneScript) — самостоятельная функция
-   * (Function); прочие процедуры и функции — Method.
+   * конструктор OneScript-класса — Constructor; метод модуля без состояния (общий модуль BSL,
+   * модуль OneScript) — самостоятельная функция (Function); прочие процедуры и функции — Method.
    */
   private static CompletionItemKind methodCompletionKind(SymbolKind symbolKind) {
     return switch (symbolKind) {
       case Event -> CompletionItemKind.Event;
+      case Constructor -> CompletionItemKind.Constructor;
       case Function -> CompletionItemKind.Function;
       default -> CompletionItemKind.Method;
     };

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndex.java
@@ -236,6 +236,9 @@ public class ReferenceIndex {
    * событий попадают в дерево символов как {@code EventMethodSymbol} (display-вид {@code Event}),
    * но их прямые вызовы индексируются {@link #methodCallOccurrence} под {@code Method} — без
    * канонизации Find References/Call Hierarchy не нашли бы ни одного прямого вызова обработчика.
+   * И так же — {@link SymbolKind#Function}: методы модулей без состояния (общих модулей BSL и
+   * модулей OneScript) отдаются в дереве символов как {@code Function}
+   * (см. {@code RegularMethodSymbol#getSymbolKind()}), но их вызовы индексируются под {@code Method}.
    * Точка расширения при появлении новых callable-{@link SymbolKind} — сюда достаточно добавить
    * очередной случай.
    *
@@ -243,7 +246,9 @@ public class ReferenceIndex {
    * @return канонический вид для ключа индекса.
    */
   private static SymbolKind indexedKindOf(SymbolKind symbolKind) {
-    if (symbolKind == SymbolKind.Constructor || symbolKind == SymbolKind.Event) {
+    if (symbolKind == SymbolKind.Constructor
+      || symbolKind == SymbolKind.Event
+      || symbolKind == SymbolKind.Function) {
       return SymbolKind.Method;
     }
     return symbolKind;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolKindTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/computer/MethodSymbolKindTest.java
@@ -1,0 +1,154 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.context.computer;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.types.ModuleType;
+import org.eclipse.lsp4j.SymbolKind;
+import org.junit.jupiter.api.Test;
+
+import java.nio.file.Path;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Регрессы для вычисления {@link SymbolKind} символа метода в {@link MethodSymbolComputer}.
+ * <p>
+ * Методы модулей без состояния (общий модуль BSL, модуль OneScript) получают
+ * {@link SymbolKind#Function}, методы модулей со состоянием (модуль объекта, класс OneScript
+ * и т. п.) — {@link SymbolKind#Method}, конструкторы OneScript-классов —
+ * {@link SymbolKind#Constructor}. Вид фиксируется в модели символов, поэтому един для всех
+ * потребителей (структура документа, индекс рабочей области, автодополнение и т. п.).
+ */
+@CleanupContextBeforeClassAndAfterClass
+class MethodSymbolKindTest extends AbstractServerContextAwareTest {
+
+  private static final String OSCRIPT_FIXTURE_DIR = "src/test/resources/oscript-libraries/internal-classes-test";
+  private static final String OSCRIPT_CLASS_FILE =
+    OSCRIPT_FIXTURE_DIR + "/oscript_modules/internal-classes-lib/src/Классы/PublicEntity.os";
+
+  /**
+   * Метод общего модуля BSL — функция без состояния, поэтому символ метода
+   * получает {@link SymbolKind#Function}.
+   */
+  @Test
+  void commonModuleMethodHasFunctionKind() {
+    // given — общий модуль конфигурации (модуль без состояния)
+    initServerContextOnce(Path.of(TestUtils.PATH_TO_METADATA));
+    context.getConfiguration();
+    var documentContext = context
+      .getDocument("CommonModule.ПервыйОбщийМодуль", ModuleType.CommonModule)
+      .orElseThrow();
+
+    // when
+    var method = documentContext.getSymbolTree()
+      .getMethodSymbol("НеУстаревшаяФункция")
+      .orElseThrow();
+
+    // then
+    assertThat(method.getSymbolKind()).isEqualTo(SymbolKind.Function);
+  }
+
+  /**
+   * Метод модуля объекта BSL — член объекта со состоянием, поэтому символ метода
+   * остаётся {@link SymbolKind#Method}.
+   */
+  @Test
+  void objectModuleMethodHasMethodKind() {
+    // given — модуль объекта справочника (модуль со состоянием)
+    initServerContextOnce(Path.of(TestUtils.PATH_TO_METADATA));
+    context.getConfiguration();
+    var documentContext = context
+      .getDocument("Catalog.Справочник1", ModuleType.ObjectModule)
+      .orElseThrow();
+
+    // when
+    var method = documentContext.getSymbolTree()
+      .getMethodSymbol("Тест")
+      .orElseThrow();
+
+    // then
+    assertThat(method.getSymbolKind()).isEqualTo(SymbolKind.Method);
+  }
+
+  /**
+   * Метод модуля OneScript — функция без состояния, поэтому символ метода
+   * получает {@link SymbolKind#Function}.
+   */
+  @Test
+  void oneScriptModuleMethodHasFunctionKind() {
+    // given — модуль OneScript (.os, модуль без состояния)
+    var documentContext = TestUtils.getDocumentContext(
+      TestUtils.FAKE_OSCRIPT_DOCUMENT_URI,
+      """
+        Процедура Тест() Экспорт
+        КонецПроцедуры""");
+
+    // when
+    var method = documentContext.getSymbolTree()
+      .getMethodSymbol("Тест")
+      .orElseThrow();
+
+    // then
+    assertThat(method.getSymbolKind()).isEqualTo(SymbolKind.Function);
+  }
+
+  /**
+   * Конструктор OneScript-класса остаётся {@link SymbolKind#Constructor}: вычисление
+   * вида метода модуля без состояния его не затрагивает.
+   */
+  @Test
+  void oneScriptClassConstructorKeepsConstructorKind() {
+    // given — OneScript-класс с процедурой ПриСозданииОбъекта
+    initServerContext(Path.of(OSCRIPT_FIXTURE_DIR).toAbsolutePath(), true);
+    var documentContext = TestUtils.getDocumentContextFromFile(OSCRIPT_CLASS_FILE, context);
+
+    // when
+    var constructor = documentContext.getSymbolTree().getConstructor().orElseThrow();
+
+    // then
+    assertThat(constructor.getSymbolKind()).isEqualTo(SymbolKind.Constructor);
+  }
+
+  /**
+   * Обычный (не конструктор) метод OneScript-класса — член инстанцируемого объекта
+   * со состоянием, поэтому символ метода остаётся {@link SymbolKind#Method}, а не
+   * {@link SymbolKind#Function}.
+   */
+  @Test
+  void oneScriptClassMethodHasMethodKind() {
+    // given — OneScript-класс (модуль со состоянием) с функцией Echo
+    initServerContext(Path.of(OSCRIPT_FIXTURE_DIR).toAbsolutePath(), true);
+    var documentContext = TestUtils.getDocumentContextFromFile(OSCRIPT_CLASS_FILE, context);
+
+    // when
+    var method = documentContext.getSymbolTree()
+      .getMethodSymbol("Echo")
+      .orElseThrow();
+
+    // then
+    assertThat(documentContext.getModuleType()).isEqualTo(ModuleType.OScriptClass);
+    assertThat(method.getSymbolKind()).isEqualTo(SymbolKind.Method);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -34,6 +34,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.types.ModuleType;
 import org.eclipse.lsp4j.ClientCapabilities;
 import org.eclipse.lsp4j.CompletionCapabilities;
 import org.eclipse.lsp4j.CompletionItem;
@@ -452,6 +453,41 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void noDotCompletionCommonModuleLocalMethodHasFunctionKind() {
+    // given — документ является общим модулем (модуль без состояния): его собственные методы
+    // в автодополнении должны получать CompletionItemKind.Function, как и в структуре документа.
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    var commonModuleUri = Path.of(
+      "./src/test/resources/metadata/designer/CommonModules/ПервыйОбщийМодуль/Ext/Module.bsl").toUri();
+    var content = """
+      Функция МояФункция() Экспорт
+      Возврат 1;
+      КонецФункции
+
+      Процедура Тест()
+      МояФун
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(commonModuleUri, content, context);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    // строка `МояФун` (line 5, 0-based), позиция сразу после префикса
+    params.setPosition(new Position(5, 6));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    assertThat(documentContext.getModuleType()).isEqualTo(ModuleType.CommonModule);
+    assertThat(items)
+      .filteredOn(it -> "МояФункция".equals(it.getLabel()))
+      .hasSize(1)
+      .allMatch(it -> it.getKind() == CompletionItemKind.Function);
+  }
+
+  @Test
   void noDotCompletionShowsInferredTypeForEventHandlerParameter() {
     // given: тип параметра обработчика события известен из контракта события —
     // должен показываться в detail пункта completion, а не оставаться пустым
@@ -625,7 +661,9 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
       .findFirst()
       .orElseThrow(() -> new AssertionError("метод общего модуля должен попасть в dot-completion"));
 
-    assertThat(item.getKind()).isEqualTo(CompletionItemKind.Method);
+    // метод общего модуля — модуль без состояния, поэтому иконка — Function (как и в структуре
+    // документа); вид берётся из символа-источника метода
+    assertThat(item.getKind()).isEqualTo(CompletionItemKind.Function);
     assertThat(item.getDetail())
       .as("сигнатура и тип возврата метода общего модуля — как у платформенного")
       .isEqualTo("(Значение): Массив");

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -488,6 +488,34 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void noDotCompletionOScriptClassConstructorHasConstructorKind() {
+    // given — OneScript-класс: конструктор ПриСозданииОбъекта в структуре документа имеет
+    // SymbolKind.Constructor, поэтому и в автодополнении иконка должна быть Constructor,
+    // а не Method (вид берётся из символа через methodCompletionKind).
+    initServerContext(
+      Path.of("src/test/resources/oscript-libraries/internal-classes-test").toAbsolutePath(), true);
+    var documentContext = TestUtils.getDocumentContextFromFile(
+      "src/test/resources/oscript-libraries/internal-classes-test"
+        + "/oscript_modules/internal-classes-lib/src/Классы/PublicEntity.os",
+      context);
+
+    var params = new CompletionParams();
+    params.setTextDocument(new TextDocumentIdentifier(documentContext.getUri().toString()));
+    // пустая строка между методами (line 3, 0-based) — контекст модуля без префикса
+    params.setPosition(new Position(3, 0));
+
+    // when
+    var items = completionProvider.getCompletion(documentContext, params).getItems();
+
+    // then
+    assertThat(documentContext.getModuleType()).isEqualTo(ModuleType.OScriptClass);
+    assertThat(items)
+      .filteredOn(it -> "ПриСозданииОбъекта".equals(it.getLabel()))
+      .isNotEmpty()
+      .allMatch(it -> it.getKind() == CompletionItemKind.Constructor);
+  }
+
+  @Test
   void noDotCompletionShowsInferredTypeForEventHandlerParameter() {
     // given: тип параметра обработчика события известен из контракта события —
     // должен показываться в detail пункта completion, а не оставаться пустым

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/DocumentSymbolProviderTest.java
@@ -21,32 +21,41 @@
  */
 package com.github._1c_syntax.bsl.languageserver.providers;
 
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
+import com.github._1c_syntax.bsl.types.ModuleType;
 import org.eclipse.lsp4j.DocumentSymbol;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.SymbolTag;
+import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentMatchers;
 import org.springframework.beans.factory.annotation.Autowired;
-import org.springframework.boot.test.context.SpringBootTest;
 import org.springframework.test.context.bean.override.mockito.MockitoBean;
 
+import java.nio.file.Path;
 import java.util.ArrayList;
 import java.util.List;
+import java.util.Optional;
 
 import static org.mockito.Mockito.when;
 import static org.assertj.core.api.Assertions.assertThat;
 
-@SpringBootTest
-class DocumentSymbolProviderTest {
+class DocumentSymbolProviderTest extends AbstractServerContextAwareTest {
 
   @Autowired
   private DocumentSymbolProvider documentSymbolProvider;
 
   @MockitoBean
   private EventHandlerResolver eventHandlerResolver;
+
+  @BeforeEach
+  void resetEventHandlerResolver() {
+    when(eventHandlerResolver.lookupContract(ArgumentMatchers.any(), ArgumentMatchers.anyString()))
+      .thenReturn(Optional.empty());
+  }
 
   /**
    * Регрессионный тест: незавершённое объявление переменной ({@code Перем} без имени)
@@ -120,6 +129,79 @@ class DocumentSymbolProviderTest {
       .filteredOn(documentSymbol -> documentSymbol.getKind() == SymbolKind.Method)
       .hasSize(1)
       .allMatch(documentSymbol -> documentSymbol.getDetail().equals("()"));
+  }
+
+  /**
+   * Методы общего модуля (BSL) — это функции без состояния, не члены объекта,
+   * поэтому в структуре документа они отдаются как {@link SymbolKind#Function}.
+   */
+  @Test
+  void testCommonModuleMethodsReportedAsFunction() {
+    // given — общий модуль конфигурации (модуль без состояния)
+    initServerContextOnce(Path.of(TestUtils.PATH_TO_METADATA));
+    context.getConfiguration();
+    var documentContext = context
+      .getDocument("CommonModule.ПервыйОбщийМодуль", ModuleType.CommonModule)
+      .orElseThrow();
+
+    // when
+    List<DocumentSymbol> documentSymbols = documentSymbolProvider.getDocumentSymbols(documentContext);
+
+    // then — методы общего модуля отдаются как Function, ни один не остаётся Method
+    var allSymbols = flatten(documentSymbols);
+    assertThat(allSymbols)
+      .anyMatch(documentSymbol -> documentSymbol.getName().equals("НеУстаревшаяПроцедура")
+        && documentSymbol.getKind() == SymbolKind.Function)
+      .anyMatch(documentSymbol -> documentSymbol.getName().equals("НеУстаревшаяФункция")
+        && documentSymbol.getKind() == SymbolKind.Function)
+      .noneMatch(documentSymbol -> documentSymbol.getKind() == SymbolKind.Method);
+  }
+
+  /**
+   * Методы модуля объекта (BSL) — члены объекта со состоянием,
+   * поэтому в структуре документа они остаются {@link SymbolKind#Method}.
+   */
+  @Test
+  void testObjectModuleMethodsStayMethod() {
+    // given — модуль объекта справочника (модуль со состоянием)
+    initServerContextOnce(Path.of(TestUtils.PATH_TO_METADATA));
+    context.getConfiguration();
+    var documentContext = context
+      .getDocument("Catalog.Справочник1", ModuleType.ObjectModule)
+      .orElseThrow();
+
+    // when
+    List<DocumentSymbol> documentSymbols = documentSymbolProvider.getDocumentSymbols(documentContext);
+
+    // then — метод модуля объекта остаётся Method, не превращается в Function
+    var allSymbols = flatten(documentSymbols);
+    assertThat(allSymbols)
+      .anyMatch(documentSymbol -> documentSymbol.getName().equals("Тест")
+        && documentSymbol.getKind() == SymbolKind.Method)
+      .noneMatch(documentSymbol -> documentSymbol.getKind() == SymbolKind.Function);
+  }
+
+  /**
+   * Методы модуля OneScript — функции без состояния,
+   * поэтому в структуре документа они отдаются как {@link SymbolKind#Function}.
+   */
+  @Test
+  void testOneScriptModuleMethodsReportedAsFunction() {
+    // given — модуль OneScript (.os, модуль без состояния)
+    var documentContext = TestUtils.getDocumentContext(
+      TestUtils.FAKE_OSCRIPT_DOCUMENT_URI,
+      """
+        Процедура Тест() Экспорт
+        КонецПроцедуры""");
+
+    // when
+    List<DocumentSymbol> documentSymbols = documentSymbolProvider.getDocumentSymbols(documentContext);
+
+    // then — метод модуля OneScript отдаётся как Function
+    assertThat(flatten(documentSymbols))
+      .anyMatch(documentSymbol -> documentSymbol.getName().equals("Тест")
+        && documentSymbol.getKind() == SymbolKind.Function)
+      .noneMatch(documentSymbol -> documentSymbol.getKind() == SymbolKind.Method);
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/SymbolProviderTest.java
@@ -91,21 +91,24 @@ class SymbolProviderTest {
     assertThat(symbols)
       .hasSizeGreaterThan(0)
       .anyMatch(symbolInformation ->
+        // общий модуль — модуль без состояния, метод отдаётся как Function
         symbolInformation.getName().equals("НеУстаревшаяПроцедура")
           && uriContains(symbolInformation, "ПервыйОбщийМодуль")
-          && symbolInformation.getKind() == SymbolKind.Method
+          && symbolInformation.getKind() == SymbolKind.Function
           && !symbolInformation.getTags().contains(SymbolTag.Deprecated)
       )
       .anyMatch(symbolInformation ->
+        // модуль менеджера регистра — модуль со состоянием, метод остаётся Method
         symbolInformation.getName().equals("НеУстаревшаяПроцедура")
           && uriContains(symbolInformation, "РегистрСведений1")
           && symbolInformation.getKind() == SymbolKind.Method
           && !symbolInformation.getTags().contains(SymbolTag.Deprecated)
       )
       .anyMatch(symbolInformation ->
+        // общий модуль — модуль без состояния, метод отдаётся как Function
         symbolInformation.getName().equals("УстаревшаяПроцедура")
           && uriContains(symbolInformation, "ПервыйОбщийМодуль")
-          && symbolInformation.getKind() == SymbolKind.Method
+          && symbolInformation.getKind() == SymbolKind.Function
           && symbolInformation.getTags().contains(SymbolTag.Deprecated)
       )
       .anyMatch(symbolInformation ->

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/references/ReferenceIndexTest.java
@@ -145,6 +145,32 @@ class ReferenceIndexTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void commonModuleMethodIsFunctionAndItsCallsAreFound() {
+    // given
+    var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);
+    var callerMethod = documentContext.getSymbolTree().getMethodSymbol("ИмяПроцедуры").orElseThrow();
+
+    var commonModuleContext = context
+      .getDocument("CommonModule.ПервыйОбщийМодуль", ModuleType.CommonModule)
+      .orElseThrow();
+    var calledMethod = commonModuleContext.getSymbolTree().getMethodSymbol("УстаревшаяПроцедура").orElseThrow();
+
+    var location = new Location(documentContext.getUri().toString(), Ranges.create(2, 22, 41));
+
+    // when
+    var references = referenceIndex.getReferencesTo(calledMethod);
+
+    // then
+    // метод общего модуля BSL — самостоятельная функция (SymbolKind.Function); его вызовы
+    // индексируются под каноническим SymbolKind.Method (ReferenceIndex#indexedKindOf), поэтому
+    // Find References/Rename находят их без приведения вида на месте вызова
+    assertThat(calledMethod.getSymbolKind()).isEqualTo(SymbolKind.Function);
+    assertThat(references)
+      .isNotEmpty()
+      .contains(Reference.of(callerMethod, calledMethod, location));
+  }
+
+  @Test
   void testGetReferenceToCommonModuleMethod() {
     // given
     var documentContext = TestUtils.getDocumentContextFromFile(PATH_TO_FILE);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndexTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/WorkspaceSymbolIndexTest.java
@@ -26,6 +26,7 @@ import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextCo
 import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextDocumentRemovedEvent;
 import com.github._1c_syntax.bsl.languageserver.types.registry.EventHandlerResolver;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.types.ModuleType;
 import org.eclipse.lsp4j.SymbolKind;
 import org.eclipse.lsp4j.jsonrpc.CancelChecker;
 import org.junit.jupiter.api.BeforeEach;
@@ -556,6 +557,80 @@ class WorkspaceSymbolIndexTest extends AbstractServerContextAwareTest {
 
   private static Set<Entry> emptyExclude() {
     return Collections.newSetFromMap(new IdentityHashMap<>());
+  }
+
+  /**
+   * Методы общего модуля (BSL) — функции без состояния, поэтому в индексе рабочей
+   * области они получают вид {@link SymbolKind#Function}.
+   */
+  @Test
+  void indexesCommonModuleMethodsAsFunction() {
+    // given — общий модуль конфигурации (модуль без состояния)
+    initServerContext(TestUtils.PATH_TO_METADATA);
+    var documentContext = TestUtils.getDocumentContextFromFile(
+      "src/test/resources/metadata/designer/CommonModules/ПервыйОбщийМодуль/Ext/Module.bsl", context);
+
+    // when
+    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
+    var result = index.search("НеУстаревшаяФункция", NO_CANCEL);
+
+    // then — запись метода общего модуля проиндексирована как Function
+    // (фильтр по контейнеру: метод с тем же именем есть и в stateful-модуле менеджера)
+    assertThat(documentContext.getModuleType()).isEqualTo(ModuleType.CommonModule);
+    assertThat(result)
+      .filteredOn(entry -> entry.name().equals("НеУстаревшаяФункция")
+        && entry.containerName().contains("ПервыйОбщийМодуль"))
+      .isNotEmpty()
+      .allMatch(entry -> entry.kind() == SymbolKind.Function);
+  }
+
+  /**
+   * Методы модуля объекта (BSL) — члены объекта со состоянием, поэтому в индексе
+   * рабочей области они остаются {@link SymbolKind#Method}.
+   */
+  @Test
+  void indexesObjectModuleMethodsAsMethod() {
+    // given — модуль объекта справочника (модуль со состоянием)
+    initServerContext(TestUtils.PATH_TO_METADATA);
+    var documentContext = TestUtils.getDocumentContextFromFile(
+      "src/test/resources/metadata/designer/Catalogs/Справочник1/Ext/ObjectModule.bsl", context);
+
+    // when
+    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
+    var result = index.search("Тест", NO_CANCEL);
+
+    // then — запись метода модуля объекта остаётся Method
+    // (фильтр по контейнеру: метод с тем же именем есть и в stateless-модулях)
+    assertThat(documentContext.getModuleType()).isEqualTo(ModuleType.ObjectModule);
+    assertThat(result)
+      .filteredOn(entry -> entry.name().equals("Тест")
+        && entry.containerName().contains("Справочник1"))
+      .isNotEmpty()
+      .allMatch(entry -> entry.kind() == SymbolKind.Method);
+  }
+
+  /**
+   * Методы модуля OneScript — функции без состояния, поэтому в индексе рабочей
+   * области они получают вид {@link SymbolKind#Function}.
+   */
+  @Test
+  void indexesOneScriptModuleMethodsAsFunction() {
+    // given — модуль OneScript (.os, модуль без состояния)
+    var documentContext = TestUtils.getDocumentContext(
+      TestUtils.FAKE_OSCRIPT_DOCUMENT_URI,
+      """
+        Процедура УникальныйМетодОС() Экспорт
+        КонецПроцедуры""");
+
+    // when
+    eventPublisher.publishEvent(new DocumentContextContentChangedEvent(documentContext));
+    var result = index.search("УникальныйМетодОС", NO_CANCEL);
+
+    // then — запись метода модуля OneScript проиндексирована как Function
+    assertThat(result)
+      .filteredOn(entry -> entry.name().equals("УникальныйМетодОС"))
+      .isNotEmpty()
+      .allMatch(entry -> entry.kind() == SymbolKind.Function);
   }
 
   @Test


### PR DESCRIPTION
## Описание

Методы модулей без состояния — **модулей OneScript** и **общих модулей BSL** — теперь отдаются как `SymbolKind.Function`, а не `SymbolKind.Method`.

В LSP нет отдельного `SymbolKind` для процедуры, поэтому процедуры и функции BSL исторически отдавались одинаково — как `SymbolKind.Method`. Но методы модулей без состояния — это самостоятельные функции, а не члены объекта со состоянием. Для них семантически корректнее `SymbolKind.Function`, что даёт IDE более точную иконку в outline и в результатах workspace-поиска.

Модули **со** состоянием (модуль объекта, менеджера, формы, класс OneScript) по-прежнему отдают методы как `Method`. Конструкторы OneScript-классов (`SymbolKind.Constructor`) и обработчики платформенных событий (`SymbolKind.Event`) — без изменений.

Переоткрытая с нуля версия #4117 (тот PR закрыт как устаревший): реализация упрощена с учётом инфраструктуры, появившейся в `develop` после #4301 (обработчики событий как отдельный вид символа). Затрагивается 3 файла основного кода вместо 18.

### Как

- Вид фиксируется **в модели символов** флагом `RegularMethodSymbol#standaloneFunction`, который выставляет `MethodSymbolComputer` по признаку «модуль без состояния»: `ModuleType.CommonModule` **или** `.os`-файл, не являющийся классом (`FileType.OS && ModuleType != OScriptClass`). Так вид един для всех потребителей (структура документа, индекс рабочей области, автодополнение) и не дублирует логику по провайдерам.
- Флаг влияет **только** на `getSymbolKind()`; во всех прочих отношениях символ остаётся обычным `RegularMethodSymbol` и идёт общим путём (hover, автодополнение, семантические токены — там процедуры и функции по-прежнему трактуются как методы).
- `ReferenceIndex#indexedKindOf` канонизирует `Function → Method` (рядом с уже имевшимися `Constructor`/`Event`): вызовы методов индексируются под единым `SymbolKind.Method`, поэтому **Find References / Rename / Call Hierarchy** находят вызовы функций модулей без состояния без приведения вида на месте вызова.

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (`spotlessCheck`, `javadoc` и затронутые тесты зелёные)

## Дополнительно

### Тесты

- `MethodSymbolKindTest` (новый) — вид символа метода в модели: общий модуль BSL → `Function`; модуль объекта → `Method`; модуль OneScript → `Function`; конструктор OneScript-класса → `Constructor`; обычный метод OneScript-класса → `Method`.
- `DocumentSymbolProviderTest` — `textDocument/documentSymbol`: общий модуль / OneScript → `Function`, модуль объекта → `Method`.
- `WorkspaceSymbolIndexTest` — записи индекса рабочей области: общий модуль / OneScript → `Function`, модуль объекта → `Method`.
- `SymbolProviderTest` — ожидания по методам общего модуля обновлены на `Function`; метод одноимённой процедуры в модуле менеджера регистра остаётся `Method`.
- `ReferenceIndexTest` — метод общего модуля имеет вид `Function`, и Find References по-прежнему находит его вызовы (через каноничный `Method`).

Прогонялись затронутые классы и downstream-потребители индекса ссылок (диагностики `MissingCommonModuleMethod`/`DeprecatedMethodCall`/`MissedRequiredParameter`/`PrivilegedModuleMethodCall`, семантические токены, inlay hints, call hierarchy, rename) — `BUILD SUCCESSFUL`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved symbol kind classification for stateless/common-module procedures: standalone routines are now shown as **Function**.
  * Stateful object-module methods remain **Method**, while OneScript class constructors keep their specialized kind.
  * Updated workspace/document symbol views, reference indexing/search, and symbol lookups to stay consistent with the new kind mapping.
  * Adjusted completion item icon kinds so local/common-module methods display the correct **Function/Method/Event** styling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->