### PR TITLE
fix(types): тип элемента коллекции доезжает до возвращаемого значения метода

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndex.java
@@ -529,10 +529,42 @@ public class SymbolTypeIndex {
       // (`Структура: * Поле - ...`) — на сам тип.
       if (td.variant() != TypeDescription.Variant.COLLECTION) {
         resolved = applyFields(resolved, td, context);
+        // У коллекционной записи автор перечислил элементы сам — даже если они не
+        // разрешились, подставлять вместо них умолчание реестра нельзя.
+        resolved = attachDefaultElementTypes(resolved);
       }
       acc = acc.union(resolved);
     }
     return acc;
+  }
+
+  /**
+   * Прикрепить к типам набора элементы-по-умолчанию из реестра — те, что известны
+   * самому типу ({@code КлючИЗначение} у соответствия, строка у табличной части).
+   * <p>
+   * Делается на выходе разбора объявления, а не у каждого потребителя: объявленный
+   * тип уходит и в переменную, и в возврат метода, и в параметр, и обход коллекции
+   * должен видеть тип элемента везде одинаково. Уточнение, записанное в самом
+   * объявлении ({@code Массив из Строка}), не перетирается — оно точнее.
+   *
+   * @param types набор объявленных типов.
+   * @return тот же набор с элементами-по-умолчанию там, где своих не объявлено.
+   */
+  private TypeSet attachDefaultElementTypes(TypeSet types) {
+    var result = types;
+    for (var ref : types.refs()) {
+      // Проверяется наличие объявленной записи, а не её значение: у ленивой ссылки
+      // значение брать рано — она разрешается в момент чтения, а не индексации.
+      if (!types.elementTypes().getOrDefault(ref, TypeSet.EMPTY).isEmpty()
+        || types.lazyElements().containsKey(ref)) {
+        continue;
+      }
+      var defaults = typeRegistry.getDefaultElementTypes(ref);
+      if (!defaults.isEmpty()) {
+        result = result.withElement(ref, defaults);
+      }
+    }
+    return result;
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/CallResultElementTypeInferenceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/CallResultElementTypeInferenceTest.java
@@ -1,0 +1,116 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Path;
+import java.util.List;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Тип элемента коллекции у значения, возвращённого методом: обход результата вызова
+ * должен давать тот же тип элемента, что и обход переменной с этим значением.
+ */
+@CleanupContextBeforeClassAndAfterClass
+class CallResultElementTypeInferenceTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private TypeService typeService;
+
+  @BeforeEach
+  void prepareMetadataServerContext() {
+    initServerContextOnce(Path.of(TestUtils.PATH_TO_METADATA));
+  }
+
+  @Test
+  void forEachOverCallResultKnowsRowColumns() {
+    // given: функция возвращает табличную часть справочника.
+    var documentContext = TestUtils.getDocumentContext("""
+      // Возвращаемое значение:
+      //  СправочникТабличнаяЧасть.Справочник1.ТабличнаяЧасть1 -
+      Функция ЧастьТовары()
+      	Возврат Неопределено;
+      КонецФункции
+
+      Процедура Обход()
+      	Для Каждого СтрокаЧасти Из ЧастьТовары() Цикл
+      		КолонкаСтроки = СтрокаЧасти.Реквизит1;
+      	КонецЦикла;
+      КонецПроцедуры
+      """, context);
+
+    // when
+    var types = at(documentContext, "КолонкаСтроки = СтрокаЧасти.Реквизит1", "КолонкаСтроки = СтрокаЧасти.".length());
+
+    // then: колонка строки типизирована так же, как при обходе переменной.
+    assertThat(names(types)).containsExactly("Строка");
+  }
+
+  @Test
+  void forEachOverCallResultGivesPlatformElementType() {
+    // given: функция возвращает соответствие — у него тип элемента известен реестру.
+    var documentContext = TestUtils.getDocumentContext("""
+      // Возвращаемое значение:
+      //  Соответствие -
+      Функция НовыеДанные()
+      	Возврат Новый Соответствие;
+      КонецФункции
+
+      Процедура Обход()
+      	Для Каждого КлючЗначение Из НовыеДанные() Цикл
+      		ЭлементОбхода = КлючЗначение;
+      	КонецЦикла;
+      КонецПроцедуры
+      """, context);
+
+    // when
+    var types = at(documentContext, "ЭлементОбхода = КлючЗначение", "ЭлементОбхода = ".length());
+
+    // then
+    assertThat(names(types)).containsExactly("КлючИЗначение");
+  }
+
+  private TypeSet at(DocumentContext documentContext, String marker, int offsetInMarker) {
+    var content = documentContext.getContent();
+    var markerStart = content.indexOf(marker);
+    assertThat(markerStart).as("маркер '%s' найден в фикстуре", marker).isNotNegative();
+    var targetOffset = markerStart + offsetInMarker;
+    var lineStart = content.lastIndexOf('\n', targetOffset - 1) + 1;
+    var line = content.substring(0, targetOffset).split("\n").length - 1;
+    return typeService.expressionTypesAt(documentContext, new Position(line, targetOffset - lineStart + 1));
+  }
+
+  private static List<String> names(TypeSet types) {
+    return types.refs().stream().map(TypeRef::qualifiedName).toList();
+  }
+}


### PR DESCRIPTION
## Симптом

Обход результата вызова не знал типа элемента коллекции, хотя обход переменной с тем же значением знал:

```bsl
// Возвращаемое значение:
//  СправочникТабличнаяЧасть.Справочник1.ТабличнаяЧасть1 -
Функция ЧастьТовары()
	Возврат Неопределено;
КонецФункции

Процедура Обход()
	// тип колонки не выводился вовсе
	Для Каждого СтрокаЧасти Из ЧастьТовары() Цикл
		КолонкаСтроки = СтрокаЧасти.Реквизит1;
	КонецЦикла;

	// а так — выводился
	Часть = ЧастьТовары();
	Для Каждого СтрокаЧасти Из Часть Цикл
		КолонкаСтроки = СтрокаЧасти.Реквизит1;
	КонецЦикла;
КонецПроцедуры
```

Разбор показал, что дело не в конкретном типе и не в способе его записи: то же самое было и у соответствия, и когда тип возврата записан именем, и когда он задан ссылкой `См.`.

## Причина

`ExpressionTypeInferencer#elementTypesOfCollection` берёт у типа коллекции `getElementTypes()`. Тип элемента реестр знает сам (`TypeRegistry#getDefaultElementTypes`: `КлючИЗначение` у соответствия, строка у табличной части), но в набор он попадает только явным прикреплением `attachDefaultElementTypes`.

Прикрепление стояло у потребителей объявленного типа поодиночке — у конструктора, у вызова члена, у переменной, — и путь «объявленный тип возврата метода» остался непокрытым. Это четвёртый дефект этого вида, и причина у всех одна: о прикреплении должен помнить каждый новый потребитель.

## Исправление

Прикрепление перенесено туда, где объявленный тип рождается, — в разбор описания (`SymbolTypeIndex#resolveTypes`). Оттуда тип уходит и в переменную, и в параметр, и в возвращаемое значение, поэтому обход коллекции видит элемент везде одинаково, а новым потребителям помнить об этом уже не нужно.

Две границы:

* коллекционная запись (`Массив из Строка`, `Массив из См. Метод`) исключена — в ней элементы перечислил автор, и подставлять вместо неразрешившейся ссылки умолчание реестра нельзя (это ломало бы `NestedSeeRefInferenceTest`);
* наличие уже объявленного элемента проверяется по записи, а не по значению: у ленивой ссылки значение брать в момент индексации рано, она разрешается при чтении.

Более широкая централизация — прикрепление на общем стыке вывода выражений (`ExpressionTypeInferencer#inferInternal`) — проверена и отклонена: она меняет поведение индексного доступа (`Элементы["НетТакого"]` начинает отдавать все виды элементов формы вместо пустоты, `FormModuleInferenceTest#unknownItemNameLeavesTheGeneralPath`).

## Проверки

Новый `CallResultElementTypeInferenceTest`: обход результата вызова даёт колонки строки табличной части и `КлючИЗначение` у соответствия. Оба теста красные до правки.

Прогоны без правок ожиданий: `*types.*`, `*hover.*`, `*Completion*` (1900 тестов) и `*providers.*`, `*diagnostics.*` — зелёные.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for non-collection declarations by applying default element types when no explicit type is provided.
  * Preserved explicitly declared and lazily resolved element types.
  * Improved inferred types when iterating over function results representing tabular sections or correspondences.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->