### PR TITLE
fix(types): сорвавшийся расчёт типа больше не молчит

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -161,6 +161,10 @@ public class ExpressionTypeInferencer {
     try {
       return inferInternal(expression, ctx);
     } catch (StackOverflowError | RuntimeException e) {
+      // Сорвавшийся расчёт отдаёт пустой тип — анализ из-за одного выражения падать не
+      // должен. Но молча это делать нельзя: снаружи пустой тип неотличим от честного
+      // «ничего не вывелось», и поломка выглядит как «типы просто не выводятся».
+      LOGGER.error("Вывод типа выражения сорвался: {}", documentContext.getUri(), e);
       return TypeSet.EMPTY;
     }
   }
@@ -904,6 +908,11 @@ public class ExpressionTypeInferencer {
       }
       return new MethodReturnTypeIndexer.ComputedReturnTypes(types, Set.copyOf(ctx.consulted), ctx.sawMissing);
     } catch (StackOverflowError | RuntimeException e) {
+      // Пустое значение метода сохранится как окончательное, и все его вызывающие останутся
+      // ни с чем. Без записи в журнал это выглядит как «у метода не выводится тип», а не
+      // как сорвавшийся расчёт, и найти причину можно только замером на живой конфигурации.
+      LOGGER.error("Расчёт значения метода {} сорвался: {}", method.getName(),
+        method.getOwner().getUri(), e);
       return new MethodReturnTypeIndexer.ComputedReturnTypes(TypeSet.EMPTY, Set.of(), false);
     }
   }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/DeclaredStructureFieldsTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/DeclaredStructureFieldsTest.java
@@ -65,9 +65,9 @@ class DeclaredStructureFieldsTest extends AbstractServerContextAwareTest {
       //   Структура - описание.
       //
       Функция Ф() Экспорт
-      \tР = Новый Структура;
-      \tР.Вставить("Первое", "");
-      \tВозврат Р;
+        Р = Новый Структура;
+        Р.Вставить("Первое", "");
+        Возврат Р;
       КонецФункции
       """);
     var method = documentContext.getSymbolTree().getMethodSymbol("Ф");
@@ -80,9 +80,9 @@ class DeclaredStructureFieldsTest extends AbstractServerContextAwareTest {
       //   Структура - описание.
       //
       Функция Ф() Экспорт
-      \tР = Новый Структура;
-      \tР.Вставить("Второе", "");
-      \tВозврат Р;
+        Р = Новый Структура;
+        Р.Вставить("Второе", "");
+        Возврат Р;
       КонецФункции
       """);
 
@@ -103,10 +103,10 @@ class DeclaredStructureFieldsTest extends AbstractServerContextAwareTest {
       //   Структура - узел дерева.
       //
       Функция Узел() Экспорт
-      \tР = Новый Структура;
-      \tР.Вставить("Имя", "");
-      \tР.Вставить("Вложенный", Узел());
-      \tВозврат Р;
+        Р = Новый Структура;
+        Р.Вставить("Имя", "");
+        Р.Вставить("Вложенный", Узел());
+        Возврат Р;
       КонецФункции
       """);
     var method = documentContext.getSymbolTree().getMethodSymbol("Узел");

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/InferenceFailureTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/InferenceFailureTest.java
@@ -1,0 +1,105 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.types.inferencer.CommonModuleByNameInference;
+import com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer;
+import com.github._1c_syntax.bsl.languageserver.types.inferencer.ReturnTypeFromBodyInference;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.bsl.languageserver.utils.expressiontree.ExpressionTreeBuildingVisitor;
+import com.github._1c_syntax.bsl.languageserver.utils.Trees;
+import com.github._1c_syntax.bsl.parser.BSLParser;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+import org.springframework.test.context.bean.override.mockito.MockitoBean;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.assertj.core.api.Assertions.assertThatCode;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.Mockito.when;
+
+/**
+ * Сорвавшийся расчёт не роняет анализ: он отдаёт пустой тип и оставляет запись в журнале.
+ * <p>
+ * Молчать здесь нельзя. Снаружи пустой тип неотличим от честного «ничего не вывелось»,
+ * поэтому поломка выглядит как «типы просто не выводятся» и обнаруживается только замером
+ * на большой конфигурации.
+ */
+@CleanupContextBeforeClassAndAfterClass
+class InferenceFailureTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private ExpressionTypeInferencer inferencer;
+
+  @MockitoBean
+  private ReturnTypeFromBodyInference returnTypeFromBodyInference;
+
+  @MockitoBean
+  private CommonModuleByNameInference commonModuleByNameInference;
+
+  @Test
+  void failedComputationOfMethodValueYieldsEmptyInsteadOfPropagating() {
+    // given: расчёт значения метода срывается.
+    when(returnTypeFromBodyInference.of(any(), any())).thenThrow(new IllegalStateException("сбой"));
+    var documentContext = TestUtils.getDocumentContext("""
+      Функция Ф() Экспорт
+        Возврат Новый Массив;
+      КонецФункции
+      """);
+    var method = documentContext.getSymbolTree().getMethodSymbol("Ф");
+    assertThat(method).isPresent();
+
+    // when, then: наружу срыв не выходит, значение выходит пустым.
+    assertThatCode(() -> {
+      var computed = inferencer.computeReturnTypes(method.get());
+      assertThat(computed.types().isEmpty()).isTrue();
+    }).doesNotThrowAnyException();
+  }
+
+  @Test
+  void failedInferenceOfExpressionYieldsEmptyInsteadOfPropagating() {
+    // given: срывается уточнение вызова — оно зовётся прямо из разбора выражения, поэтому
+    // срыв доходит до самого вывода, а не гасится расчётом значения метода по дороге.
+    when(commonModuleByNameInference.localCallTypes(any(), any()))
+      .thenThrow(new IllegalStateException("сбой"));
+    var documentContext = TestUtils.getDocumentContext("""
+      Процедура Проверка() Экспорт
+        Значение = Ф();
+      КонецПроцедуры
+      Функция Ф()
+        Возврат Новый Массив;
+      КонецФункции
+      """);
+    var assignment = Trees.findAllRuleNodes(documentContext.getAst(), BSLParser.RULE_assignment)
+      .stream().findFirst();
+    assertThat(assignment).isPresent();
+    var expression = ExpressionTreeBuildingVisitor.buildExpressionTree(
+      ((BSLParser.AssignmentContext) assignment.get()).expression());
+    assertThat(expression).isNotNull();
+
+    // when, then
+    assertThatCode(() -> assertThat(inferencer.infer(expression, documentContext).isEmpty()).isTrue())
+      .doesNotThrowAnyException();
+  }
+}


### PR DESCRIPTION
## Проблема

Расчёт типа перехватывает срыв в трёх местах и отдаёт пустой тип, чтобы анализ не падал из-за одного выражения. Писало в журнал только одно из трёх — расчёт по потоку. Вывод типа выражения и расчёт значения метода молчали.

Снаружи пустой тип неотличим от честного «ничего не вывелось». Поэтому поломка выглядит как «типы просто не выводятся», а не как ошибка: она проходит все тесты и обнаруживается только замером на большой конфигурации.

Сегодня это случилось дважды. В худшем случае прогон по ssl_3_1 давал **212 переполнений стека**, молча превращённых в пустые значения, — при том, что весь набор тестов был зелёным.

## Что сделано

Поведение прежнее: наружу срыв не выходит, тип пустой. Добавлена запись в журнал с именем метода и документом — ровно в том же стиле, что уже была у расчёта по потоку.

## Тесты

`InferenceFailureTest` закрепляет контракт с обеих сторон: срыв не пробивается наружу, а значение выходит пустым. Отдельно проверено, что оба обработчика при этом действительно исполняются — по записям в журнале теста, а не по одному лишь зелёному результату.

## Связанные задачи

Побочная находка из работы над #4429.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

- **Bug Fixes**
  - Improved resilience when expression type inference encounters unexpected failures or stack overflows.
  - The language server now continues operating and returns an empty result instead of propagating inference errors.
  - Added diagnostic logging to help identify affected documents, methods, and requests.

- **Tests**
  - Added coverage confirming inference failures are handled gracefully without interrupting processing.
  - Standardized formatting in embedded test examples.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->