### PR TITLE
feat(types): наследование типов параметров между модулями

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/DeclaredParameterTypeResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/DeclaredParameterTypeResolver.java
@@ -128,7 +128,7 @@ public class DeclaredParameterTypeResolver implements VariableTypeSource {
 
   /**
    * Тип одноимённого параметра метода, на который ссылается документирующий комментарий
-   * ({@code // См. Метод}). Работает в пределах одного модуля.
+   * ({@code // См. Метод} либо {@code // См. Модуль.Метод}).
    *
    * @param method    метод со ссылкой.
    * @param paramName имя параметра.
@@ -146,17 +146,52 @@ public class DeclaredParameterTypeResolver implements VariableTypeSource {
     }
     var owner = method.getOwner();
     for (var link : links) {
-      var target = localMethod(owner, link.link());
+      var target = referencedMethod(owner, link.link());
       if (target == null) {
         continue;
       }
-      for (var targetParam : target.getParameters()) {
-        if (targetParam.getName().equalsIgnoreCase(paramName)) {
-          var types = symbolTypeIndex.getDeclaredParameterTypes(targetParam, owner);
-          if (!types.isEmpty()) {
-            return types;
-          }
-        }
+      var types = parameterTypes(target, paramName);
+      if (!types.isEmpty()) {
+        return types;
+      }
+    }
+    return TypeSet.EMPTY;
+  }
+
+  /**
+   * Метод-цель ссылки: своего модуля по короткому имени либо чужого — по
+   * квалифицированному.
+   *
+   * @param owner документ со ссылкой.
+   * @param link  текст ссылки.
+   * @return метод-цель либо {@code null}, если ссылка никуда не ведёт.
+   */
+  @Nullable
+  private MethodSymbol referencedMethod(DocumentContext owner, @Nullable String link) {
+    if (link == null) {
+      return null;
+    }
+    if (!link.contains(".")) {
+      return localMethod(owner, link);
+    }
+    return symbolTypeIndex.resolveReferenceSymbol(link, owner.getFileType())
+      .filter(MethodSymbol.class::isInstance)
+      .map(MethodSymbol.class::cast)
+      .orElse(null);
+  }
+
+  /**
+   * Типы одноимённого параметра метода-цели.
+   *
+   * @param target    метод-цель.
+   * @param paramName имя параметра.
+   * @return объявленные типы параметра; пустой набор, если такого параметра нет либо
+   *     тип у него не объявлен.
+   */
+  private TypeSet parameterTypes(MethodSymbol target, String paramName) {
+    for (var targetParam : target.getParameters()) {
+      if (targetParam.getName().equalsIgnoreCase(paramName)) {
+        return symbolTypeIndex.getDeclaredParameterTypes(targetParam, target.getOwner());
       }
     }
     return TypeSet.EMPTY;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/SeeMethodParameterRefInferenceTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/SeeMethodParameterRefInferenceTest.java
@@ -99,6 +99,26 @@ class SeeMethodParameterRefInferenceTest extends AbstractServerContextAwareTest 
     assertThat(names(element)).containsExactly("Строка");
   }
 
+  @Test
+  void parameterTypesInheritedFromMethodOfAnotherModule() {
+    // given: у метода нет описания параметров — только ссылка на метод-интерфейс
+    // другого модуля, где параметр с тем же именем объявлен как «Строка».
+    var documentContext = TestUtils.getDocumentContext("""
+      // См. ОбщегоНазначения.ОбщийМодуль
+      Процедура ОбработкаИмени(ИмяМодуля) Экспорт
+
+      	ТипИмени = ИмяМодуля;
+
+      КонецПроцедуры
+      """, context);
+
+    // when
+    var types = at(documentContext, "ТипИмени = ИмяМодуля", "ТипИмени = ".length());
+
+    // then
+    assertThat(names(types)).containsExactly("Строка");
+  }
+
   private TypeSet at(DocumentContext documentContext, String marker, int offsetInMarker) {
     var content = documentContext.getContent();
     var markerStart = content.indexOf(marker);


### PR DESCRIPTION
Поверх #4387 (базовая ветка — `feat/types-see-ref-parameter-elements`).

Пункт 3.36 рекомендации «Типизация кода», подраздел «Наследование типов параметров по сигнатуре метода»: «В модуле менеджера соответствующих объектов можно сослаться на сигнатуру параметров метода, чтобы не описывать полностью все типы… будет выполнено сопоставление имен параметров текущего метода с именами параметров метода "интерфейса"».

```bsl
// См. ОбщийМодульПодсистема1Переопределяемый.ОбработкаОбъекта
Процедура ОбработкаОбъекта(Список, Реквизит, Объект)
```

## Что было

Внутри одного модуля наследование работало (`SignatureInheritanceInferenceTest`), между модулями — нет: цель ссылки искалась только среди методов своего модуля, а квалифицированное имя отбрасывалось (`DeclaredParameterTypeResolver#localMethod` возвращал `null` на имени с точкой).

## Что сделано

Квалифицированная ссылка разрешается в символ метода-цели тем же путём, каким разрешаются ссылки на члены (`SymbolTypeIndex#resolveReferenceSymbol`), и типы берутся у его одноимённого параметра. Короткое имя по-прежнему ищется в своём модуле.

## Проверки

`SeeMethodParameterRefInferenceTest#parameterTypesInheritedFromMethodOfAnotherModule`: у метода нет описания параметров, только `// См. ОбщегоНазначения.ОбщийМодуль`, и параметр `ИмяМодуля` получает `Строка` — тип, объявленный у одноимённого параметра метода-интерфейса. Тест красный до правки; прежний тест наследования внутри модуля остаётся зелёным.

Прогоны `*types.*` и `*providers.*` — зелёные.
