### PR TITLE
perf(context): не клонировать массив значений VariableKind на каждый getKind()

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/AbstractVariableSymbol.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/AbstractVariableSymbol.java
@@ -102,7 +102,7 @@ public abstract class AbstractVariableSymbol implements VariableSymbol {
 
   @Override
   public VariableKind getKind() {
-    return VariableKind.values()[kind];
+    return VariableKind.byOrdinal(kind);
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/variable/VariableKind.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/symbol/variable/VariableKind.java
@@ -44,5 +44,25 @@ public enum VariableKind {
   /**
    * Глобальная переменная.
    */
-  GLOBAL
+  GLOBAL;
+
+  /**
+   * Значения перечисления, вычисленные один раз.
+   * <p>
+   * {@link #values()} по контракту возвращает новый массив на каждый вызов (клон внутреннего),
+   * а вид переменной спрашивают на горячем пути — обход дерева символов, автодополнение,
+   * вывод типов, диагностики по переменным.
+   */
+  private static final VariableKind[] VALUES = values();
+
+  /**
+   * Значение перечисления по его порядковому номеру.
+   *
+   * @param ordinal порядковый номер значения ({@link #ordinal()}).
+   * @return значение перечисления с указанным порядковым номером.
+   * @throws ArrayIndexOutOfBoundsException если номер выходит за границы перечисления.
+   */
+  public static VariableKind byOrdinal(int ordinal) {
+    return VALUES[ordinal];
+  }
 }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MetadataObjectNameLengthDiagnostic.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/diagnostics/MetadataObjectNameLengthDiagnostic.java
@@ -47,6 +47,12 @@ public class MetadataObjectNameLengthDiagnostic extends AbstractMetadataDiagnost
 
   private static final int MAX_METADATA_OBJECT_NAME_LENGTH = 80;
 
+  /**
+   * Все типы объектов метаданных, вычисленные один раз: {@link MDOType#values()} клонирует
+   * внутренний массив на каждый вызов, а диагностика создаётся на каждый документ.
+   */
+  private static final List<MDOType> ALL_MDO_TYPES = List.of(MDOType.values());
+
   @DiagnosticParameter(
     type = Integer.class,
     defaultValue = "" + MAX_METADATA_OBJECT_NAME_LENGTH
@@ -54,7 +60,7 @@ public class MetadataObjectNameLengthDiagnostic extends AbstractMetadataDiagnost
   private int maxMetadataObjectNameLength = MAX_METADATA_OBJECT_NAME_LENGTH;
 
   MetadataObjectNameLengthDiagnostic() {
-    super(List.of(MDOType.values()));
+    super(ALL_MDO_TYPES);
   }
 
   @Override

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/FormByNameResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/FormByNameResolver.java
@@ -89,6 +89,12 @@ public class FormByNameResolver {
 
   private static final List<String> MANAGER_SUFFIXES = List.of("Менеджер", "Manager");
 
+  /**
+   * Виды основных форм, вычисленные один раз: {@link DefaultFormKind#values()} клонирует
+   * внутренний массив на каждый вызов, а виды перебираются на каждом резолве имени формы.
+   */
+  private static final DefaultFormKind[] DEFAULT_FORM_KINDS = DefaultFormKind.values();
+
   private final TypeRegistry typeRegistry;
 
   /**
@@ -139,7 +145,7 @@ public class FormByNameResolver {
       return Optional.empty();
     }
     var kindName = formName.substring(separator + 1);
-    for (var kind : DefaultFormKind.values()) {
+    for (var kind : DEFAULT_FORM_KINDS) {
       if (!matchesKind(kind, kindName)) {
         continue;
       }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -96,6 +96,12 @@ public class TypeRegistry {
    */
   static final TypeRef GLOBAL_CONTEXT = new TypeRef(TypeKind.PLATFORM, "ГлобальныйКонтекст");
 
+  /**
+   * Языки файлов, вычисленные один раз: {@link FileType#values()} клонирует внутренний
+   * массив на каждый вызов, а перебор языков идёт при каждой точечной инвалидации кэша.
+   */
+  private static final FileType[] FILE_TYPES = FileType.values();
+
   private final List<PlatformTypesProvider> platformProviders;
   /**
    * Индекс метаданных членов (read-only свойства + версионные члены) для
@@ -788,7 +794,7 @@ public class TypeRegistry {
    * @param ref тип, memo членов которого нужно пересобрать.
    */
   public void invalidateMembers(TypeRef ref) {
-    for (var fileType : FileType.values()) {
+    for (var fileType : FILE_TYPES) {
       membersGeneration.merge(new MembersKey(ref, fileType), 1L, Long::sum);
     }
   }


### PR DESCRIPTION
## Описание

`VariableKind.values()` по контракту возвращает **новый массив на каждый вызов** — клон внутреннего. `AbstractVariableSymbol.getKind()` звал его на горячем пути (обход дерева символов, автодополнение, вывод типов, диагностики по переменным), что на анализе конфигурации из 23 575 модулей давало **15,7 ГБ** оборота (JFR, `jdk.ObjectAllocationSample`) на ровном месте: массив создаётся, читается один элемент, массив выбрасывается.

Значения вынесены в статическую константу самого перечисления, доступ — через `VariableKind.byOrdinal(int)`:

```java
public enum VariableKind {
  DYNAMIC, LOCAL, PARAMETER, MODULE, GLOBAL;

  private static final VariableKind[] VALUES = values();

  public static VariableKind byOrdinal(int ordinal) {
    return VALUES[ordinal];
  }
}
```

Поле объявлено после констант, поэтому инициализация корректна: синтетический `$VALUES` компилятор присваивает до пользовательской статики.

### Сквозная проверка остальных перечислений

Всего в `src/main/java` восемь вызовов `X.values()`. Одноразовые не трогал: `WebColor` и `ModuleType` — статические фабрики статических полей, `FormElementType` / `TableDataKind` — разовая регистрация типов форм. Повторяющиеся поправлены той же техникой:

| место | как часто зовётся | было |
|---|---|---|
| `TypeRegistry.invalidateMembers` | на каждую точечную инвалидацию кэша членов | `FileType.values()` |
| `FormByNameResolver.resolveDefaultForm` | на каждый резолв имени формы | `DefaultFormKind.values()` |
| `MetadataObjectNameLengthDiagnostic` | конструктор — на каждый документ | `List.of(MDOType.values())` |

Два последних — перечисления mdclasses, поля туда не добавить, поэтому константа в вызывающем классе.

### Почему не как в mdclasses

В issue предлагалось посмотреть на `EnumWithName.computeKeys(values())`. Приём здесь неприменим: базового класса в mdclasses нет и быть не может (enum в Java не наследует классы) — это интерфейс со статическим хелпером, а поле `KEYS` всё равно объявлено в каждом перечислении отдельно. Хелпер там оправдан реальной логикой внутри (сборка карты «имя → значение» по `nameRu()`/`nameEn()` в нижнем регистре). У поиска по порядковому номеру такой логики нет — всё тело это одно поле, выносить нечего.

## Связанные задачи

Closes #4418

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [x] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [x] Неприменимо — диагностики не добавлялись и не менялись по поведению

## Дополнительно

**Проверка.** `compileJava`, `spotlessCheck`, `precommit` — чисто. Тесты: `VariableSymbolTest` (7), `SymbolTreeTest` (4), `SymbolTreeComputerTest` (1), `MetadataObjectNameLengthDiagnosticTest` (16), `FormModuleInferenceTest` (25), `MultiWorkspaceTypeRegistryTest` (2), `ArchitectureTest` (16) — все зелёные. Новых тестов нет: изменение чисто перформансное, поведение `getKind()` покрыто существующими.

**Повторный замер JFR не делал** — для него нужна большая реальная конфигурация, которой нет в этом окружении. Проверку оборота по этому месту стоит прогнать отдельно.

**Не относится к PR, но всплыло:** `gradlew precommit` на чистом develop оставляет несвязанную правку в `configuration/schema.json` — задача `updateJsonSchema` перезаписывает живую кириллицу в `\uXXXX` (`"^[^<]*Имя\sтеста\s<([^>]+)>.*"` → `"^[^<]*Имя\s..."`). Из этого PR я её откатил.

---
_Generated by [Claude Code](https://claude.ai/code/session_01TLsHDUZNXpxQ8KJrn8K9d5)_

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Performance Improvements**
  * Improved internal handling of variable, form, file, and metadata type information.
  * Reduced repeated allocation during diagnostic creation and type resolution.
  * Maintained existing behavior while making related operations more efficient.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->