### PR TITLE
Переработанная модель содержимого формы из mdclasses

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -98,8 +98,8 @@ dependencies {
     // 1c-syntax
     api("io.github.1c-syntax:bsl-parser:0.37.2")
     api("io.github.1c-syntax:utils:0.10.1")
-    api("io.github.1c-syntax:mdclasses:0.20.0")
-    api("io.github.1c-syntax:bsl-common-library:0.12.3")
+    api("io.github.1c-syntax:mdclasses:0.19.0.82-SNAPSHOT")
+    api("io.github.1c-syntax:bsl-common-library:0.12.4")
     api("io.github.1c-syntax:supportconf:0.17.1")
     api("io.github.1c-syntax:bsl-context:0.9.2")
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongDataPathForFormElementsDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/WrongDataPathForFormElementsDiagnostic.java
@@ -29,7 +29,8 @@ import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticT
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.mdo.Form;
 import com.github._1c_syntax.bsl.mdo.MD;
-import com.github._1c_syntax.bsl.mdo.storage.form.FormItem;
+import com.github._1c_syntax.bsl.mdo.storage.form.FormDataPathOwner;
+import com.github._1c_syntax.bsl.mdo.storage.form.FormElement;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import org.eclipse.lsp4j.Range;
 
@@ -62,8 +63,8 @@ public class WrongDataPathForFormElementsDiagnostic extends AbstractDiagnostic {
     }
   }
 
-  private static boolean wrongDataPath(FormItem formItem) {
-    return formItem.getDataPath().startsWith("~");
+  private static boolean wrongDataPath(FormElement formItem) {
+    return formItem instanceof FormDataPathOwner owner && owner.getDataPath().startsWith("~");
   }
 
   private static boolean haveFormModules(Form form) {
@@ -99,7 +100,7 @@ public class WrongDataPathForFormElementsDiagnostic extends AbstractDiagnostic {
     if (formData.isEmpty()) {
       return;
     }
-    formData.getPlainItems()
+    formData.getPlainElements()
       .stream()
       .filter(WrongDataPathForFormElementsDiagnostic::wrongDataPath)
       .forEach(formItem -> diagnosticStorage.addDiagnostic(diagnosticRange,

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/ForbiddenMetadataNameDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/ForbiddenMetadataNameDiagnosticTest.java
@@ -82,7 +82,7 @@ class ForbiddenMetadataNameDiagnosticTest extends AbstractDiagnosticTest<Forbidd
 
     List<Diagnostic> diagnostics = diagnosticInstance.getDiagnostics(documentContext);
 
-    assertThat(diagnostics).hasSize(19);
+    assertThat(diagnostics).hasSize(17);
     assertThat(diagnostics, true)
       .hasMessageOnRange("Запрещено использовать имя `Справочник` для `Справочник.Справочник1`", 0, 0, 9)
       .hasMessageOnRange(


### PR DESCRIPTION
Подъём mdclasses на переработанную модель содержимого формы ([mdclasses#674](https://github.com/1c-syntax/mdclasses/pull/674)) и адаптация к ней.

Вместо плоского `FormItem` — иерархия `FormElement` с наследниками (`FormField`, `FormGroup`, `FormTable`, `FormButton`, `FormDecoration`, `FormAddition`) и интерфейсами-ролями (`FormElementOwner`, `FormDataPathOwner`, `FormEventHandlerOwner`). Здесь только подъём и адаптация к переименованиям; новые данные (команды и параметры формы, признак основного реквизита, колонки реквизитов, события элементов) пока не используются — это отдельная работа.

Что поменялось в коде:

- `FormData.getPlainItems()` → `getPlainElements()`;
- `ПутьКДанным` спрашивается через `FormDataPathOwner`: у элементов, у которых его быть не может, метода больше нет — раньше он возвращал пустую строку.

Два неочевидных момента:

- **`bsl-common-library` поднята вынужденно.** Новая mdclasses требует 0.12.4; на 0.12.3 падает чтение конфигурации целиком — `NoSuchFieldError: V8ValueType.DATA_COMPOSITION_FIELD`, то есть метаданные не читаются вовсе, а не только формы.
- **`ForbiddenMetadataNameDiagnosticTest`: 19 → 17.** Реализовано чтение иерархии справочника ([mdclasses#656](https://github.com/1c-syntax/mdclasses/issues/656)), и у неиерархического справочника фикстуры больше нет стандартных реквизитов `Родитель` и `ЭтоГруппа` — их и не должно быть.

Версия mdclasses пока снапшотная: правка влита в develop, релиза ещё нет. Перед вливанием заменить на релизную.

Проверка: полный `check` зелёный, 639 тестовых классов.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved validation of form element data paths, providing more accurate diagnostics for applicable elements.
  * Updated diagnostic expectations to reflect corrected validation results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->