### PR TITLE
build(deps): bsl-parser 0.38.0

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -96,7 +96,7 @@ dependencies {
     api("org.springframework.ai:spring-ai-starter-mcp-server-webmvc")
 
     // 1c-syntax
-    api("io.github.1c-syntax:bsl-parser:0.37.2")
+    api("io.github.1c-syntax:bsl-parser:0.38.0")
     api("io.github.1c-syntax:utils:0.10.1")
     api("io.github.1c-syntax:mdclasses:0.19.0.82-SNAPSHOT")
     api("io.github.1c-syntax:bsl-common-library:0.12.4")


### PR DESCRIPTION
Подтягивает [bsl-parser 0.38.0](https://github.com/1c-syntax/bsl-parser/releases/tag/v0.38.0).

## Что там

Координаты элементов описания (`DescriptionElement#range`, диапазоны параметров и типов) теперь учитывают отступ каждой строки, а не только первой — 1c-syntax/bsl-parser#403, PR 1c-syntax/bsl-parser#404.

Раньше на строках после первой они отсчитывались от начала комментария, и семантическая подсветка BSLDoc у описания с отступом накрывала не те символы: вместо `Строка` подсвечивалось `- Стро`.

```bsl
    // Параметры:
        //  Парам - Строка - описание
```

Заодно в релизе удалены перегрузки `SimpleRange.create(Token, int, int)` и `shift(SimpleRange, int, int)`, оставлявшие прежнее неверное поведение доступным. В языковом сервере они не использовались — только координатные фабрики `SimpleRange.create(int, int, int[, int])`, они не менялись.

## Проверка

Прогнаны `semantictokens`, `context`, `hover`, `types`, `diagnostics`, `providers`, `inlayhints`, `completion` — правок ожиданий не потребовалось.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnWpDdNSEFohPZHG6voe6y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated the BSL parser dependency to version 0.38.0.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->