### PR TITLE
Реестр умеет убирать члены, которых у типа не существует

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -354,6 +354,7 @@ public class ConfigurationTypesProvider {
     var familyCore = fullName.getRu();
     registerFamilySpecializations(familyCore, name);
     registerTypesRegistrar.registerFamilyFixups(md, familyCore, name);
+    registerHierarchySuppressions(md, familyCore, name);
     registerDerivedSpecializations(md, name);
     if (md instanceof DocumentJournal journal) {
       registerDocumentJournalColumnMembers(journal, familyCore, name);
@@ -690,6 +691,32 @@ public class ConfigurationTypesProvider {
         genericExpander.registerFamilySpecializations(familyCore,
           Map.of(parameters.get(0), mdName));
       }
+    }
+  }
+
+  /**
+   * Убирает реквизиты иерархии там, где их не существует: у неиерархического справочника
+   * нет ни {@code Родитель}, ни {@code ЭтоГруппа}, а при иерархии элементов нет
+   * {@code ЭтоГруппа}.
+   * <p>
+   * Платформа объявляет их у всего семейства сразу, поэтому перекрыть их нечем — член
+   * приходится именно убирать (см. {@link TypeRegistry#registerMemberSuppression}).
+   * Подавление вешается на все типы семейства: где реквизита и так нет, оно безвредно.
+   */
+  private void registerHierarchySuppressions(MD md, String familyCore, String mdName) {
+    var absent = StandardAttributesResolver.hierarchyAttributesAbsentIn(md);
+    if (absent.isEmpty()) {
+      return;
+    }
+    for (var generic : typeRegistry.findAllGenericsByFamilyCore(familyCore)) {
+      var parameters = typeRegistry.getTypeParameters(generic);
+      if (parameters.size() != 1) {
+        continue;
+      }
+      var bindings = Map.of(parameters.get(0), mdName);
+      typeRegistry.resolve(TypeRef.specialize(generic, bindings).qualifiedName())
+        .filter(specialized -> !specialized.equals(generic))
+        .ifPresent(specialized -> typeRegistry.registerMemberSuppression(specialized, absent, FileType.BSL));
     }
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/StandardAttributesResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/StandardAttributesResolver.java
@@ -103,13 +103,30 @@ final class StandardAttributesResolver {
    * </ul>
    */
   private static boolean appliesTo(MD md, String attributeName) {
-    if (PARENT.equalsIgnoreCase(attributeName)) {
-      return isHierarchical(md);
-    }
-    if (IS_FOLDER.equalsIgnoreCase(attributeName)) {
-      return isHierarchical(md) && hasFolders(md);
+    for (var absent : hierarchyAttributesAbsentIn(md)) {
+      if (absent.equalsIgnoreCase(attributeName)) {
+        return false;
+      }
     }
     return true;
+  }
+
+  /**
+   * Стандартные реквизиты иерархии, которых у этого объекта нет.
+   * <p>
+   * Тот же ответ нужен дважды: коллекции {@code Метаданные.<Объект>.СтандартныеРеквизиты}
+   * (не показывать в списке) и прикладным типам {@code СправочникСсылка.<Имя>} /
+   * {@code СправочникОбъект.<Имя>} (подавить объявленный платформой член). Решение о
+   * применимости при этом одно, поэтому и живёт в одном месте.
+   *
+   * @param md объект метаданных.
+   * @return имена отсутствующих реквизитов; пустой список — все на месте.
+   */
+  static List<String> hierarchyAttributesAbsentIn(MD md) {
+    if (!isHierarchical(md)) {
+      return List.of(PARENT, IS_FOLDER);
+    }
+    return hasFolders(md) ? List.of() : List.of(IS_FOLDER);
   }
 
   private static boolean isHierarchical(MD md) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -581,7 +581,7 @@ public class TypeRegistry {
     // Ключ дедупликации — (kind, имя): метод и свойство с одинаковым именем —
     // разные члены (например, self-completion может видеть self-метод и
     // одноимённую self-переменную типа), один не должен вытеснять другой.
-    var suppressed = memberSuppressions.get(fileType).getOrDefault(ref, Set.of());
+    var suppressed = resolveSuppressions(ref, fileType);
     var byNameAndKind = new LinkedHashMap<MemberKey, MemberDescriptor>();
     for (var source : List.copyOf(resolveMemberSources(ref, fileType))) {
       for (var member : source.getMembers()) {
@@ -634,12 +634,36 @@ public class TypeRegistry {
     var byRef = memberSources.get(fileType);
     var sources = byRef.get(ref);
     if (sources == null) {
-      var canonical = aliasIndex.get(ref.qualifiedName().toLowerCase(Locale.ROOT));
-      if (canonical != null && !canonical.equals(ref)) {
+      var canonical = canonicalOf(ref);
+      if (canonical != null) {
         sources = byRef.get(canonical);
       }
     }
     return asSourceList(sources);
+  }
+
+  /**
+   * Подавления для типа — тем же путём, что и источники членов.
+   * <p>
+   * Путь обязан совпадать: если ref не канонический, источники находятся по канону, а
+   * подавления — нет, и подавленный член вернулся бы в ответ через «боковую» ссылку.
+   */
+  private Set<String> resolveSuppressions(TypeRef ref, FileType fileType) {
+    var byRef = memberSuppressions.get(fileType);
+    var names = byRef.get(ref);
+    if (names == null) {
+      var canonical = canonicalOf(ref);
+      if (canonical != null) {
+        names = byRef.get(canonical);
+      }
+    }
+    return names == null ? Set.of() : names;
+  }
+
+  /** Канонический ref по имени; {@code null}, если он же и передан либо алиаса нет. */
+  private @Nullable TypeRef canonicalOf(TypeRef ref) {
+    var canonical = aliasIndex.get(ref.qualifiedName().toLowerCase(Locale.ROOT));
+    return canonical != null && !canonical.equals(ref) ? canonical : null;
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -212,6 +212,13 @@ public class TypeRegistry {
    */
   private final Map<FileType, Map<TypeRef, BilingualString>> typeDescriptionsBilingual = perFileType();
 
+  /**
+   * Члены, которых у типа не существует, — по языку файла (см.
+   * {@link #registerMemberSuppression}). Хранятся именами, а не дескрипторами:
+   * подавление объявляется до того, как члены собраны.
+   */
+  private final Map<FileType, Map<TypeRef, Set<String>>> memberSuppressions = perFileType();
+
   /** Пустой контейнер с разрезами по всем языкам. */
   private static <V> Map<FileType, Map<TypeRef, V>> perFileType() {
     return Map.of(FileType.BSL, new ConcurrentHashMap<>(), FileType.OS, new ConcurrentHashMap<>());
@@ -574,9 +581,13 @@ public class TypeRegistry {
     // Ключ дедупликации — (kind, имя): метод и свойство с одинаковым именем —
     // разные члены (например, self-completion может видеть self-метод и
     // одноимённую self-переменную типа), один не должен вытеснять другой.
+    var suppressed = memberSuppressions.get(fileType).getOrDefault(ref, Set.of());
     var byNameAndKind = new LinkedHashMap<MemberKey, MemberDescriptor>();
     for (var source : List.copyOf(resolveMemberSources(ref, fileType))) {
       for (var member : source.getMembers()) {
+        if (isSuppressed(member, suppressed)) {
+          continue;
+        }
         byNameAndKind.putIfAbsent(
           new MemberKey(member.kind(), member.name().toLowerCase(Locale.ROOT)), member);
       }
@@ -584,6 +595,20 @@ public class TypeRegistry {
     // Неизменяемый список: память шарится между вызовами, случайная мутация
     // упадёт сразу (все потребители только итерируют).
     return List.copyOf(byNameAndKind.values());
+  }
+
+  /**
+   * Подавлен ли член (см. {@link #registerMemberSuppression}). Сравнение идёт по
+   * дескриптору, а не по строке имени, — иначе подавление сняло бы член только в
+   * том написании, которым его назвали.
+   */
+  private static boolean isSuppressed(MemberDescriptor member, Set<String> suppressed) {
+    for (var name : suppressed) {
+      if (member.matches(name)) {
+        return true;
+      }
+    }
+    return false;
   }
 
   /**
@@ -689,6 +714,33 @@ public class TypeRegistry {
    */
   public void registerMemberSource(TypeRef ref, MemberSource source, FileType fileType) {
     memberSources.get(fileType).merge(ref, source, TypeRegistry::appendSource);
+    membersEpoch.incrementAndGet();
+  }
+
+  /**
+   * Объявить, что членов с такими именами у типа не существует.
+   * <p>
+   * Источник умеет только <b>перекрыть</b> член, но не убрать: {@code registerMemberOverride}
+   * встаёт в начало списка, а дедуп берёт первое вхождение. Когда член приходит из объявления
+   * платформы, а применимость его зависит от конфигурации, перекрывать нечем — нужно убрать.
+   * Так у неиерархического справочника не существует {@code Родитель} и {@code ЭтоГруппа},
+   * хотя платформа объявляет их у всего семейства справочников.
+   * <p>
+   * Подавление сравнивает имена через {@link MemberDescriptor#matches(String)}, то есть
+   * снимает член в обоих написаниях: подавлять по строке было бы ошибкой — английское имя
+   * пережило бы подавление.
+   *
+   * @param ref         тип, у которого членов нет.
+   * @param memberNames имена подавляемых членов (ru либо en, регистр не важен).
+   * @param fileType    язык файла-потребителя.
+   */
+  public void registerMemberSuppression(TypeRef ref, Collection<String> memberNames, FileType fileType) {
+    if (memberNames.isEmpty()) {
+      return;
+    }
+    memberSuppressions.get(fileType)
+      .computeIfAbsent(ref, key -> ConcurrentHashMap.newKeySet())
+      .addAll(memberNames);
     membersEpoch.incrementAndGet();
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/ForbiddenMetadataNameDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/ForbiddenMetadataNameDiagnosticTest.java
@@ -122,7 +122,7 @@ class ForbiddenMetadataNameDiagnosticTest extends AbstractDiagnosticTest<Forbidd
 
     // должен отфильтроваться справочник, т.к. модули у него есть
     assertThat(diagnostics)
-      .hasSize(2)
+      .hasSize(3)
       .noneMatch(diagnostic -> DiagnosticMessage.getStringValue(diagnostic.getMessage()).contains("для `Справочник.Справочник1"));
   }
 
@@ -157,7 +157,7 @@ class ForbiddenMetadataNameDiagnosticTest extends AbstractDiagnosticTest<Forbidd
 
     // должен отфильтроваться справочник, т.к. модули у него есть
     assertThat(diagnostics)
-      .hasSize(5)
+      .hasSize(6)
       .allMatch(diagnostic -> DiagnosticMessage.getStringValue(diagnostic.getMessage()).contains("Запрещено использовать имя `РегистрСведений` для"))
       .anyMatch(diagnostic -> DiagnosticMessage.getStringValue(diagnostic.getMessage()).contains("для `Справочник.РегистрСведений"))
       .anyMatch(diagnostic -> DiagnosticMessage.getStringValue(diagnostic.getMessage()).contains("для `Документ.РегистрСведений"))

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/SameMetadataObjectAndChildNamesDiagnosticTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/SameMetadataObjectAndChildNamesDiagnosticTest.java
@@ -147,7 +147,7 @@ class SameMetadataObjectAndChildNamesDiagnosticTest extends AbstractDiagnosticTe
     List<Diagnostic> diagnostics = diagnosticInstance.getDiagnostics(documentContext);
 
     assertThat(diagnostics)
-      .hasSize(16)
+      .hasSize(25)
       .noneMatch(diagnostic -> DiagnosticMessage.getStringValue(diagnostic.getMessage()).contains("имя `Справочник.Справочник1"))
       .anyMatch(diagnostic -> DiagnosticMessage.getStringValue(diagnostic.getMessage()).contains("имя `Документ.Документ1.Реквизит"))
       .anyMatch(diagnostic -> DiagnosticMessage.getStringValue(diagnostic.getMessage()).contains("имя `Документ.Документ1.ТабличнаяЧасть"))

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/HierarchyMemberSuppressionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/HierarchyMemberSuppressionTest.java
@@ -24,6 +24,8 @@ package com.github._1c_syntax.bsl.languageserver.types.registry;
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.utils.Absolute;
 import org.junit.jupiter.api.BeforeEach;
@@ -96,6 +98,27 @@ class HierarchyMemberSuppressionTest extends AbstractServerContextAwareTest {
     assertThat(propertyNames("СправочникСсылка.Справочник1"))
       .as("подавление снимает только объявленное, а не всё подряд")
       .contains("Код", "Наименование", "Ссылка", "ПометкаУдаления");
+  }
+
+  @Test
+  void hierarchyOfItemsKeepsParentButNotIsFolder() {
+    // Третий режим: иерархия есть, а групп в ней не бывает — значит нет и признака группы.
+    assertThat(propertyNames("СправочникСсылка.СправочникБезГрупп"))
+      .contains("Родитель")
+      .doesNotContain("ЭтоГруппа");
+  }
+
+  @Test
+  void suppressionSurvivesNonCanonicalReference() {
+    // Источники членов находятся и по неканонической ссылке — через индекс алиасов.
+    // Подавления обязаны идти тем же путём, иначе подавленный член вернулся бы боком.
+    var canonical = typeRegistry.resolve("СправочникСсылка.Справочник1").orElseThrow();
+    var alien = new TypeRef(TypeKind.PLATFORM, canonical.qualifiedName());
+    assertThat(alien).isNotEqualTo(canonical);
+    assertThat(typeRegistry.getMembers(alien, FileType.BSL))
+      .as("по неканонической ссылке члены есть — значит и подавление должно действовать")
+      .isNotEmpty()
+      .noneMatch(member -> member.matches("Родитель") || member.matches("ЭтоГруппа"));
   }
 
   private List<String> propertyNames(String typeName) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/HierarchyMemberSuppressionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/HierarchyMemberSuppressionTest.java
@@ -1,0 +1,108 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.utils.Absolute;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Реквизиты иерархии есть не у каждого справочника, хотя платформа объявляет их у всего
+ * семейства сразу. Проверяется на синтакс-помощнике: в JSON-фолбэке этих объявлений нет,
+ * и подавлять было бы нечего.
+ */
+@CleanupContextBeforeClassAndAfterClass
+@TestPropertySource(properties = "app.platform-context.enabled=true")
+@EnabledIfEnvironmentVariable(named = "BSL_LANGUAGE_SERVER_RUN_HBK_TESTS", matches = "true",
+  disabledReason = "Требует синтакс-помощник: без него платформенных объявлений нет. "
+    + "Локально: BSL_LANGUAGE_SERVER_RUN_HBK_TESTS=true ./gradlew test --tests '*HierarchyMemberSuppressionTest*'")
+class HierarchyMemberSuppressionTest extends AbstractServerContextAwareTest {
+
+  private static final String PATH_TO_METADATA = "src/test/resources/metadata/designer";
+
+  @Autowired
+  private ConfigurationTypesProvider provider;
+
+  @Autowired
+  private TypeRegistry typeRegistry;
+
+  @BeforeEach
+  void setUp() {
+    initServerContextOnce(Absolute.path(PATH_TO_METADATA));
+    context.getConfiguration();
+    provider.tryRegister();
+  }
+
+  @Test
+  void flatCatalogHasNoHierarchyAttributes() {
+    // Справочник1 в фикстуре неиерархический — этих реквизитов у него не существует,
+    // хотя у семейства справочников платформа их объявляет.
+    assertThat(propertyNames("СправочникСсылка.Справочник1"))
+      .doesNotContain("Родитель", "ЭтоГруппа");
+    assertThat(propertyNames("СправочникОбъект.Справочник1"))
+      .doesNotContain("Родитель", "ЭтоГруппа");
+  }
+
+  @Test
+  void hierarchicalCatalogKeepsThem() {
+    assertThat(propertyNames("СправочникСсылка.СправочникСМенеджером"))
+      .contains("Родитель", "ЭтоГруппа");
+  }
+
+  @Test
+  void suppressionRemovesBothSpellings() {
+    // Подавление сравнивает по дескриптору, а не по строке: английское написание
+    // не должно пережить подавление русского имени.
+    var ref = typeRegistry.resolve("СправочникСсылка.Справочник1").orElseThrow();
+    assertThat(typeRegistry.findMember(ref, MemberKind.PROPERTY, "IsFolder", FileType.BSL))
+      .as("IsFolder — то же самое, что ЭтоГруппа")
+      .isEmpty();
+    assertThat(typeRegistry.findMember(ref, MemberKind.PROPERTY, "Parent", FileType.BSL))
+      .isEmpty();
+  }
+
+  @Test
+  void otherMembersSurvive() {
+    assertThat(propertyNames("СправочникСсылка.Справочник1"))
+      .as("подавление снимает только объявленное, а не всё подряд")
+      .contains("Код", "Наименование", "Ссылка", "ПометкаУдаления");
+  }
+
+  private List<String> propertyNames(String typeName) {
+    var ref = typeRegistry.resolve(typeName).orElseThrow();
+    return typeRegistry.getMembers(ref, FileType.BSL).stream()
+      .filter(member -> member.kind() == MemberKind.PROPERTY)
+      .map(member -> member.name())
+      .toList();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/HierarchyMemberSuppressionTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/HierarchyMemberSuppressionTest.java
@@ -23,6 +23,7 @@ package com.github._1c_syntax.bsl.languageserver.types.registry;
 
 import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
@@ -125,7 +126,7 @@ class HierarchyMemberSuppressionTest extends AbstractServerContextAwareTest {
     var ref = typeRegistry.resolve(typeName).orElseThrow();
     return typeRegistry.getMembers(ref, FileType.BSL).stream()
       .filter(member -> member.kind() == MemberKind.PROPERTY)
-      .map(member -> member.name())
+      .map(MemberDescriptor::name)
       .toList();
   }
 }

--- a/src/test/resources/metadata/designer/Catalogs/СправочникБезГрупп.xml
+++ b/src/test/resources/metadata/designer/Catalogs/СправочникБезГрупп.xml
@@ -1,0 +1,85 @@
+﻿<?xml version="1.0" encoding="UTF-8"?>
+<MetaDataObject xmlns="http://v8.1c.ru/8.3/MDClasses" xmlns:app="http://v8.1c.ru/8.2/managed-application/core" xmlns:cfg="http://v8.1c.ru/8.1/data/enterprise/current-config" xmlns:cmi="http://v8.1c.ru/8.2/managed-application/cmi" xmlns:ent="http://v8.1c.ru/8.1/data/enterprise" xmlns:lf="http://v8.1c.ru/8.2/managed-application/logform" xmlns:style="http://v8.1c.ru/8.1/data/ui/style" xmlns:sys="http://v8.1c.ru/8.1/data/ui/fonts/system" xmlns:v8="http://v8.1c.ru/8.1/data/core" xmlns:v8ui="http://v8.1c.ru/8.1/data/ui" xmlns:web="http://v8.1c.ru/8.1/data/ui/colors/web" xmlns:win="http://v8.1c.ru/8.1/data/ui/colors/windows" xmlns:xen="http://v8.1c.ru/8.3/xcf/enums" xmlns:xpr="http://v8.1c.ru/8.3/xcf/predef" xmlns:xr="http://v8.1c.ru/8.3/xcf/readable" xmlns:xs="http://www.w3.org/2001/XMLSchema" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" version="2.10">
+	<Catalog uuid="b1000000-0000-4000-8000-000000000001">
+		<InternalInfo>
+			<xr:GeneratedType name="CatalogObject.СправочникБезГрупп" category="Object">
+				<xr:TypeId>b1000000-0000-4000-8000-000000000011</xr:TypeId>
+				<xr:ValueId>b1000000-0000-4000-8000-000000000012</xr:ValueId>
+			</xr:GeneratedType>
+			<xr:GeneratedType name="CatalogRef.СправочникБезГрупп" category="Ref">
+				<xr:TypeId>b1000000-0000-4000-8000-000000000013</xr:TypeId>
+				<xr:ValueId>b1000000-0000-4000-8000-000000000014</xr:ValueId>
+			</xr:GeneratedType>
+			<xr:GeneratedType name="CatalogSelection.СправочникБезГрупп" category="Selection">
+				<xr:TypeId>b1000000-0000-4000-8000-000000000015</xr:TypeId>
+				<xr:ValueId>b1000000-0000-4000-8000-000000000016</xr:ValueId>
+			</xr:GeneratedType>
+			<xr:GeneratedType name="CatalogList.СправочникБезГрупп" category="List">
+				<xr:TypeId>b1000000-0000-4000-8000-000000000017</xr:TypeId>
+				<xr:ValueId>b1000000-0000-4000-8000-000000000018</xr:ValueId>
+			</xr:GeneratedType>
+			<xr:GeneratedType name="CatalogManager.СправочникБезГрупп" category="Manager">
+				<xr:TypeId>b1000000-0000-4000-8000-000000000019</xr:TypeId>
+				<xr:ValueId>b1000000-0000-4000-8000-00000000001a</xr:ValueId>
+			</xr:GeneratedType>
+		</InternalInfo>
+		<Properties>
+			<Name>СправочникБезГрупп</Name>
+			<Synonym/>
+			<Comment/>
+			<Hierarchical>true</Hierarchical>
+			<HierarchyType>HierarchyOfItems</HierarchyType>
+			<LimitLevelCount>false</LimitLevelCount>
+			<LevelCount>2</LevelCount>
+			<FoldersOnTop>true</FoldersOnTop>
+			<UseStandardCommands>true</UseStandardCommands>
+			<Owners/>
+			<SubordinationUse>ToItems</SubordinationUse>
+			<CodeLength>9</CodeLength>
+			<DescriptionLength>25</DescriptionLength>
+			<CodeType>String</CodeType>
+			<CodeAllowedLength>Variable</CodeAllowedLength>
+			<CodeSeries>WholeCatalog</CodeSeries>
+			<CheckUnique>true</CheckUnique>
+			<Autonumbering>true</Autonumbering>
+			<DefaultPresentation>AsDescription</DefaultPresentation>
+			<Characteristics/>
+			<PredefinedDataUpdate>Auto</PredefinedDataUpdate>
+			<EditType>InDialog</EditType>
+			<QuickChoice>false</QuickChoice>
+			<ChoiceMode>BothWays</ChoiceMode>
+			<InputByString>
+				<xr:Field>Catalog.СправочникБезГрупп.StandardAttribute.Description</xr:Field>
+				<xr:Field>Catalog.СправочникБезГрупп.StandardAttribute.Code</xr:Field>
+			</InputByString>
+			<SearchStringModeOnInputByString>Begin</SearchStringModeOnInputByString>
+			<FullTextSearchOnInputByString>DontUse</FullTextSearchOnInputByString>
+			<ChoiceDataGetModeOnInputByString>Directly</ChoiceDataGetModeOnInputByString>
+			<DefaultObjectForm/>
+			<DefaultFolderForm/>
+			<DefaultListForm/>
+			<DefaultChoiceForm/>
+			<DefaultFolderChoiceForm/>
+			<AuxiliaryObjectForm/>
+			<AuxiliaryFolderForm/>
+			<AuxiliaryListForm/>
+			<AuxiliaryChoiceForm/>
+			<AuxiliaryFolderChoiceForm/>
+			<IncludeHelpInContents>false</IncludeHelpInContents>
+			<BasedOn/>
+			<DataLockFields/>
+			<DataLockControlMode>Managed</DataLockControlMode>
+			<FullTextSearch>Use</FullTextSearch>
+			<ObjectPresentation/>
+			<ExtendedObjectPresentation/>
+			<ListPresentation/>
+			<ExtendedListPresentation/>
+			<Explanation/>
+			<CreateOnInput>Use</CreateOnInput>
+			<ChoiceHistoryOnInput>Auto</ChoiceHistoryOnInput>
+			<DataHistory>DontUse</DataHistory>
+			<UpdateDataHistoryImmediatelyAfterWrite>false</UpdateDataHistoryImmediatelyAfterWrite>
+			<ExecuteAfterWriteDataHistoryVersionProcessing>false</ExecuteAfterWriteDataHistoryVersionProcessing>
+				</Properties>
+	</Catalog>
+</MetaDataObject>

--- a/src/test/resources/metadata/designer/Configuration.xml
+++ b/src/test/resources/metadata/designer/Configuration.xml
@@ -204,6 +204,7 @@
 			<CommonAttribute>ОбщийРеквизит1</CommonAttribute>
 			<Catalog>Справочник1</Catalog>
 			<Catalog>СправочникСМенеджером</Catalog>
+			<Catalog>СправочникБезГрупп</Catalog>
 			<InformationRegister>РегистрСведений1</InformationRegister>
 			<FilterCriterion>КритерийОтбора1</FilterCriterion>
 			<Document>Документ1</Document>


### PR DESCRIPTION
Стековый поверх #4332 — опирается на иерархичность справочника, которая появилась там.

## Чего не хватало

Источник членов умел только **перекрыть** член: `registerMemberOverride` встаёт в начало списка, а дедуп в `getMembers` берёт первое вхождение по паре (вид, имя). Сказать «такого члена у этого типа нет» было нечем. Там, где член приходит из объявления платформы, а применимость его зависит от конфигурации, перекрывать нечем — член нужно именно убрать.

## Первый случай — иерархия справочника

`Родитель` и `ЭтоГруппа` платформа объявляет у всего семейства справочников сразу. Но у **неиерархического** справочника их не существует, а при **иерархии элементов** не существует `ЭтоГруппа` — групп там не бывает. До этой правки они показывались у любого справочника: и в подсказке, и в разыменовании.

Замер до правки, синтакс-помощник включён, `Справочник1` в фикстуре неиерархический:

```
СправочникСсылка.Справочник1 → Родитель=[СправочникСсылка.Справочник1], ЭтоГруппа=[Булево]
СправочникОбъект.Справочник1 → Родитель=[…],                            ЭтоГруппа=[Булево]
```

## Как сделано

`TypeRegistry.registerMemberSuppression(ref, names, fileType)` — карта подавлений рядом с источниками членов, с той же epoch-инвалидацией. `computeMembers` пропускает подавлённые при сборке.

Две детали, которые легко сделать неправильно:

- **сравнение по дескриптору, а не по строке.** Подавив `ЭтоГруппа`, надо убрать и `IsFolder` — это один и тот же член. Поэтому используется `MemberDescriptor.matches`, а не сравнение имён; на это есть отдельный тест;
- **решение о применимости одно на двоих.** Тот же вопрос («каких реквизитов иерархии у объекта нет») уже решался в #4332 для коллекции `Метаданные.<Объект>.СтандартныеРеквизиты`. Ответ вынесен в одну функцию, потребителя два — список метаданных и прикладные типы. Разъехаться они теперь не могут.

Подавление вешается на все типы семейства: там, где реквизита и так нет, оно безвредно.

## Что дальше

Механизм заводился не ради одного случая — в очереди ещё три места, где член платформы не существует у конкретного объекта: `ПараметрОтборПоВладельцу`/`ПараметрВыборПоВладельцу` у неподчинённого справочника, `ПараметрОтборПоРегистратору` у независимого регистра и `ПараметрТекущаяСтрока` у журнала документов без зарегистрированных документов. Все три — параметры форм, поэтому поедут вместе с формами.

Проверка: `HierarchyMemberSuppressionTest` (закрыт синтакс-помощником — в JSON-фолбэке этих объявлений нет и подавлять было бы нечего; без него честно пропускается, 4 skipped). Полный `check` зелёный, 641 тестовый класс.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Metadata types now show only hierarchy properties supported by the specific object.
  - Flat catalogs no longer display irrelevant parent or grouping properties.
  - Objects without folder support no longer expose the folder-related property.
  - Hierarchical catalogs continue to display applicable hierarchy properties.
  - Property filtering works consistently under both Russian and English names, while unrelated properties remain available.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->