### PR TITLE
fix(types): контракты обработчиков сервиса живут на типе самого сервиса

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolver.java
@@ -343,8 +343,12 @@ public class EventHandlerResolver implements EventHandlerClassifier {
    * Owner-тип модуля: {@code ДокументОбъект.Покупатели},
    * {@code СправочникМенеджер.Контрагенты}, {@code РегистрСведенийНаборЗаписей.Курсы},
    * {@code КонстантаМенеджерЗначения.КодВалюты} — для MDO-specific обёрток.
-   * Для модулей с фиксированным типом (команды, HTTP/Web/Bot/Integration сервисы)
-   * — прямой qualifiedName типа из HBK без специализации по имени.
+   * <p>
+   * У модулей сервисов имя типа в HBK не параметризовано, поэтому спрашивается сначала
+   * тип этого сервиса ({@code Модуль Web-сервиса.Обмен}, заводит
+   * {@link ServiceModuleEventRegistrar}), и только если его нет — общий тип вида.
+   * Обработчики объявлены в конкретном сервисе, и контракт надо брать у него: у разных
+   * сервисов одноимённые операции сплошь и рядом принимают разные параметры.
    */
   private Optional<TypeRef> resolveOwnerType(DocumentContext documentContext, ModuleType moduleType) {
     if (moduleType == ModuleType.FormModule) {
@@ -354,7 +358,10 @@ public class EventHandlerResolver implements EventHandlerClassifier {
     }
     var fixed = MODULE_TYPE_TO_FIXED_OWNER_RU.get(moduleType);
     if (fixed != null) {
-      return typeRegistry.resolve(fixed);
+      return documentContext.getMdObject()
+        .map(md -> fixed + "." + md.getName())
+        .flatMap(typeRegistry::resolve)
+        .or(() -> typeRegistry.resolve(fixed));
     }
     var wrapperRu = MODULE_TYPE_TO_WRAPPER_RU.get(moduleType);
     if (wrapperRu == null) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ServiceModuleEventRegistrar.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ServiceModuleEventRegistrar.java
@@ -66,78 +66,104 @@ public class ServiceModuleEventRegistrar {
 
   private final TypeRegistry typeRegistry;
 
-  /** Развернуть generic-события сервисных модулей для всех MD-объектов конфигурации. */
+  /**
+   * Развернуть generic-события сервисных модулей для всех MD-объектов конфигурации.
+   * <p>
+   * У модуля сервиса есть владелец — сам сервис, и обработчики каждого объявлены только в
+   * нём. Синтакс-помощник этого не выражает: у него один тип на все сервисы вида
+   * ({@code Модуль Web-сервиса}) с единственным членом-шаблоном {@code <Имя обработчика>},
+   * тогда как у справочников параметризовано само имя типа
+   * ({@code СправочникМенеджер.<Имя справочника>}). Поэтому специализация по владельцу
+   * заводится здесь: на каждый сервис — свой тип {@code <тип модуля>.<Имя сервиса>} с
+   * операциями только этого сервиса. Иначе одноимённые операции разных сервисов (а в
+   * типовых конфигурациях у версий одного сервиса они называются одинаково) складывались
+   * бы в один член, и чей контракт уцелеет, решал бы порядок обхода метаданных.
+   *
+   * @param children объекты метаданных конфигурации.
+   */
   public void register(Iterable<MD> children) {
-    var httpEvents = new ArrayList<HandlerSpec>();
-    var webEvents = new ArrayList<HandlerSpec>();
-    var integrationEvents = new ArrayList<HandlerSpec>();
     for (var md : children) {
-      collectHttpHandlers(md, httpEvents);
-      collectWebProcedures(md, webEvents);
-      collectIntegrationHandlers(md, integrationEvents);
+      registerServiceHandlerEvents("Модуль HTTP-сервиса", "Имя обработчика",
+        md, collectHttpHandlers(md));
+      registerServiceHandlerEvents("Модуль Web-сервиса", "Имя обработчика",
+        md, collectWebProcedures(md));
+      registerServiceHandlerEvents("Модуль сервиса интеграции",
+        "Имя обработчика полученного сообщения", md, collectIntegrationHandlers(md));
     }
-    registerServiceHandlerEvents("Модуль HTTP-сервиса", "Имя обработчика", httpEvents);
-    registerServiceHandlerEvents("Модуль Web-сервиса", "Имя обработчика", webEvents);
-    registerServiceHandlerEvents("Модуль сервиса интеграции",
-      "Имя обработчика полученного сообщения", integrationEvents);
   }
 
-  private void collectHttpHandlers(MD md, List<HandlerSpec> sink) {
+  private List<HandlerSpec> collectHttpHandlers(MD md) {
     if (!(md instanceof HTTPService http)) {
-      return;
+      return List.of();
     }
+    var sink = new ArrayList<HandlerSpec>();
     http.getUrlTemplates().forEach(tpl -> tpl.getMethods().forEach((HTTPServiceMethod m) -> {
       if (!m.getHandler().isBlank()) {
         sink.add(new HandlerSpec(m.getHandler(), httpServiceMethodSignature()));
       }
     }));
+    return sink;
   }
 
-  private static void collectWebProcedures(MD md, List<HandlerSpec> sink) {
+  private static List<HandlerSpec> collectWebProcedures(MD md) {
     if (!(md instanceof WebService web)) {
-      return;
+      return List.of();
     }
+    var sink = new ArrayList<HandlerSpec>();
     web.getOperations().forEach((WebServiceOperation op) -> {
       if (!op.getProcedureName().isBlank()) {
         sink.add(new HandlerSpec(op.getProcedureName(), webOperationSignature(op)));
       }
     });
+    return sink;
   }
 
-  private static void collectIntegrationHandlers(MD md, List<HandlerSpec> sink) {
+  private static List<HandlerSpec> collectIntegrationHandlers(MD md) {
     if (!(md instanceof IntegrationService isvc)) {
-      return;
+      return List.of();
     }
+    var sink = new ArrayList<HandlerSpec>();
     isvc.getIntegrationServiceChannels().forEach((IntegrationServiceChannel ch) -> {
       if (!ch.getReceiveMessageProcessing().isBlank()) {
         sink.add(new HandlerSpec(ch.getReceiveMessageProcessing(),
           integrationChannelSignature()));
       }
     });
+    return sink;
   }
 
   /**
-   * Материализует generic-event типа по placeholder'у и подменяет signatures
-   * на сигнатуру с реальными параметрами обработчика из mdclasses.
+   * Материализует generic-event типа модуля по placeholder'у и подменяет signatures
+   * на сигнатуры с реальными параметрами обработчиков этого сервиса из mdclasses.
    * <p>
    * Описание/двуязычие/sinceVersion event'а наследуются от HBK-шаблона: общий
    * для всего семейства источник правды.
+   * <p>
+   * Члены вешаются не на общий тип вида, а на тип этого сервиса
+   * ({@code Модуль Web-сервиса.Обмен}), зарегистрированный специализацией от общего.
+   *
+   * @param typeQualifiedName имя платформенного типа модуля этого вида сервиса.
+   * @param placeholder       имя параметра generic-члена в шаблоне HBK.
+   * @param service           объект метаданных сервиса — владелец модуля.
+   * @param specs             обработчики этого сервиса.
    */
   private void registerServiceHandlerEvents(String typeQualifiedName, String placeholder,
-                                            List<HandlerSpec> specs) {
+                                            MD service, List<HandlerSpec> specs) {
     if (specs.isEmpty()) {
       return;
     }
-    var typeRef = typeRegistry.resolve(typeQualifiedName).orElse(null);
-    if (typeRef == null) {
+    var genericRef = typeRegistry.resolve(typeQualifiedName).orElse(null);
+    if (genericRef == null || service.getName().isBlank()) {
       return;
     }
     var names = specs.stream().map(HandlerSpec::name).distinct().toList();
-    var templates = typeRegistry.expandedMembers(typeRef, Map.of(),
+    var templates = typeRegistry.expandedMembers(genericRef, Map.of(),
       Map.of(placeholder, names), FileType.BSL);
     if (templates.isEmpty()) {
       return;
     }
+    // Имена обработчиков в пределах одного сервиса уникальны: у операции ровно одна
+    // процедура, а двух операций с одним именем в сервисе не бывает.
     var sigByName = specs.stream()
       .collect(Collectors.toMap(HandlerSpec::name, HandlerSpec::signature, (a, b) -> a));
     var withSignatures = templates.stream()
@@ -146,7 +172,9 @@ public class ServiceModuleEventRegistrar {
         return sig == null ? m : m.withSignatures(List.of(sig));
       })
       .toList();
-    typeRegistry.registerMemberSource(typeRef, () -> withSignatures, FileType.BSL);
+    var serviceRef = typeRegistry.registerSpecialization(
+      typeQualifiedName + "." + service.getName(), genericRef, Map.of(), FileType.BSL);
+    typeRegistry.registerMemberSource(serviceRef, () -> withSignatures, FileType.BSL);
   }
 
   /** Сигнатура HTTP-обработчика: один параметр {@code Запрос} типа {@code HTTPСервисЗапрос}. */

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderHelpersTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderHelpersTest.java
@@ -697,7 +697,7 @@ class ConfigurationTypesProviderHelpersTest {
       java.util.Map.of(http.getMdoReference(), (MD) http),
       (registry, p) -> {
         p.tryRegister();
-        var typeRef = registry.resolve("Модуль HTTP-сервиса").orElseThrow();
+        var typeRef = registry.resolve("Модуль HTTP-сервиса.HTTPСервис1").orElseThrow();
         var names = registry.getMembers(typeRef, FileType.BSL).stream().map(MemberDescriptor::name).toList();
         assertThat(names).contains("URLTemplate1GET");
       });
@@ -771,7 +771,9 @@ class ConfigurationTypesProviderHelpersTest {
       java.util.Map.of(web.getMdoReference(), (MD) web),
       (registry, p) -> {
         p.tryRegister();
-        var typeRef = registry.resolve("Модуль Web-сервиса").orElseThrow();
+        // Обработчики висят на типе своего сервиса: у разных сервисов операции сплошь
+        // и рядом называются одинаково, а параметры у них разные.
+        var typeRef = registry.resolve("Модуль Web-сервиса.WebСервис1").orElseThrow();
         var names = registry.getMembers(typeRef, FileType.BSL).stream().map(MemberDescriptor::name).toList();
         assertThat(names).contains("Операция1");
       });
@@ -804,7 +806,7 @@ class ConfigurationTypesProviderHelpersTest {
       java.util.Map.of(isvc.getMdoReference(), (MD) isvc),
       (registry, p) -> {
         p.tryRegister();
-        var typeRef = registry.resolve("Модуль сервиса интеграции").orElseThrow();
+        var typeRef = registry.resolve("Модуль сервиса интеграции.Сервис1").orElseThrow();
         var names = registry.getMembers(typeRef, FileType.BSL).stream().map(MemberDescriptor::name).toList();
         assertThat(names).contains("ОбработчикСообщения");
       });

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/EventHandlerResolverTest.java
@@ -215,6 +215,53 @@ class EventHandlerResolverTest {
   }
 
   @Test
+  void webServiceModuleTakesContractOfItsOwnService() {
+    // given: у сервиса свой тип модуля, и контракт операции объявлен в нём.
+    var serviceRef = new TypeRef(TypeKind.PLATFORM, "Модуль Web-сервиса.Обмен");
+    when(typeRegistry.resolve("Модуль Web-сервиса.Обмен")).thenReturn(Optional.of(serviceRef));
+    when(typeRegistry.getMembers(eq(serviceRef), any())).thenReturn(List.of(
+      MemberDescriptor.event("Загрузить", "",
+        List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")))));
+    // Общий тип вида объявляет операцию другого сервиса — брать её нельзя.
+    var genericRef = new TypeRef(TypeKind.PLATFORM, "Модуль Web-сервиса");
+    when(typeRegistry.resolve("Модуль Web-сервиса")).thenReturn(Optional.of(genericRef));
+    when(typeRegistry.getMembers(eq(genericRef), any())).thenReturn(List.of(
+      MemberDescriptor.event("Выгрузить", "",
+        List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")))));
+
+    var doc = webServiceModuleDoc("Обмен");
+
+    // when, then
+    assertThat(resolver.lookupContract(doc, "Загрузить")).isPresent();
+    assertThat(resolver.lookupContract(doc, "Выгрузить")).isEmpty();
+  }
+
+  @Test
+  void webServiceModuleFallsBackToSharedTypeWhenServiceTypeIsAbsent() {
+    // given: типа сервиса нет — например, метаданные сервиса не прочитались.
+    var genericRef = new TypeRef(TypeKind.PLATFORM, "Модуль Web-сервиса");
+    when(typeRegistry.resolve("Модуль Web-сервиса.Обмен")).thenReturn(Optional.empty());
+    when(typeRegistry.resolve("Модуль Web-сервиса")).thenReturn(Optional.of(genericRef));
+    when(typeRegistry.getMembers(eq(genericRef), any())).thenReturn(List.of(
+      MemberDescriptor.event("Загрузить", "",
+        List.of(new SignatureDescriptor(List.of(), TypeSet.EMPTY, "")))));
+
+    var doc = webServiceModuleDoc("Обмен");
+
+    // when, then
+    assertThat(resolver.lookupContract(doc, "Загрузить")).isPresent();
+  }
+
+  private static DocumentContext webServiceModuleDoc(String serviceName) {
+    var service = com.github._1c_syntax.bsl.mdo.WebService.builder().name(serviceName).build();
+    var doc = mock(DocumentContext.class);
+    when(doc.getModuleType()).thenReturn(ModuleType.WEBServiceModule);
+    when(doc.getMdObject()).thenReturn(Optional.of(service));
+    when(doc.getFileType()).thenReturn(FileType.BSL);
+    return doc;
+  }
+
+  @Test
   void ownerTypeEventResolvesByEnglishAliasNotJustRuPrimaryName() {
     var objectRef = new TypeRef(TypeKind.CONFIGURATION, "ДокументОбъект.Заказ");
     when(typeRegistry.resolve("ДокументОбъект.Заказ")).thenReturn(Optional.of(objectRef));

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ServiceModuleEventRegistrarTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ServiceModuleEventRegistrarTest.java
@@ -1,0 +1,151 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.MemberSource;
+import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.mdo.WebService;
+import com.github._1c_syntax.bsl.mdo.children.WebServiceOperation;
+import com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.mockito.ArgumentCaptor;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Одноимённые операции разных веб-сервисов принимают разные параметры — в типовых
+ * конфигурациях так выглядят версии одного и того же сервиса. Контракт каждой должен
+ * оставаться при своём сервисе.
+ */
+class ServiceModuleEventRegistrarTest {
+
+  private static final String WEB_SERVICE_MODULE = "Модуль Web-сервиса";
+  private static final TypeRef GENERIC = new TypeRef(TypeKind.PLATFORM, WEB_SERVICE_MODULE);
+
+  private TypeRegistry typeRegistry;
+  private ServiceModuleEventRegistrar registrar;
+  private Map<TypeRef, List<MemberDescriptor>> registeredMembers;
+
+  @BeforeEach
+  void prepare() {
+    typeRegistry = mock(TypeRegistry.class);
+    registrar = new ServiceModuleEventRegistrar(typeRegistry);
+    registeredMembers = new HashMap<>();
+
+    when(typeRegistry.resolve(WEB_SERVICE_MODULE)).thenReturn(Optional.of(GENERIC));
+    // Реестр материализует шаблон «<Имя обработчика>» по переданным именам.
+    when(typeRegistry.expandedMembers(eq(GENERIC), any(), any(), any()))
+      .thenAnswer(invocation -> {
+        Map<String, List<String>> expansions = invocation.getArgument(2);
+        return expansions.get("Имя обработчика").stream()
+          .map(name -> MemberDescriptor.event(name, "", List.of()))
+          .toList();
+      });
+    when(typeRegistry.registerSpecialization(anyString(), eq(GENERIC), any(), any()))
+      .thenAnswer(invocation ->
+        new TypeRef(TypeKind.PLATFORM, invocation.getArgument(0, String.class)));
+  }
+
+  @Test
+  void eachServiceKeepsItsOwnHandlerContract() {
+    // given: два сервиса объявляют операцию «Обмен», но с разным числом параметров.
+    var first = webService("Exchange_3_0_1_1", operation("Обмен", "Параметры"));
+    var second = webService("Exchange_3_0_2_1", operation("Обмен", "Параметры", "Зона"));
+
+    // when
+    registrar.register(List.of(first, second));
+
+    // then: у каждого сервиса свой тип со своей сигнатурой — ни один контракт не потерян.
+    captureRegisteredMembers();
+    assertThat(parameterNamesOf("Модуль Web-сервиса.Exchange_3_0_1_1", "Обмен"))
+      .containsExactly("Параметры");
+    assertThat(parameterNamesOf("Модуль Web-сервиса.Exchange_3_0_2_1", "Обмен"))
+      .containsExactly("Параметры", "Зона");
+  }
+
+  @Test
+  void sharedTypeGetsNoServiceHandlers() {
+    // given
+    var service = webService("Обмен", operation("Загрузить", "Данные"));
+
+    // when
+    registrar.register(List.of(service));
+
+    // then: общий тип вида остаётся ни при чём — обработчики висят на типе сервиса.
+    captureRegisteredMembers();
+    assertThat(registeredMembers).doesNotContainKey(GENERIC);
+    assertThat(registeredMembers).containsKey(new TypeRef(TypeKind.PLATFORM, "Модуль Web-сервиса.Обмен"));
+  }
+
+  private void captureRegisteredMembers() {
+    var refCaptor = ArgumentCaptor.forClass(TypeRef.class);
+    var sourceCaptor = ArgumentCaptor.forClass(MemberSource.class);
+    org.mockito.Mockito.verify(typeRegistry, org.mockito.Mockito.atLeastOnce())
+      .registerMemberSource(refCaptor.capture(), sourceCaptor.capture(), eq(FileType.BSL));
+    for (var index = 0; index < refCaptor.getAllValues().size(); index++) {
+      registeredMembers.put(refCaptor.getAllValues().get(index),
+        List.copyOf(sourceCaptor.getAllValues().get(index).getMembers()));
+    }
+  }
+
+  private List<String> parameterNamesOf(String typeName, String handler) {
+    var members = registeredMembers.get(new TypeRef(TypeKind.PLATFORM, typeName));
+    assertThat(members).as("члены типа " + typeName).isNotNull();
+    return members.stream()
+      .filter(member -> member.name().equals(handler))
+      .flatMap(member -> member.signatures().stream())
+      .flatMap((SignatureDescriptor signature) -> signature.parameters().stream())
+      .map(parameter -> parameter.name())
+      .toList();
+  }
+
+  private static WebService webService(String name, WebServiceOperation... operations) {
+    return WebService.builder().name(name).operations(List.of(operations)).build();
+  }
+
+  private static WebServiceOperation operation(String name, String... parameterNames) {
+    var parameters = java.util.Arrays.stream(parameterNames)
+      .map(parameterName -> WebServiceOperationParameter.builder().name(parameterName).build())
+      .toList();
+    return WebServiceOperation.builder()
+      .name(name)
+      .procedureName(name)
+      .parameters(parameters)
+      .build();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ServiceModuleEventRegistrarTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ServiceModuleEventRegistrarTest.java
@@ -24,17 +24,24 @@ package com.github._1c_syntax.bsl.languageserver.types.registry;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.MemberSource;
+import com.github._1c_syntax.bsl.languageserver.types.model.ParameterDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.SignatureDescriptor;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
-import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.mdo.HTTPService;
+import com.github._1c_syntax.bsl.mdo.IntegrationService;
+import com.github._1c_syntax.bsl.mdo.MD;
 import com.github._1c_syntax.bsl.mdo.WebService;
+import com.github._1c_syntax.bsl.mdo.children.HTTPServiceMethod;
+import com.github._1c_syntax.bsl.mdo.children.HTTPServiceURLTemplate;
+import com.github._1c_syntax.bsl.mdo.children.IntegrationServiceChannel;
 import com.github._1c_syntax.bsl.mdo.children.WebServiceOperation;
 import com.github._1c_syntax.bsl.mdo.children.WebServiceOperationParameter;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 import org.mockito.ArgumentCaptor;
 
+import java.util.Arrays;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -44,18 +51,24 @@ import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.ArgumentMatchers.anyString;
 import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.atLeastOnce;
 import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
 
 /**
- * Одноимённые операции разных веб-сервисов принимают разные параметры — в типовых
- * конфигурациях так выглядят версии одного и того же сервиса. Контракт каждой должен
- * оставаться при своём сервисе.
+ * Обработчики каждого сервиса должны оставаться при своём сервисе: у разных сервисов
+ * операции сплошь и рядом называются одинаково — так выглядят версии одного и того же
+ * сервиса, — а параметры у них разные.
  */
 class ServiceModuleEventRegistrarTest {
 
-  private static final String WEB_SERVICE_MODULE = "Модуль Web-сервиса";
-  private static final TypeRef GENERIC = new TypeRef(TypeKind.PLATFORM, WEB_SERVICE_MODULE);
+  private static final String WEB_MODULE = "Модуль Web-сервиса";
+  private static final String HTTP_MODULE = "Модуль HTTP-сервиса";
+  private static final String INTEGRATION_MODULE = "Модуль сервиса интеграции";
+
+  private static final String HANDLER_NAME = "Имя обработчика";
+  private static final String RECEIVE_HANDLER_NAME = "Имя обработчика полученного сообщения";
 
   private TypeRegistry typeRegistry;
   private ServiceModuleEventRegistrar registrar;
@@ -67,22 +80,26 @@ class ServiceModuleEventRegistrarTest {
     registrar = new ServiceModuleEventRegistrar(typeRegistry);
     registeredMembers = new HashMap<>();
 
-    when(typeRegistry.resolve(WEB_SERVICE_MODULE)).thenReturn(Optional.of(GENERIC));
-    // Реестр материализует шаблон «<Имя обработчика>» по переданным именам.
-    when(typeRegistry.expandedMembers(eq(GENERIC), any(), any(), any()))
+    for (var moduleType : List.of(WEB_MODULE, HTTP_MODULE, INTEGRATION_MODULE)) {
+      when(typeRegistry.resolve(moduleType))
+        .thenReturn(Optional.of(new TypeRef(TypeKind.PLATFORM, moduleType)));
+    }
+    // Реестр материализует член-шаблон по переданным именам обработчиков.
+    when(typeRegistry.expandedMembers(any(), any(), any(), any()))
       .thenAnswer(invocation -> {
         Map<String, List<String>> expansions = invocation.getArgument(2);
-        return expansions.get("Имя обработчика").stream()
+        return expansions.values().stream()
+          .flatMap(List::stream)
           .map(name -> MemberDescriptor.event(name, "", List.of()))
           .toList();
       });
-    when(typeRegistry.registerSpecialization(anyString(), eq(GENERIC), any(), any()))
+    when(typeRegistry.registerSpecialization(anyString(), any(), any(), any()))
       .thenAnswer(invocation ->
         new TypeRef(TypeKind.PLATFORM, invocation.getArgument(0, String.class)));
   }
 
   @Test
-  void eachServiceKeepsItsOwnHandlerContract() {
+  void eachWebServiceKeepsItsOwnHandlerContract() {
     // given: два сервиса объявляют операцию «Обмен», но с разным числом параметров.
     var first = webService("Exchange_3_0_1_1", operation("Обмен", "Параметры"));
     var second = webService("Exchange_3_0_2_1", operation("Обмен", "Параметры", "Зона"));
@@ -99,23 +116,62 @@ class ServiceModuleEventRegistrarTest {
   }
 
   @Test
-  void sharedTypeGetsNoServiceHandlers() {
-    // given
-    var service = webService("Обмен", operation("Загрузить", "Данные"));
+  void eachHttpServiceKeepsItsOwnHandlers() {
+    // given: два HTTP-сервиса с одноимённым обработчиком у разных шаблонов URL.
+    var first = httpService("ОбменДанными", urlTemplate("Корень", "GET", "ОбработчикGET"));
+    var second = httpService("Файлы", urlTemplate("Корень", "GET", "ОбработчикGET"));
 
     // when
-    registrar.register(List.of(service));
+    registrar.register(List.of(first, second));
 
-    // then: общий тип вида остаётся ни при чём — обработчики висят на типе сервиса.
+    // then
     captureRegisteredMembers();
-    assertThat(registeredMembers).doesNotContainKey(GENERIC);
-    assertThat(registeredMembers).containsKey(new TypeRef(TypeKind.PLATFORM, "Модуль Web-сервиса.Обмен"));
+    assertThat(handlerNamesOf("Модуль HTTP-сервиса.ОбменДанными")).containsExactly("ОбработчикGET");
+    assertThat(handlerNamesOf("Модуль HTTP-сервиса.Файлы")).containsExactly("ОбработчикGET");
+  }
+
+  @Test
+  void eachIntegrationServiceKeepsItsOwnHandlers() {
+    // given: два сервиса интеграции с одноимёнными обработчиками полученного сообщения.
+    var first = integrationService("Обмен", channel("Канал1", "ПриПолучении"));
+    var second = integrationService("Уведомления", channel("Канал1", "ПриПолучении"));
+
+    // when
+    registrar.register(List.of(first, second));
+
+    // then
+    captureRegisteredMembers();
+    assertThat(handlerNamesOf("Модуль сервиса интеграции.Обмен")).containsExactly("ПриПолучении");
+    assertThat(handlerNamesOf("Модуль сервиса интеграции.Уведомления")).containsExactly("ПриПолучении");
+  }
+
+  @Test
+  void sharedTypesGetNoServiceHandlers() {
+    // given: по одному сервису каждого вида.
+    var web = webService("Обмен", operation("Загрузить", "Данные"));
+    var http = httpService("Файлы", urlTemplate("Корень", "GET", "ОбработчикGET"));
+    var integration = integrationService("Уведомления", channel("Канал1", "ПриПолучении"));
+
+    // when
+    registrar.register(List.of(web, http, integration));
+
+    // then: общие типы вида остаются ни при чём — обработчики висят на типах сервисов.
+    captureRegisteredMembers();
+    assertThat(registeredMembers.keySet())
+      .doesNotContain(
+        new TypeRef(TypeKind.PLATFORM, WEB_MODULE),
+        new TypeRef(TypeKind.PLATFORM, HTTP_MODULE),
+        new TypeRef(TypeKind.PLATFORM, INTEGRATION_MODULE))
+      .contains(
+        new TypeRef(TypeKind.PLATFORM, "Модуль Web-сервиса.Обмен"),
+        new TypeRef(TypeKind.PLATFORM, "Модуль HTTP-сервиса.Файлы"),
+        new TypeRef(TypeKind.PLATFORM, "Модуль сервиса интеграции.Уведомления"));
   }
 
   private void captureRegisteredMembers() {
     var refCaptor = ArgumentCaptor.forClass(TypeRef.class);
     var sourceCaptor = ArgumentCaptor.forClass(MemberSource.class);
-    org.mockito.Mockito.verify(typeRegistry, org.mockito.Mockito.atLeastOnce())
+    verify(typeRegistry, atLeastOnce())
       .registerMemberSource(refCaptor.capture(), sourceCaptor.capture(), eq(FileType.BSL));
     for (var index = 0; index < refCaptor.getAllValues().size(); index++) {
       registeredMembers.put(refCaptor.getAllValues().get(index),
@@ -123,29 +179,60 @@ class ServiceModuleEventRegistrarTest {
     }
   }
 
-  private List<String> parameterNamesOf(String typeName, String handler) {
+  private List<MemberDescriptor> membersOf(String typeName) {
     var members = registeredMembers.get(new TypeRef(TypeKind.PLATFORM, typeName));
     assertThat(members).as("члены типа " + typeName).isNotNull();
-    return members.stream()
+    return members;
+  }
+
+  private List<String> handlerNamesOf(String typeName) {
+    return membersOf(typeName).stream().map(MemberDescriptor::name).toList();
+  }
+
+  private List<String> parameterNamesOf(String typeName, String handler) {
+    return membersOf(typeName).stream()
       .filter(member -> member.name().equals(handler))
       .flatMap(member -> member.signatures().stream())
       .flatMap((SignatureDescriptor signature) -> signature.parameters().stream())
-      .map(parameter -> parameter.name())
+      .map(ParameterDescriptor::name)
       .toList();
   }
 
-  private static WebService webService(String name, WebServiceOperation... operations) {
+  private static MD webService(String name, WebServiceOperation... operations) {
     return WebService.builder().name(name).operations(List.of(operations)).build();
   }
 
   private static WebServiceOperation operation(String name, String... parameterNames) {
-    var parameters = java.util.Arrays.stream(parameterNames)
+    var parameters = Arrays.stream(parameterNames)
       .map(parameterName -> WebServiceOperationParameter.builder().name(parameterName).build())
       .toList();
     return WebServiceOperation.builder()
       .name(name)
       .procedureName(name)
       .parameters(parameters)
+      .build();
+  }
+
+  private static MD httpService(String name, HTTPServiceURLTemplate... urlTemplates) {
+    return HTTPService.builder().name(name).urlTemplates(List.of(urlTemplates)).build();
+  }
+
+  private static HTTPServiceURLTemplate urlTemplate(String name, String method, String handler) {
+    return HTTPServiceURLTemplate.builder()
+      .name(name)
+      .method(HTTPServiceMethod.builder().name(method).handler(handler).build())
+      .build();
+  }
+
+  private static MD integrationService(String name, IntegrationServiceChannel... channels) {
+    return IntegrationService.builder().name(name)
+      .integrationServiceChannels(List.of(channels)).build();
+  }
+
+  private static IntegrationServiceChannel channel(String name, String receiveHandler) {
+    return IntegrationServiceChannel.builder()
+      .name(name)
+      .receiveMessageProcessing(receiveHandler)
       .build();
   }
 }


### PR DESCRIPTION
## Проблема

У модуля сервиса есть владелец — сам сервис, и обработчики объявлены только в нём. Синтакс-помощник этого не выражает. Сырые данные из HBK (8.3.26.1521, через bsl-context):

```
СправочникМенеджер.<Имя справочника>   | параметры типа: [Имя справочника]
Модуль Web-сервиса                     | параметры типа: []   член: EVENT <Имя обработчика>
Модуль HTTP-сервиса                    | параметры типа: []   член: EVENT <Имя обработчика>
Модуль сервиса интеграции              | параметры типа: []   член: EVENT <Имя обработчика полученного сообщения>
```

У справочников платформа параметризует **имя типа** и прямо пишет об этом в описании. У модулей сервисов параметризовано только **имя члена**, а тип один на вид сервиса. Это не потеря в bsl-context: `BslContextPlatformTypesProvider` берёт `context.typeParameters()` как есть, и у справочника параметр приходит.

Типа «сам сервис» в HBK тоже нет: есть `СервисИнтеграцииМенеджер.<Имя сервиса интеграции>`, `КаналСервисаИнтеграцииМенеджер.<…>`, `WSСсылкаМенеджер.<Имя WS-Ссылки>` — но ни `WebСервисМенеджер.<…>`, ни `HTTPСервисМенеджер.<…>`. К веб-сервису конфигурации из кода не обратиться, поэтому типа-значения у него нет; `ОбъектМетаданных: WebСервис` — это описание метаданных, а не сервис.

`ServiceModuleEventRegistrar` следовал HBK буквально: собирал обработчики **всех** сервисов конфигурации и материализовал их на одном типе, разрешая столкновения имён так:

```java
Collectors.toMap(HandlerSpec::name, HandlerSpec::signature, (a, b) -> a)
```

### Насколько это массово (ssl_3_1)

| | |
|---|---|
| пар «сервис — операция» в веб-сервисах | 143 |
| различных имён обработчиков | 47 |
| имён, объявленных больше чем одним сервисом | 41 |
| имён, у которых наборы параметров различаются | 16 |

Пример: `СоздатьУзелОбмена` в `Exchange_3_0_1_1` принимает `Parameters`, в `Exchange_3_0_2_1` — `Parameters, Zone`. Контракт доставался тому, чей объект метаданных попался раньше, а обработчики остальных сервисов объявлялись несоответствующими. Порядок обхода метаданных между запусками не гарантирован, поэтому и набор замечаний плавал: в замерах по ишью #4429 ровно эти строки расходились между прогонами.

## Что сделано

На каждый сервис регистрируется свой тип модуля — `Модуль Web-сервиса.Обмен` — специализацией от HBK-шаблона, с операциями только этого сервиса и их настоящими параметрами. `EventHandlerResolver.resolveOwnerType` спрашивает сперва тип конкретного сервиса и лишь потом общий тип вида (запасной путь на случай, когда метаданные сервиса не прочитались).

Одинаково для всех трёх видов: Web-сервисы, HTTP-сервисы, сервисы интеграции.

## Замеры на ssl_3_1

| | `EventHandlerInvalidSignature` |
|---|---|
| develop | 557 |
| ветка | **519** |

Убрано 38, добавлено 0 — все убранные приходятся на обработчики, проверявшиеся по контракту чужого сервиса (`WebServices/Exchange`, `EnterpriseDataUpload_1_0_1_1` и т. д.).

## Тесты

Новые: `ServiceModuleEventRegistrarTest` — два сервиса с одноимённой операцией и разными параметрами сохраняют каждый свой контракт, на общий тип обработчики не попадают; в `EventHandlerResolverTest` — контракт берётся у своего сервиса, а не у чужого, и запасной путь на общий тип.

Правлены: три проверки в `ConfigurationTypesProviderHelpersTest` спрашивали члены у общего типа вида — теперь спрашивают у типа сервиса. Контракт переехал туда намеренно, это и есть суть правки.

Замечание на будущее: `Модуль команды` и `Модуль бота` тоже сидят на фиксированном типе, но у них имена событий не параметризованы (`ОбработкаКоманды` и пять событий бота), поэтому сталкиваться нечему — их не трогал.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved event handling for service modules by resolving handlers against the correct service-specific type.
  * Preserved distinct parameter contracts for same-named operations across different services.
  * Added fallback behavior to shared service types when a specialized type is unavailable.
  * Prevented handlers from being incorrectly shared between independent services.

* **Tests**
  * Expanded coverage for web-service event resolution and independent service handler registration.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->