### PR TITLE
Уточнённый тип строки коллекции доезжает до подсказки автодополнения

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/CollectionReturnsSpecializer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/CollectionReturnsSpecializer.java
@@ -23,6 +23,8 @@ package com.github._1c_syntax.bsl.languageserver.types.registry;
 
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberSource;
+import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import org.jspecify.annotations.Nullable;
@@ -99,13 +101,9 @@ final class CollectionReturnsSpecializer {
   @Nullable
   private static MemberDescriptor refine(MemberDescriptor member, TypeRef genericRow, TypeRef row,
                                          TypeSet unloadedRow) {
-    var refs = member.returnTypes().refs();
-    if (refs.contains(genericRow)) {
-      var converted = new ArrayList<TypeRef>(refs.size());
-      for (var ref : refs) {
-        converted.add(ref.equals(genericRow) ? row : ref);
-      }
-      return member.withReturnTypes(TypeSet.of(converted));
+    var withRow = replaceRow(member, genericRow, row);
+    if (withRow != null) {
+      return withRow;
     }
     if (member.matches(ROWS_SEARCH_METHOD)) {
       return member.withReturnTypes(withElements(member.returnTypes(), TypeSet.of(row)));
@@ -114,6 +112,67 @@ final class CollectionReturnsSpecializer {
       return member.withReturnTypes(withElements(member.returnTypes(), unloadedRow));
     }
     return null;
+  }
+
+  /**
+   * Заменяет обобщённую строку на конкретную <b>во всех позициях</b> члена: тип возврата,
+   * тип возврата сигнатуры и типы параметров ({@code Индекс(Строка)},
+   * {@code Сдвинуть(Строка, …)}).
+   * <p>
+   * Одного типа на уровне члена мало: подсказка автодополнения показывает тип из
+   * сигнатуры ({@code CompletionProvider.applyMethodDetail}), и без этой замены у
+   * {@code Добавить()} там оставалось обобщённое объявление.
+   *
+   * @return копия члена с конкретной строкой; {@code null}, если обобщённой строки в нём нет.
+   */
+  @Nullable
+  private static MemberDescriptor replaceRow(MemberDescriptor member, TypeRef genericRow, TypeRef row) {
+    var returnTypes = replaceRow(member.returnTypes(), genericRow, row);
+    var signatures = new ArrayList<SignatureDescriptor>(member.signatures().size());
+    var signaturesChanged = false;
+    for (var signature : member.signatures()) {
+      var replaced = replaceRow(signature, genericRow, row);
+      signaturesChanged |= replaced != signature;
+      signatures.add(replaced);
+    }
+    if (returnTypes == null && !signaturesChanged) {
+      return null;
+    }
+    var result = returnTypes == null ? member : member.withReturnTypes(returnTypes);
+    return signaturesChanged ? result.withSignatures(signatures) : result;
+  }
+
+  private static SignatureDescriptor replaceRow(SignatureDescriptor signature, TypeRef genericRow, TypeRef row) {
+    var returnTypes = replaceRow(signature.returnTypes(), genericRow, row);
+    var parameters = new ArrayList<ParameterDescriptor>(signature.parameters().size());
+    var parametersChanged = false;
+    for (var parameter : signature.parameters()) {
+      var replaced = replaceRow(parameter.types(), genericRow, row);
+      parametersChanged |= replaced != null;
+      parameters.add(replaced == null ? parameter : new ParameterDescriptor(parameter.bilingualName(),
+        replaced, parameter.optional(), parameter.bilingualDescription(), parameter.defaultValue(),
+        parameter.variadic()));
+    }
+    if (returnTypes == null && !parametersChanged) {
+      return signature;
+    }
+    return new SignatureDescriptor(parameters,
+      returnTypes == null ? signature.returnTypes() : returnTypes,
+      signature.bilingualDescription(), signature.metadata());
+  }
+
+  /** @return набор с заменённой строкой; {@code null}, если обобщённой строки в нём нет. */
+  @Nullable
+  private static TypeSet replaceRow(TypeSet types, TypeRef genericRow, TypeRef row) {
+    var refs = types.refs();
+    if (!refs.contains(genericRow)) {
+      return null;
+    }
+    var converted = new ArrayList<TypeRef>(refs.size());
+    for (var ref : refs) {
+      converted.add(ref.equals(genericRow) ? row : ref);
+    }
+    return TypeSet.of(converted);
   }
 
   /** Тот же набор типов, но с проставленным типом элемента у каждой ссылки. */

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/CollectionReturnsSpecializer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/CollectionReturnsSpecializer.java
@@ -132,8 +132,8 @@ final class CollectionReturnsSpecializer {
     var signaturesChanged = false;
     for (var signature : member.signatures()) {
       var replaced = replaceRow(signature, genericRow, row);
-      signaturesChanged |= replaced != signature;
-      signatures.add(replaced);
+      signaturesChanged |= replaced != null;
+      signatures.add(replaced == null ? signature : replaced);
     }
     if (returnTypes == null && !signaturesChanged) {
       return null;
@@ -142,6 +142,8 @@ final class CollectionReturnsSpecializer {
     return signaturesChanged ? result.withSignatures(signatures) : result;
   }
 
+  /** @return копия сигнатуры с конкретной строкой; {@code null}, если обобщённой строки в ней нет. */
+  @Nullable
   private static SignatureDescriptor replaceRow(SignatureDescriptor signature, TypeRef genericRow, TypeRef row) {
     var returnTypes = replaceRow(signature.returnTypes(), genericRow, row);
     var parameters = new ArrayList<ParameterDescriptor>(signature.parameters().size());
@@ -154,7 +156,7 @@ final class CollectionReturnsSpecializer {
         parameter.variadic()));
     }
     if (returnTypes == null && !parametersChanged) {
-      return signature;
+      return null;
     }
     return new SignatureDescriptor(parameters,
       returnTypes == null ? signature.returnTypes() : returnTypes,

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json
@@ -1491,7 +1491,45 @@
         "nameEn": "Insert",
         "kind": "METHOD",
         "returnType": "Строка табличной части",
-        "description": "Вставляет строку в указанную позицию."
+        "description": "Вставляет строку в указанную позицию.",
+        "signatures": [
+          {
+            "parameters": [
+              {
+                "name": "Индекс",
+                "nameRu": "Индекс",
+                "nameEn": "Index",
+                "types": [
+                  "Число"
+                ],
+                "description": "Позиция, на которую вставляется строка."
+              }
+            ]
+          }
+        ]
+      },
+      {
+        "name": "Индекс",
+        "nameRu": "Индекс",
+        "nameEn": "IndexOf",
+        "kind": "METHOD",
+        "returnType": "Число",
+        "description": "Возвращает индекс строки в табличной части.",
+        "signatures": [
+          {
+            "parameters": [
+              {
+                "name": "Строка",
+                "nameRu": "Строка",
+                "nameEn": "Row",
+                "types": [
+                  "Строка табличной части"
+                ],
+                "description": "Строка, индекс которой нужно получить."
+              }
+            ]
+          }
+        ]
       },
       {
         "name": "Получить",

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-platform-types.json
@@ -1509,29 +1509,6 @@
         ]
       },
       {
-        "name": "Индекс",
-        "nameRu": "Индекс",
-        "nameEn": "IndexOf",
-        "kind": "METHOD",
-        "returnType": "Число",
-        "description": "Возвращает индекс строки в табличной части.",
-        "signatures": [
-          {
-            "parameters": [
-              {
-                "name": "Строка",
-                "nameRu": "Строка",
-                "nameEn": "Row",
-                "types": [
-                  "Строка табличной части"
-                ],
-                "description": "Строка, индекс которой нужно получить."
-              }
-            ]
-          }
-        ]
-      },
-      {
         "name": "Получить",
         "nameRu": "Получить",
         "nameEn": "Get",
@@ -1610,7 +1587,22 @@
         "nameEn": "IndexOf",
         "kind": "METHOD",
         "returnType": "Число",
-        "description": "Возвращает индекс строки."
+        "description": "Возвращает индекс строки.",
+        "signatures": [
+          {
+            "parameters": [
+              {
+                "name": "Строка",
+                "nameRu": "Строка",
+                "nameEn": "Row",
+                "types": [
+                  "Строка табличной части"
+                ],
+                "description": "Строка, индекс которой нужно получить."
+              }
+            ]
+          }
+        ]
       },
       {
         "name": "Итог",

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TabularSectionMembersTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TabularSectionMembersTest.java
@@ -97,12 +97,29 @@ class TabularSectionMembersTest extends AbstractServerContextAwareTest {
       assertThat(method.returnTypes().refs()).extracting(TypeRef::qualifiedName)
         .as("%s возвращает строку этой табличной части", methodName)
         .contains(ROW);
-      assertThat(method.signatures())
-        .as("%s: тип уточнён и в сигнатуре — её показывает подсказка автодополнения", methodName)
-        .allSatisfy(signature -> assertThat(signature.returnTypes().refs())
-          .extracting(TypeRef::qualifiedName)
-          .contains(ROW));
     }
+  }
+
+  @Test
+  void rowTypeIsRefinedInSignatureReturnAndParameters() {
+    // Подсказка автодополнения показывает тип из сигнатуры, а не из члена, поэтому
+    // уточнение обязано доехать и туда. Параметры — тот же случай: `Индекс(Строка)`
+    // принимает строку именно этой табличной части.
+    var insert = member(SECTION, "Вставить");
+    assertThat(insert.signatures()).isNotEmpty();
+    assertThat(insert.signatures().get(0).returnTypes().refs())
+      .extracting(TypeRef::qualifiedName)
+      .containsExactly(ROW);
+
+    var indexOf = member(SECTION, "Индекс");
+    assertThat(indexOf.signatures()).isNotEmpty();
+    assertThat(indexOf.signatures().get(0).parameters().get(0).types().refs())
+      .extracting(TypeRef::qualifiedName)
+      .containsExactly(ROW);
+    assertThat(indexOf.returnTypes().refs())
+      .as("тип возврата у метода свой — его подменять нечем")
+      .extracting(TypeRef::qualifiedName)
+      .containsExactly("Число");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TabularSectionMembersTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TabularSectionMembersTest.java
@@ -97,6 +97,11 @@ class TabularSectionMembersTest extends AbstractServerContextAwareTest {
       assertThat(method.returnTypes().refs()).extracting(TypeRef::qualifiedName)
         .as("%s возвращает строку этой табличной части", methodName)
         .contains(ROW);
+      assertThat(method.signatures())
+        .as("%s: тип уточнён и в сигнатуре — её показывает подсказка автодополнения", methodName)
+        .allSatisfy(signature -> assertThat(signature.returnTypes().refs())
+          .extracting(TypeRef::qualifiedName)
+          .contains(ROW));
     }
   }
 


### PR DESCRIPTION
@
Уточнение типа строки коллекции проставлялось только на уровне члена, а подсказка автодополнения показывает тип **из сигнатуры** (`CompletionProvider.applyMethodDetail` → `signature.returnType()`). В результате у `Товары.Добавить()` в списке оставалось обобщённое объявление платформы — `Строка табличной части` вместо строки этой табличной части.

Замена обобщённой строки на конкретную идёт теперь во всех позициях члена:

- тип возврата члена;
- тип возврата сигнатуры;
- типы параметров — `Индекс(Строка)`, `Сдвинуть(Строка, …)`, `Удалить(Строка)`.

Вывод типов и разыменование работали и раньше — расходился только тот путь, по которому строится подсказка.

Проверка: `TabularSectionMembersTest` дополнен утверждением про сигнатуры; полный `check` с HBK-тестами зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
@

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Updated built-in “Tabular section” type metadata with an explicit `Insert` signature (parameter `Index: Number`) and enhanced `IndexOf` with a typed `Row` parameter.

* **Bug Fixes**
  * Improved collection/tabular-section specialization so refined row types propagate through method signature return types and parameter types (without changing intended method-level return types).

* **Tests**
  * Added a test covering row-type refinement in signature return/parameter types, while ensuring the method-level return type remains unchanged where expected.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->