### PR TITLE
feat(inlayhints): составной тип «Тип, Неопределено» показывается как «Тип?»

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplier.java
@@ -53,6 +53,13 @@ import java.util.Optional;
  * из литерала), показывает подсказку {@link InlayHintKind#Type} сразу после
  * имени переменной — например {@code Контрагент: Массив = Новый Массив()}.
  * <p>
+ * Значимый тип должен быть <b>один</b>: перечислять union подсказкой слишком шумно.
+ * Исключение — {@code Тип, Неопределено}: значимый тип там всё равно один, а
+ * {@code Неопределено} говорит лишь «значения может не оказаться», и подсказка пишет его
+ * знаком вопроса — {@code Значение: Число?}. Так выглядит всё необязательное: ключ
+ * структуры, прочитанный через {@code Свойство}, поиск по имени, ветвление с
+ * {@code Неопределено} в одной из ветвей.
+ * <p>
  * Если имя переменной уже содержит имя выведенного типа (например
  * {@code Массив = ...} или {@code МассивТоваров = ...} с типом {@code Массив}),
  * подсказка лишь дублирует видимое в имени и по умолчанию подавляется — по аналогии
@@ -139,9 +146,12 @@ public class VariableTypeInlayHintSupplier implements InlayHintSupplier<Variable
     if (maybeInferredType.isEmpty()) {
       return Optional.empty();
     }
-    var inferredType = maybeInferredType.get();
+    var inferredType = maybeInferredType.get().ref();
 
     var typeName = typeService.displayName(inferredType, configuration.getLanguage());
+    // `?` вместо перечисления: `Число, Неопределено` читается как «число, которого может
+    // не быть», и знак вопроса говорит это короче, чем вторая половина union'а.
+    var label = maybeInferredType.get().nullable() ? typeName + "?" : typeName;
 
     // Имя переменной уже несёт имя типа (напр. «Массив = ...» с выведенным типом
     // «Массив» или «МассивТоваров = ...» с типом «Массив») — подсказка лишь дублирует
@@ -159,7 +169,7 @@ public class VariableTypeInlayHintSupplier implements InlayHintSupplier<Variable
     inlayHint.setPosition(namePosition);
     inlayHint.setPaddingRight(Boolean.TRUE);
 
-    var labelPart = new InlayHintLabelPart(": " + typeName);
+    var labelPart = new InlayHintLabelPart(": " + label);
     inlayHint.setLabel(List.of(labelPart));
 
     // Tooltip (полное описание типа) дорассчитывается лениво на inlayHint/resolve —
@@ -228,25 +238,41 @@ public class VariableTypeInlayHintSupplier implements InlayHintSupplier<Variable
   }
 
   /**
-   * Единственный выведенный тип выражения правой части присваивания.
+   * Выведенный тип выражения правой части присваивания вместе с признаком «может быть
+   * и {@code Неопределено}».
    *
    * @param documentContext Контекст документа.
    * @param expression      Выражение правой части присваивания.
    * @return Выведенный тип, либо {@code empty}, если тип не выведен, выведен как
-   *   union из нескольких типов или тривиален ({@link TypeRef#ANY}/{@link TypeRef#UNKNOWN}).
+   *   union из нескольких значимых типов или тривиален ({@link TypeRef#ANY}/{@link TypeRef#UNKNOWN}).
    */
-  private Optional<TypeRef> inferType(DocumentContext documentContext, BSLParser.ExpressionContext expression) {
+  private Optional<InferredType> inferType(DocumentContext documentContext,
+                                           BSLParser.ExpressionContext expression) {
     var start = expression.getStart();
     var position = new Position(start.getLine() - 1, start.getCharPositionInLine());
     var types = typeService.expressionTypesAt(documentContext, position);
-    if (types.size() != 1) {
+    // `Тип, Неопределено` — самый частый union: так выглядит всё, чего может не оказаться
+    // (ключ структуры, поиск по имени, необязательный параметр). Значимый тип там один,
+    // и подсказка по нему осмысленна — `Неопределено` уходит в `?`.
+    var nullable = types.size() == 2 && types.refs().contains(TypeRef.UNDEFINED);
+    var significant = nullable ? types.without(TypeRef.UNDEFINED) : types;
+    if (significant.size() != 1) {
       return Optional.empty();
     }
-    var ref = types.refs().iterator().next();
+    var ref = significant.refs().iterator().next();
     if (ref.equals(TypeRef.ANY) || ref.equals(TypeRef.UNKNOWN)) {
       return Optional.empty();
     }
-    return Optional.of(ref);
+    return Optional.of(new InferredType(ref, nullable));
+  }
+
+  /**
+   * Тип для подсказки: значимый тип и признак, что рядом с ним стоит {@code Неопределено}.
+   *
+   * @param ref      значимый тип.
+   * @param nullable может ли значение оказаться {@code Неопределено}.
+   */
+  private record InferredType(TypeRef ref, boolean nullable) {
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplier.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplier.java
@@ -86,6 +86,9 @@ import java.util.Optional;
 @Component
 public class VariableTypeInlayHintSupplier implements InlayHintSupplier<VariableTypeInlayHintData> {
 
+  /** Значимый тип плюс {@code Неопределено} — единственный union, который подсказка показывает. */
+  private static final int NULLABLE_UNION_SIZE = 2;
+
   private final TypeService typeService;
   private final LanguageServerConfiguration configuration;
 
@@ -149,9 +152,6 @@ public class VariableTypeInlayHintSupplier implements InlayHintSupplier<Variable
     var inferredType = maybeInferredType.get().ref();
 
     var typeName = typeService.displayName(inferredType, configuration.getLanguage());
-    // `?` вместо перечисления: `Число, Неопределено` читается как «число, которого может
-    // не быть», и знак вопроса говорит это короче, чем вторая половина union'а.
-    var label = maybeInferredType.get().nullable() ? typeName + "?" : typeName;
 
     // Имя переменной уже несёт имя типа (напр. «Массив = ...» с выведенным типом
     // «Массив» или «МассивТоваров = ...» с типом «Массив») — подсказка лишь дублирует
@@ -169,6 +169,9 @@ public class VariableTypeInlayHintSupplier implements InlayHintSupplier<Variable
     inlayHint.setPosition(namePosition);
     inlayHint.setPaddingRight(Boolean.TRUE);
 
+    // `?` вместо перечисления: `Число, Неопределено` читается как «число, которого может
+    // не быть», и знак вопроса говорит это короче, чем вторая половина union'а.
+    var label = maybeInferredType.get().nullable() ? (typeName + "?") : typeName;
     var labelPart = new InlayHintLabelPart(": " + label);
     inlayHint.setLabel(List.of(labelPart));
 
@@ -254,7 +257,7 @@ public class VariableTypeInlayHintSupplier implements InlayHintSupplier<Variable
     // `Тип, Неопределено` — самый частый union: так выглядит всё, чего может не оказаться
     // (ключ структуры, поиск по имени, необязательный параметр). Значимый тип там один,
     // и подсказка по нему осмысленна — `Неопределено` уходит в `?`.
-    var nullable = types.size() == 2 && types.refs().contains(TypeRef.UNDEFINED);
+    var nullable = types.size() == NULLABLE_UNION_SIZE && types.refs().contains(TypeRef.UNDEFINED);
     var significant = nullable ? types.without(TypeRef.UNDEFINED) : types;
     if (significant.size() != 1) {
       return Optional.empty();

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeRef.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/model/TypeRef.java
@@ -48,6 +48,8 @@ public record TypeRef(TypeKind kind, String qualifiedName) implements Comparable
 
   public static final TypeRef UNKNOWN = new TypeRef(TypeKind.UNKNOWN, "Unknown");
   public static final TypeRef ANY = new TypeRef(TypeKind.ANY, "Any");
+  /** {@code Неопределено} — «значения нет»; в наборе типов встречается чаще прочих примитивов. */
+  public static final TypeRef UNDEFINED = new TypeRef(TypeKind.PRIMITIVE, "Неопределено");
 
   /**
    * Канонизация на самом нижнем уровне: универсальный тип-вершина решётки,

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/inlayhints/VariableTypeInlayHintSupplierTest.java
@@ -85,6 +85,65 @@ class VariableTypeInlayHintSupplierTest extends AbstractServerContextAwareTest {
   }
 
   @Test
+  void testNullableTypeIsRenderedWithQuestionMark() {
+
+    // given
+    // `Число, Неопределено` — самый частый union: значимый тип один, а `Неопределено`
+    // говорит лишь «значения может не быть». Подсказка показывает это знаком вопроса.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Тест(Условие)
+      	Если Условие Тогда
+      		Значение = 1;
+      	Иначе
+      		Значение = Неопределено;
+      	КонецЕсли;
+      	Итог = Значение;
+      КонецПроцедуры
+      """);
+    var method = documentContext.getSymbolTree().getMethods().getFirst();
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var params = new InlayHintParams(textDocumentIdentifier, method.getRange());
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then
+    assertThat(inlayHints)
+      .hasSize(1)
+      .first()
+      .satisfies(inlayHint -> assertThat(labelValue(inlayHint)).isEqualTo(": Число?"));
+  }
+
+  @Test
+  void testNoHintForUnionOfSignificantTypes() {
+
+    // given
+    // Два значимых типа — знаком вопроса не обойтись, а перечислять их подсказкой
+    // слишком шумно: хинт не строится, как и раньше.
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Тест(Условие)
+      	Если Условие Тогда
+      		Значение = 1;
+      	Иначе
+      		Значение = "Текст";
+      	КонецЕсли;
+      	Итог = Значение;
+      КонецПроцедуры
+      """);
+    var method = documentContext.getSymbolTree().getMethods().getFirst();
+
+    var textDocumentIdentifier = TestUtils.getTextDocumentIdentifier(documentContext.getUri());
+    var params = new InlayHintParams(textDocumentIdentifier, method.getRange());
+
+    // when
+    List<InlayHint> inlayHints = supplier.getInlayHints(documentContext, params);
+
+    // then
+    assertThat(inlayHints).isEmpty();
+  }
+
+  @Test
   void testNoHintForNewExpressionAssignment() {
 
     // given


### PR DESCRIPTION
## Проблема

Подсказка типа переменной строилась только когда выведенный тип **ровно один**. При union'е
она молча не появлялась — и `Число, Неопределено` не показывалось никогда.

Между тем это самый частый union: так выглядит всё, чего может не оказаться — ключ структуры,
поиск по имени, ветвление с `Неопределено` в одной из ветвей. Значимый тип там всё равно один.

## Решение

```bsl
Значение: Число? = ...     // Число, Неопределено
Итог: Массив = ...         // один тип — как и раньше
                            // Число, Строка — подсказки по-прежнему нет
```

Знак вопроса говорит «значения может не быть» короче, чем вторая половина перечисления.

Правило узкое намеренно: два значимых типа знаком вопроса не выразить, а перечислять их
подсказкой шумно — там ничего не изменилось.

Попутно `TypeRef.UNDEFINED` встал рядом с `ANY` и `UNKNOWN`: константа была продублирована
в четырёх местах, и это стало бы пятым.

## Проверка

Два теста: пара с `Неопределено` даёт `: Число?`, два значимых типа — по-прежнему пусто.
Оба построены на обычном ветвлении `Если/Иначе`, без завязки на другие ветки в работе.

Полный `check` зелёный.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

- **New Features**
  - Variable type hints now display nullable types with a `?` suffix, such as `Число?`, when a value may also be `Неопределено`.
  - Hints are shown when one specific type is identified, including nullable types.

- **Bug Fixes**
  - Improved handling of inferred variable types involving `Неопределено`.
  - Hints remain hidden for ambiguous combinations containing multiple significant types.

- **Tests**
  - Added coverage for nullable types and ambiguous type combinations.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->