### PR TITLE
fix(types): объявленные типы пересобираются после наполнения области

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndex.java
@@ -24,6 +24,7 @@ package com.github._1c_syntax.bsl.languageserver.types.index;
 import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
 import com.github._1c_syntax.bsl.languageserver.context.FileType;
 import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopulatedEvent;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.MethodSymbol;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.ParameterDefinition;
 import com.github._1c_syntax.bsl.languageserver.context.symbol.SourceDefinedSymbol;
@@ -137,6 +138,28 @@ public class SymbolTypeIndex {
     var documentContext = event.getSource();
     clear(documentContext.getUri());
     reindexDeclared(documentContext);
+  }
+
+  /**
+   * Пересобирает объявленные типы возвращаемых значений по всей рабочей области.
+   * <p>
+   * Имя типа в описании метода разрешается в момент разбора его документа, а до части
+   * модулей области очередь тогда ещё не дошла: такое имя никуда не ведёт, и объявленный
+   * тип выходит беднее написанного. Кому не повезло — решает порядок обхода файлов, то
+   * есть без пересборки результат от него и зависит. Теперь область наполнена, и все имена
+   * разрешаются одинаково.
+   * <p>
+   * Разбор документов для этого не нужен: объявленные типы читаются по дереву символов,
+   * которое переживает освобождение вторичных данных.
+   *
+   * @param event событие наполнения рабочей области.
+   */
+  // Раньше MethodReturnTypeIndexer: расчёт типов по телу читает объявленные типы вызванных
+  // методов, поэтому пересобрать их надо до него.
+  @Order(100)
+  @EventListener
+  public void handleServerContextPopulated(ServerContextPopulatedEvent event) {
+    event.getSource().getDocuments().values().forEach(this::reindexDeclared);
   }
 
   /**

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndexDeclaredTypesTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndexDeclaredTypesTest.java
@@ -1,0 +1,126 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.index;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.ServerContext;
+import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.context.events.ServerContextPopulatedEvent;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.languageserver.types.registry.FormByNameResolver;
+import com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Map;
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Объявленные типы возвращаемых значений собираются в момент разбора документа — когда
+ * часть рабочей области ещё не зарегистрирована, и написанное в описании метода имя
+ * разрешается не полностью. Проверяется, что такие типы пересобираются заново, как только
+ * рабочая область наполнена.
+ */
+@SpringBootTest
+class SymbolTypeIndexDeclaredTypesTest {
+
+  private static final String MODULE = """
+    // Возвращаемое значение:
+    //  Массив
+    //
+    Функция Значения() Экспорт
+     Возврат Новый Массив;
+    КонецФункции
+    """;
+
+  private static final TypeRef PLATFORM_ARRAY = new TypeRef(TypeKind.PLATFORM, "Массив");
+
+  private TypeRegistry typeRegistry;
+  private SymbolTypeIndex index;
+  private DocumentContext documentContext;
+
+  @BeforeEach
+  void prepare() {
+    typeRegistry = mock(TypeRegistry.class);
+    // Незнакомое реестру имя остаётся пользовательским типом — так же, как в бою.
+    when(typeRegistry.intern(TypeKind.USER, "Массив"))
+      .thenReturn(new TypeRef(TypeKind.USER, "Массив"));
+    when(typeRegistry.getDefaultElementTypes(any())).thenReturn(TypeSet.EMPTY);
+    index = new SymbolTypeIndex(typeRegistry, mock(FormByNameResolver.class));
+    documentContext = TestUtils.getDocumentContext(MODULE);
+  }
+
+  @Test
+  void declaredTypesAreRebuiltWhenWorkspaceIsPopulated() {
+    // given: документ разобран, когда имя типа реестру ещё неизвестно.
+    knownToRegistry(false);
+    index.handleEvent(new DocumentContextContentChangedEvent(documentContext));
+    assertThat(declaredTypeOfFirstMethod().refs()).containsExactly(new TypeRef(TypeKind.USER, "Массив"));
+
+    // when: рабочая область наполнена, и то же самое имя теперь разрешается.
+    knownToRegistry(true);
+    index.handleServerContextPopulated(new ServerContextPopulatedEvent(serverContextWithDocument()));
+
+    // then: объявленный тип пересобран по нынешнему состоянию реестра.
+    assertThat(declaredTypeOfFirstMethod().refs()).containsExactly(PLATFORM_ARRAY);
+  }
+
+  @Test
+  void rereadDocumentKeepsDeclaredTypes() {
+    // given: документ разобран при наполненной рабочей области.
+    knownToRegistry(true);
+    index.handleEvent(new DocumentContextContentChangedEvent(documentContext));
+
+    // when: тот же самый текст перечитан заново, а реестр вдруг «забыл» имя.
+    knownToRegistry(false);
+    index.handleEvent(new DocumentContextContentChangedEvent(documentContext, false));
+
+    // then: перечитывание ничего не пересчитывает, поэтому прежний тип остался на месте.
+    assertThat(declaredTypeOfFirstMethod().refs()).containsExactly(PLATFORM_ARRAY);
+  }
+
+  private void knownToRegistry(boolean known) {
+    when(typeRegistry.resolveSet(anyString())).thenReturn(TypeSet.EMPTY);
+    when(typeRegistry.resolve("Массив"))
+      .thenReturn(known ? Optional.of(PLATFORM_ARRAY) : Optional.empty());
+  }
+
+  private TypeSet declaredTypeOfFirstMethod() {
+    return index.getDeclaredReturnTypes(documentContext.getSymbolTree().getMethods().get(0));
+  }
+
+  private ServerContext serverContextWithDocument() {
+    var serverContext = mock(ServerContext.class);
+    when(serverContext.getDocuments()).thenReturn(Map.of(documentContext.getUri(), documentContext));
+    return serverContext;
+  }
+}


### PR DESCRIPTION
## Проблема

Имя типа в описании метода (`// Возвращаемое значение: см. Модуль.Метод`, имя типа конфигурации) разрешается в момент разбора **его** документа. Пока рабочая область наполняется, до части модулей очередь ещё не дошла — такое имя никуда не ведёт, и объявленный тип выходит беднее написанного.

Кому не повезло, решает порядок обхода файлов. То есть это прямая причина того, что результат анализа зависит от порядка: один и тот же код при повторном запуске даёт другой набор замечаний.

## Что сделано

По событию наполнения рабочей области объявленные типы пересобираются целиком — теперь все имена разрешаются при одинаковом состоянии реестра.

Разбор документов для этого не нужен: объявленные типы читаются по дереву символов, которое переживает освобождение вторичных данных. Слушатель идёт раньше `MethodReturnTypeIndexer` (`@Order(100)`): расчёт типов по телу читает объявленные типы вызванных методов, поэтому пересобрать их надо до него.

## Замеры на ssl_3_1

Пакетный анализ, репортер SARIF, `mode: only` с `UnknownMember` + `EventHandlerInvalidSignature`. Метрика — расхождение отсортированной подписи замечаний между прогонами **одной и той же сборки на одной и той же кодовой базе**; в идеале ноль.

Прогоны вперемежку, по три на сборку:

| | расхождения между прогонами |
|---|---|
| develop | 590 / 408 / 450 |
| ветка | **50 / 247 / 217** |

Отдельная серия по четыре прогона на сборку, там же считалось устойчивое ядро (замечания, встретившиеся во всех четырёх):

| | ядро | мерцающих | расхождения |
|---|---|---|---|
| develop | 29841 | 1101 | 757 / 544 / 292 / 903 |
| ветка | 30511 | **295** | **232 / 227 / 44 / 113** |

Мерцание втрое меньше, расхождения — вчетверо. Направление воспроизвелось в обеих сериях.

Замечаний становится больше (30200 → 30600): объявленные типы теперь разрешаются полнее, и диагностика судит там, где раньше молчала из-за невыведенного типа. Полнота выводимых наборов полей — отдельная задача, здесь она не решается.

По времени вывода нет: на моей машине результаты противоречивы (в одной серии разницы нет, в другой ветка на 9–23 секунды медленнее из ~75), а машина шумит — прогоны одной сборки давали от 35 до 98 секунд. Ориентируюсь на бенчмарк CI.

## Тесты

`SymbolTypeIndexDeclaredTypesTest`: документ разобран, когда имя типа реестру ещё неизвестно; после наполнения области объявленный тип пересобран по нынешнему состоянию реестра. Отдельно закреплено, что перечитывание того же текста объявленные типы не роняет.

## Связанные задачи

Часть работы по #4429.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved return-type resolution after workspace initialization.
  - Previously unresolved return types are now correctly recognized when platform types become available.
  - Existing resolved return types remain stable when documents are reread.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->