### PR TITLE
refactor(types): срыв расчёта по потоку виден в журнале, а не подменяется типом

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -715,8 +715,9 @@ public class ExpressionTypeInferencer {
       }
       return byFlow;
     } catch (StackOverflowError | RuntimeException e) {
-      LOGGER.error("Расчёт типа по потоку сорвался на переменной {} (объявлена {}): {}",
-        variable.getName(), at(variable.getSelectionRange().getStart()), owner.getUri(), e);
+      LOGGER.error("Расчёт типа по потоку сорвался на переменной {} (объявлена {}): {} {}",
+        variable.getName(), at(variable.getSelectionRange().getStart()),
+        owner.getUri(), at(Ranges.create(use).getStart()), e);
       return TypeSet.EMPTY;
     }
   }
@@ -726,7 +727,8 @@ public class ExpressionTypeInferencer {
    * присваивания и изменения на месте уже случились на путях к ней.
    *
    * @param reference ссылка на переменную — несёт и документ, и позицию.
-   * @return тип в этой точке; пустой набор, если ссылка не на переменную своего документа.
+   * @return тип в этой точке; пустой набор, если ссылка не на переменную своего документа
+   *     либо расчёт по потоку сорвался — тогда срыв пишется в журнал ошибкой.
    */
   public TypeSet inferVariableAt(Reference reference) {
     if (!(reference.getSourceDefinedSymbol().orElse(null) instanceof VariableSymbol variable)) {
@@ -754,7 +756,8 @@ public class ExpressionTypeInferencer {
    *
    * @param variable переменная.
    * @param position точка в теле, для которой нужен тип.
-   * @return тип в этой точке.
+   * @return тип в этой точке; пустой набор, если расчёт по потоку сорвался — тогда срыв
+   *     пишется в журнал ошибкой.
    */
   public TypeSet inferVariableAt(VariableSymbol variable, Position position) {
     return inferVariableAt(variable, position, false);
@@ -770,7 +773,8 @@ public class ExpressionTypeInferencer {
    * @param variable     переменная.
    * @param position     точка в теле, для которой нужен тип.
    * @param atDefinition стоит ли точка на присваивании: тогда берётся тип после него.
-   * @return тип в этой точке.
+   * @return тип в этой точке; пустой набор, если расчёт по потоку сорвался — тогда срыв
+   *     пишется в журнал ошибкой.
    */
   private TypeSet inferVariableAt(VariableSymbol variable, Position position, boolean atDefinition) {
     var owner = variable.getOwner();
@@ -782,8 +786,9 @@ public class ExpressionTypeInferencer {
         ? variableFlowAnalyzer.typesAcrossScope(owner, position, variable, inputs)
         : atPoint;
     } catch (StackOverflowError | RuntimeException e) {
-      LOGGER.error("Расчёт типа по потоку сорвался на переменной {} (объявлена {}): {}",
-        variable.getName(), at(variable.getSelectionRange().getStart()), owner.getUri(), e);
+      LOGGER.error("Расчёт типа по потоку сорвался на переменной {} (объявлена {}): {} {}",
+        variable.getName(), at(variable.getSelectionRange().getStart()),
+        owner.getUri(), at(position), e);
       return TypeSet.EMPTY;
     }
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -704,17 +704,20 @@ public class ExpressionTypeInferencer {
     // текущим оператором. Зацикливания не будет: строящееся окружение отвечает чтением из
     // карты, не запуская расчёт заново.
     try {
-      var inputs = flowInputs(variable, ctx);
-      var byFlow = variableFlowAnalyzer.typeAt(owner, use, variable, inputs);
-      return byFlow == null
-        ? variableFlowAnalyzer.typesAcrossScope(owner, Ranges.create(use).getStart(), variable, inputs)
-        : byFlow;
+      var byFlow = variableFlowAnalyzer.typeAt(owner, use, variable, flowInputs(variable, ctx));
+      if (byFlow == null) {
+        // Обращение к переменной есть, а расчёт его не разместил — это дефект расчёта, а не
+        // особенность кода 1С. Подменять ответ нечем: любая подмена скрыла бы дефект.
+        LOGGER.error("Обращение к переменной {} (объявлена {}) не размещено в расчёте по потоку: {} {}",
+          variable.getName(), at(variable.getSelectionRange().getStart()),
+          owner.getUri(), at(Ranges.create(use).getStart()));
+        return TypeSet.EMPTY;
+      }
+      return byFlow;
     } catch (StackOverflowError | RuntimeException e) {
-      // Страховка: граф мог не построиться на неожиданной форме кода, рекурсия — уйти
-      // слишком глубоко. Переменной остаётся объявленное о ней, а не обнулённое всё
-      // выражение, как сделал бы общий перехват в infer().
-      LOGGER.debug("Расчёт типа по потоку не удался для переменной {}", variable.getName(), e);
-      return declaredTypes(variable);
+      LOGGER.error("Расчёт типа по потоку сорвался на переменной {} (объявлена {}): {}",
+        variable.getName(), at(variable.getSelectionRange().getStart()), owner.getUri(), e);
+      return TypeSet.EMPTY;
     }
   }
 
@@ -779,11 +782,20 @@ public class ExpressionTypeInferencer {
         ? variableFlowAnalyzer.typesAcrossScope(owner, position, variable, inputs)
         : atPoint;
     } catch (StackOverflowError | RuntimeException e) {
-      // Срыв расчёта (граф не построился на неожиданной форме кода либо рекурсия ушла
-      // слишком глубоко) оставляет переменной объявленное о ней, а не обнуляет её тип.
-      LOGGER.debug("Расчёт типа по потоку не удался для переменной {}", variable.getName(), e);
-      return declaredTypes(variable);
+      LOGGER.error("Расчёт типа по потоку сорвался на переменной {} (объявлена {}): {}",
+        variable.getName(), at(variable.getSelectionRange().getStart()), owner.getUri(), e);
+      return TypeSet.EMPTY;
     }
+  }
+
+  /**
+   * Позиция в записи «строка:колонка», считая от единицы, — как её показывает редактор.
+   *
+   * @param position позиция, считающая от нуля.
+   * @return запись позиции для журнала.
+   */
+  private static String at(Position position) {
+    return (position.getLine() + 1) + ":" + (position.getCharacter() + 1);
   }
 
   /**


### PR DESCRIPTION
## Что и почему

Обращение к переменной, которое расчёт по потоку не смог разместить в графе, уходило в объединение типов по всей области видимости. Подмена скрывала дефект: тип получался, значит и проблемы будто нет.

Теперь такое место пишется `LOGGER.error` — с документом, позицией обращения и позицией объявления переменной, — а тип остаётся пустым. Туда же ушли перехваты срыва расчёта (`StackOverflowError`/`RuntimeException`), раньше молчавшие в `debug`.

Объединение по области видимости осталось ответом там, где точки исполнения нет по существу: на объявлении `Перем` оператора не существует, и тип такой переменной — то, с чем она свою область покидает.

## Почему это безопасно сейчас

Замер на cpm (`analyze`, счётчик в месте фоллбэка):

| | обращений | отказов |
|---|---|---|
| `develop` | 2 376 525 | 182 |
| `develop` + #4337 | 2 351 882 | **0** |

Все 182 отказа на `develop` — реквизиты управляемой формы, резолвившиеся переменными вида `DYNAMIC`. С типами форм (#4337) таких мест не остаётся.

## Проверки

Полный `./gradlew test` локально: 643 класса, падений по коду нет (четыре класса упали от исчерпания `inotify` на машине и проходят по отдельности).

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference accuracy for variables at specific code locations.
  * Prevented incorrect fallback to broader-scope or declared types when analysis is unavailable.
  * Improved handling of runtime and stack-overflow errors during inference.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->