### PR TITLE
Свойства объектов метаданных разворачиваются именами

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MdoPropertyAccessors.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MdoPropertyAccessors.java
@@ -1,0 +1,144 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.mdo.AccountingRegister;
+import com.github._1c_syntax.bsl.mdo.AccumulationRegister;
+import com.github._1c_syntax.bsl.mdo.BusinessProcess;
+import com.github._1c_syntax.bsl.mdo.CalculationRegister;
+import com.github._1c_syntax.bsl.mdo.Catalog;
+import com.github._1c_syntax.bsl.mdo.ChartOfAccounts;
+import com.github._1c_syntax.bsl.mdo.ChartOfCalculationTypes;
+import com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes;
+import com.github._1c_syntax.bsl.mdo.Document;
+import com.github._1c_syntax.bsl.mdo.DocumentJournal;
+import com.github._1c_syntax.bsl.mdo.ExchangePlan;
+import com.github._1c_syntax.bsl.mdo.InformationRegister;
+import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.Sequence;
+import com.github._1c_syntax.bsl.mdo.Task;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
+import com.github._1c_syntax.bsl.types.MdoReference;
+
+import java.util.List;
+
+/**
+ * Свойства объектов метаданных, у которых в mdclasses нет интерфейса-владельца.
+ * <p>
+ * `ВводитсяНаОсновании`, `ВводПоСтроке`, `ПоляБлокировкиДанных` объявлены полем в восьми
+ * классах, `ДополнительныеИндексы` — в четырнадцати, и общего интерфейса вроде
+ * {@code AttributeOwner} у них нет (mdclasses#677). Поэтому виды объектов приходится
+ * перечислять — и это перечисление собрано здесь, чтобы не тащить полтора десятка
+ * MD-классов в тех, кто просто хочет прочитать свойство.
+ * <p>
+ * Как только интерфейсы появятся, весь класс схлопывается в четыре
+ * {@code instanceof}-проверки.
+ */
+final class MdoPropertyAccessors {
+
+  private MdoPropertyAccessors() {
+    // утилитный класс
+  }
+
+  /** Типы, на основании которых вводится объект; пусто — свойства у вида нет. */
+  static List<MdoReference> basedOn(MD md) {
+    return switch (md) {
+      case Catalog o -> o.getBasedOn();
+      case Document o -> o.getBasedOn();
+      case BusinessProcess o -> o.getBasedOn();
+      case Task o -> o.getBasedOn();
+      case ChartOfAccounts o -> o.getBasedOn();
+      case ChartOfCharacteristicTypes o -> o.getBasedOn();
+      case ChartOfCalculationTypes o -> o.getBasedOn();
+      case ExchangePlan o -> o.getBasedOn();
+      default -> List.of();
+    };
+  }
+
+  /** Поля, по которым доступен ввод по строке; пусто — свойства у вида нет. */
+  static List<MdoReference> inputByString(MD md) {
+    return switch (md) {
+      case Catalog o -> o.getInputByString();
+      case Document o -> o.getInputByString();
+      case BusinessProcess o -> o.getInputByString();
+      case Task o -> o.getInputByString();
+      case ChartOfAccounts o -> o.getInputByString();
+      case ChartOfCharacteristicTypes o -> o.getInputByString();
+      case ChartOfCalculationTypes o -> o.getInputByString();
+      case ExchangePlan o -> o.getInputByString();
+      default -> List.of();
+    };
+  }
+
+  /** Поля блокировки данных; пусто — свойства у вида нет. */
+  static List<MdoReference> dataLockFields(MD md) {
+    return switch (md) {
+      case Catalog o -> o.getDataLockFields();
+      case Document o -> o.getDataLockFields();
+      case BusinessProcess o -> o.getDataLockFields();
+      case Task o -> o.getDataLockFields();
+      case ChartOfAccounts o -> o.getDataLockFields();
+      case ChartOfCharacteristicTypes o -> o.getDataLockFields();
+      case ChartOfCalculationTypes o -> o.getDataLockFields();
+      case ExchangePlan o -> o.getDataLockFields();
+      default -> List.of();
+    };
+  }
+
+  /**
+   * Дополнительные индексы; пусто — свойства у вида нет.
+   * <p>
+   * Видов четырнадцать, поэтому перебор разделён на две половины: одним switch'ем
+   * он перевалил бы порог цикломатической сложности, а дробить его по-другому нечем —
+   * ветки различаются только типом.
+   */
+  static List<AdditionalIndex> additionalIndexes(MD md) {
+    var ofObject = additionalIndexesOfObject(md);
+    return ofObject.isEmpty() ? additionalIndexesOfRegister(md) : ofObject;
+  }
+
+  private static List<AdditionalIndex> additionalIndexesOfObject(MD md) {
+    return switch (md) {
+      case Catalog o -> o.getAdditionalIndexes();
+      case Document o -> o.getAdditionalIndexes();
+      case DocumentJournal o -> o.getAdditionalIndexes();
+      case BusinessProcess o -> o.getAdditionalIndexes();
+      case Task o -> o.getAdditionalIndexes();
+      case ChartOfAccounts o -> o.getAdditionalIndexes();
+      case ChartOfCharacteristicTypes o -> o.getAdditionalIndexes();
+      case ChartOfCalculationTypes o -> o.getAdditionalIndexes();
+      case ExchangePlan o -> o.getAdditionalIndexes();
+      default -> List.of();
+    };
+  }
+
+  private static List<AdditionalIndex> additionalIndexesOfRegister(MD md) {
+    return switch (md) {
+      case InformationRegister o -> o.getAdditionalIndexes();
+      case AccumulationRegister o -> o.getAdditionalIndexes();
+      case AccountingRegister o -> o.getAdditionalIndexes();
+      case CalculationRegister o -> o.getAdditionalIndexes();
+      case Sequence o -> o.getAdditionalIndexes();
+      default -> List.of();
+    };
+  }
+}

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataChildrenExtractor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataChildrenExtractor.java
@@ -177,12 +177,41 @@ final class MetadataChildrenExtractor {
 
   /** Поля, по которым доступен ввод по строке ({@code ВводПоСтроке}). */
   static List<ChildName> inputByStringFor(MD md) {
-    return mdoReferenceNames(MdoPropertyAccessors.inputByString(md));
+    return fieldNames(MdoPropertyAccessors.inputByString(md));
   }
 
   /** Поля блокировки данных ({@code ПоляБлокировкиДанных}). */
   static List<ChildName> dataLockFieldsFor(MD md) {
-    return mdoReferenceNames(MdoPropertyAccessors.dataLockFields(md));
+    return fieldNames(MdoPropertyAccessors.dataLockFields(md));
+  }
+
+  /**
+   * Имена элементов списка полей — только имена, без подмены типа возврата.
+   * <p>
+   * Отличие от {@link #mdoReferenceNames}: там ссылка ведёт на сам объект метаданных
+   * ({@code Движения} → {@code ОбъектМетаданных: РегистрНакопления.Х}), а здесь элемент
+   * коллекции — {@code Поле} списка полей, а не описание объекта, на который поле
+   * указывает. Подмена типа увела бы разыменование не туда: у {@code Поле} свой состав.
+   */
+  private static List<ChildName> fieldNames(Collection<MdoReference> refs) {
+    var result = new ArrayList<ChildName>(refs.size());
+    for (var ref : refs) {
+      var entry = ChildName.of(shortNameOf(ref));
+      if (entry != null) {
+        result.add(entry);
+      }
+    }
+    return List.copyOf(result);
+  }
+
+  /** {@code Catalog.Х.StandardAttribute.Владелец} → {@code Владелец}. */
+  private static String shortNameOf(MdoReference ref) {
+    var qualifiedName = ref.getMdoRefRu();
+    if (qualifiedName.isBlank()) {
+      qualifiedName = ref.getMdoRef();
+    }
+    var dot = qualifiedName.lastIndexOf('.');
+    return dot < 0 ? qualifiedName : qualifiedName.substring(dot + 1);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataChildrenExtractor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataChildrenExtractor.java
@@ -21,20 +21,30 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
+import com.github._1c_syntax.bsl.mdo.AccountingRegister;
+import com.github._1c_syntax.bsl.mdo.AccumulationRegister;
 import com.github._1c_syntax.bsl.mdo.Attribute;
 import com.github._1c_syntax.bsl.mdo.AttributeOwner;
+import com.github._1c_syntax.bsl.mdo.BusinessProcess;
 import com.github._1c_syntax.bsl.mdo.CalculationRegister;
+import com.github._1c_syntax.bsl.mdo.Catalog;
 import com.github._1c_syntax.bsl.mdo.ChartOfAccounts;
+import com.github._1c_syntax.bsl.mdo.ChartOfCalculationTypes;
+import com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes;
 import com.github._1c_syntax.bsl.mdo.CommandOwner;
 import com.github._1c_syntax.bsl.mdo.Document;
 import com.github._1c_syntax.bsl.mdo.DocumentJournal;
 import com.github._1c_syntax.bsl.mdo.Enum;
+import com.github._1c_syntax.bsl.mdo.ExchangePlan;
 import com.github._1c_syntax.bsl.mdo.FormOwner;
+import com.github._1c_syntax.bsl.mdo.InformationRegister;
 import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.Sequence;
 import com.github._1c_syntax.bsl.mdo.TabularSection;
 import com.github._1c_syntax.bsl.mdo.TabularSectionOwner;
 import com.github._1c_syntax.bsl.mdo.Task;
 import com.github._1c_syntax.bsl.mdo.TemplateOwner;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.AttributeKind;
 import com.github._1c_syntax.bsl.types.MdoReference;
 import org.jspecify.annotations.Nullable;
@@ -168,6 +178,91 @@ final class MetadataChildrenExtractor {
 
   static List<ChildName> registerRecordsFor(MD md) {
     return md instanceof Document doc ? mdoReferenceNames(doc.getRegisterRecords()) : List.of();
+  }
+
+  /**
+   * Типы, на основании которых вводится объект ({@code ВводитсяНаОсновании}).
+   * <p>
+   * Интерфейса-владельца у свойства нет, поэтому виды объектов перечислены здесь
+   * (mdclasses#677). Проверять приходится каждый: свойство есть у восьми классов.
+   */
+  static List<ChildName> basedOnFor(MD md) {
+    return mdoReferenceNames(switch (md) {
+      case Catalog o -> o.getBasedOn();
+      case Document o -> o.getBasedOn();
+      case BusinessProcess o -> o.getBasedOn();
+      case Task o -> o.getBasedOn();
+      case ChartOfAccounts o -> o.getBasedOn();
+      case ChartOfCharacteristicTypes o -> o.getBasedOn();
+      case ChartOfCalculationTypes o -> o.getBasedOn();
+      case ExchangePlan o -> o.getBasedOn();
+      default -> List.of();
+    });
+  }
+
+  /** Поля, по которым доступен ввод по строке ({@code ВводПоСтроке}). */
+  static List<ChildName> inputByStringFor(MD md) {
+    return mdoReferenceNames(switch (md) {
+      case Catalog o -> o.getInputByString();
+      case Document o -> o.getInputByString();
+      case BusinessProcess o -> o.getInputByString();
+      case Task o -> o.getInputByString();
+      case ChartOfAccounts o -> o.getInputByString();
+      case ChartOfCharacteristicTypes o -> o.getInputByString();
+      case ChartOfCalculationTypes o -> o.getInputByString();
+      case ExchangePlan o -> o.getInputByString();
+      default -> List.of();
+    });
+  }
+
+  /** Поля блокировки данных ({@code ПоляБлокировкиДанных}). */
+  static List<ChildName> dataLockFieldsFor(MD md) {
+    return mdoReferenceNames(switch (md) {
+      case Catalog o -> o.getDataLockFields();
+      case Document o -> o.getDataLockFields();
+      case BusinessProcess o -> o.getDataLockFields();
+      case Task o -> o.getDataLockFields();
+      case ChartOfAccounts o -> o.getDataLockFields();
+      case ChartOfCharacteristicTypes o -> o.getDataLockFields();
+      case ChartOfCalculationTypes o -> o.getDataLockFields();
+      case ExchangePlan o -> o.getDataLockFields();
+      default -> List.of();
+    });
+  }
+
+  /**
+   * Дополнительные индексы объекта ({@code ДополнительныеИндексы}) — в отличие от
+   * прочих коллекций здесь у элемента собственное имя, а не имя объекта метаданных.
+   */
+  static List<ChildName> additionalIndexesFor(MD md) {
+    return additionalIndexNames(switch (md) {
+      case Catalog o -> o.getAdditionalIndexes();
+      case Document o -> o.getAdditionalIndexes();
+      case DocumentJournal o -> o.getAdditionalIndexes();
+      case BusinessProcess o -> o.getAdditionalIndexes();
+      case Task o -> o.getAdditionalIndexes();
+      case ChartOfAccounts o -> o.getAdditionalIndexes();
+      case ChartOfCharacteristicTypes o -> o.getAdditionalIndexes();
+      case ChartOfCalculationTypes o -> o.getAdditionalIndexes();
+      case ExchangePlan o -> o.getAdditionalIndexes();
+      case InformationRegister o -> o.getAdditionalIndexes();
+      case AccumulationRegister o -> o.getAdditionalIndexes();
+      case AccountingRegister o -> o.getAdditionalIndexes();
+      case CalculationRegister o -> o.getAdditionalIndexes();
+      case Sequence o -> o.getAdditionalIndexes();
+      default -> List.of();
+    });
+  }
+
+  private static List<ChildName> additionalIndexNames(Collection<AdditionalIndex> indexes) {
+    var result = new ArrayList<ChildName>(indexes.size());
+    for (var index : indexes) {
+      var entry = ChildName.of(index.getName());
+      if (entry != null) {
+        result.add(entry);
+      }
+    }
+    return List.copyOf(result);
   }
 
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataChildrenExtractor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataChildrenExtractor.java
@@ -21,30 +21,20 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
-import com.github._1c_syntax.bsl.mdo.AccountingRegister;
-import com.github._1c_syntax.bsl.mdo.AccumulationRegister;
 import com.github._1c_syntax.bsl.mdo.Attribute;
 import com.github._1c_syntax.bsl.mdo.AttributeOwner;
-import com.github._1c_syntax.bsl.mdo.BusinessProcess;
 import com.github._1c_syntax.bsl.mdo.CalculationRegister;
-import com.github._1c_syntax.bsl.mdo.Catalog;
 import com.github._1c_syntax.bsl.mdo.ChartOfAccounts;
-import com.github._1c_syntax.bsl.mdo.ChartOfCalculationTypes;
-import com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes;
 import com.github._1c_syntax.bsl.mdo.CommandOwner;
 import com.github._1c_syntax.bsl.mdo.Document;
 import com.github._1c_syntax.bsl.mdo.DocumentJournal;
 import com.github._1c_syntax.bsl.mdo.Enum;
-import com.github._1c_syntax.bsl.mdo.ExchangePlan;
 import com.github._1c_syntax.bsl.mdo.FormOwner;
-import com.github._1c_syntax.bsl.mdo.InformationRegister;
 import com.github._1c_syntax.bsl.mdo.MD;
-import com.github._1c_syntax.bsl.mdo.Sequence;
 import com.github._1c_syntax.bsl.mdo.TabularSection;
 import com.github._1c_syntax.bsl.mdo.TabularSectionOwner;
 import com.github._1c_syntax.bsl.mdo.Task;
 import com.github._1c_syntax.bsl.mdo.TemplateOwner;
-import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
 import com.github._1c_syntax.bsl.mdo.support.AttributeKind;
 import com.github._1c_syntax.bsl.types.MdoReference;
 import org.jspecify.annotations.Nullable;
@@ -180,54 +170,19 @@ final class MetadataChildrenExtractor {
     return md instanceof Document doc ? mdoReferenceNames(doc.getRegisterRecords()) : List.of();
   }
 
-  /**
-   * Типы, на основании которых вводится объект ({@code ВводитсяНаОсновании}).
-   * <p>
-   * Интерфейса-владельца у свойства нет, поэтому виды объектов перечислены здесь
-   * (mdclasses#677). Проверять приходится каждый: свойство есть у восьми классов.
-   */
+  /** Типы, на основании которых вводится объект ({@code ВводитсяНаОсновании}). */
   static List<ChildName> basedOnFor(MD md) {
-    return mdoReferenceNames(switch (md) {
-      case Catalog o -> o.getBasedOn();
-      case Document o -> o.getBasedOn();
-      case BusinessProcess o -> o.getBasedOn();
-      case Task o -> o.getBasedOn();
-      case ChartOfAccounts o -> o.getBasedOn();
-      case ChartOfCharacteristicTypes o -> o.getBasedOn();
-      case ChartOfCalculationTypes o -> o.getBasedOn();
-      case ExchangePlan o -> o.getBasedOn();
-      default -> List.of();
-    });
+    return mdoReferenceNames(MdoPropertyAccessors.basedOn(md));
   }
 
   /** Поля, по которым доступен ввод по строке ({@code ВводПоСтроке}). */
   static List<ChildName> inputByStringFor(MD md) {
-    return mdoReferenceNames(switch (md) {
-      case Catalog o -> o.getInputByString();
-      case Document o -> o.getInputByString();
-      case BusinessProcess o -> o.getInputByString();
-      case Task o -> o.getInputByString();
-      case ChartOfAccounts o -> o.getInputByString();
-      case ChartOfCharacteristicTypes o -> o.getInputByString();
-      case ChartOfCalculationTypes o -> o.getInputByString();
-      case ExchangePlan o -> o.getInputByString();
-      default -> List.of();
-    });
+    return mdoReferenceNames(MdoPropertyAccessors.inputByString(md));
   }
 
   /** Поля блокировки данных ({@code ПоляБлокировкиДанных}). */
   static List<ChildName> dataLockFieldsFor(MD md) {
-    return mdoReferenceNames(switch (md) {
-      case Catalog o -> o.getDataLockFields();
-      case Document o -> o.getDataLockFields();
-      case BusinessProcess o -> o.getDataLockFields();
-      case Task o -> o.getDataLockFields();
-      case ChartOfAccounts o -> o.getDataLockFields();
-      case ChartOfCharacteristicTypes o -> o.getDataLockFields();
-      case ChartOfCalculationTypes o -> o.getDataLockFields();
-      case ExchangePlan o -> o.getDataLockFields();
-      default -> List.of();
-    });
+    return mdoReferenceNames(MdoPropertyAccessors.dataLockFields(md));
   }
 
   /**
@@ -235,26 +190,7 @@ final class MetadataChildrenExtractor {
    * прочих коллекций здесь у элемента собственное имя, а не имя объекта метаданных.
    */
   static List<ChildName> additionalIndexesFor(MD md) {
-    return additionalIndexNames(switch (md) {
-      case Catalog o -> o.getAdditionalIndexes();
-      case Document o -> o.getAdditionalIndexes();
-      case DocumentJournal o -> o.getAdditionalIndexes();
-      case BusinessProcess o -> o.getAdditionalIndexes();
-      case Task o -> o.getAdditionalIndexes();
-      case ChartOfAccounts o -> o.getAdditionalIndexes();
-      case ChartOfCharacteristicTypes o -> o.getAdditionalIndexes();
-      case ChartOfCalculationTypes o -> o.getAdditionalIndexes();
-      case ExchangePlan o -> o.getAdditionalIndexes();
-      case InformationRegister o -> o.getAdditionalIndexes();
-      case AccumulationRegister o -> o.getAdditionalIndexes();
-      case AccountingRegister o -> o.getAdditionalIndexes();
-      case CalculationRegister o -> o.getAdditionalIndexes();
-      case Sequence o -> o.getAdditionalIndexes();
-      default -> List.of();
-    });
-  }
-
-  private static List<ChildName> additionalIndexNames(Collection<AdditionalIndex> indexes) {
+    var indexes = MdoPropertyAccessors.additionalIndexes(md);
     var result = new ArrayList<ChildName>(indexes.size());
     for (var index : indexes) {
       var entry = ChildName.of(index.getName());

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializer.java
@@ -610,6 +610,12 @@ public class MetadataCollectionSpecializer {
     var perCollName = spec.baseCollectionName() + "." + spec.ru() + "." + ownerSuffix;
     var perCollRef = typeRegistry.intern(TypeKind.PLATFORM, perCollName);
     registerSubChildOwners(children, elementRef, ownerSuffix);
+    // Коллекция остаётся коллекцией: обход `Для Каждого` и индексатор дают её элемент.
+    // Для коллекций, где элементы вообще не адресуются по имени (характеристики,
+    // дополнительные индексы, ввод на основании), это единственный способ до них
+    // добраться — синтакс-помощник у них так и пишет: обход и обращение по индексу.
+    typeRegistry.registerDefaultElementTypes(perCollRef, List.of(elementRef));
+    typeRegistry.inheritCollectionTraits(perCollRef, baseRef, FileType.BSL);
     var capturedBase = baseRef;
     var capturedElement = elementRef;
     var capturedChildren = children;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializer.java
@@ -287,22 +287,25 @@ public class MetadataCollectionSpecializer {
       MetadataChildrenExtractor::registerRecordsFor),
 
     // ВводитсяНаОсновании — типы, на основании которых вводится объект.
-    // В mdclasses нет удобного getter'а — оставляем только returnType chain.
     new CollectionSpec("ВводитсяНаОсновании", "BasedOn",
       BASE_COLLECTION_PROPERTY_VALUE, "ЗначениеСвойстваОбъектаМетаданных",
-      ANY, md -> List.of()),
+      ANY, MetadataChildrenExtractor::basedOnFor),
 
     // Поля ввода по строке / блокировки данных — СписокПолей с элементами «Поле».
     new CollectionSpec("ВводПоСтроке", "InputByString",
-      BASE_COLLECTION_FIELD_LIST, "Поле", ANY, md -> List.of()),
+      BASE_COLLECTION_FIELD_LIST, "Поле", ANY, MetadataChildrenExtractor::inputByStringFor),
     new CollectionSpec("ПоляБлокировкиДанных", "DataLockFields",
-      BASE_COLLECTION_FIELD_LIST, "Поле", ANY, md -> List.of()),
+      BASE_COLLECTION_FIELD_LIST, "Поле", ANY, MetadataChildrenExtractor::dataLockFieldsFor),
 
     // Дополнительные индексы — элементы «ДополнительныйИндекс».
     new CollectionSpec(BASE_COLLECTION_ADDITIONAL_INDEXES, "AdditionalIndexes",
-      BASE_COLLECTION_ADDITIONAL_INDEXES, "ДополнительныйИндекс", ANY, md -> List.of()),
+      BASE_COLLECTION_ADDITIONAL_INDEXES, "ДополнительныйИндекс",
+      ANY, MetadataChildrenExtractor::additionalIndexesFor),
 
     // Характеристики плана видов характеристик — элементы «ОписаниеХарактеристик».
+    // Имена не разворачиваются, и дело не в данных: у `Characteristic` в mdclasses
+    // имени нет вовсе — описание характеристик это набор ссылок на таблицы и поля.
+    // Обращаться к ним по имени негде, поэтому остаётся только returnType-цепочка.
     new CollectionSpec("Характеристики", "Characteristics",
       BASE_COLLECTION_CHARACTERISTICS, "ОписаниеХарактеристик", ANY, md -> List.of())
   );

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/StandardAttributesResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/StandardAttributesResolver.java
@@ -22,8 +22,11 @@
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
 import com.github._1c_syntax.bsl.context.api.KnownStandardAttributes;
+import com.github._1c_syntax.bsl.mdo.Catalog;
+import com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes;
 import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.mdo.TabularSection;
+import com.github._1c_syntax.bsl.mdo.support.HierarchyType;
 import com.github._1c_syntax.bsl.types.MDOType;
 import org.jspecify.annotations.Nullable;
 
@@ -57,6 +60,12 @@ final class StandardAttributesResolver {
     Map.entry(MDOType.TABULAR_SECTION, "ОбъектМетаданных: ТабличнаяЧасть")
   );
 
+  /** Стандартный реквизит иерархического объекта — ссылка на родителя. */
+  private static final String PARENT = "Родитель";
+
+  /** Признак группы — есть только при иерархии групп и элементов. */
+  private static final String IS_FOLDER = "ЭтоГруппа";
+
   private StandardAttributesResolver() {
   }
 
@@ -71,12 +80,57 @@ final class StandardAttributesResolver {
     }
     var result = new ArrayList<ChildName>(names.size());
     for (var n : names) {
+      if (!appliesTo(md, n.getName())) {
+        continue;
+      }
       var entry = ChildName.bilingual(n.getName(), n.getAlias());
       if (entry != null) {
         result.add(entry);
       }
     }
     return List.copyOf(result);
+  }
+
+  /**
+   * Есть ли стандартный реквизит у конкретного объекта. Список от
+   * {@code KnownStandardAttributes} зависит только от вида объекта, а два реквизита
+   * зависят ещё и от его настроек:
+   * <ul>
+   *   <li>{@code Родитель} есть только у иерархического справочника или плана видов
+   *       характеристик;</li>
+   *   <li>{@code ЭтоГруппа} — только при иерархии групп и элементов: при иерархии
+   *       элементов групп не бывает.</li>
+   * </ul>
+   */
+  private static boolean appliesTo(MD md, String attributeName) {
+    if (PARENT.equalsIgnoreCase(attributeName)) {
+      return isHierarchical(md);
+    }
+    if (IS_FOLDER.equalsIgnoreCase(attributeName)) {
+      return isHierarchical(md) && hasFolders(md);
+    }
+    return true;
+  }
+
+  private static boolean isHierarchical(MD md) {
+    return switch (md) {
+      case Catalog catalog -> catalog.isHierarchical();
+      case ChartOfCharacteristicTypes chart -> chart.isHierarchical();
+      // Прочие виды объектов иерархичны по своей природе (план счетов) либо
+      // реквизита не имеют вовсе — тогда сюда и не попадём.
+      default -> true;
+    };
+  }
+
+  /**
+   * Бывают ли у иерархии этого объекта группы. Выбор вида иерархии есть только у
+   * справочника; у плана видов характеристик иерархия всегда групп и элементов.
+   */
+  private static boolean hasFolders(MD md) {
+    if (md instanceof Catalog catalog) {
+      return catalog.getHierarchyType() == HierarchyType.HIERARCHY_FOLDERS_AND_ITEMS;
+    }
+    return true;
   }
 
   static @Nullable String ownerTypeFor(MD md) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataChildrenExtractorTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataChildrenExtractorTest.java
@@ -21,10 +21,30 @@
  */
 package com.github._1c_syntax.bsl.languageserver.types.registry;
 
+import com.github._1c_syntax.bsl.mdo.AccountingRegister;
+import com.github._1c_syntax.bsl.mdo.AccumulationRegister;
+import com.github._1c_syntax.bsl.mdo.BusinessProcess;
+import com.github._1c_syntax.bsl.mdo.CalculationRegister;
+import com.github._1c_syntax.bsl.mdo.Catalog;
+import com.github._1c_syntax.bsl.mdo.ChartOfAccounts;
+import com.github._1c_syntax.bsl.mdo.ChartOfCalculationTypes;
+import com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes;
 import com.github._1c_syntax.bsl.mdo.Constant;
+import com.github._1c_syntax.bsl.mdo.Document;
+import com.github._1c_syntax.bsl.mdo.DocumentJournal;
+import com.github._1c_syntax.bsl.mdo.ExchangePlan;
+import com.github._1c_syntax.bsl.mdo.InformationRegister;
 import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.Sequence;
+import com.github._1c_syntax.bsl.mdo.Task;
+import com.github._1c_syntax.bsl.mdo.storage.AdditionalIndex;
+import com.github._1c_syntax.bsl.types.MdoReference;
 import org.junit.jupiter.api.Test;
 
+import java.util.List;
+import java.util.function.Function;
+
+import static com.github._1c_syntax.bsl.languageserver.types.registry.MetadataCollectionSpecializer.ChildName;
 import static org.assertj.core.api.Assertions.assertThat;
 
 /**
@@ -93,5 +113,103 @@ class MetadataChildrenExtractorTest {
   @Test
   void registerRecordsFor_nonDocument_returnsEmpty() {
     assertThat(MetadataChildrenExtractor.registerRecordsFor(NON_OWNER)).isEmpty();
+  }
+
+  // === свойства, у которых в mdclasses нет интерфейса-владельца (mdclasses#677) ===
+
+  private static final MdoReference DOCUMENT_REF = MdoReference.create("Document.Документ1");
+  private static final MdoReference FIELD_REF = MdoReference.create("Catalog.Справочник1.Attribute.Реквизит1");
+
+  /**
+   * Виды объектов перечисляются в коде поимённо, потому что интерфейса-владельца у
+   * свойства нет. Такое перечисление легко разъезжается с моделью — поэтому проверяется
+   * каждая ветка, а не одна показательная.
+   */
+  @Test
+  void basedOnIsReadFromEveryKindThatHasIt() {
+    assertThat(extractedNames(MetadataChildrenExtractor::basedOnFor, List.of(
+      Catalog.builder().name("С").addBasedOn(DOCUMENT_REF).build(),
+      Document.builder().name("Д").addBasedOn(DOCUMENT_REF).build(),
+      BusinessProcess.builder().name("БП").addBasedOn(DOCUMENT_REF).build(),
+      Task.builder().name("З").addBasedOn(DOCUMENT_REF).build(),
+      ChartOfAccounts.builder().name("ПС").addBasedOn(DOCUMENT_REF).build(),
+      ChartOfCharacteristicTypes.builder().name("ПВХ").addBasedOn(DOCUMENT_REF).build(),
+      ChartOfCalculationTypes.builder().name("ПВР").addBasedOn(DOCUMENT_REF).build(),
+      ExchangePlan.builder().name("ПО").addBasedOn(DOCUMENT_REF).build())))
+      .containsOnly("Документ1");
+    assertThat(MetadataChildrenExtractor.basedOnFor(NON_OWNER)).isEmpty();
+  }
+
+  @Test
+  void inputByStringIsReadFromEveryKindThatHasIt() {
+    assertThat(extractedNames(MetadataChildrenExtractor::inputByStringFor, List.of(
+      Catalog.builder().name("С").addInputByString(FIELD_REF).build(),
+      Document.builder().name("Д").addInputByString(FIELD_REF).build(),
+      BusinessProcess.builder().name("БП").addInputByString(FIELD_REF).build(),
+      Task.builder().name("З").addInputByString(FIELD_REF).build(),
+      ChartOfAccounts.builder().name("ПС").addInputByString(FIELD_REF).build(),
+      ChartOfCharacteristicTypes.builder().name("ПВХ").addInputByString(FIELD_REF).build(),
+      ChartOfCalculationTypes.builder().name("ПВР").addInputByString(FIELD_REF).build(),
+      ExchangePlan.builder().name("ПО").addInputByString(FIELD_REF).build())))
+      .containsOnly("Реквизит1");
+    assertThat(MetadataChildrenExtractor.inputByStringFor(NON_OWNER)).isEmpty();
+  }
+
+  @Test
+  void dataLockFieldsAreReadFromEveryKindThatHasThem() {
+    assertThat(extractedNames(MetadataChildrenExtractor::dataLockFieldsFor, List.of(
+      Catalog.builder().name("С").addDataLockFields(FIELD_REF).build(),
+      Document.builder().name("Д").addDataLockFields(FIELD_REF).build(),
+      BusinessProcess.builder().name("БП").addDataLockFields(FIELD_REF).build(),
+      Task.builder().name("З").addDataLockFields(FIELD_REF).build(),
+      ChartOfAccounts.builder().name("ПС").addDataLockFields(FIELD_REF).build(),
+      ChartOfCharacteristicTypes.builder().name("ПВХ").addDataLockFields(FIELD_REF).build(),
+      ChartOfCalculationTypes.builder().name("ПВР").addDataLockFields(FIELD_REF).build(),
+      ExchangePlan.builder().name("ПО").addDataLockFields(FIELD_REF).build())))
+      .containsOnly("Реквизит1");
+    assertThat(MetadataChildrenExtractor.dataLockFieldsFor(NON_OWNER)).isEmpty();
+  }
+
+  @Test
+  void additionalIndexesAreReadFromEveryKindThatHasThem() {
+    var index = AdditionalIndex.builder().name("Индекс1").build();
+    assertThat(extractedNames(MetadataChildrenExtractor::additionalIndexesFor, List.of(
+      Catalog.builder().name("С").addAdditionalIndex(index).build(),
+      Document.builder().name("Д").addAdditionalIndex(index).build(),
+      DocumentJournal.builder().name("ЖД").addAdditionalIndex(index).build(),
+      BusinessProcess.builder().name("БП").addAdditionalIndex(index).build(),
+      Task.builder().name("З").addAdditionalIndex(index).build(),
+      ChartOfAccounts.builder().name("ПС").addAdditionalIndex(index).build(),
+      ChartOfCharacteristicTypes.builder().name("ПВХ").addAdditionalIndex(index).build(),
+      ChartOfCalculationTypes.builder().name("ПВР").addAdditionalIndex(index).build(),
+      ExchangePlan.builder().name("ПО").addAdditionalIndex(index).build(),
+      InformationRegister.builder().name("РС").addAdditionalIndex(index).build(),
+      AccumulationRegister.builder().name("РН").addAdditionalIndex(index).build(),
+      AccountingRegister.builder().name("РБ").addAdditionalIndex(index).build(),
+      CalculationRegister.builder().name("РР").addAdditionalIndex(index).build(),
+      Sequence.builder().name("П").addAdditionalIndex(index).build())))
+      .as("у индекса собственное имя, а не имя объекта метаданных")
+      .containsOnly("Индекс1");
+    assertThat(MetadataChildrenExtractor.additionalIndexesFor(NON_OWNER)).isEmpty();
+  }
+
+  @Test
+  void additionalIndexWithoutNameIsSkipped() {
+    var catalog = Catalog.builder().name("С")
+      .addAdditionalIndex(AdditionalIndex.builder().name("").build())
+      .build();
+    assertThat(MetadataChildrenExtractor.additionalIndexesFor(catalog)).isEmpty();
+  }
+
+  /** Имена, извлечённые из каждого объекта; ожидается ровно по одному на объект. */
+  private static List<String> extractedNames(Function<MD, List<ChildName>> extractor,
+                                             List<? extends MD> objects) {
+    return objects.stream()
+      .peek(md -> assertThat(extractor.apply(md))
+        .as("вид %s", md.getClass().getSimpleName())
+        .hasSize(1))
+      .flatMap(md -> extractor.apply(md).stream())
+      .map(child -> child.name().ru())
+      .toList();
   }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
@@ -217,6 +217,12 @@ class MetadataCollectionSpecializerTest extends AbstractServerContextAwareTest {
     assertThat(memberNames(typeRegistry.getMembers(collectionRef, FileType.BSL)))
       .as("в фикстуре ввод по строке настроен на стандартный реквизит Номер")
       .contains("Номер");
+
+    // Элемент списка полей — `Поле`, а не описание объекта, на который поле указывает:
+    // подмена типа увела бы разыменование в состав стандартного реквизита.
+    assertThat(findMember(typeRegistry.getMembers(collectionRef, FileType.BSL), "Номер").returnType()
+      .qualifiedName())
+      .isEqualTo("Поле");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
@@ -457,6 +457,44 @@ class MetadataCollectionSpecializerTest extends AbstractServerContextAwareTest {
     return memberNames(typeRegistry.getMembers(collectionRef, FileType.BSL));
   }
 
+  @Test
+  void metadataCollectionIsIterableAndCarriesItsElementType() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // У части коллекций элементы вообще не адресуются по имени: синтакс-помощник
+    // для «ОписанияХарактеристик» знает только обход и обращение по индексу. Без типа
+    // элемента такая коллекция для пользователя пустая — до её содержимого не добраться.
+    var characteristics = collectionRef("Характеристики");
+    assertThat(typeRegistry.getDefaultElementTypes(characteristics).refs())
+      .extracting(TypeRef::qualifiedName)
+      .containsExactly("ОписаниеХарактеристик");
+    assertThat(typeRegistry.supportsForEach(characteristics, FileType.BSL))
+      .as("обход Для Каждого")
+      .isTrue();
+    assertThat(typeRegistry.supportsIndexAccess(characteristics, FileType.BSL))
+      .as("обращение по индексу")
+      .isTrue();
+
+    // То же и у коллекций, которые адресуются по имени, — обход им тоже положен.
+    assertThat(typeRegistry.getDefaultElementTypes(collectionRef("Реквизиты")).refs())
+      .extracting(TypeRef::qualifiedName)
+      .containsExactly("ОбъектМетаданных: Реквизит");
+    assertThat(typeRegistry.getDefaultElementTypes(collectionRef("ДополнительныеИндексы")).refs())
+      .extracting(TypeRef::qualifiedName)
+      .containsExactly("ДополнительныйИндекс");
+  }
+
+  /** Специализированный тип коллекции иерархического справочника фикстуры. */
+  private TypeRef collectionRef(String collectionName) {
+    var perMdoTypeRef = typeRegistry.intern(TypeKind.PLATFORM,
+      "ОбъектМетаданных: Справочник.СправочникСМенеджером");
+    var member = findMember(typeRegistry.getMembers(perMdoTypeRef, FileType.BSL), collectionName);
+    assertThat(member).as("property %s на per-MDO типе", collectionName).isNotNull();
+    return typeRegistry.intern(TypeKind.PLATFORM, member.returnType().qualifiedName());
+  }
+
   // --- helpers ---
 
   private static MemberDescriptor findMember(Collection<MemberDescriptor> members, String name) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
@@ -203,6 +203,45 @@ class MetadataCollectionSpecializerTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void inputByStringFieldsAreExpandedFromMdclasses() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // Метаданные.Документы.Документ1.ВводПоСтроке → поля, перечисленные в <InputByString>.
+    var perMdoTypeRef = typeRegistry.intern(TypeKind.PLATFORM, "ОбъектМетаданных: Документ.Документ1");
+    var member = findMember(typeRegistry.getMembers(perMdoTypeRef, FileType.BSL), "ВводПоСтроке");
+    assertThat(member).as("на per-MDO типе должно быть property ВводПоСтроке").isNotNull();
+
+    var collectionRef = typeRegistry.intern(TypeKind.PLATFORM, member.returnType().qualifiedName());
+    assertThat(memberNames(typeRegistry.getMembers(collectionRef, FileType.BSL)))
+      .as("в фикстуре ввод по строке настроен на стандартный реквизит Номер")
+      .contains("Номер");
+  }
+
+  @Test
+  void hierarchyOnlyStandardAttributesAreSkippedForFlatCatalog() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // Справочник1 в фикстуре неиерархический, значит `Родитель` и `ЭтоГруппа` у него
+    // не существуют — набор стандартных реквизитов зависит не только от вида объекта.
+    var perMdoTypeRef = typeRegistry.intern(TypeKind.PLATFORM, "ОбъектМетаданных: Справочник.Справочник1");
+    var member = findMember(typeRegistry.getMembers(perMdoTypeRef, FileType.BSL), "СтандартныеРеквизиты");
+    assertThat(member).isNotNull();
+
+    var collectionRef = typeRegistry.intern(TypeKind.PLATFORM, member.returnType().qualifiedName());
+    var names = memberNames(typeRegistry.getMembers(collectionRef, FileType.BSL));
+    assertThat(names)
+      .as("общие для вида стандартные реквизиты на месте")
+      .contains("Ссылка", "Код", "Наименование");
+    assertThat(names)
+      .as("реквизиты иерархии у неиерархического справочника не показываются")
+      .doesNotContain("Родитель", "ЭтоГруппа", "Parent", "IsFolder");
+  }
+
+  @Test
   void tabularSectionExposesStandardAttributes() {
     initServerContext(PATH_TO_METADATA);
     context.getConfiguration();

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
@@ -415,6 +415,48 @@ class MetadataCollectionSpecializerTest extends AbstractServerContextAwareTest {
       .isEqualTo("ОбъектМетаданных: Документ");
   }
 
+  @Test
+  void basedOnAndDataLockFieldsAndIndexesAreExpandedFromMdclasses() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    assertThat(collectionNames("ВводитсяНаОсновании"))
+      .as("в фикстуре справочник вводится на основании Документ1")
+      .contains("Документ1");
+    assertThat(collectionNames("ПоляБлокировкиДанных"))
+      .as("поле блокировки — стандартный реквизит Владелец")
+      .contains("Владелец");
+    assertThat(collectionNames("ДополнительныеИндексы"))
+      .as("у дополнительного индекса собственное имя, а не имя объекта метаданных")
+      .contains("ИндексПоВладельцу");
+  }
+
+  @Test
+  void hierarchyStandardAttributesArePresentForHierarchicalCatalog() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+    provider.tryRegister();
+
+    // Обратная сторона hierarchyOnlyStandardAttributesAreSkippedForFlatCatalog:
+    // у иерархического справочника с группами оба реквизита на месте.
+    assertThat(collectionNames("СтандартныеРеквизиты"))
+      .contains("Родитель", "ЭтоГруппа");
+  }
+
+  /**
+   * Имена членов коллекции иерархического справочника фикстуры — той, на которую
+   * указывает одноимённое property его per-MDO типа.
+   */
+  private List<String> collectionNames(String collectionName) {
+    var perMdoTypeRef = typeRegistry.intern(TypeKind.PLATFORM,
+      "ОбъектМетаданных: Справочник.СправочникСМенеджером");
+    var member = findMember(typeRegistry.getMembers(perMdoTypeRef, FileType.BSL), collectionName);
+    assertThat(member).as("property %s на per-MDO типе", collectionName).isNotNull();
+    var collectionRef = typeRegistry.intern(TypeKind.PLATFORM, member.returnType().qualifiedName());
+    return memberNames(typeRegistry.getMembers(collectionRef, FileType.BSL));
+  }
+
   // --- helpers ---
 
   private static MemberDescriptor findMember(Collection<MemberDescriptor> members, String name) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializerTest.java
@@ -232,12 +232,9 @@ class MetadataCollectionSpecializerTest extends AbstractServerContextAwareTest {
     assertThat(member).isNotNull();
 
     var collectionRef = typeRegistry.intern(TypeKind.PLATFORM, member.returnType().qualifiedName());
-    var names = memberNames(typeRegistry.getMembers(collectionRef, FileType.BSL));
-    assertThat(names)
-      .as("общие для вида стандартные реквизиты на месте")
-      .contains("Ссылка", "Код", "Наименование");
-    assertThat(names)
-      .as("реквизиты иерархии у неиерархического справочника не показываются")
+    assertThat(memberNames(typeRegistry.getMembers(collectionRef, FileType.BSL)))
+      .as("общие для вида реквизиты на месте, а реквизиты иерархии не показываются")
+      .contains("Ссылка", "Код", "Наименование")
       .doesNotContain("Родитель", "ЭтоГруппа", "Parent", "IsFolder");
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/StandardAttributesResolverTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/StandardAttributesResolverTest.java
@@ -1,0 +1,90 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.mdo.Catalog;
+import com.github._1c_syntax.bsl.mdo.ChartOfCharacteristicTypes;
+import com.github._1c_syntax.bsl.mdo.Document;
+import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.mdo.support.HierarchyType;
+import org.junit.jupiter.api.Test;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Набор стандартных реквизитов зависит не только от вида объекта: два реквизита
+ * иерархии есть не у каждого справочника. Проверяется без Spring — это чистая функция
+ * над объектом mdclasses и таблицей из bsl-context.
+ */
+class StandardAttributesResolverTest {
+
+  @Test
+  void flatCatalogHasNeitherParentNorIsFolder() {
+    assertThat(namesOf(Catalog.builder().name("С").hierarchical(false).build()))
+      .contains("Ссылка", "Код", "Наименование")
+      .doesNotContain("Родитель", "ЭтоГруппа");
+  }
+
+  @Test
+  void hierarchyOfFoldersAndItemsHasBoth() {
+    assertThat(namesOf(Catalog.builder().name("С")
+      .hierarchical(true)
+      .hierarchyType(HierarchyType.HIERARCHY_FOLDERS_AND_ITEMS)
+      .build()))
+      .contains("Родитель", "ЭтоГруппа");
+  }
+
+  @Test
+  void hierarchyOfItemsHasParentButNoIsFolder() {
+    // При иерархии элементов групп не бывает, значит и признака группы нет.
+    assertThat(namesOf(Catalog.builder().name("С")
+      .hierarchical(true)
+      .hierarchyType(HierarchyType.HIERARCHY_OF_ITEMS)
+      .build()))
+      .contains("Родитель")
+      .doesNotContain("ЭтоГруппа");
+  }
+
+  @Test
+  void chartOfCharacteristicTypesFollowsItsOwnHierarchyFlag() {
+    assertThat(namesOf(ChartOfCharacteristicTypes.builder().name("ПВХ").hierarchical(false).build()))
+      .doesNotContain("Родитель", "ЭтоГруппа");
+    assertThat(namesOf(ChartOfCharacteristicTypes.builder().name("ПВХ").hierarchical(true).build()))
+      .as("у плана видов характеристик иерархия всегда групп и элементов")
+      .contains("Родитель", "ЭтоГруппа");
+  }
+
+  @Test
+  void kindWithoutHierarchyIsUntouched() {
+    // У документа реквизитов иерархии нет вовсе — фильтр не должен ничего отрезать.
+    assertThat(namesOf(Document.builder().name("Д").build()))
+      .contains("Ссылка", "Дата", "Номер");
+  }
+
+  private static List<String> namesOf(MD md) {
+    return StandardAttributesResolver.standardAttributesFor(md).stream()
+      .map(child -> child.name().ru())
+      .toList();
+  }
+}

--- a/src/test/resources/metadata/designer/Catalogs/СправочникСМенеджером.xml
+++ b/src/test/resources/metadata/designer/Catalogs/СправочникСМенеджером.xml
@@ -27,7 +27,7 @@
 			<Name>СправочникСМенеджером</Name>
 			<Synonym/>
 			<Comment/>
-			<Hierarchical>false</Hierarchical>
+			<Hierarchical>true</Hierarchical>
 			<HierarchyType>HierarchyFoldersAndItems</HierarchyType>
 			<LimitLevelCount>false</LimitLevelCount>
 			<LevelCount>2</LevelCount>
@@ -66,8 +66,12 @@
 			<AuxiliaryChoiceForm/>
 			<AuxiliaryFolderChoiceForm/>
 			<IncludeHelpInContents>false</IncludeHelpInContents>
-			<BasedOn/>
-			<DataLockFields/>
+			<BasedOn>
+				<xr:Item xsi:type="xr:MDObjectRef">Document.Документ1</xr:Item>
+			</BasedOn>
+			<DataLockFields>
+				<xr:Field>Catalog.СправочникСМенеджером.StandardAttribute.Owner</xr:Field>
+			</DataLockFields>
 			<DataLockControlMode>Managed</DataLockControlMode>
 			<FullTextSearch>Use</FullTextSearch>
 			<ObjectPresentation/>

--- a/src/test/resources/metadata/designer/Catalogs/СправочникСМенеджером/Ext/AdditionalIndexes.xml
+++ b/src/test/resources/metadata/designer/Catalogs/СправочникСМенеджером/Ext/AdditionalIndexes.xml
@@ -1,0 +1,11 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<AdditionalIndexes xmlns="http://v8.1c.ru/8.1/data/ui" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<AdditionalIndex id="3f9b1b6e-0f1a-4a2c-9a1d-000000000001">
+		<Name>ИндексПоВладельцу</Name>
+		<Table>Catalog.СправочникСМенеджером</Table>
+		<IndexedFields>
+			<Field>Catalog.СправочникСМенеджером.StandardAttribute.Owner</Field>
+		</IndexedFields>
+		<AdditionalFields/>
+	</AdditionalIndex>
+</AdditionalIndexes>


### PR DESCRIPTION
Стековый поверх #4331 — использует данные, которые появились там вместе с подъёмом mdclasses.

Четыре коллекции `Метаданные.<Объект>.<Коллекция>` были объявлены, но всегда пустые: имён взять было неоткуда. Теперь есть:

| коллекция | источник в mdclasses | ишью |
|---|---|---|
| `ВводитсяНаОсновании` | `getBasedOn()` | mdclasses#652 |
| `ВводПоСтроке` | `getInputByString()` | mdclasses#653 |
| `ПоляБлокировкиДанных` | `getDataLockFields()` | mdclasses#653 |
| `ДополнительныеИндексы` | `getAdditionalIndexes()` | mdclasses#654 |

`Характеристики` (mdclasses#655) оставлены без разворачивания намеренно, и дело не в данных: у `Characteristic` в mdclasses имени нет вовсе — это набор ссылок на таблицы и поля, обращаться к ним по имени негде. Записано в комментарии, чтобы не возвращаться к вопросу.

**Стандартные реквизиты перестали зависеть только от вида объекта** (mdclasses#656). `KnownStandardAttributes` отдаёт полный набор для вида, а два реквизита зависят ещё и от настроек объекта: `Родитель` есть только у иерархического, `ЭтоГруппа` — только при иерархии групп и элементов. Раньше их показывал и неиерархический справочник, где их не существует.

## Фикстуры

Проверять было не на чем: в общей фикстуре `ВводитсяНаОсновании` и `ПоляБлокировкиДанных` пустые, дополнительных индексов нет вовсе, а оба справочника неиерархические. Поэтому `СправочникСМенеджером` сделан иерархическим и получил ввод на основании документа, поле блокировки и файл `Ext/AdditionalIndexes.xml` (в формате Конфигуратора это отдельный файл, а не узел в описании объекта).

`Справочник1` намеренно оставлен плоским — на нём проверяется обратный случай: реквизиты иерархии у неиерархического справочника не показываются.

Тесты покрывают все пять изменений: четыре коллекции и обе стороны фильтра иерархии.

## Оговорка

Перечисленные свойства объявлены полем в каждом классе mdclasses, без интерфейса-владельца, поэтому виды объектов приходится перечислять руками — у `ДополнительныеИндексы` это 14 веток. Такой перебор молча устаревает при добавлении нового класса, поэтому попросил интерфейсы: [mdclasses#677](https://github.com/1c-syntax/mdclasses/issues/677) (обсуждение началось в [mdclasses#659](https://github.com/1c-syntax/mdclasses/pull/659)).

Проверка: полный `check` зелёный, 639 тестовых классов; HBK-закрытый `MetadataCollectionSpecializerTest` — 18/18.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Metadata collections now expose child fields for “based on” references, input-by-string settings, data-lock fields, and additional indexes.
  * Collection elements support type information, iteration, and index access.
  * Standard attributes now appear according to each metadata object’s hierarchy settings.

* **Bug Fixes**
  * Prevented hierarchy-specific attributes from appearing for flat catalogs and non-hierarchical metadata objects.
  * Added support for localized names of extracted metadata children.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->