### PR TITLE
Вариант языка проекта считается в одном месте

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/codeactions/GenerateStandardRegionsSupplier.java
@@ -27,7 +27,6 @@ import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
 import com.github._1c_syntax.bsl.languageserver.utils.Regions;
 import com.github._1c_syntax.bsl.languageserver.configuration.Resources;
-import com.github._1c_syntax.bsl.types.ConfigurationSource;
 import com.github._1c_syntax.bsl.types.ScriptVariant;
 import org.eclipse.lsp4j.CodeAction;
 import org.eclipse.lsp4j.CodeActionKind;
@@ -81,7 +80,10 @@ public class GenerateStandardRegionsSupplier implements CodeActionSupplier {
     var moduleType = documentContext.getModuleType();
     var fileType = documentContext.getFileType();
 
-    var regionsLanguage = getRegionsLanguage(documentContext, fileType);
+    // Язык, на котором пишет проект, считает сам документ: у файла конфигурации — её
+    // ScriptVariant, у одиночного файла и у OneScript — язык интерфейса сервера.
+    var regionsLanguage = ScriptVariant.valueByName(
+      documentContext.getScriptVariantLanguage().getLanguageCode());
     Set<String> neededStandardRegions;
 
     if (fileType == FileType.BSL) {
@@ -122,18 +124,6 @@ public class GenerateStandardRegionsSupplier implements CodeActionSupplier {
     codeAction.setKind(CodeActionKind.Refactor);
     codeAction.setEdit(edit);
     return List.of(codeAction);
-  }
-
-  private ScriptVariant getRegionsLanguage(DocumentContext documentContext, FileType fileType) {
-
-    ScriptVariant regionsLanguage;
-    var configuration = documentContext.getServerContext().getConfiguration();
-    if (configuration.getConfigurationSource() == ConfigurationSource.EMPTY || fileType == FileType.OS) {
-      regionsLanguage = ScriptVariant.valueByName(languageServerConfiguration.getLanguage().getLanguageCode());
-    } else {
-      regionsLanguage = documentContext.getServerContext().getConfiguration().getScriptVariant();
-    }
-    return regionsLanguage;
   }
 
   private static Range calculateFixRange(Range range) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerOutsideEventRegionDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerOutsideEventRegionDiagnostic.java
@@ -21,9 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
-import com.github._1c_syntax.bsl.languageserver.configuration.LanguageServerConfiguration;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
-import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.EventMethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.RegionSymbol;
@@ -35,9 +33,7 @@ import com.github._1c_syntax.bsl.languageserver.diagnostics.metadata.DiagnosticT
 import com.github._1c_syntax.bsl.languageserver.types.registry.FormHandlerRoleIndex;
 import com.github._1c_syntax.bsl.languageserver.utils.Keywords;
 import com.github._1c_syntax.bsl.languageserver.utils.Ranges;
-import com.github._1c_syntax.bsl.types.ConfigurationSource;
 import com.github._1c_syntax.bsl.types.ModuleType;
-import com.github._1c_syntax.bsl.types.ScriptVariant;
 import org.eclipse.lsp4j.CodeAction;
 import org.jspecify.annotations.Nullable;
 import org.eclipse.lsp4j.CodeActionParams;
@@ -68,12 +64,9 @@ import java.util.stream.Collectors;
 public class EventHandlerOutsideEventRegionDiagnostic extends AbstractDiagnostic implements QuickFixProvider {
 
   private final FormHandlerRoleIndex formHandlerRoleIndex;
-  private final LanguageServerConfiguration languageServerConfiguration;
 
-  public EventHandlerOutsideEventRegionDiagnostic(FormHandlerRoleIndex formHandlerRoleIndex,
-                                                 LanguageServerConfiguration languageServerConfiguration) {
+  public EventHandlerOutsideEventRegionDiagnostic(FormHandlerRoleIndex formHandlerRoleIndex) {
     this.formHandlerRoleIndex = formHandlerRoleIndex;
-    this.languageServerConfiguration = languageServerConfiguration;
   }
 
   @Override
@@ -89,24 +82,10 @@ public class EventHandlerOutsideEventRegionDiagnostic extends AbstractDiagnostic
       return;
     }
     // Имя области — на языке модуля, а не интерфейса: его пользователю писать в коде.
-    var regionName = EventHandlerTargetRegion.orFallback(expectedRegion).forVariant(scriptVariantOf(documentContext));
+    var regionName = EventHandlerTargetRegion.orFallback(expectedRegion)
+      .forLanguage(documentContext.getScriptVariantLanguage());
     diagnosticStorage.addDiagnostic(method.getSubNameRange(),
       info.getMessage(method.getName(), regionName));
-  }
-
-  /**
-   * Вариант встроенного языка, в котором называем области: у файла конфигурации — её
-   * собственный ({@code ScriptVariant}), у одиночного файла (конфигурация не прочитана)
-   * и у OneScript — язык интерфейса сервера. Написание в самом модуле роли не играет:
-   * платформа понимает оба, а проект пишет на своём.
-   */
-  private ScriptVariant scriptVariantOf(DocumentContext documentContext) {
-    var configuration = documentContext.getServerContext().getConfiguration();
-    if (configuration.getConfigurationSource() == ConfigurationSource.EMPTY
-      || documentContext.getFileType() == FileType.OS) {
-      return ScriptVariant.valueByName(languageServerConfiguration.getLanguage().getLanguageCode());
-    }
-    return configuration.getScriptVariant();
   }
 
   /**
@@ -184,8 +163,9 @@ public class EventHandlerOutsideEventRegionDiagnostic extends AbstractDiagnostic
     }
     // Область берётся по первому методу: fix-all группирует методы одной области,
     // а разные роли дают разные области — их правки не смешиваются.
-    var variant = scriptVariantOf(documentContext);
-    var targetRegion = EventHandlerTargetRegion.orFallback(expectedRegion(methods.get(0), documentContext)).forVariant(variant);
+    var language = documentContext.getScriptVariantLanguage();
+    var targetRegion = EventHandlerTargetRegion
+      .orFallback(expectedRegion(methods.get(0), documentContext)).forLanguage(language);
     var existingRegion = findRegionByName(documentContext, targetRegion);
     if (existingRegion.isPresent()) {
       var insertPos = positionBeforeEndRegion(existingRegion.get());
@@ -204,8 +184,9 @@ public class EventHandlerOutsideEventRegionDiagnostic extends AbstractDiagnostic
       var body = String.join("\n\n", methodTexts);
       // Директивы — в варианте встроенного языка конфигурации. Компилируются оба
       // написания, но создавать мы обязаны на том языке, на котором пишет проект.
-      var insertText = leading + "#" + Keywords.REGION.get(variant) + " " + targetRegion + "\n\n"
-        + body + "\n\n#" + Keywords.ENDREGION.get(variant) + "\n";
+      var languageCode = language.getLanguageCode();
+      var insertText = leading + "#" + Keywords.REGION.get(languageCode) + " " + targetRegion + "\n\n"
+        + body + "\n\n#" + Keywords.ENDREGION.get(languageCode) + "\n";
       textEdits.add(new TextEdit(new Range(anchor, anchor), insertText));
     }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerTargetRegion.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/EventHandlerTargetRegion.java
@@ -21,10 +21,10 @@
  */
 package com.github._1c_syntax.bsl.languageserver.diagnostics;
 
-import com.github._1c_syntax.bsl.languageserver.utils.Keywords;
+import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import com.github._1c_syntax.bsl.languageserver.types.registry.FormHandlerRoleIndex;
+import com.github._1c_syntax.bsl.languageserver.utils.Keywords;
 import com.github._1c_syntax.bsl.types.MultiName;
-import com.github._1c_syntax.bsl.types.ScriptVariant;
 import org.jspecify.annotations.Nullable;
 
 import java.util.Locale;
@@ -99,8 +99,8 @@ record EventHandlerTargetRegion(MultiName name, String suffix) {
   }
 
   /** Имя области на языке модуля — его и надо написать в коде. */
-  String forVariant(ScriptVariant variant) {
-    return name.get(variant) + suffix;
+  String forLanguage(Language language) {
+    return name.get(language.getLanguageCode()) + suffix;
   }
 
   /** Это ли та самая область — независимо от языка, на котором она названа. */


### PR DESCRIPTION
По замечанию ревьюера в #4347: «кажется, этот расчёт уже где-то есть». Есть — и даже дважды.

`DocumentContext.getScriptVariantLanguage()` отвечает ровно на этот вопрос: на каком языке писать в код пользователя. Им уже пользуются сворачивание областей (`RegionFoldingRangeSupplier` — буквально слово `Область`/`Region`), `CodeBlockFoldingRangeSupplier`, автодополнение и quick fix `EventHandlerInvalidSignatureDiagnostic`.

Рядом с ним жили две копии того же правила:

| место | что было |
|---|---|
| `GenerateStandardRegionsSupplier.getRegionsLanguage` | своя реализация, до этих правок |
| `EventHandlerOutsideEventRegionDiagnostic.scriptVariantOf` | третья копия, добавлена в #4347 |

Обе удалены, оба места зовут канонический метод.

## Побочно закрытая дыра

У копий не было отступного пути на `ScriptVariant.UNKNOWN`, который есть у `getScriptVariantLanguage()`. `MultiName.get(ScriptVariant)` трактует всё, кроме `ENGLISH`, как русский, поэтому в конфигурации с неопознанным вариантом языка области назывались по-русски независимо от языка проекта. Теперь там язык интерфейса сервера — как и задумано.

## Мелочи

`ScriptVariant` остался нужен `GenerateStandardRegionsSupplier`: его требует API `Regions`. На месте вызова это одна строка-переходник `ScriptVariant.valueByName(...getLanguageCode())` — приведение типа, а не расчёт правила.

Из диагностики вместе с расчётом ушла зависимость от `LanguageServerConfiguration`: она была нужна только ради него.

Итог: −46 строк, +17.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved language detection for standard region generation and event-handler diagnostics.
  * Region names and generated directives now use the document’s actual language, providing more accurate localized results.
  * Quick fixes for event handlers outside their expected regions now generate language-appropriate region names and directives.
  * Removed reliance on separate language configuration for these code actions and diagnostics.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->