### PR TITLE
Методы коллекции у реквизита-таблицы формы отдают строку этой таблицы

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/FormDataTypesRegistrar.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/FormDataTypesRegistrar.java
@@ -231,6 +231,10 @@ class FormDataTypesRegistrar {
     var columnTypes = prepareAttributeTypes(columns, kind, suffix);
     MemberSource columnMembers = () -> buildAttributeMembers(columns, columnTypes);
     typeRegistry.registerMemberSource(itemRef, columnMembers, FileType.BSL);
+    // Тем же помощником, что и у табличной части: типы элементов задают только обход
+    // коллекции, а `НайтиПоИдентификатору`, `Добавить`, `Получить`, `НайтиСтроки` и
+    // `Выгрузить` объявлены платформой через обобщённую строку и без замены отдают её.
+    specializeCollectionReturns(collectionRef, collectionBase, itemBase, itemRef, columnMembers);
     rowByCollection.put(collectionRef, itemRef);
     return collectionRef;
   }
@@ -271,6 +275,12 @@ class FormDataTypesRegistrar {
    * @param tabularSectionRef тип табличной части ({@code ДокументТабличнаяЧасть.X.Y}).
    * @param columns           источник колонок табличной части.
    */
+  // TODO mdclasses#679: форма может добавить табличной части свои колонки
+  //  (`<AdditionalColumns table="Объект.Товары">` у основного реквизита) — в модель
+  //  метаданных они не попадают, и обращение к ним в модуле формы не резолвится.
+  //  Когда появятся: такие колонки пер-форменные, а зеркало здесь одно на прикладной
+  //  тип, поэтому форме с ними понадобится своя специализация — и коллекции, и
+  //  структуры `Объект`.
   public void registerTabularSectionData(TypeRef tabularSectionRef, MemberSource columns) {
     var collectionBase = typeRegistry.resolve(FormPlatformTypes.FORM_DATA_COLLECTION_RU).orElse(null);
     var itemBase = typeRegistry.resolve(FormPlatformTypes.FORM_DATA_COLLECTION_ITEM_RU).orElse(null);
@@ -299,13 +309,33 @@ class FormDataTypesRegistrar {
     // Типы возврата уточняются тем же помощником, что и у табличной части объекта:
     // задача одна — заменить обобщённую строку на строку этой коллекции и доопределить
     // «массив чего» у `НайтиСтроки` и «таблицу с какими колонками» у `Выгрузить`.
+    specializeCollectionReturns(collectionRef, collectionBase, itemBase, itemRef, columns);
+    tabularSectionData.put(tabularSectionRef, collectionRef);
+    rowByCollection.put(collectionRef, itemRef);
+  }
+
+  /**
+   * Уточняет типы возврата у членов коллекции данных формы под её строку.
+   * <p>
+   * Нужно всякой коллекции данных формы, откуда бы её колонки ни пришли: и зеркалу
+   * табличной части, и реквизиту-таблице (дереву) значений. Явные типы элементов
+   * ({@code registerDefaultElementTypes}) закрывают только обход коллекции — обращение
+   * же {@code Товары.НайтиПоИдентификатору(Ид).Цена} идёт через объявление члена, а там
+   * платформа называет обобщённую строку.
+   *
+   * @param collectionRef  тип этой коллекции.
+   * @param collectionBase базовый платформенный тип коллекции — источник объявлений.
+   * @param itemBase       обобщённый тип строки, который надо заменить.
+   * @param itemRef        строка этой коллекции.
+   * @param columns        колонки — они же колонки выгруженной таблицы значений.
+   */
+  private void specializeCollectionReturns(TypeRef collectionRef, TypeRef collectionBase,
+                                           TypeRef itemBase, TypeRef itemRef, MemberSource columns) {
     var valueTableRow = typeRegistry.resolve(CollectionReturnsSpecializer.VALUE_TABLE_ROW).orElse(null);
     typeRegistry.registerMemberOverride(collectionRef,
       () -> CollectionReturnsSpecializer.specialize(
         typeRegistry.getMembers(collectionBase, FileType.BSL), itemBase, itemRef,
         CollectionReturnsSpecializer.unloadedRow(valueTableRow, columns)), FileType.BSL);
-    tabularSectionData.put(tabularSectionRef, collectionRef);
-    rowByCollection.put(collectionRef, itemRef);
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/FormModuleInferenceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/FormModuleInferenceTest.java
@@ -170,6 +170,58 @@ class FormModuleInferenceTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void valueTableAttributeMethodsCarryItsRowToo() {
+    // Репорт: `Таблица.НайтиПоИдентификатору(Ид)` отдавал нетипизированный элемент
+    // коллекции. Явные типы элементов закрывают только обход, а обращение по методу
+    // идёт через его объявление — платформа называет там обобщённую строку. У зеркала
+    // табличной части замена была, у реквизита-таблицы значений — нет.
+    var documentContext = formModuleWith("""
+      &НаСервере
+      Процедура Тест()
+        ПоИдентификатору = ТаблицаПодбора.НайтиПоИдентификатору(1);
+        Добавленная = ТаблицаПодбора.Добавить();
+        КолонкаНайденной = ТаблицаПодбора.НайтиПоИдентификатору(1).Номенклатура;
+        КолонкаДобавленной = ТаблицаПодбора.Добавить().Количество;
+      КонецПроцедуры
+      """);
+
+    var row = "ДанныеФормыЭлементКоллекции.Документ.Документ1.Форма.ФормаДокумента.ТаблицаПодбора";
+    // Не containsExactly: в синтакс-помощнике возврат объявлен как «строка либо
+    // Неопределено», в JSON-фолбэке — одной строкой. Важна сама строка: обобщённой
+    // в наборе быть не должно.
+    assertThat(typesAtRhs(documentContext, "ПоИдентификатору"))
+      .contains(row)
+      .doesNotContain("ДанныеФормыЭлементКоллекции");
+    assertThat(typesAtRhs(documentContext, "Добавленная")).containsExactly(row);
+    assertThat(typesAtRhs(documentContext, "КолонкаНайденной"))
+      .as("колонки реквизита-таблицы объявлены в самой форме")
+      .containsExactly("СправочникСсылка.Справочник1");
+    assertThat(typesAtRhs(documentContext, "КолонкаДобавленной")).containsExactly("Число");
+  }
+
+  @Test
+  void unloadedValueTableAttributeCarriesItsColumns() {
+    var documentContext = formModuleWith("""
+      &НаСервере
+      Процедура Тест()
+        Выгруженная = ТаблицаПодбора.Выгрузить();
+        Найденные = ТаблицаПодбора.НайтиСтроки(Новый Структура);
+      КонецПроцедуры
+      """);
+
+    var unloaded = typeSetAtRhs(documentContext, "Выгруженная");
+    assertThat(unloaded.refs()).extracting(TypeRef::qualifiedName).containsExactly("ТаблицаЗначений");
+    assertThat(unloaded.getElementTypes().getLocalFields(
+      unloaded.getElementTypes().refs().iterator().next()))
+      .as("колонки выгруженной таблицы — колонки реквизита")
+      .containsKeys("Номенклатура", "Количество");
+
+    assertThat(typeSetAtRhs(documentContext, "Найденные").getElementTypes().refs())
+      .extracting(TypeRef::qualifiedName)
+      .containsExactly("ДанныеФормыЭлементКоллекции.Документ.Документ1.Форма.ФормаДокумента.ТаблицаПодбора");
+  }
+
+  @Test
   void unloadedValueTableCarriesColumns() {
     var documentContext = formModuleWith("""
       &НаСервере


### PR DESCRIPTION
У реквизита формы типа `ТаблицаЗначений`/`ДеревоЗначений` методы коллекции отдавали обобщённую строку данных формы вместо строки этой таблицы. Обращение к колонке сразу за вызовом не резолвилось:

| выражение | было | стало |
|---|---|---|
| `ТаблицаПодбора.НайтиПоИдентификатору(Ид)` | `ДанныеФормыЭлементКоллекции` | `ДанныеФормыЭлементКоллекции.<форма>.ТаблицаПодбора` |
| `…НайтиПоИдентификатору(Ид).Номенклатура` | не резолвится | `СправочникСсылка.…` |
| `ТаблицаПодбора.Добавить().Количество` | не резолвится | `Число` |
| `ТаблицаПодбора.Выгрузить()` | `ТаблицаЗначений` без колонок | с колонками реквизита |
| `ТаблицаПодбора.НайтиСтроки(…)` | `Массив` без типа элемента | массив строк этой таблицы |

`registerAttributeCollection` делал всё то же, что и `registerTabularSectionData` для зеркала табличной части, кроме одного — не вешал `CollectionReturnsSpecializer`. Явные типы элементов (`registerDefaultElementTypes`) закрывают только обход `Для Каждого`, а обращение по методу идёт через его объявление, где платформа называет обобщённую строку. Общий кусок вынесен в `specializeCollectionReturns` и зовётся из обеих точек.

### Заодно — пометка о смежном дефекте

Форма может добавить табличной части объекта **свои** колонки — блок `<AdditionalColumns table="Объект.Товары">` у основного реквизита. В модель метаданных они не попадают вовсе, поэтому обращение к ним в модуле формы не резолвится, а `UnknownMember` считает их опечаткой:

```bsl
ДанныеСтроки = Объект.Товары.НайтиПоИдентификатору(Строка);
ДанныеСтроки.ТипНоменклатуры // «У типа … нет метода или свойства "ТипНоменклатуры"»
```

Живой пример — `Документ.ЗаказПоставщику.Форма.ФормаДокумента` в 1С:ERP. Завёл [mdclasses#679](https://github.com/1c-syntax/mdclasses/issues/679) с разбором, почему теряется (`FormElementReaderContext.mergeAdditionalColumns` вливает такие колонки в уже существующую одноимённую колонку реквизита, а у объектного реквизита табличные части в `Form.xml` не перечислены — вливать не во что). Здесь только `TODO mdclasses#679` в том месте, где колонки зеркала и берутся.

Когда данные появятся, доработка будет не бесплатной, и это записано в самой пометке: дополнительные колонки **пер-форменные**, а зеркало табличной части у нас одно на прикладной тип — форме с такими колонками понадобится своя специализация и коллекции, и структуры `Объект`.

### Проверки

Два теста в `FormModuleInferenceTest`: методы реквизита-таблицы отдают её строку и её колонки; `Выгрузить`/`НайтиСтроки` несут колонки и тип элемента. `Получить` в тест не взял — его нет в JSON-фолбэке, а класс гоняется без синтакс-помощника.

Полный `cleanTest check` локально зелёный; отдельно прогонял `*Form*`/`*Type*` с включённым HBK.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for form value-table attributes.
  * Row-returning methods now retain the table’s row type.
  * Chained column access resolves declared column types more accurately.
  * Table operations such as `Выгрузить` and `НайтиСтроки` now preserve row and column metadata.

* **Tests**
  * Added coverage for value-table attribute type inference and related operations.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->