### PR TITLE
revert(hover): убрана звёздочка у вычисленного по коду типа

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilder.java
@@ -66,9 +66,6 @@ public class VariableSymbolMarkupContentBuilder implements MarkupContentBuilder 
   private static final String EXPORT_KEY = "export";
   private static final String TYPE_KEY = "type";
 
-  /** Пометка типа, выведенного из кода, а не объявленного о переменной. */
-  private static final String FROM_CODE_MARK = "*";
-
   private final LanguageServerConfiguration configuration;
   private final DescriptionFormatter descriptionFormatter;
   private final Resources resources;
@@ -92,9 +89,8 @@ public class VariableSymbolMarkupContentBuilder implements MarkupContentBuilder 
     var variableInfo = getVariableInfo(symbol);
     descriptionFormatter.addSectionIfNotEmpty(markupBuilder, variableInfo);
 
-    // тип в этой точке; вычисленное по коду помечается звёздочкой, чтобы не выдавать
-    // его за объявленное комментарием, параметром или аннотацией внедрения
-    var typesInfo = getTypes(symbol, typeService.typesAt(reference), typeService.declaredTypesOf(symbol));
+    // тип в этой точке
+    var typesInfo = getTypes(symbol, typeService.typesAt(reference));
     descriptionFormatter.addSectionIfNotEmpty(markupBuilder, typesInfo);
 
     // местоположение переменной
@@ -147,22 +143,19 @@ public class VariableSymbolMarkupContentBuilder implements MarkupContentBuilder 
   /**
    * Раздел типа переменной.
    *
-   * @param symbol   переменная.
-   * @param types    типы в точке обращения.
-   * @param declared объявленное о переменной: остальные типы вычислены по коду и
-   *                 помечаются звёздочкой.
+   * @param symbol переменная.
+   * @param types  типы в точке обращения.
    * @return текст раздела; пусто, если типов нет.
    */
-  private String getTypes(VariableSymbol symbol, TypeSet types, TypeSet declared) {
+  private String getTypes(VariableSymbol symbol, TypeSet types) {
     if (types.isEmpty()) {
       return "";
     }
     // Hover — элемент интерфейса, поэтому язык отображения берём из настроек
     // LS (configuration), а не из ScriptVariant (язык исходников).
     var lang = configuration.getLanguage();
-    var declaredRefs = declared.refs();
     String header = types.refs().stream()
-      .map(ref -> inlineTypeLabel(types, ref, lang, false) + (declaredRefs.contains(ref) ? "" : FROM_CODE_MARK))
+      .map(ref -> inlineTypeLabel(types, ref, lang, false))
       .collect(Collectors.joining(" | "));
 
     var sb = new StringBuilder("%s: %s".formatted(getResourceString(TYPE_KEY), header));

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/TypeService.java
@@ -106,18 +106,6 @@ public class TypeService implements SelfMemberClassifier {
   }
 
   /**
-   * Типы, объявленные о переменной помимо кода: типизирующий комментарий, тип параметра,
-   * аннотация внедрения. То, что кладут в переменную тела, сюда не входит — это
-   * {@link #typesAt(Reference)}.
-   *
-   * @param variable переменная.
-   * @return объявленные типы; {@link TypeSet#EMPTY}, если о переменной ничего не объявлено.
-   */
-  public TypeSet declaredTypesOf(VariableSymbol variable) {
-    return inferencer.declaredTypes(variable);
-  }
-
-  /**
    * Тип переменной в указанной точке её документа — позиционный ответ там, где обращения
    * к переменной в этой точке нет и {@link Reference} не существует.
    *

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -948,7 +948,7 @@ public class ExpressionTypeInferencer {
    * @param variable переменная.
    * @return типы из объявления; пустой набор, если ничего не объявлено.
    */
-  public TypeSet declaredTypes(VariableSymbol variable) {
+  private TypeSet declaredTypes(VariableSymbol variable) {
     var entry = TypeSet.EMPTY;
     for (var source : variableTypeSources) {
       entry = entry.union(source.typesOf(variable));

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderTest.java
@@ -27,6 +27,7 @@ import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
 import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.utils.CaseInsensitivePattern;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import org.junit.jupiter.api.BeforeEach;
 import org.eclipse.lsp4j.Location;
@@ -265,8 +266,8 @@ class VariableSymbolMarkupContentBuilderTest extends AbstractServerContextAwareT
    * @param label ожидаемая подпись типа.
    * @return выражение для {@code containsPattern}.
    */
-  private static String typeLine(String label) {
-    return "(?m)^Тип: " + Pattern.quote(label) + "$";
+  private static Pattern typeLine(String label) {
+    return CaseInsensitivePattern.compile("(?m)^Тип: " + Pattern.quote(label) + "$");
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderTest.java
@@ -35,6 +35,7 @@ import org.springframework.beans.factory.annotation.Autowired;
 
 import java.nio.file.Path;
 import java.util.Arrays;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -255,6 +256,19 @@ class VariableSymbolMarkupContentBuilderTest extends AbstractServerContextAwareT
     assertThat(content).contains("Тест");
   }
 
+  /**
+   * Регулярное выражение на строку раздела типа целиком.
+   * <p>
+   * Проверка вхождением подстроки прошла бы и при вернувшейся пометке вычисленного
+   * по коду типа ({@code Тип: Строка*}) — привязка к концу строки её не пропустит.
+   *
+   * @param label ожидаемая подпись типа.
+   * @return выражение для {@code containsPattern}.
+   */
+  private static String typeLine(String label) {
+    return "(?m)^Тип: " + Pattern.quote(label) + "$";
+  }
+
   @Test
   void testInferredTypeShownInHover() {
     // given
@@ -269,7 +283,7 @@ class VariableSymbolMarkupContentBuilderTest extends AbstractServerContextAwareT
     var content = markupContentBuilder.getContent(referenceTo(documentContext, varSymbol)).getValue();
 
     // then
-    assertThat(content).contains("Тип: Строка");
+    assertThat(content).containsPattern(typeLine("Строка"));
   }
 
   @Test
@@ -287,7 +301,7 @@ class VariableSymbolMarkupContentBuilderTest extends AbstractServerContextAwareT
 
     // then: у структуры с полями элемент-итератор (КлючИЗначение) в заголовке не показываем.
     assertThat(content)
-      .contains("Тип: Структура")
+      .containsPattern(typeLine("Структура"))
       .doesNotContain("КлючИЗначение")
       .contains("* **Имя**: `Строка`")
       .contains("* **Возраст**: `Число`");
@@ -309,7 +323,7 @@ class VariableSymbolMarkupContentBuilderTest extends AbstractServerContextAwareT
 
     // then: колонки строки ТЗ показываются маркдаун-списком.
     assertThat(content)
-      .contains("Тип: ТаблицаЗначений из СтрокаТаблицыЗначений")
+      .containsPattern(typeLine("ТаблицаЗначений из СтрокаТаблицыЗначений"))
       .contains("* **Сумма**");
   }
 
@@ -333,7 +347,7 @@ class VariableSymbolMarkupContentBuilderTest extends AbstractServerContextAwareT
 
     // then: ключи показаны с типами и описаниями из doc-комментария, без шума «из КлючИЗначение».
     assertThat(content)
-      .contains("Тип: Структура")
+      .containsPattern(typeLine("Структура"))
       .doesNotContain("КлючИЗначение")
       .contains("* **Адрес**: `Строка` — адрес сервера.")
       .contains("* **Порт**: `Число` — номер порта.");

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolMarkupContentBuilderTest.java
@@ -268,8 +268,8 @@ class VariableSymbolMarkupContentBuilderTest extends AbstractServerContextAwareT
     // when
     var content = markupContentBuilder.getContent(referenceTo(documentContext, varSymbol)).getValue();
 
-    // then: тип не объявлен, а вычислен по присваиванию — это видно по звёздочке
-    assertThat(content).contains("Тип: Строка*");
+    // then
+    assertThat(content).contains("Тип: Строка");
   }
 
   @Test
@@ -287,7 +287,7 @@ class VariableSymbolMarkupContentBuilderTest extends AbstractServerContextAwareT
 
     // then: у структуры с полями элемент-итератор (КлючИЗначение) в заголовке не показываем.
     assertThat(content)
-      .contains("Тип: Структура*")
+      .contains("Тип: Структура")
       .doesNotContain("КлючИЗначение")
       .contains("* **Имя**: `Строка`")
       .contains("* **Возраст**: `Число`");
@@ -309,7 +309,7 @@ class VariableSymbolMarkupContentBuilderTest extends AbstractServerContextAwareT
 
     // then: колонки строки ТЗ показываются маркдаун-списком.
     assertThat(content)
-      .contains("Тип: ТаблицаЗначений из СтрокаТаблицыЗначений*")
+      .contains("Тип: ТаблицаЗначений из СтрокаТаблицыЗначений")
       .contains("* **Сумма**");
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolStructureRenderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolStructureRenderTest.java
@@ -46,6 +46,7 @@ import org.mockito.quality.Strictness;
 
 import java.util.Optional;
 import java.util.StringJoiner;
+import java.util.regex.Pattern;
 
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
@@ -113,6 +114,19 @@ class VariableSymbolStructureRenderTest {
     return builder.getContent(reference).getValue();
   }
 
+  /**
+   * Регулярное выражение на строку раздела типа целиком.
+   * <p>
+   * Проверка вхождением подстроки прошла бы и при вернувшейся пометке вычисленного
+   * по коду типа ({@code Тип: Строка*}) — привязка к концу строки её не пропустит.
+   *
+   * @param label ожидаемая подпись типа.
+   * @return выражение для {@code containsPattern}.
+   */
+  private static String typeLine(String label) {
+    return "(?m)^Тип: " + Pattern.quote(label) + "$";
+  }
+
   private static TypeRef platform(String name) {
     return new TypeRef(TypeKind.PLATFORM, name);
   }
@@ -130,7 +144,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: Структура")
+      .containsPattern(typeLine("Структура"))
       .contains("* **Имя**: `Строка`")
       .contains("* **Возраст**: `Число`")
       .doesNotContain("{");
@@ -147,7 +161,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: Соответствие")
+      .containsPattern(typeLine("Соответствие"))
       .contains("* **Ключ1**: `Строка`");
   }
 
@@ -162,7 +176,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: ФиксированнаяСтруктура")
+      .containsPattern(typeLine("ФиксированнаяСтруктура"))
       .contains("* **Код**: `Число`");
   }
 
@@ -177,7 +191,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: ФиксированноеСоответствие")
+      .containsPattern(typeLine("ФиксированноеСоответствие"))
       .contains("* **Логин**: `Строка`");
   }
 
@@ -194,7 +208,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: ТаблицаЗначений из СтрокаТаблицыЗначений")
+      .containsPattern(typeLine("ТаблицаЗначений из СтрокаТаблицыЗначений"))
       .contains("* **Сумма**: `Число`");
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolStructureRenderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolStructureRenderTest.java
@@ -88,8 +88,6 @@ class VariableSymbolStructureRenderTest {
     when(typeService.displayName(any(TypeRef.class), any(Language.class)))
       .thenAnswer(inv -> ((TypeRef) inv.getArgument(0)).qualifiedName());
     when(resources.getResourceString(VariableSymbolMarkupContentBuilder.class, "type")).thenReturn("Тип");
-    // Объявленного о переменной в этих тестах нет: проверяется отрисовка вычисленного по коду.
-    when(typeService.declaredTypesOf(symbol)).thenReturn(TypeSet.EMPTY);
     when(resources.getResourceString(VariableSymbolMarkupContentBuilder.class, "moduleVariable"))
       .thenReturn("Переменная уровня модуля");
 
@@ -132,7 +130,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: Структура*")
+      .contains("Тип: Структура")
       .contains("* **Имя**: `Строка`")
       .contains("* **Возраст**: `Число`")
       .doesNotContain("{");
@@ -149,7 +147,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: Соответствие*")
+      .contains("Тип: Соответствие")
       .contains("* **Ключ1**: `Строка`");
   }
 
@@ -164,7 +162,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: ФиксированнаяСтруктура*")
+      .contains("Тип: ФиксированнаяСтруктура")
       .contains("* **Код**: `Число`");
   }
 
@@ -179,7 +177,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: ФиксированноеСоответствие*")
+      .contains("Тип: ФиксированноеСоответствие")
       .contains("* **Логин**: `Строка`");
   }
 
@@ -196,7 +194,7 @@ class VariableSymbolStructureRenderTest {
 
     // then
     assertThat(content)
-      .contains("Тип: ТаблицаЗначений из СтрокаТаблицыЗначений*")
+      .contains("Тип: ТаблицаЗначений из СтрокаТаблицыЗначений")
       .contains("* **Сумма**: `Число`");
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolStructureRenderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/hover/VariableSymbolStructureRenderTest.java
@@ -32,6 +32,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.languageserver.configuration.Resources;
+import com.github._1c_syntax.utils.CaseInsensitivePattern;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
@@ -123,8 +124,8 @@ class VariableSymbolStructureRenderTest {
    * @param label ожидаемая подпись типа.
    * @return выражение для {@code containsPattern}.
    */
-  private static String typeLine(String label) {
-    return "(?m)^Тип: " + Pattern.quote(label) + "$";
+  private static Pattern typeLine(String label) {
+    return CaseInsensitivePattern.compile("(?m)^Тип: " + Pattern.quote(label) + "$");
   }
 
   private static TypeRef platform(String name) {


### PR DESCRIPTION
## Описание

Убрана пометка звёздочкой у типа переменной в ховере, добавленная в abd0461.

Пометка обещала больше, чем давала. Критерий был «типа нет в объявлении о самой переменной» (`TypeService.declaredTypesOf` — типизирующий комментарий, тип параметра, аннотация внедрения), поэтому звёздочку получал в том числе тип, полученный из строгого факта:

```bsl
// в модуле Справочника1, у которого Реквизит1 имеет тип Число
Переменная = Реквизит1;       // показывалось «Тип: Число*»
Переменная2 = Реквизит1 + 1;  // показывалось «Тип: Число*»
```

Тип реквизита известен на 100%, сложение двух чисел даёт строго число — звёздочки здесь быть не должно, но отличить это от эмпирической догадки ховер не может: у него на руках только итоговый `TypeSet`.

Чтобы пометка означала заявленное — «тип выведен эмпирически из кода, а не строго типизирован по входным фактам», — строгость должна стать свойством самого вывода типов и ехать по нему от источника к результату: пер-`TypeRef` пометка в `TypeSet`, проставляемая на эмпирических источниках (охватывающий расчёт по области видимости для переменных модуля; состав «открытых» объектов, собранный по найденным операторам-мутаторам), при том что присваивания и операторы наследуют строгость операндов. Это правка модели типов и инференсера, а не ховера; до неё пометка вводит в заблуждение и убрана.

Состав изменений:

- `VariableSymbolMarkupContentBuilder` — удалены `FROM_CODE_MARK` и параметр `declared` у `getTypes`;
- `TypeService.declaredTypesOf` удалён — единственным его потребителем была пометка; `ExpressionTypeInferencer.declaredTypes` вернулся в private (внутри класса он по-прежнему нужен как входной факт расчёта по потоку);
- обновлены ожидания в `VariableSymbolMarkupContentBuilderTest` и `VariableSymbolStructureRenderTest`.

## Связанные задачи

Closes

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков

## Дополнительно

Прогнал `VariableSymbolMarkupContentBuilderTest`, `VariableSymbolStructureRenderTest`, `HoverProviderTest` и `spotlessCheck` — проходят. Полный `gradlew precommit` не запускал.

---
_Generated by [Claude Code](https://claude.ai/code/session_01GamTsXaLqnWLgfEPS4J8FQ)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated variable hover information to display inferred types without the trailing asterisk marker.
  * Improved consistency and accuracy of type labels for strings, structures, maps, fixed types, and value tables.
  * Preserved existing structure field rendering behavior.
  * Refined hover type presentation so complete type labels are shown consistently across supported variable types.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->