### PR TITLE
fix(types): ссылки специализированных членов приводятся к каноническим

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
@@ -266,16 +266,15 @@ public record MemberDescriptor(
    * специализация платформенного шаблона даёт платформенную ссылку и на
    * конфигурационный тип. Канонизация приводит её к той, что зарегистрирована в
    * реестре под этим именем: иначе за одним именем оказываются две разные ссылки,
-   * и объединение наборов их не схлопывает.
+   * и объединение наборов их не схлопывает. Приведение выполняется и при пустых
+   * {@code bindings} — так подмешанные расширением члены тоже получают канонические
+   * ссылки.
    *
    * @param bindings      placeholder → имя заменителя.
    * @param canonicalizer приведение ссылки к канонической.
    * @return специализированная копия дескриптора; {@code this}, если ничего не изменилось.
    */
   public MemberDescriptor specialize(Map<String, String> bindings, UnaryOperator<TypeRef> canonicalizer) {
-    if (bindings == null || bindings.isEmpty()) {
-      return this;
-    }
     var newReturnTypes = TypeRef.specialize(returnTypes, bindings).mapRefs(canonicalizer);
     var newSignatures = signatures;
     boolean signaturesChanged = false;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
@@ -31,6 +31,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
+import java.util.function.UnaryOperator;
 
 /**
  * Член типа (метод или свойство).
@@ -261,17 +262,34 @@ public record MemberDescriptor(
    * по {@code bindings}.
    */
   public MemberDescriptor specialize(Map<String, String> bindings) {
+    return specialize(bindings, UnaryOperator.identity());
+  }
+
+  /**
+   * То же, что {@link #specialize(Map)}, но каждая полученная ссылка на тип пропускается
+   * через {@code canonicalizer}.
+   * <p>
+   * Структурная подстановка имени сохраняет {@link com.github._1c_syntax.bsl.languageserver.types.model.TypeKind}
+   * шаблона, поэтому специализация платформенного шаблона даёт платформенную ссылку и
+   * на конфигурационный тип. Канонизация приводит её к той, что зарегистрирована в
+   * реестре под этим именем.
+   *
+   * @param bindings      placeholder → имя заменителя.
+   * @param canonicalizer приведение ссылки к канонической.
+   * @return специализированная копия дескриптора; {@code this}, если ничего не изменилось.
+   */
+  public MemberDescriptor specialize(Map<String, String> bindings, UnaryOperator<TypeRef> canonicalizer) {
     if (bindings == null || bindings.isEmpty()) {
       return this;
     }
-    var newReturnTypes = TypeRef.specialize(returnTypes, bindings);
+    var newReturnTypes = TypeRef.map(TypeRef.specialize(returnTypes, bindings), canonicalizer);
     var newSignatures = signatures;
     boolean signaturesChanged = false;
     if (!newSignatures.isEmpty()) {
       var rebuilt = new ArrayList<SignatureDescriptor>(newSignatures.size());
       for (var sig : newSignatures) {
-        var specializedReturn = TypeRef.specialize(sig.returnTypes(), bindings);
-        var specializedParameters = specializeParameters(sig.parameters(), bindings);
+        var specializedReturn = TypeRef.map(TypeRef.specialize(sig.returnTypes(), bindings), canonicalizer);
+        var specializedParameters = specializeParameters(sig.parameters(), bindings, canonicalizer);
         var returnChanged = !specializedReturn.equals(sig.returnTypes());
         var parametersChanged = !specializedParameters.equals(sig.parameters());
         if (returnChanged || parametersChanged) {
@@ -299,14 +317,15 @@ public record MemberDescriptor(
    * сравнение по ссылке сработало без аллокаций.
    */
   private static List<ParameterDescriptor> specializeParameters(List<ParameterDescriptor> params,
-                                                                Map<String, String> bindings) {
+                                                                Map<String, String> bindings,
+                                                                UnaryOperator<TypeRef> canonicalizer) {
     if (params.isEmpty()) {
       return params;
     }
     List<ParameterDescriptor> rebuilt = null;
     for (var i = 0; i < params.size(); i++) {
       var p = params.get(i);
-      var specializedTypes = TypeRef.specialize(p.types(), bindings);
+      var specializedTypes = TypeRef.map(TypeRef.specialize(p.types(), bindings), canonicalizer);
       if (specializedTypes.equals(p.types())) {
         if (rebuilt != null) {
           rebuilt.add(p);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
@@ -259,20 +259,14 @@ public record MemberDescriptor(
   /**
    * Возвращает копию дескриптора, в которой placeholder'ы {@code <X>} в
    * {@link #returnTypes} и {@link SignatureDescriptor#returnType} заменены
-   * по {@code bindings}.
-   */
-  public MemberDescriptor specialize(Map<String, String> bindings) {
-    return specialize(bindings, UnaryOperator.identity());
-  }
-
-  /**
-   * То же, что {@link #specialize(Map)}, но каждая полученная ссылка на тип пропускается
-   * через {@code canonicalizer}.
+   * по {@code bindings}, а каждая полученная ссылка на тип пропущена через
+   * {@code canonicalizer}.
    * <p>
-   * Структурная подстановка имени сохраняет {@link com.github._1c_syntax.bsl.languageserver.types.model.TypeKind}
-   * шаблона, поэтому специализация платформенного шаблона даёт платформенную ссылку и
-   * на конфигурационный тип. Канонизация приводит её к той, что зарегистрирована в
-   * реестре под этим именем.
+   * Структурная подстановка имени сохраняет {@link TypeKind} шаблона, поэтому
+   * специализация платформенного шаблона даёт платформенную ссылку и на
+   * конфигурационный тип. Канонизация приводит её к той, что зарегистрирована в
+   * реестре под этим именем: иначе за одним именем оказываются две разные ссылки,
+   * и объединение наборов их не схлопывает.
    *
    * @param bindings      placeholder → имя заменителя.
    * @param canonicalizer приведение ссылки к канонической.

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptor.java
@@ -282,13 +282,13 @@ public record MemberDescriptor(
     if (bindings == null || bindings.isEmpty()) {
       return this;
     }
-    var newReturnTypes = TypeRef.map(TypeRef.specialize(returnTypes, bindings), canonicalizer);
+    var newReturnTypes = TypeRef.specialize(returnTypes, bindings).mapRefs(canonicalizer);
     var newSignatures = signatures;
     boolean signaturesChanged = false;
     if (!newSignatures.isEmpty()) {
       var rebuilt = new ArrayList<SignatureDescriptor>(newSignatures.size());
       for (var sig : newSignatures) {
-        var specializedReturn = TypeRef.map(TypeRef.specialize(sig.returnTypes(), bindings), canonicalizer);
+        var specializedReturn = TypeRef.specialize(sig.returnTypes(), bindings).mapRefs(canonicalizer);
         var specializedParameters = specializeParameters(sig.parameters(), bindings, canonicalizer);
         var returnChanged = !specializedReturn.equals(sig.returnTypes());
         var parametersChanged = !specializedParameters.equals(sig.parameters());
@@ -325,7 +325,7 @@ public record MemberDescriptor(
     List<ParameterDescriptor> rebuilt = null;
     for (var i = 0; i < params.size(); i++) {
       var p = params.get(i);
-      var specializedTypes = TypeRef.map(TypeRef.specialize(p.types(), bindings), canonicalizer);
+      var specializedTypes = TypeRef.specialize(p.types(), bindings).mapRefs(canonicalizer);
       if (specializedTypes.equals(p.types())) {
         if (rebuilt != null) {
           rebuilt.add(p);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeRef.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeRef.java
@@ -31,7 +31,6 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.function.UnaryOperator;
 
 /**
  * Лёгкая ссылка-ключ на тип.
@@ -171,34 +170,6 @@ public record TypeRef(TypeKind kind, String qualifiedName) implements Comparable
         changed = true;
       }
       rebuilt.add(specialized);
-    }
-    return changed ? TypeSet.of(rebuilt) : typeSet;
-  }
-
-  /**
-   * Применяет {@code mapper} к каждому {@link TypeRef} в {@link TypeSet}.
-   * <p>
-   * Нужно, чтобы после структурной специализации привести полученные ссылки к
-   * каноническим — тем, что зарегистрированы в реестре под этим именем. Иначе за одним
-   * именем оказываются две разные ссылки, различающиеся только {@link TypeKind},
-   * и объединение наборов их не схлопывает.
-   *
-   * @param typeSet исходный набор.
-   * @param mapper  преобразование ссылки.
-   * @return набор с преобразованными ссылками; исходный, если ни одна не изменилась.
-   */
-  public static TypeSet map(TypeSet typeSet, UnaryOperator<TypeRef> mapper) {
-    if (typeSet == null || typeSet.isEmpty()) {
-      return typeSet;
-    }
-    var rebuilt = new ArrayList<TypeRef>(typeSet.refs().size());
-    boolean changed = false;
-    for (var ref : typeSet.refs()) {
-      var mapped = mapper.apply(ref);
-      if (!mapped.equals(ref)) {
-        changed = true;
-      }
-      rebuilt.add(mapped);
     }
     return changed ? TypeSet.of(rebuilt) : typeSet;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeRef.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeRef.java
@@ -31,6 +31,7 @@ import java.util.List;
 import java.util.Locale;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.function.UnaryOperator;
 
 /**
  * Лёгкая ссылка-ключ на тип.
@@ -170,6 +171,34 @@ public record TypeRef(TypeKind kind, String qualifiedName) implements Comparable
         changed = true;
       }
       rebuilt.add(specialized);
+    }
+    return changed ? TypeSet.of(rebuilt) : typeSet;
+  }
+
+  /**
+   * Применяет {@code mapper} к каждому {@link TypeRef} в {@link TypeSet}.
+   * <p>
+   * Нужно, чтобы после структурной специализации привести полученные ссылки к
+   * каноническим — тем, что зарегистрированы в реестре под этим именем. Иначе за одним
+   * именем оказываются две разные ссылки, различающиеся только {@link TypeKind},
+   * и объединение наборов их не схлопывает.
+   *
+   * @param typeSet исходный набор.
+   * @param mapper  преобразование ссылки.
+   * @return набор с преобразованными ссылками; исходный, если ни одна не изменилась.
+   */
+  public static TypeSet map(TypeSet typeSet, UnaryOperator<TypeRef> mapper) {
+    if (typeSet == null || typeSet.isEmpty()) {
+      return typeSet;
+    }
+    var rebuilt = new ArrayList<TypeRef>(typeSet.refs().size());
+    boolean changed = false;
+    for (var ref : typeSet.refs()) {
+      var mapped = mapper.apply(ref);
+      if (!mapped.equals(ref)) {
+        changed = true;
+      }
+      rebuilt.add(mapped);
     }
     return changed ? TypeSet.of(rebuilt) : typeSet;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSet.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSet.java
@@ -29,7 +29,9 @@ import java.util.LinkedHashSet;
 import java.util.Locale;
 import java.util.Map;
 import java.util.Set;
+import java.util.function.BinaryOperator;
 import java.util.function.Predicate;
+import java.util.function.UnaryOperator;
 
 /**
  * Неизменяемый, hash-stable union типов.
@@ -196,6 +198,66 @@ public record TypeSet(
     }
 
     return new TypeSet(merged, mergedElements, mergedFields, mergedLazyElements, mergedLazyFields);
+  }
+
+  /**
+   * Применяет {@code mapper} к каждой ссылке набора — вместе с ключами декораций.
+   * <p>
+   * Нужно, чтобы после структурной специализации привести полученные ссылки к
+   * каноническим: иначе за одним именем оказываются две разные ссылки, и объединение
+   * наборов их не схлопывает. Декорации переезжают на новую ссылку, а если в одну
+   * каноническую ссылку сходятся несколько исходных — сливаются между собой.
+   *
+   * @param mapper преобразование ссылки.
+   * @return набор с преобразованными ссылками; исходный, если ни одна не изменилась.
+   */
+  public TypeSet mapRefs(UnaryOperator<TypeRef> mapper) {
+    var mappedRefs = new LinkedHashSet<TypeRef>();
+    var changed = false;
+    for (var ref : refs) {
+      var mapped = mapper.apply(ref);
+      changed = changed || !mapped.equals(ref);
+      mappedRefs.add(mapped);
+    }
+    if (!changed) {
+      return this;
+    }
+    return new TypeSet(
+      mappedRefs,
+      mapKeys(elementTypes, mapper, TypeSet::union),
+      mapNestedKeys(localFields, mapper, LocalField::merge),
+      mapKeys(lazyElements, mapper, LazyTypeSet::combine),
+      mapNestedKeys(lazyFields, mapper, LazyField::merge)
+    );
+  }
+
+  private static <V> Map<TypeRef, V> mapKeys(
+    Map<TypeRef, V> source,
+    UnaryOperator<TypeRef> mapper,
+    BinaryOperator<V> merger
+  ) {
+    if (source.isEmpty()) {
+      return source;
+    }
+    var result = new LinkedHashMap<TypeRef, V>();
+    source.forEach((ref, value) -> result.merge(mapper.apply(ref), value, merger));
+    return result;
+  }
+
+  private static <V> Map<TypeRef, Map<String, V>> mapNestedKeys(
+    Map<TypeRef, Map<String, V>> source,
+    UnaryOperator<TypeRef> mapper,
+    BinaryOperator<V> merger
+  ) {
+    if (source.isEmpty()) {
+      return source;
+    }
+    var result = new LinkedHashMap<TypeRef, Map<String, V>>();
+    source.forEach((ref, fields) -> {
+      var target = result.computeIfAbsent(mapper.apply(ref), key -> new LinkedHashMap<>());
+      fields.forEach((name, field) -> target.merge(name, field, merger));
+    });
+    return result;
   }
 
   /** Есть ли у набора декорации (element/field, в т.ч. ленивые). */

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSet.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSet.java
@@ -201,12 +201,15 @@ public record TypeSet(
   }
 
   /**
-   * Применяет {@code mapper} к каждой ссылке набора — вместе с ключами декораций.
+   * Применяет {@code mapper} к каждой ссылке набора — вместе с ключами декораций и
+   * ссылками внутри них: типами элементов коллекции и типами полей объекта.
    * <p>
    * Нужно, чтобы после структурной специализации привести полученные ссылки к
    * каноническим: иначе за одним именем оказываются две разные ссылки, и объединение
    * наборов их не схлопывает. Декорации переезжают на новую ссылку, а если в одну
-   * каноническую ссылку сходятся несколько исходных — сливаются между собой.
+   * каноническую ссылку сходятся несколько исходных — сливаются между собой. Ленивая
+   * декорация не форсится: преобразование применяется к тому, что её источник вернёт
+   * при чтении.
    *
    * @param mapper преобразование ссылки.
    * @return набор с преобразованными ссылками; исходный, если ни одна не изменилась.
@@ -219,43 +222,63 @@ public record TypeSet(
       changed = changed || !mapped.equals(ref);
       mappedRefs.add(mapped);
     }
+    var mappedElements = mapKeys(elementTypes, mapper, TypeSet::union, types -> types.mapRefs(mapper));
+    var mappedFields = mapNestedKeys(localFields, mapper, LocalField::merge,
+      field -> new LocalField(field.types().mapRefs(mapper), field.description()));
+    // Ленивая декорация равна прежней по ключу, поэтому изменилось ли её содержимое,
+    // сравнением не узнать — набор с ленивыми декорациями пересобирается всегда.
+    changed = changed
+      || !mappedElements.equals(elementTypes)
+      || !mappedFields.equals(localFields)
+      || !lazyElements.isEmpty()
+      || !lazyFields.isEmpty();
     if (!changed) {
       return this;
     }
     return new TypeSet(
       mappedRefs,
-      mapKeys(elementTypes, mapper, TypeSet::union),
-      mapNestedKeys(localFields, mapper, LocalField::merge),
-      mapKeys(lazyElements, mapper, LazyTypeSet::combine),
-      mapNestedKeys(lazyFields, mapper, LazyField::merge)
+      mappedElements,
+      mappedFields,
+      // Ленивую декорацию не форсим — оборачиваем: приведение применится к тому, что
+      // источник вернёт при чтении. Ключ у обёртки прежний, поэтому равенство и слияние
+      // ленивых ссылок работают как раньше.
+      mapKeys(lazyElements, mapper, LazyTypeSet::combine, lazy -> mapLazy(lazy, mapper)),
+      mapNestedKeys(lazyFields, mapper, LazyField::merge,
+        field -> new LazyField(mapLazy(field.types(), mapper), field.description()))
     );
+  }
+
+  private static LazyTypeSet mapLazy(LazyTypeSet lazy, UnaryOperator<TypeRef> mapper) {
+    return new LazyTypeSet(lazy.key(), () -> lazy.get().mapRefs(mapper));
   }
 
   private static <V> Map<TypeRef, V> mapKeys(
     Map<TypeRef, V> source,
     UnaryOperator<TypeRef> mapper,
-    BinaryOperator<V> merger
+    BinaryOperator<V> merger,
+    UnaryOperator<V> valueMapper
   ) {
     if (source.isEmpty()) {
       return source;
     }
     var result = new LinkedHashMap<TypeRef, V>();
-    source.forEach((ref, value) -> result.merge(mapper.apply(ref), value, merger));
+    source.forEach((ref, value) -> result.merge(mapper.apply(ref), valueMapper.apply(value), merger));
     return result;
   }
 
   private static <V> Map<TypeRef, Map<String, V>> mapNestedKeys(
     Map<TypeRef, Map<String, V>> source,
     UnaryOperator<TypeRef> mapper,
-    BinaryOperator<V> merger
+    BinaryOperator<V> merger,
+    UnaryOperator<V> valueMapper
   ) {
     if (source.isEmpty()) {
       return source;
     }
     var result = new LinkedHashMap<TypeRef, Map<String, V>>();
-    source.forEach((ref, fields) -> {
+    source.forEach((TypeRef ref, Map<String, V> fields) -> {
       var target = result.computeIfAbsent(mapper.apply(ref), key -> new LinkedHashMap<>());
-      fields.forEach((name, field) -> target.merge(name, field, merger));
+      fields.forEach((name, field) -> target.merge(name, valueMapper.apply(field), merger));
     });
     return result;
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/FormParametersRegistrar.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/FormParametersRegistrar.java
@@ -101,7 +101,7 @@ class FormParametersRegistrar {
    * внешних источников данных — там их два, и однозначной подстановки нет,
    * поэтому такие типы остаются обобщёнными.
    */
-  private static List<MemberDescriptor> specializeByOwner(List<MemberDescriptor> parameters, String ownerName) {
+  private List<MemberDescriptor> specializeByOwner(List<MemberDescriptor> parameters, String ownerName) {
     if (ownerName.isEmpty()) {
       return parameters;
     }
@@ -110,7 +110,7 @@ class FormParametersRegistrar {
       var placeholder = PlaceholderBinder.singlePlaceholder(parameter);
       result.add(placeholder == null
         ? parameter
-        : parameter.specialize(Map.of(placeholder, ownerName)));
+        : parameter.specialize(Map.of(placeholder, ownerName), typeRegistry::canonicalRef));
     }
     return List.copyOf(result);
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/FormTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/FormTypesProvider.java
@@ -521,12 +521,14 @@ public class FormTypesProvider {
    * это {@code ДокументОбъект.<Имя документа>}), а на конкретной форме известно, какой
    * именно объект туда придёт.
    */
-  private static MemberDescriptor specializeByOwner(MemberDescriptor contract, String ownerName) {
+  private MemberDescriptor specializeByOwner(MemberDescriptor contract, String ownerName) {
     if (ownerName.isEmpty()) {
       return contract;
     }
     var placeholder = PlaceholderBinder.singlePlaceholder(contract);
-    return placeholder == null ? contract : contract.specialize(Map.of(placeholder, ownerName));
+    return placeholder == null
+      ? contract
+      : contract.specialize(Map.of(placeholder, ownerName), typeRegistry::canonicalRef);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlaceholderBinder.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/PlaceholderBinder.java
@@ -74,7 +74,7 @@ final class PlaceholderBinder {
       if (!substitutionExists(typeRegistry, member, bindings)) {
         continue;
       }
-      var specialized = member.specialize(bindings);
+      var specialized = member.specialize(bindings, typeRegistry::canonicalRef);
       bound = bound == null ? specialized : merge(bound, specialized);
     }
     return bound;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/RegisterTypesRegistrar.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/RegisterTypesRegistrar.java
@@ -253,7 +253,7 @@ public class RegisterTypesRegistrar {
       if (member.generic()) {
         continue;
       }
-      var specialized = member.specialize(bindings);
+      var specialized = member.specialize(bindings, typeRegistry::canonicalRef);
       var fixed = RegisterFamilies.ownFamilyMember(typeRegistry, specialized, familyCore, mdName);
       if (fixed == null) {
         fixed = PlaceholderBinder.bind(typeRegistry, specialized, recorders);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -993,7 +993,7 @@ public class TypeRegistry {
         if (member.generic()) {
           continue;
         }
-        var specialized = member.specialize(bindings);
+        var specialized = member.specialize(bindings, this::canonicalRef);
         result.add(specialized);
         memberMetadataIndex.index(target, specialized);
       }
@@ -1725,6 +1725,22 @@ public class TypeRegistry {
 
   private void addAlias(String name, TypeRef ref) {
     aliasIndex.put(name.toLowerCase(Locale.ROOT), ref);
+  }
+
+  /**
+   * Каноническая ссылка на тип с этим именем — та, что зарегистрирована в реестре.
+   * <p>
+   * Структурная специализация шаблона ({@code СправочникСсылка.<Имя>} →
+   * {@code СправочникСсылка.Справочник1}) сохраняет вид шаблона, а шаблоны приходят из
+   * синтакс-помощника платформенными. Без приведения за одним именем оказываются две
+   * ссылки разного вида, и объединение наборов их не схлопывает.
+   *
+   * @param ref ссылка после структурной специализации.
+   * @return зарегистрированная ссылка с этим именем; исходная, если такого имени в
+   *     реестре нет.
+   */
+  private TypeRef canonicalRef(TypeRef ref) {
+    return resolve(ref.qualifiedName()).orElse(ref);
   }
 
   private static Type hydrate(TypeRef ref) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -899,7 +899,7 @@ public class TypeRegistry {
    *   <li>берёт members generic-типа через {@link #getMembers(TypeRef, FileType)};</li>
    *   <li>отфильтровывает {@link MemberDescriptor#generic()} (слотовые
    *       члены вида {@code <Имя реквизита>});</li>
-   *   <li>применяет {@link MemberDescriptor#specialize(Map)} к каждому
+   *   <li>применяет {@link MemberDescriptor#specialize(Map, UnaryOperator)} к каждому
    *       члену — подставляет {@code bindings} в возвращаемые типы и
    *       сигнатуры.</li>
    * </ol>

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -66,6 +66,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
+import java.util.function.UnaryOperator;
 
 /**
  * Реестр известных типов.
@@ -1102,7 +1103,7 @@ public class TypeRegistry {
     var result = new ArrayList<MemberDescriptor>();
     for (var template : raw) {
       if (template.generic()) {
-        expandTemplate(template, memberExpansions, typeBindings, result);
+        expandTemplate(template, memberExpansions, typeBindings, result, this::canonicalRef);
       }
     }
     return result;
@@ -1111,7 +1112,8 @@ public class TypeRegistry {
   private static void expandTemplate(MemberDescriptor template,
                                      Map<String, List<String>> memberExpansions,
                                      Map<String, String> typeBindings,
-                                     List<MemberDescriptor> sink) {
+                                     List<MemberDescriptor> sink,
+                                     UnaryOperator<TypeRef> canonicalizer) {
     var ruName = template.bilingualName().primary();
     var ruPlaceholders = ContextNames.placeholders(ruName);
     var ruMatch = ruPlaceholders.stream()
@@ -1128,7 +1130,7 @@ public class TypeRegistry {
     var ruIndex = ruPlaceholders.indexOf(ruMatch);
     var enMatch = ruIndex >= 0 && ruIndex < enPlaceholders.size() ? enPlaceholders.get(ruIndex) : null;
     for (var value : memberExpansions.get(ruMatch.name())) {
-      sink.add(materializeGenericMember(template, ruMatch, enMatch, value, typeBindings));
+      sink.add(materializeGenericMember(template, ruMatch, enMatch, value, typeBindings, canonicalizer));
     }
   }
 
@@ -1142,7 +1144,8 @@ public class TypeRegistry {
                                                            Placeholder ruPlaceholder,
                                                            @Nullable Placeholder enPlaceholder,
                                                            String value,
-                                                           Map<String, String> typeBindings) {
+                                                           Map<String, String> typeBindings,
+                                                           UnaryOperator<TypeRef> canonicalizer) {
     var ruName = template.bilingualName().primary();
     var newRu = ruName.substring(0, ruPlaceholder.start()) + value + ruName.substring(ruPlaceholder.end());
     var enName = template.bilingualName().en();
@@ -1155,7 +1158,7 @@ public class TypeRegistry {
     var combined = new HashMap<>(typeBindings);
     combined.put(ruPlaceholder.name(), value);
     return template
-      .specialize(combined)
+      .specialize(combined, canonicalizer)
       .withBilingualName(BilingualString.of(newRu, newEn))
       .withGeneric(false);
   }
@@ -1739,7 +1742,7 @@ public class TypeRegistry {
    * @return зарегистрированная ссылка с этим именем; исходная, если такого имени в
    *     реестре нет.
    */
-  private TypeRef canonicalRef(TypeRef ref) {
+  TypeRef canonicalRef(TypeRef ref) {
     return resolve(ref.qualifiedName()).orElse(ref);
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptorFactoryTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptorFactoryTest.java
@@ -25,6 +25,8 @@ import com.github._1c_syntax.bsl.languageserver.configuration.Language;
 import org.junit.jupiter.api.Test;
 
 import java.util.List;
+import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -259,8 +261,8 @@ class MemberDescriptorFactoryTest {
     var m = MemberDescriptor.method("X");
 
     // when
-    var noOp = m.specialize(java.util.Map.of());
-    var nullOp = m.specialize(null);
+    var noOp = m.specialize(Map.of(), UnaryOperator.identity());
+    var nullOp = m.specialize(null, UnaryOperator.identity());
 
     // then
     assertThat(noOp).isSameAs(m);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptorSpecializeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/model/MemberDescriptorSpecializeTest.java
@@ -25,6 +25,7 @@ import org.junit.jupiter.api.Test;
 
 import java.util.List;
 import java.util.Map;
+import java.util.function.UnaryOperator;
 
 import static org.assertj.core.api.Assertions.assertThat;
 
@@ -52,7 +53,7 @@ class MemberDescriptorSpecializeTest {
       false,
       PlatformMetadata.EMPTY);
 
-    var specialized = member.specialize(Map.of("Имя справочника", "X"));
+    var specialized = member.specialize(Map.of("Имя справочника", "X"), UnaryOperator.identity());
     var returnNames = specialized.returnTypes().refs().stream().map(TypeRef::qualifiedName).toList();
     assertThat(returnNames).containsExactlyInAnyOrder("СправочникОбъект.X", "Неопределено");
 
@@ -64,14 +65,14 @@ class MemberDescriptorSpecializeTest {
   @Test
   void specializeIsNoOpWhenNoPlaceholderInDescriptor() {
     var member = MemberDescriptor.property("Имя", new TypeRef(TypeKind.PRIMITIVE, "Строка"));
-    var specialized = member.specialize(Map.of("Имя справочника", "X"));
+    var specialized = member.specialize(Map.of("Имя справочника", "X"), UnaryOperator.identity());
     assertThat(specialized).isSameAs(member);
   }
 
   @Test
   void specializeIsNoOpWithEmptyBindings() {
     var member = MemberDescriptor.property("Ссылка", CATALOG_REF_GENERIC);
-    var specialized = member.specialize(Map.of());
+    var specialized = member.specialize(Map.of(), UnaryOperator.identity());
     assertThat(specialized).isSameAs(member);
   }
 
@@ -93,7 +94,7 @@ class MemberDescriptorSpecializeTest {
       false,
       PlatformMetadata.EMPTY);
 
-    var specialized = event.specialize(Map.of("Имя справочника", "Контрагенты"));
+    var specialized = event.specialize(Map.of("Имя справочника", "Контрагенты"), UnaryOperator.identity());
 
     var params = specialized.signatures().get(0).parameters();
     assertThat(params.get(0).types().refs().iterator().next().qualifiedName())
@@ -130,7 +131,7 @@ class MemberDescriptorSpecializeTest {
       false,
       meta);
 
-    var specialized = member.specialize(Map.of("Имя справочника", "X"));
+    var specialized = member.specialize(Map.of("Имя справочника", "X"), UnaryOperator.identity());
     assertThat(specialized.name()).isEqualTo("Ссылка");
     assertThat(specialized.description()).isEqualTo("описание");
     assertThat(specialized.metadata()).isSameAs(meta);

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSetTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeSetTest.java
@@ -467,4 +467,70 @@ class TypeSetTest {
     // when / then
     assertThat(ts.without(ARRAY)).isSameAs(TypeSet.EMPTY);
   }
+
+  @Test
+  void mapRefsMovesDecorationsToMappedRef() {
+    // given
+    var ts = TypeSet.of(ARRAY)
+      .withElement(ARRAY, TypeSet.of(NUMBER))
+      .withField(ARRAY, "Поле", TypeSet.of(STRING));
+    var renamed = new TypeRef(TypeKind.CONFIGURATION, "Массив");
+
+    // when
+    var mapped = ts.mapRefs(ref -> ARRAY.equals(ref) ? renamed : ref);
+
+    // then
+    assertThat(mapped.refs()).containsExactly(renamed);
+    assertThat(mapped.getElementTypes(renamed).refs()).containsExactly(NUMBER);
+    assertThat(mapped.getLocalFields(renamed)).containsOnlyKeys("Поле");
+  }
+
+  @Test
+  void mapRefsGoesIntoDecorationsWhenOuterRefUnchanged() {
+    // given: снаружи менять нечего, а внутри декораций ссылка неканоническая.
+    var innerAlias = new TypeRef(TypeKind.PLATFORM, "Структура");
+    var ts = TypeSet.of(ARRAY)
+      .withElement(ARRAY, TypeSet.of(innerAlias))
+      .withField(ARRAY, "Поле", TypeSet.of(innerAlias));
+    var canonical = new TypeRef(TypeKind.CONFIGURATION, "Структура");
+
+    // when
+    var mapped = ts.mapRefs(ref -> innerAlias.equals(ref) ? canonical : ref);
+
+    // then
+    assertThat(mapped.refs()).containsExactly(ARRAY);
+    assertThat(mapped.getElementTypes(ARRAY).refs()).containsExactly(canonical);
+    assertThat(mapped.getLocalFields(ARRAY).get("Поле").types().refs()).containsExactly(canonical);
+  }
+
+  @Test
+  void mapRefsAppliesToLazyDecorationOnRead() {
+    // given: тип элемента отложен — источник вернёт неканоническую ссылку.
+    var alias = new TypeRef(TypeKind.PLATFORM, "Структура");
+    var canonical = new TypeRef(TypeKind.CONFIGURATION, "Структура");
+    var forced = new boolean[1];
+    var lazy = new LazyTypeSet("источник", () -> {
+      forced[0] = true;
+      return TypeSet.of(alias);
+    });
+    var ts = TypeSet.of(ARRAY).withLazyElement(ARRAY, lazy);
+
+    // when
+    var mapped = ts.mapRefs(ref -> alias.equals(ref) ? canonical : ref);
+
+    // then: приведение не форсит источник...
+    assertThat(forced[0]).as("ленивая декорация не вычисляется при приведении").isFalse();
+    // ...но применяется к тому, что он вернёт при чтении.
+    assertThat(mapped.getElementTypes(ARRAY).refs()).containsExactly(canonical);
+    assertThat(forced[0]).isTrue();
+  }
+
+  @Test
+  void mapRefsWithoutChangesReturnsSelf() {
+    // given
+    var ts = TypeSet.of(ARRAY).withElement(ARRAY, TypeSet.of(NUMBER));
+
+    // when / then
+    assertThat(ts.mapRefs(ref -> ref)).isSameAs(ts);
+  }
 }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistrySpecializationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistrySpecializationTest.java
@@ -128,6 +128,28 @@ class TypeRegistrySpecializationTest {
   }
 
   @Test
+  void extensionMemberTypesAreCanonicalRefsFromRegistry() {
+    // given: тип-источник объявляет член с платформенной ссылкой, а тип с тем же именем
+    // зарегистрирован как конфигурационный.
+    var canonical = typeRegistry.registerConfigurationType("СправочникОбъект.Подмешанный");
+    var source = typeRegistry.registerConfigurationType("ИсточникРасширения");
+    var target = typeRegistry.registerConfigurationType("ЦельРасширения");
+    typeRegistry.registerMemberSource(source,
+      () -> List.of(MemberDescriptor.property("Объект",
+        new TypeRef(TypeKind.PLATFORM, "СправочникОбъект.Подмешанный"), "")),
+      FileType.BSL);
+
+    // when: члены источника подмешиваются в цель.
+    typeRegistry.registerExtension(target, source, FileType.BSL);
+    var member = typeRegistry.getMembers(target, FileType.BSL).stream()
+      .filter(candidate -> "Объект".equals(candidate.name()))
+      .findFirst().orElseThrow();
+
+    // then: подмешанный член несёт каноническую ссылку, а не платформенную.
+    assertThat(member.returnType()).isEqualTo(canonical);
+  }
+
+  @Test
   void specializedTypeDisplayNameIsBilingualFromGenericDisplay() {
     // Двуязычное display-имя специализации: ru — из qualifiedName, en —
     // структурная подстановка MD-имени в en-написание display-имени generic'а

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistrySpecializationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistrySpecializationTest.java
@@ -105,6 +105,29 @@ class TypeRegistrySpecializationTest {
   }
 
   @Test
+  void specializedMemberTypesAreCanonicalRefsFromRegistry() {
+    // given: generic пришёл из синтакс-помощника платформенным, а тип с тем же именем,
+    // что получится после подстановки, зарегистрирован как конфигурационный.
+    var generic = typeRegistry.resolve("СправочникСсылка.<Имя справочника>").orElseThrow();
+    var objectRef = typeRegistry.registerConfigurationType("СправочникОбъект.Канонический");
+
+    // when
+    var specRef = typeRegistry.registerSpecialization(
+      "СправочникСсылка.Канонический", generic,
+      Map.of("Имя справочника", "Канонический"),
+      FileType.BSL);
+    var getObject = typeRegistry.getMembers(specRef, FileType.BSL).stream()
+      .filter(member -> "ПолучитьОбъект".equals(member.name()))
+      .findFirst().orElseThrow();
+
+    // then: специализация не плодит вторую ссылку на тот же тип — иначе объединение
+    // наборов её не схлопнуло бы и один тип показывался бы дважды.
+    assertThat(getObject.returnType())
+      .as("тип возврата специализированного члена — канонический ref из реестра")
+      .isEqualTo(objectRef);
+  }
+
+  @Test
   void specializedTypeDisplayNameIsBilingualFromGenericDisplay() {
     // Двуязычное display-имя специализации: ru — из qualifiedName, en —
     // структурная подстановка MD-имени в en-написание display-имени generic'а


### PR DESCRIPTION
Первый из трёх стека, выделенного из #4348.

## Что было

Шаблон вида «СправочникСсылка.&lt;Имя справочника&gt;» приходит из синтакс-помощника платформенным, а конфигурационные типы регистрируются своим видом. Структурная специализация сохраняла вид шаблона, поэтому за одним именем оказывались две ссылки, различающиеся только видом: объединение наборов их не схлопывало и тип показывался дважды.

## Что стало

Ссылки специализированных членов приводятся к зарегистрированным в реестре. Приведение:

- не теряет декорации — поля объекта и типы элементов коллекции переезжают на новую ссылку, а если несколько исходных сходятся в одну каноническую, сливаются (`TypeSet.mapRefs`);
- заходит внутрь декораций, включая вложенные наборы;
- доходит до ленивых декораций — они оборачиваются, преобразование применяется к тому, что источник вернёт при чтении, форсить его не нужно;
- применяется во всех местах специализации, а не только в `registerSpecialization`: перегрузка без приведения удалена, чтобы неканонические ссылки не попадали в members другими путями.

## Проверка

`TypeRegistrySpecializationTest`, `TypeSetTest` (перенос декораций, вложенные наборы, ленивые), `MemberDescriptorSpecializeTest`. Прогнан пакет `types`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01MnWpDdNSEFohPZHG6voe6y

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type specialization so equivalent type references consistently resolve to canonical definitions.
  * Improved handling of nested, decorated, and deferred type references during type mapping.
  * Prevented duplicate type references when specialized members match registered types.

* **Tests**
  * Added coverage for canonical type reuse, reference mapping, lazy evaluation, and unchanged type sets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->