### PR TITLE
ci: отмена устаревших запусков воркфлоу для pull request

### DIFF
--- a/.github/workflows/benchmark.yml
+++ b/.github/workflows/benchmark.yml
@@ -21,6 +21,13 @@ on:
     - 'gradle/wrapper/gradle-wrapper.properties'
     - 'lombok.config'
 
+# Для pull_request группа общая для всех запусков одного PR - новый коммит отменяет предыдущие запуски.
+# Для push (замер ветки с публикацией результата) в группу попадает уникальный run_id,
+# поэтому запуски не отменяются.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   check-pr-exists:
     runs-on: ubuntu-latest

--- a/.github/workflows/codeql-analysis.yml
+++ b/.github/workflows/codeql-analysis.yml
@@ -9,6 +9,13 @@ on:
   schedule:
     - cron: '0 0 * * 5'
 
+# Для pull_request группа общая для всех запусков одного PR - новый коммит отменяет предыдущие запуски.
+# Для push (анализ ветки, например develop) и schedule в группу попадает уникальный run_id,
+# поэтому запуски не отменяются.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   gatekeeper:
     runs-on: ubuntu-latest

--- a/.github/workflows/dependabot-automerge.yaml
+++ b/.github/workflows/dependabot-automerge.yaml
@@ -3,6 +3,12 @@ on:
   pull_request_target:
     types: [opened, synchronize]
 
+# Воркфлоу срабатывает только на события PR, поэтому группа всегда общая для одного PR:
+# новый коммит отменяет предыдущий запуск, актуальный запуск делает ту же работу заново.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 permissions:
   contents: write
   pull-requests: write

--- a/.github/workflows/gradle.yml
+++ b/.github/workflows/gradle.yml
@@ -6,6 +6,12 @@ on:
       - "translations_*"
   pull_request:
 
+# Для pull_request группа общая для всех запусков одного PR - новый коммит отменяет предыдущие запуски.
+# Для push (анализ ветки, например develop) в группу попадает уникальный run_id, поэтому запуски не отменяются.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   gatekeeper:
     runs-on: ubuntu-latest

--- a/.github/workflows/javadoc.yml
+++ b/.github/workflows/javadoc.yml
@@ -6,6 +6,12 @@ on:
       - "translations_*"
   pull_request:
 
+# Для pull_request группа общая для всех запусков одного PR - новый коммит отменяет предыдущие запуски.
+# Для push (анализ ветки, например develop) в группу попадает уникальный run_id, поэтому запуски не отменяются.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   gatekeeper:
     runs-on: ubuntu-latest

--- a/.github/workflows/pre-qa.yml
+++ b/.github/workflows/pre-qa.yml
@@ -6,6 +6,12 @@ on:
       - "translations_*"
   pull_request:
 
+# Для pull_request группа общая для всех запусков одного PR - новый коммит отменяет предыдущие запуски.
+# Для push (анализ ветки, например develop) в группу попадает уникальный run_id, поэтому запуски не отменяются.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  cancel-in-progress: true
+
 jobs:
   gatekeeper:
     runs-on: ubuntu-latest

--- a/.github/workflows/qa.yml
+++ b/.github/workflows/qa.yml
@@ -1,9 +1,16 @@
 name: QA
 
-on: 
+on:
   workflow_run:
     workflows: [Pre-QA]
     types: [completed]
+
+# Номер PR здесь недоступен (workflow_run), поэтому PR идентифицируется парой "репозиторий-источник + ветка".
+# Новый коммит в PR отменяет предыдущий анализ. Для push (анализ ветки, например develop)
+# в группу попадает уникальный run_id, поэтому запуски не отменяются.
+concurrency:
+  group: ${{ github.workflow }}-${{ github.event.workflow_run.event == 'pull_request' && format('{0}:{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch) || github.run_id }}
+  cancel-in-progress: true
 
 jobs:
 


### PR DESCRIPTION
## Описание

При пуше нового коммита в PR предыдущие запуски воркфлоу теперь отменяются, а анализ веток (`develop`, `master` и прочие push-события) продолжает работать как раньше.

Реализовано через `concurrency` на уровне воркфлоу:

```yaml
concurrency:
  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
  cancel-in-progress: true
```

Ключевой момент — в fallback'е группы. Для `pull_request` группа общая для всех запусков одного PR, поэтому новый коммит отменяет предыдущий прогон. Для `push` (и `schedule`) в группу подставляется `github.run_id`, уникальный для каждого запуска, — группа всегда «своя», отменять нечего. За счёт этого `cancel-in-progress` можно держать просто `true`, а branch-анализ остаётся нетронутым.

Затронутые воркфлоу:

| Воркфлоу | Триггеры |
| --- | --- |
| `gradle.yml` (Java CI) | push + PR |
| `pre-qa.yml` | push + PR |
| `qa.yml` | `workflow_run` от Pre-QA |
| `javadoc.yml` | push + PR |
| `codeql-analysis.yml` | push + PR + schedule |
| `benchmark.yml` | push + PR |
| `dependabot-automerge.yaml` | `pull_request_target` |

В `qa.yml` номер PR недоступен (событие `workflow_run`, номер вычитывается позже из артефакта `PR_NUMBER`), поэтому PR идентифицируется парой «репозиторий-источник + head-ветка»:

```yaml
group: ${{ github.workflow }}-${{ github.event.workflow_run.event == 'pull_request'
  && format('{0}:{1}', github.event.workflow_run.head_repository.full_name, github.event.workflow_run.head_branch)
  || github.run_id }}
```

`head_repository.full_name` нужен, чтобы одноимённые ветки из разных форков не схлопнулись в одну группу.

Намеренно не затронуты:

- `claude.yml`, `build-bootJar-on-comment.yaml`, `rebase.yml` — триггерятся комментариями (`issue_comment` / `pull_request_review*`). Формально привязаны к PR, но каждый запуск здесь — отдельный запрос человека, а не пересчёт одного и того же состояния: отмена «предыдущего» при втором `@claude` в треде оборвала бы живую сессию.
- `check-package.yml`, `sentry.yml`, `gh-pages.yml`, `dependency-submission.yaml`, `release.yml`, `publish-*.yml`, `update-gradle.yml` — PR-триггера не имеют.

## Связанные задачи

Closes

<!-- Связанной задачи нет: PR создан по прямому запросу в чате. -->

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами — не применимо, меняется только конфигурация GitHub Actions; YAML провалидирован парсером
- [ ] Обязательные действия перед коммитом выполнены (`gradlew precommit`) — не запускался, код проекта не затрагивается

### Для диагностик

Не применимо — диагностики не затрагиваются.

## Дополнительно

Отменённый запуск даёт на PR статус-чек в состоянии *cancelled*, а не *success*. Если какой-то из этих чеков настроен как required в branch protection, «хвостовой» отменённый прогон может некоторое время показываться как непройденный, пока не завершится актуальный. На merge это не влияет — GitHub учитывает последний прогон для head-коммита.


---
_Generated by [Claude Code](https://claude.ai/code/session_01X4GsjrW9STTTEYciRHAzJi)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Automated checks now manage overlapping runs more efficiently by canceling superseded pull request and workflow executions.
  * Push and scheduled checks continue running independently without being canceled by newer activity.
  * QA validation now begins after the preceding pre-QA workflow completes successfully.
  * These updates reduce redundant processing and help surface results from the latest changes sooner.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->