### PR TITLE
Цепочка обращения к дереву метаданных размечается семантическими токенами целиком

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/GlobalScopeSemanticTokensSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/GlobalScopeSemanticTokensSupplier.java
@@ -30,6 +30,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.MemberKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.registry.GlobalScopeProvider;
+import com.github._1c_syntax.bsl.languageserver.types.registry.MetadataTypeNames;
 import com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
 import com.github._1c_syntax.bsl.languageserver.utils.Trees;
@@ -59,6 +60,13 @@ import java.util.List;
  * </ul>
  * Идентификаторы, перекрытые локальной переменной/параметром, пропускаются —
  * локальный символ имеет приоритет.
+ * <p>
+ * <b>Цепочка после корня</b> размечается целиком, пока резолвятся члены: имя объекта
+ * конфигурации ({@code Справочники.Контрагенты}, {@code Метаданные.Справочники.Контрагенты})
+ * → {@code Class}, значение перечисления → {@code EnumMember}, остальные свойства
+ * ({@code Метаданные.Справочники}, {@code ….Реквизиты}, {@code ….Тип}) →
+ * {@code Property + DefaultLibrary}. Как только очередное имя не резолвится, разметка
+ * цепочки прекращается: выдуманный тип хуже отсутствия подсветки.
  */
 @Component
 @RequiredArgsConstructor
@@ -184,9 +192,16 @@ public class GlobalScopeSemanticTokensSupplier implements SemanticTokensSupplier
     if (ownerType.equals(returnType)) {
       // self-typed property — значение enum (.UTF8).
       helper.addRange(entries, Ranges.create(idNode), SemanticTokenTypes.EnumMember);
-    } else if (returnType.kind() == TypeKind.CONFIGURATION) {
-      // mdo-ссылка (Справочники.Контрагенты).
+    } else if (returnType.kind() == TypeKind.CONFIGURATION || MetadataTypeNames.isMetadataObject(returnType)) {
+      // Имя объекта конфигурации: mdo-ссылка (Справочники.Контрагенты) либо объект
+      // дерева метаданных (Метаданные.Справочники.Контрагенты). Формально это
+      // свойство, но в коде оно читается как имя объекта — красим так же.
       helper.addRange(entries, Ranges.create(idNode), SemanticTokenTypes.Class);
+    } else {
+      // Прочие звенья цепочки — обычные свойства платформенных объектов
+      // (`Метаданные.Справочники`, `….Реквизиты`, `….Тип`). Без этого вся цепочка
+      // после глобального имени оставалась неразмеченной.
+      helper.addRange(entries, Ranges.create(idNode), SemanticTokenTypes.Property, DEFAULT_LIBRARY_MODIFIERS);
     }
     return returnType;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataCollectionSpecializer.java
@@ -98,7 +98,7 @@ import org.jspecify.annotations.Nullable;
 @RequiredArgsConstructor
 public class MetadataCollectionSpecializer {
 
-  private static final String BASE_COLLECTION_METADATA = "КоллекцияОбъектовМетаданных";
+  private static final String BASE_COLLECTION_METADATA = MetadataTypeNames.METADATA_COLLECTION;
   private static final String BASE_COLLECTION_STD_ATTR = "ОписанияСтандартныхРеквизитов";
   private static final String BASE_COLLECTION_PROPERTY_VALUE = "КоллекцияЗначенийСвойстваОбъектаМетаданных";
   private static final String BASE_COLLECTION_FIELD_LIST = "СписокПолей";

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataTypeNames.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataTypeNames.java
@@ -28,10 +28,9 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
  * <p>
  * Синтетические типы дерева ({@code ОбъектМетаданных: Справочник.Контрагенты},
  * {@code КоллекцияОбъектовМетаданных.Реквизиты.Контрагенты}) заводит
- * {@link MetadataCollectionSpecializer} — здесь собраны их имена и предикаты,
- * чтобы потребители снаружи ({@code semantictokens}, hover) могли отличить
- * <b>объект</b> метаданных от <b>коллекции</b> объектов, не зная, как эти имена
- * складываются.
+ * {@link MetadataCollectionSpecializer} — здесь собраны их имена, чтобы
+ * потребители снаружи ({@code semantictokens}) могли отличить <b>объект</b>
+ * метаданных от коллекции объектов, не зная, как эти имена складываются.
  */
 public final class MetadataTypeNames {
 
@@ -54,16 +53,5 @@ public final class MetadataTypeNames {
    */
   public static boolean isMetadataObject(TypeRef ref) {
     return ref.qualifiedName().startsWith(METADATA_OBJECT);
-  }
-
-  /**
-   * Описывает ли тип коллекцию объектов дерева метаданных
-   * ({@code КоллекцияОбъектовМетаданных.Справочники}).
-   *
-   * @param ref тип.
-   * @return {@code true} — за типом стоит коллекция объектов метаданных.
-   */
-  public static boolean isMetadataCollection(TypeRef ref) {
-    return ref.qualifiedName().startsWith(METADATA_COLLECTION);
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataTypeNames.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/MetadataTypeNames.java
@@ -1,0 +1,69 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+
+/**
+ * Имена типов дерева метаданных и вопросы к ним.
+ * <p>
+ * Синтетические типы дерева ({@code ОбъектМетаданных: Справочник.Контрагенты},
+ * {@code КоллекцияОбъектовМетаданных.Реквизиты.Контрагенты}) заводит
+ * {@link MetadataCollectionSpecializer} — здесь собраны их имена и предикаты,
+ * чтобы потребители снаружи ({@code semantictokens}, hover) могли отличить
+ * <b>объект</b> метаданных от <b>коллекции</b> объектов, не зная, как эти имена
+ * складываются.
+ */
+public final class MetadataTypeNames {
+
+  /** Начало имени типа конкретного объекта дерева метаданных. */
+  static final String METADATA_OBJECT = "ОбъектМетаданных";
+
+  /** Начало имени типа коллекции объектов дерева метаданных. */
+  static final String METADATA_COLLECTION = "КоллекцияОбъектовМетаданных";
+
+  private MetadataTypeNames() {
+    // утилитный класс
+  }
+
+  /**
+   * Описывает ли тип конкретный объект дерева метаданных
+   * ({@code ОбъектМетаданных: Справочник.Контрагенты}, {@code ОбъектМетаданных: Реквизит}).
+   *
+   * @param ref тип.
+   * @return {@code true} — за типом стоит объект метаданных, а не коллекция и не значение.
+   */
+  public static boolean isMetadataObject(TypeRef ref) {
+    return ref.qualifiedName().startsWith(METADATA_OBJECT);
+  }
+
+  /**
+   * Описывает ли тип коллекцию объектов дерева метаданных
+   * ({@code КоллекцияОбъектовМетаданных.Справочники}).
+   *
+   * @param ref тип.
+   * @return {@code true} — за типом стоит коллекция объектов метаданных.
+   */
+  public static boolean isMetadataCollection(TypeRef ref) {
+    return ref.qualifiedName().startsWith(METADATA_COLLECTION);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MetadataChainSemanticTokensHbkTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MetadataChainSemanticTokensHbkTest.java
@@ -1,0 +1,106 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.semantictokens;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
+import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
+import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.junit.jupiter.api.Test;
+import org.junit.jupiter.api.condition.EnabledIfEnvironmentVariable;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+import org.springframework.test.context.TestPropertySource;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.lsp4j.SemanticTokenModifiers.DefaultLibrary;
+
+/**
+ * Разметка цепочки обращения к дереву метаданных
+ * ({@code Метаданные.Справочники.Справочник1.Реквизиты.Реквизит1.Тип}).
+ * <p>
+ * Само свойство {@code Метаданные} объявлено только в синтакс-помощнике — в
+ * JSON-фолбэке его нет, и цепочка не резолвится вовсе, поэтому тест требует
+ * установленной 1С.
+ */
+@CleanupContextBeforeClassAndAfterEachTestMethod
+@Import(SemanticTokensTestHelper.class)
+@TestPropertySource(properties = "app.platform-context.enabled=true")
+@EnabledIfEnvironmentVariable(named = "BSL_LANGUAGE_SERVER_RUN_HBK_TESTS",
+  matches = "true",
+  disabledReason = "Требует HBK 1С (свойство `Метаданные` объявлено только в синтакс-помощнике)")
+class MetadataChainSemanticTokensHbkTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private GlobalScopeSemanticTokensSupplier supplier;
+
+  @Autowired
+  private SemanticTokensTestHelper helper;
+
+  @Test
+  void wholeMetadataChainIsPainted() {
+    initServerContext(TestUtils.PATH_TO_METADATA);
+    var bsl = """
+      Процедура Тест()
+          А = Метаданные.Справочники.Справочник1.Реквизиты.Реквизит1.Тип;
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(bsl, context);
+
+    var decoded = helper.decodeFromEntries(supplier.getSemanticTokens(documentContext));
+
+    // Корень — платформенная коллекция; коллекции внутри дерева — свойства;
+    // имена объектов метаданных читаются в коде как имена объектов, поэтому Class.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(1, 8, 10, SemanticTokenTypes.Class, Set.of(DefaultLibrary), "Метаданные"),
+      new ExpectedToken(1, 19, 11, SemanticTokenTypes.Property, Set.of(DefaultLibrary), "Справочники"),
+      new ExpectedToken(1, 31, 11, SemanticTokenTypes.Class, "Справочник1"),
+      new ExpectedToken(1, 43, 9, SemanticTokenTypes.Property, Set.of(DefaultLibrary), "Реквизиты"),
+      new ExpectedToken(1, 53, 9, SemanticTokenTypes.Class, "Реквизит1"),
+      new ExpectedToken(1, 63, 3, SemanticTokenTypes.Property, Set.of(DefaultLibrary), "Тип")
+    ));
+  }
+
+  @Test
+  void chainBreaksOnUnknownMember() {
+    initServerContext(TestUtils.PATH_TO_METADATA);
+    var bsl = """
+      Процедура Тест()
+          А = Метаданные.Справочники.НетТакогоСправочника.Реквизиты;
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(bsl, context);
+
+    var decoded = helper.decodeFromEntries(supplier.getSemanticTokens(documentContext));
+
+    // Несуществующее имя не красится, и дальше по цепочке разметка не идёт:
+    // выдуманный тип — хуже, чем отсутствие подсветки.
+    assertThat(decoded)
+      .filteredOn(token -> token.start() >= 31)
+      .isEmpty();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MetadataChainSemanticTokensTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/MetadataChainSemanticTokensTest.java
@@ -1,0 +1,133 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.semantictokens;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.types.model.BilingualString;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
+import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper;
+import com.github._1c_syntax.bsl.languageserver.util.SemanticTokensTestHelper.ExpectedToken;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.SemanticTokenTypes;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.context.annotation.Import;
+
+import java.util.List;
+import java.util.Set;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.eclipse.lsp4j.SemanticTokenModifiers.DefaultLibrary;
+
+/**
+ * Разметка цепочки обращения к дереву метаданных.
+ * <p>
+ * Настоящее дерево живёт в синтакс-помощнике, поэтому здесь оно собирается
+ * вручную — ровно теми типами, какими его заводит
+ * {@code MetadataCollectionSpecializer}: корень
+ * ({@code ОбъектМетаданныхКонфигурация}), коллекция
+ * ({@code КоллекцияОбъектовМетаданных.Справочники}) и конкретный объект
+ * ({@code ОбъектМетаданных: Справочник.Справочник1}). На реальной конфигурации
+ * то же самое проверяет {@code MetadataChainSemanticTokensHbkTest}.
+ */
+@CleanupContextBeforeClassAndAfterEachTestMethod
+@Import(SemanticTokensTestHelper.class)
+class MetadataChainSemanticTokensTest extends AbstractServerContextAwareTest {
+
+  private static final String CONFIGURATION_TYPE = "ОбъектМетаданныхКонфигурация";
+  private static final String CATALOGS_COLLECTION = "КоллекцияОбъектовМетаданных.Справочники";
+  private static final String CATALOG_OBJECT = "ОбъектМетаданных: Справочник.Справочник1";
+
+  @Autowired
+  private GlobalScopeSemanticTokensSupplier supplier;
+
+  @Autowired
+  private SemanticTokensTestHelper helper;
+
+  @Autowired
+  private TypeRegistry typeRegistry;
+
+  /** Заводит корень дерева метаданных под именем {@code Метаданные} и два звена под ним. */
+  private void registerMetadataTree() {
+    var configuration = typeRegistry.intern(TypeKind.PLATFORM, CONFIGURATION_TYPE);
+    typeRegistry.registerDisplayName(configuration, BilingualString.of("Метаданные", "Metadata"));
+    typeRegistry.registerGlobalPropertyType(configuration, FileType.BSL);
+
+    var catalogs = typeRegistry.intern(TypeKind.PLATFORM, CATALOGS_COLLECTION);
+    typeRegistry.registerMemberSource(configuration,
+      () -> List.of(MemberDescriptor.property("Справочники", catalogs, "")), FileType.BSL);
+
+    var catalog = typeRegistry.intern(TypeKind.PLATFORM, CATALOG_OBJECT);
+    typeRegistry.registerMemberSource(catalogs,
+      () -> List.of(MemberDescriptor.property("Справочник1", catalog, "")), FileType.BSL);
+    typeRegistry.registerMemberSource(catalog,
+      () -> List.of(MemberDescriptor.property("Имя", TypeRef.ANY, "")), FileType.BSL);
+  }
+
+  @Test
+  void collectionsAreProperties_andMetadataObjectsAreClasses() {
+    initServerContext(TestUtils.PATH_TO_METADATA);
+    registerMetadataTree();
+    var bsl = """
+      Процедура Тест()
+          А = Метаданные.Справочники.Справочник1.Имя;
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(bsl, context);
+
+    var decoded = helper.decodeFromEntries(supplier.getSemanticTokens(documentContext));
+
+    // Имя объекта метаданных читается в коде как имя объекта — Class, как у
+    // `Справочники.Справочник1`; коллекция и обычное свойство — Property.
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(1, 8, 10, SemanticTokenTypes.Class, Set.of(DefaultLibrary), "Метаданные"),
+      new ExpectedToken(1, 19, 11, SemanticTokenTypes.Property, Set.of(DefaultLibrary), "Справочники"),
+      new ExpectedToken(1, 31, 11, SemanticTokenTypes.Class, "Справочник1"),
+      new ExpectedToken(1, 43, 3, SemanticTokenTypes.Property, Set.of(DefaultLibrary), "Имя")
+    ));
+  }
+
+  @Test
+  void chainStopsAtTheFirstUnknownMember() {
+    initServerContext(TestUtils.PATH_TO_METADATA);
+    registerMetadataTree();
+    var bsl = """
+      Процедура Тест()
+          А = Метаданные.Справочники.НетТакого.Имя;
+      КонецПроцедуры
+      """;
+    var documentContext = TestUtils.getDocumentContext(bsl, context);
+
+    var decoded = helper.decodeFromEntries(supplier.getSemanticTokens(documentContext));
+
+    // Несуществующее имя не красится, и разметка дальше не идёт: выдуманный тип
+    // хуже отсутствия подсветки.
+    assertThat(decoded)
+      .filteredOn(token -> token.line() == 1 && token.start() >= 31)
+      .isEmpty();
+  }
+}


### PR DESCRIPTION
## Проблема

В цепочке `Метаданные.РегистрыСведений.АналогиМатериалов` всё после `Метаданные.`
оставалось без семантических токенов — редактор красил эти имена как обычный текст.

## Почему

Цепочку, начинающуюся с глобального имени, размечает **только**
`GlobalScopeSemanticTokensSupplier`: `PlatformMemberPropertyAccessSemanticTokensSupplier`
такие цепочки намеренно пропускает, чтобы не конфликтовать за один и тот же токен.

А его `handleProperty` знал ровно два случая: значение перечисления (`КодировкаТекста.UTF8`
→ `EnumMember`) и возврат конфигурационного типа (`Справочники.Контрагенты` → `Class`).
У дерева метаданных все звенья — платформенные типы:

| звено | тип-значение |
|---|---|
| `Метаданные` | `ОбъектМетаданныхКонфигурация` |
| `.Справочники` | `КоллекцияОбъектовМетаданных.Справочники` |
| `.Справочник1` | `ОбъектМетаданных: Справочник.Справочник1` |
| `.Реквизиты` | `КоллекцияОбъектовМетаданных.Реквизиты.Справочник1` |
| `.Реквизит1` | `ОбъектМетаданных: Реквизит` |

Ни одно под эти две ветки не подходило.

## Что сделано

Цепочка красится целиком, пока резолвятся члены:

- **имя объекта метаданных** → `Class` — так же, как `Справочники.Контрагенты`. Один и тот
  же объект не должен выглядеть по-разному в зависимости от того, как до него добрались;
- **коллекции и прочие свойства** (`Метаданные.Справочники`, `….Реквизиты`, `….Тип`) →
  `Property + DefaultLibrary`;
- на **неизвестном имени** разметка обрывается: выдуманный тип хуже отсутствия подсветки.

Отличить объект от коллекции по признакам члена не получается — `standardLibrary` у них
ровно наоборот от ожидаемого (у коллекции `false`, у объекта `true`: флаг унаследован от
шаблонных дескрипторов, с которых члены материализуются). Поэтому вопрос задаётся
`MetadataTypeNames` — новому словарю в `types/registry`, там же, где эти имена и
складываются; сапплаер знанием про `ОбъектМетаданных:`/`КоллекцияОбъектовМетаданных`
не обрастает.

## Проверка

`MetadataChainSemanticTokensHbkTest` — под HBK (`BSL_LANGUAGE_SERVER_RUN_HBK_TESTS=true`):
проверяет всю цепочку из шести звеньев и обрыв разметки на несуществующем имени.

Тесты именно HBK-gated не по инерции: без синтакс-помощника `Метаданные` вообще не
объявлено глобальным свойством (`globalProperty("Метаданные") = false`), цепочка не
резолвится, и обычный тест зеленел бы вхолостую.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Improvements**
  * Improved semantic highlighting for metadata member chains.
  * Metadata objects are now highlighted as classes, while resolved properties receive consistent property and library styling.
  * Highlighting continues across valid chains and stops when a member cannot be resolved, preventing incorrect highlighting after unknown members.

* **Tests**
  * Added coverage for complete metadata chains, property classification, and unknown-member handling.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->