### PR TITLE
feat(types): ссылка «См.» на параметр метода другого модуля

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
@@ -368,9 +368,7 @@ public class ConfigurationModuleMembersProvider {
    * типа возвращаемого значения ({@link #resolveReturnType}).
    * <p>
    * Без них ссылка {@code См. Модуль.Метод.Параметр} упирается в пустую сигнатуру: тип
-   * возврата у члена есть, а типы параметров — нет. {@code Произвольный} в объявленные
-   * не попадает: он ничего не сообщает о значении, а в подсказках вытеснил бы собой
-   * привычный вид сигнатуры.
+   * возврата у члена есть, а типы параметров — нет.
    *
    * @param parameter параметр метода.
    * @return объявленные типы параметра; {@link TypeSet#EMPTY}, если их не объявлено.
@@ -379,7 +377,7 @@ public class ConfigurationModuleMembersProvider {
     return parameter.getDescription()
       .map(description -> description.types().stream()
         .map(this::resolveTypeName)
-        .filter(ref -> ref.kind() != TypeKind.UNKNOWN && ref.kind() != TypeKind.ANY)
+        .filter(ref -> ref.kind() != TypeKind.UNKNOWN)
         .reduce(TypeSet.EMPTY, (acc, ref) -> acc.union(TypeSet.of(ref)), TypeSet::union))
       .orElse(TypeSet.EMPTY);
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
@@ -52,6 +52,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -87,6 +88,12 @@ public class ConfigurationModuleMembersProvider {
    * значением.
    */
   private static final String COMMON_MODULE_PLATFORM_TYPE_NAME = "ОбщийМодуль";
+
+  /** Начало пояснения после имени типа: «Массив из …», «Массив&lt;…&gt;», «Массив[…]». */
+  private static final Pattern TYPE_NAME_TAIL = Pattern.compile("[\\s<\\[]");
+
+  /** Делим имя надвое: само имя и всё, что за ним. */
+  private static final int TYPE_NAME_AND_TAIL = 2;
 
   private static final Map<ModuleType, String> MODULE_TYPE_TO_WRAPPER_EN = Map.of(
     ModuleType.ManagerModule, "Manager",
@@ -390,11 +397,21 @@ public class ConfigurationModuleMembersProvider {
    * @return тип по имени; {@link TypeRef#UNKNOWN}, если имя пустое или не резолвится.
    */
   private TypeRef resolveTypeName(TypeDescription type) {
-    var raw = type.name();
-    if (raw == null || raw.isBlank()) {
+    return resolveHeadName(type.name());
+  }
+
+  /**
+   * Разрешает имя типа, отбрасывая пояснения после него: «Массив из Произвольный»,
+   * «Массив&lt;Произвольный&gt;» и «Массив[Произвольный]» — это {@code Массив}.
+   *
+   * @param raw имя типа из описания.
+   * @return тип по имени; {@link TypeRef#UNKNOWN}, если имя пустое или не резолвится.
+   */
+  private TypeRef resolveHeadName(String raw) {
+    if (raw.isBlank()) {
       return TypeRef.UNKNOWN;
     }
-    var head = raw.trim().split("[\\s<\\[]", 2)[0];
+    var head = TYPE_NAME_TAIL.split(raw.trim(), TYPE_NAME_AND_TAIL)[0];
     return typeRegistry.resolve(head).orElse(TypeRef.UNKNOWN);
   }
 
@@ -409,13 +426,6 @@ public class ConfigurationModuleMembersProvider {
     if (returnedValue == null || returnedValue.isEmpty()) {
       return TypeRef.UNKNOWN;
     }
-    var raw = returnedValue.get(0).name();
-    if (raw == null || raw.isBlank()) {
-      return TypeRef.UNKNOWN;
-    }
-    // отбрасываем пояснения после первого пробела/угловой скобки/квадратной скобки
-    // ("Массив из Произвольный", "Массив<Произвольный>" → "Массив")
-    var head = raw.trim().split("[\\s<\\[]", 2)[0];
-    return typeRegistry.resolve(head).orElse(TypeRef.UNKNOWN);
+    return resolveHeadName(returnedValue.get(0).name());
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
@@ -26,19 +26,16 @@ import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
-import com.github._1c_syntax.bsl.languageserver.context.symbol.ParameterDefinition;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.CommentTypeResolver;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
-import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.mdo.Form;
 import com.github._1c_syntax.bsl.mdo.MD;
-import com.github._1c_syntax.bsl.parser.description.TypeDescription;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -52,7 +49,6 @@ import java.util.List;
 import java.util.Map;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import java.util.regex.Pattern;
 import java.util.stream.Stream;
 
 /**
@@ -89,12 +85,6 @@ public class ConfigurationModuleMembersProvider {
    */
   private static final String COMMON_MODULE_PLATFORM_TYPE_NAME = "ОбщийМодуль";
 
-  /** Начало пояснения после имени типа: «Массив из …», «Массив&lt;…&gt;», «Массив[…]». */
-  private static final Pattern TYPE_NAME_TAIL = Pattern.compile("[\\s<\\[]");
-
-  /** Делим имя надвое: само имя и всё, что за ним. */
-  private static final int TYPE_NAME_AND_TAIL = 2;
-
   private static final Map<ModuleType, String> MODULE_TYPE_TO_WRAPPER_EN = Map.of(
     ModuleType.ManagerModule, "Manager",
     ModuleType.ObjectModule, "Object",
@@ -105,6 +95,7 @@ public class ConfigurationModuleMembersProvider {
   private final TypeRegistry typeRegistry;
   private final GlobalScopeProvider globalScopeProvider;
   private final CommentTypeResolver commentTypeResolver;
+  private final DescribedTypeResolver describedTypeResolver;
 
   /** Уже зарегистрированные источники (по URI документа), чтобы избежать дублей. */
   private final Map<URI, TypeRef> registeredByUri = new ConcurrentHashMap<>();
@@ -353,7 +344,7 @@ public class ConfigurationModuleMembersProvider {
     var params = method.getParameters().stream()
       .map(p -> new ParameterDescriptor(
         p.getName(),
-        declaredParameterTypes(p),
+        describedTypeResolver.parameterTypes(p),
         p.isOptional(),
         ""
       ))
@@ -362,70 +353,11 @@ public class ConfigurationModuleMembersProvider {
       .map(d -> d.getDescription() == null ? "" : d.getDescription().trim())
       .orElse("");
     var returnType = method.getDescription()
-      .map(d -> resolveReturnType(d.getReturnedValue()))
+      .map(d -> describedTypeResolver.returnType(d.getReturnedValue()))
       .orElse(TypeRef.UNKNOWN);
     var signature = new SignatureDescriptor(params, returnType, description);
     return MemberDescriptor
       .method(method.getName(), description, List.of(signature))
       .withSourceSymbol(method);
-  }
-
-  /**
-   * Типы параметра, объявленные в описании метода: имена разрешаются так же, как имя
-   * типа возвращаемого значения ({@link #resolveReturnType}).
-   * <p>
-   * Без них ссылка {@code См. Модуль.Метод.Параметр} упирается в пустую сигнатуру: тип
-   * возврата у члена есть, а типы параметров — нет.
-   *
-   * @param parameter параметр метода.
-   * @return объявленные типы параметра; {@link TypeSet#EMPTY}, если их не объявлено.
-   */
-  private TypeSet declaredParameterTypes(ParameterDefinition parameter) {
-    return parameter.getDescription()
-      .map(description -> description.types().stream()
-        .map(this::resolveTypeName)
-        .filter(ref -> ref.kind() != TypeKind.UNKNOWN)
-        .reduce(TypeSet.EMPTY, (acc, ref) -> acc.union(TypeSet.of(ref)), TypeSet::union))
-      .orElse(TypeSet.EMPTY);
-  }
-
-  /**
-   * Разрешает имя типа из описания: у коллекционной записи ({@code Массив из Строка})
-   * берётся её головное имя.
-   *
-   * @param type описание типа.
-   * @return тип по имени; {@link TypeRef#UNKNOWN}, если имя пустое или не резолвится.
-   */
-  private TypeRef resolveTypeName(TypeDescription type) {
-    return resolveHeadName(type.name());
-  }
-
-  /**
-   * Разрешает имя типа, отбрасывая пояснения после него: «Массив из Произвольный»,
-   * «Массив&lt;Произвольный&gt;» и «Массив[Произвольный]» — это {@code Массив}.
-   *
-   * @param raw имя типа из описания.
-   * @return тип по имени; {@link TypeRef#UNKNOWN}, если имя пустое или не резолвится.
-   */
-  private TypeRef resolveHeadName(String raw) {
-    if (raw.isBlank()) {
-      return TypeRef.UNKNOWN;
-    }
-    var head = TYPE_NAME_TAIL.split(raw.trim(), TYPE_NAME_AND_TAIL)[0];
-    return typeRegistry.resolve(head).orElse(TypeRef.UNKNOWN);
-  }
-
-  /**
-   * Парсит первый элемент {@code returnedValue} JavaDoc-описания BSL-метода
-   * (например, "Массив из Произвольный" → "Массив") и резолвит через
-   * {@link TypeRegistry}.
-   */
-  private TypeRef resolveReturnType(
-    List<TypeDescription> returnedValue
-  ) {
-    if (returnedValue == null || returnedValue.isEmpty()) {
-      return TypeRef.UNKNOWN;
-    }
-    return resolveHeadName(returnedValue.get(0).name());
   }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
@@ -26,12 +26,14 @@ import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
+import com.github._1c_syntax.bsl.languageserver.context.symbol.ParameterDefinition;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.VariableSymbol;
 import com.github._1c_syntax.bsl.languageserver.infrastructure.WorkspaceScope;
 import com.github._1c_syntax.bsl.languageserver.types.CommentTypeResolver;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.mdo.Form;
@@ -344,7 +346,7 @@ public class ConfigurationModuleMembersProvider {
     var params = method.getParameters().stream()
       .map(p -> new ParameterDescriptor(
         p.getName(),
-        TypeSet.EMPTY,
+        declaredParameterTypes(p),
         p.isOptional(),
         ""
       ))
@@ -359,6 +361,43 @@ public class ConfigurationModuleMembersProvider {
     return MemberDescriptor
       .method(method.getName(), description, List.of(signature))
       .withSourceSymbol(method);
+  }
+
+  /**
+   * Типы параметра, объявленные в описании метода: имена разрешаются так же, как имя
+   * типа возвращаемого значения ({@link #resolveReturnType}).
+   * <p>
+   * Без них ссылка {@code См. Модуль.Метод.Параметр} упирается в пустую сигнатуру: тип
+   * возврата у члена есть, а типы параметров — нет. {@code Произвольный} в объявленные
+   * не попадает: он ничего не сообщает о значении, а в подсказках вытеснил бы собой
+   * привычный вид сигнатуры.
+   *
+   * @param parameter параметр метода.
+   * @return объявленные типы параметра; {@link TypeSet#EMPTY}, если их не объявлено.
+   */
+  private TypeSet declaredParameterTypes(ParameterDefinition parameter) {
+    return parameter.getDescription()
+      .map(description -> description.types().stream()
+        .map(this::resolveTypeName)
+        .filter(ref -> ref.kind() != TypeKind.UNKNOWN && ref.kind() != TypeKind.ANY)
+        .reduce(TypeSet.EMPTY, (acc, ref) -> acc.union(TypeSet.of(ref)), TypeSet::union))
+      .orElse(TypeSet.EMPTY);
+  }
+
+  /**
+   * Разрешает имя типа из описания: у коллекционной записи ({@code Массив из Строка})
+   * берётся её головное имя.
+   *
+   * @param type описание типа.
+   * @return тип по имени; {@link TypeRef#UNKNOWN}, если имя пустое или не резолвится.
+   */
+  private TypeRef resolveTypeName(TypeDescription type) {
+    var raw = type.name();
+    if (raw == null || raw.isBlank()) {
+      return TypeRef.UNKNOWN;
+    }
+    var head = raw.trim().split("[\\s<\\[]", 2)[0];
+    return typeRegistry.resolve(head).orElse(TypeRef.UNKNOWN);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/DescribedTypeResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/DescribedTypeResolver.java
@@ -1,0 +1,108 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.languageserver.context.symbol.ParameterDefinition;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.parser.description.TypeDescription;
+import lombok.RequiredArgsConstructor;
+import org.springframework.stereotype.Component;
+
+import java.util.List;
+import java.util.regex.Pattern;
+
+/**
+ * Разрешает типы, объявленные в документирующем комментарии метода: типы параметров
+ * (секция {@code // Параметры:}) и тип возвращаемого значения
+ * (секция {@code // Возвращаемое значение:}).
+ * <p>
+ * Имя типа берётся до первого разделителя, а всё, что за ним, считается пояснением:
+ * {@code Массив из Строка}, {@code Массив<Строка>} и {@code Массив[Строка]} — это
+ * {@code Массив}.
+ */
+@Component
+@RequiredArgsConstructor
+public class DescribedTypeResolver {
+
+  /** Начало пояснения после имени типа: «Массив из …», «Массив&lt;…&gt;», «Массив[…]». */
+  private static final Pattern TYPE_NAME_TAIL = Pattern.compile("[\\s<\\[]");
+
+  /** Делим имя надвое: само имя и всё, что за ним. */
+  private static final int TYPE_NAME_AND_TAIL = 2;
+
+  private final TypeRegistry typeRegistry;
+
+  /**
+   * Типы параметра, объявленные в описании метода.
+   *
+   * @param parameter параметр метода.
+   * @return объявленные типы параметра; {@link TypeSet#EMPTY}, если их не объявлено.
+   */
+  public TypeSet parameterTypes(ParameterDefinition parameter) {
+    return parameter.getDescription()
+      .map(description -> description.types().stream()
+        .map(this::declaredType)
+        .reduce(TypeSet.EMPTY, TypeSet::union))
+      .orElse(TypeSet.EMPTY);
+  }
+
+  /**
+   * Тип возвращаемого значения по первой записи секции «Возвращаемое значение».
+   *
+   * @param returnedValue записи секции «Возвращаемое значение» описания метода.
+   * @return тип по имени первой записи; {@link TypeRef#UNKNOWN}, если записей нет
+   *     либо имя не резолвится.
+   */
+  public TypeRef returnType(List<TypeDescription> returnedValue) {
+    if (returnedValue.isEmpty()) {
+      return TypeRef.UNKNOWN;
+    }
+    return headName(returnedValue.get(0).name());
+  }
+
+  /**
+   * Разрешает одно объявление типа.
+   *
+   * @param type объявление типа из описания.
+   * @return типы объявления; {@link TypeSet#EMPTY}, если имя не резолвится.
+   */
+  private TypeSet declaredType(TypeDescription type) {
+    var ref = headName(type.name());
+    return ref.kind() == TypeKind.UNKNOWN ? TypeSet.EMPTY : TypeSet.of(ref);
+  }
+
+  /**
+   * Разрешает имя типа, отбрасывая пояснения после него.
+   *
+   * @param raw имя типа из описания.
+   * @return тип по имени; {@link TypeRef#UNKNOWN}, если имя пустое или не резолвится.
+   */
+  private TypeRef headName(String raw) {
+    if (raw.isBlank()) {
+      return TypeRef.UNKNOWN;
+    }
+    var head = TYPE_NAME_TAIL.split(raw.trim(), TYPE_NAME_AND_TAIL)[0];
+    return typeRegistry.resolve(head).orElse(TypeRef.UNKNOWN);
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/providers/CompletionProviderTest.java
@@ -778,8 +778,9 @@ class CompletionProviderTest extends AbstractServerContextAwareTest {
     // документа); вид берётся из символа-источника метода
     assertThat(item.getKind()).isEqualTo(CompletionItemKind.Function);
     assertThat(item.getDetail())
-      .as("сигнатура и тип возврата метода общего модуля — как у платформенного")
-      .isEqualTo("(Значение): Массив");
+      .as("сигнатура и тип возврата метода общего модуля — как у платформенного,"
+        + " с объявленным типом параметра")
+      .isEqualTo("(Значение: Произвольный): Массив");
     assertThat(documentationText(item))
       .as("документация метода общего модуля берётся из doc-comment")
       .contains("Создает массив");

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/SeeMethodParameterRefInferenceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/SeeMethodParameterRefInferenceTest.java
@@ -1,0 +1,89 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.eclipse.lsp4j.Position;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.List;
+
+import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Ссылка {@code См.} на параметр метода другого модуля: тип параметра берётся
+ * из описания метода-цели.
+ */
+@CleanupContextBeforeClassAndAfterClass
+class SeeMethodParameterRefInferenceTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private TypeService typeService;
+
+  @BeforeEach
+  void setUpWorkspace() {
+    initServerContext(PATH_TO_METADATA);
+    context.getConfiguration();
+  }
+
+  @Test
+  void seeRefToParameterOfCommonModuleMethod() {
+    // given: у метода-цели параметр объявлен как «ИмяМодуля - Строка».
+    var documentContext = TestUtils.getDocumentContext("""
+      // Параметры:
+      //  ИмяМодуля - См. ОбщегоНазначения.ОбщийМодуль.ИмяМодуля
+      Процедура ОбработкаИмени(ИмяМодуля) Экспорт
+
+      	ТипИмени = ИмяМодуля;
+
+      КонецПроцедуры
+      """, context);
+
+    // when
+    var types = at(documentContext, "ТипИмени = ИмяМодуля", "ТипИмени = ".length());
+
+    // then
+    assertThat(names(types)).containsExactly("Строка");
+  }
+
+  private TypeSet at(DocumentContext documentContext, String marker, int offsetInMarker) {
+    var content = documentContext.getContent();
+    var markerStart = content.indexOf(marker);
+    assertThat(markerStart).as("маркер '%s' найден в фикстуре", marker).isNotNegative();
+    var targetOffset = markerStart + offsetInMarker;
+    var lineStart = content.lastIndexOf('\n', targetOffset - 1) + 1;
+    var line = content.substring(0, targetOffset).split("\n").length - 1;
+    return typeService.expressionTypesAt(documentContext, new Position(line, targetOffset - lineStart + 1));
+  }
+
+  private static List<String> names(TypeSet types) {
+    return types.refs().stream().map(TypeRef::qualifiedName).toList();
+  }
+}


### PR DESCRIPTION
Пункт 3.34 рекомендации «Типизация кода», подраздел «Ссылка на тип параметра метода в модели менеджера, объекта, общем модуле»:

```bsl
// Параметры:
//  Список - См. Справочники.Товары.МетодМодуляМенеджера.Параметр1
Процедура ОбработкаОбъекта(Список)
```

## Что было

Тип не выводился. Разбор ссылки до параметра доходит, но берёт его типы из сигнатуры члена, а у членов модульных типов параметры заводились с пустыми типами: `ConfigurationModuleMembersProvider#toMethodMember` читал из описания метода тип возвращаемого значения, а параметрам ставил `TypeSet.EMPTY`.

## Что сделано

Типы параметра разрешаются там же и так же, как тип возврата — по головному имени из описания (`Массив из Строка` → `Массив`). Ссылка на параметр после этого работает сама: остальной путь уже был.

Объявленный `Произвольный` при этом не отбрасывается: тип написан автором описания, поэтому виден и в подсказке автодополнения — у метода общего модуля сигнатура стала `(Значение: Произвольный): Массив` вместо `(Значение): Массив`. Ожидание `CompletionProviderTest#dotCompletionCommonModuleMethodHasSignatureAndDocumentationLikePlatform` обновлено под это.

## Проверки

`SeeMethodParameterRefInferenceTest`: `См. ОбщегоНазначения.ОбщийМодуль.ИмяМодуля` даёт `Строка` — тип, объявленный у параметра метода-цели. Тест красный до правки. Общие фикстуры не менялись: взят метод, который в тестовой конфигурации уже есть.

Прогоны `*types.*`, `*providers.*`, `*hover.*` — зелёные.

## Что осталось за рамками

Пункт 3.35 (параметр метода модуля объекта, у цели объявлен `Массив из Строка`) требует ещё и типа элемента коллекции — головного имени для него мало. Пункт 3.36 (наследование типов по сигнатуре чужого метода) опирается на ту же сигнатуру и станет проверяем после этого.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved type inference for method parameters using documented parameter types.
  * Added support for resolving collection type descriptions and documented return types.
  * Enhanced completion signatures to display inferred parameter types, including unspecified types where applicable.
  * Improved type recognition when referencing parameters from common-module methods.
* **Tests**
  * Added coverage for inferring a string type from a referenced common-module method parameter and validating related completion results.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->