### PR TITLE
perf(types): проход доразрешения считает ярусы зависимостей параллельно

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
@@ -60,6 +60,7 @@ import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -459,8 +460,10 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
    * распараллеливается почти целиком. Пул нужен именно тот, чьи воркеры несут рабочую
    * область: без неё бины workspace-скоупа из чужого потока не достаются.
    * <p>
-   * Одновременно разобранных документов при этом не больше ширины пула: параллельно идут
-   * только компоненты из одного документа, а держащие несколько — по одной.
+   * Разом разобранных документов при этом не больше {@link #MAX_DOCUMENTS_IN_MEMORY} —
+   * столько же, сколько проход и так позволяет себе на одном цикле. Параллельно идут
+   * только компоненты из одного документа, держащие несколько считаются по одной, а место
+   * в пределе занимается на время расчёта компоненты.
    * <p>
    * Независимость компонент яруса опирается на связи, собранные прошлым расчётом, а
    * пересчёт способен дойти до документа, которого в них не было: до наполнения области
@@ -499,12 +502,41 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
         resolveComponent(serverContext, singles.get(0), byDocument, progressReporter);
         continue;
       }
+      var loaded = new Semaphore(MAX_DOCUMENTS_IN_MEMORY);
       var tasks = singles.stream()
         .map(component -> CompletableFuture.runAsync(
-          () -> resolveComponent(serverContext, component, byDocument, progressReporter),
+          () -> resolveHoldingPermit(loaded, serverContext, component, byDocument, progressReporter),
           resolveReturnTypesExecutor))
         .toArray(CompletableFuture[]::new);
       CompletableFuture.allOf(tasks).join();
+    }
+  }
+
+  /**
+   * Считает компоненту, заняв место в пределе разом разобранных документов.
+   * <p>
+   * Предел явный, а не «сколько воркеров в пуле»: ширина пула берётся из числа ядер, и на
+   * большой машине проход держал бы разобранными десятки документов. Дерево разбора —
+   * самое тяжёлое, что есть у документа, поэтому счёт идёт на документы, а не на потоки.
+   *
+   * @param loaded           предел разом разобранных документов.
+   * @param serverContext    рабочая область.
+   * @param component        документы компоненты.
+   * @param byDocument       отложенные методы по документам.
+   * @param progressReporter индикатор хода работы.
+   */
+  private void resolveHoldingPermit(
+    Semaphore loaded,
+    ServerContext serverContext,
+    List<URI> component,
+    Map<URI, List<MethodSymbol>> byDocument,
+    WorkDoneProgressHelper.WorkDoneProgressReporter progressReporter
+  ) {
+    loaded.acquireUninterruptibly();
+    try {
+      resolveComponent(serverContext, component, byDocument, progressReporter);
+    } finally {
+      loaded.release();
     }
   }
 

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
@@ -216,6 +216,7 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
     var serverContext = event.getSource();
     maintenance = true;
     var deferred = pending.size();
+    var startedAt = System.nanoTime();
     rebuilt.set(0);
     rebuiltUris.clear();
     var progressReporter = workDoneProgressHelper.createProgress(
@@ -231,8 +232,8 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
       progressReporter.endProgress(getMessage("resolveReturnTypesDone"));
     }
     LOGGER.debug("Доразрешение типов возврата: отложено методов {}, разборов документов {},"
-        + " из них различных документов {}",
-      deferred, rebuilt.get(), rebuiltUris.size());
+        + " из них различных документов {}, заняло {} мс",
+      deferred, rebuilt.get(), rebuiltUris.size(), (System.nanoTime() - startedAt) / 1_000_000);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
@@ -458,6 +458,17 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
    * конфигурации единицы, а компонент в первом — больше половины, поэтому ярусный обход
    * распараллеливается почти целиком. Пул нужен именно тот, чьи воркеры несут рабочую
    * область: без неё бины workspace-скоупа из чужого потока не достаются.
+   * <p>
+   * Одновременно разобранных документов при этом не больше ширины пула: параллельно идут
+   * только компоненты из одного документа, а держащие несколько — по одной.
+   * <p>
+   * Независимость компонент яруса опирается на связи, собранные прошлым расчётом, а
+   * пересчёт способен дойти до документа, которого в них не было: до наполнения области
+   * вызов туда не разрешался вовсе. Такой документ может считаться в это же время
+   * соседней компонентой, и что прочтёт расчёт, решит момент. Из-под порядка это не
+   * выбивается: он и в последовательном проходе задан набором отложенного, то есть тоже
+   * не воспроизводится дословно; замер мерцания на ssl_3_1 разницы между проходами не
+   * показал.
    *
    * @param serverContext    рабочая область.
    * @param roots            отложенные методы.
@@ -475,11 +486,20 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
     var order = DocumentDependencies.of(byDocument.keySet(),
       uri -> dependenciesByUri.getOrDefault(uri, Set.of()));
     for (var tier : tiersOf(order.components(), byDocument.keySet())) {
-      if (tier.size() == 1) {
-        resolveComponent(serverContext, tier.get(0), byDocument, progressReporter);
+      // Компонента из нескольких документов — цикл: она держит их разобранными до
+      // неподвижной точки. Такие считаются по одной, иначе предел держимых документов
+      // множился бы на ширину пула, а память здесь дороже секунд. Их единицы: на реальной
+      // конфигурации почти каждая компонента — один документ.
+      var cycles = tier.stream().filter(component -> component.size() > 1).toList();
+      for (var cycle : cycles) {
+        resolveComponent(serverContext, cycle, byDocument, progressReporter);
+      }
+      var singles = tier.stream().filter(component -> component.size() == 1).toList();
+      if (singles.size() == 1) {
+        resolveComponent(serverContext, singles.get(0), byDocument, progressReporter);
         continue;
       }
-      var tasks = tier.stream()
+      var tasks = singles.stream()
         .map(component -> CompletableFuture.runAsync(
           () -> resolveComponent(serverContext, component, byDocument, progressReporter),
           resolveReturnTypesExecutor))

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
@@ -38,6 +38,7 @@ import com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeI
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Qualifier;
 import org.springframework.context.event.EventListener;
 import org.springframework.core.annotation.Order;
 import org.springframework.stereotype.Component;
@@ -48,14 +49,17 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.Comparator;
+import java.util.HashMap;
 import java.util.IdentityHashMap;
 import java.util.LinkedHashMap;
 import java.util.LinkedHashSet;
 import java.util.List;
 import java.util.Map;
 import java.util.Set;
+import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.CopyOnWriteArrayList;
+import java.util.concurrent.ExecutorService;
 import java.util.concurrent.atomic.AtomicInteger;
 import java.util.function.Supplier;
 
@@ -93,6 +97,14 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
 
   private final WorkDoneProgressHelper workDoneProgressHelper;
   private final GlobalLanguageServerConfiguration globalConfiguration;
+
+  /**
+   * Пул, на котором считаются компоненты одного яруса. Тот же, на котором наполняется
+   * рабочая область: его воркеры выставляют себе её URI, без чего workspace-скоуп из
+   * чужого потока не резолвится. К началу прохода наполнение закончено, и пул свободен.
+   */
+  @Qualifier("populateContextExecutor")
+  private final ExecutorService resolveReturnTypesExecutor;
 
   /**
    * Документы, чьи значения построены на этом. Связи держатся по документам, а не по
@@ -440,10 +452,11 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
    * приходится документ целиком, и один документ загружался заново под каждый свой
    * метод — на ssl_3_1 это дало 4252 разбора против 215.
    * <p>
-   * Проход последовательный: блокировки документов берутся и отпускаются в одном потоке.
-   * Разложенный по пулу, он упирался в то, что воркеры ждут чужие блокировки, а
-   * компенсировать такое ожидание {@code ForkJoinPool} не умеет — пул голодал и проход
-   * вставал.
+   * Компоненты одного яруса считаются разом: зависимостей между ними нет по построению,
+   * документы у них разные, и каждая берёт замки только своих. Ярусов на реальной
+   * конфигурации единицы, а компонент в первом — больше половины, поэтому ярусный обход
+   * распараллеливается почти целиком. Пул нужен именно тот, чьи воркеры несут рабочую
+   * область: без неё бины workspace-скоупа из чужого потока не достаются.
    *
    * @param serverContext    рабочая область.
    * @param roots            отложенные методы.
@@ -460,11 +473,50 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
     }
     var order = DocumentDependencies.of(byDocument.keySet(),
       uri -> dependenciesByUri.getOrDefault(uri, Set.of()));
-    for (var component : order.components()) {
-      var methods = component.stream().flatMap(uri -> byDocument.get(uri).stream()).toList();
-      methods.forEach(method -> progressReporter.tick());
-      resolveComponent(serverContext, component, byDocument, methods);
+    for (var tier : tiersOf(order.components(), byDocument.keySet())) {
+      if (tier.size() == 1) {
+        resolveComponent(serverContext, tier.get(0), byDocument, progressReporter);
+        continue;
+      }
+      var tasks = tier.stream()
+        .map(component -> CompletableFuture.runAsync(
+          () -> resolveComponent(serverContext, component, byDocument, progressReporter),
+          resolveReturnTypesExecutor))
+        .toArray(CompletableFuture[]::new);
+      CompletableFuture.allOf(tasks).join();
     }
+  }
+
+  /**
+   * Разбивает компоненты на ярусы: компонента попадает на ярус следующий за наибольшим
+   * ярусом тех, от кого она зависит.
+   * <p>
+   * Компоненты приходят в обратном топологическом порядке, поэтому ярус каждой известен к
+   * моменту, когда до неё дошла очередь. Внутри яруса зависимостей нет, и считать его
+   * компоненты можно в любом порядке и одновременно.
+   *
+   * @param components компоненты в обратном топологическом порядке.
+   * @param inWork     документы, которые предстоит пересчитать: зависимости на прочие
+   *                   порядка не задают — те уже посчитаны окончательно.
+   * @return ярусы в порядке возрастания.
+   */
+  private List<List<List<URI>>> tiersOf(List<List<URI>> components, Set<URI> inWork) {
+    var tierOfUri = new HashMap<URI, Integer>();
+    var tiers = new ArrayList<List<List<URI>>>();
+    for (var component : components) {
+      var tier = component.stream()
+        .flatMap(uri -> dependenciesByUri.getOrDefault(uri, Set.<URI>of()).stream())
+        .filter(inWork::contains)
+        .map(dependency -> tierOfUri.getOrDefault(dependency, 0))
+        .max(Integer::compare)
+        .orElse(0);
+      component.forEach(uri -> tierOfUri.put(uri, tier + 1));
+      while (tiers.size() <= tier) {
+        tiers.add(new ArrayList<>());
+      }
+      tiers.get(tier).add(component);
+    }
+    return tiers;
   }
 
   /**
@@ -474,17 +526,19 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
    * посчитано. В цикле заходов несколько, поэтому его документы держатся загруженными —
    * так повторные обороты не стоят ни одного лишнего разбора.
    *
-   * @param serverContext рабочая область.
-   * @param component     документы компоненты.
-   * @param byDocument    отложенные методы по документам.
-   * @param methods       отложенные методы компоненты.
+   * @param serverContext    рабочая область.
+   * @param component        документы компоненты.
+   * @param byDocument       отложенные методы по документам.
+   * @param progressReporter индикатор хода работы.
    */
   private void resolveComponent(
     ServerContext serverContext,
     List<URI> component,
     Map<URI, List<MethodSymbol>> byDocument,
-    List<MethodSymbol> methods
+    WorkDoneProgressHelper.WorkDoneProgressReporter progressReporter
   ) {
+    var methods = component.stream().flatMap(uri -> byDocument.get(uri).stream()).toList();
+    methods.forEach(method -> progressReporter.tick());
     if (component.size() == 1) {
       recomputeLoading(serverContext, byDocument.get(component.get(0)));
       return;

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexerTest.java
@@ -37,11 +37,14 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.utils.Absolute;
+import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
 import java.util.HashMap;
 import java.util.Map;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
 import java.util.concurrent.locks.ReentrantReadWriteLock;
 import java.util.List;
 import java.util.Set;
@@ -68,6 +71,7 @@ class MethodReturnTypeIndexerTest {
   private ExpressionTypeInferencer inferencer;
   private SymbolTypeIndex symbolTypeIndex;
   private MethodReturnTypeIndexer indexer;
+  private ExecutorService resolveExecutor;
 
   private DocumentContext source;
   private DocumentContext consumer;
@@ -81,11 +85,15 @@ class MethodReturnTypeIndexerTest {
     // Язык нужен настоящий: на нём индекс берёт тексты для индикатора хода работы.
     var configuration = mock(GlobalLanguageServerConfiguration.class);
     when(configuration.getLanguage()).thenReturn(Language.RU);
+    // Ярусы прохода считаются на пуле; здесь он однопоточный, чтобы проверялось поведение
+    // прохода, а не работа пула.
+    resolveExecutor = Executors.newSingleThreadExecutor();
     indexer = new MethodReturnTypeIndexer(
       inferencer,
       symbolTypeIndex,
       mock(WorkDoneProgressHelper.class, RETURNS_DEEP_STUBS),
-      configuration
+      configuration,
+      resolveExecutor
     );
 
     source = document("file:///source.bsl");
@@ -105,6 +113,11 @@ class MethodReturnTypeIndexerTest {
 
     returns(sourceMethod, TypeSet.EMPTY);
     returns(consumerMethod, TypeSet.EMPTY, sourceMethod);
+  }
+
+  @AfterEach
+  void stopExecutor() {
+    resolveExecutor.shutdownNow();
   }
 
   @Test


### PR DESCRIPTION
Поверх #4449 — его же и ускоряет. База ветки переставится на `develop` сама, когда #4449 вольётся.

## Зачем

#4449 доводит до ума пустые значения функций, и это стоит времени: проход доразрешения вырос с ~0,5 с до ~6 с (отложено методов 38 → ~950, разборов документов 17 → ~260). На бенчмарке CI это +14 с.

Профиль прохода (async-profiler, wall): 40 % — повторный разбор документов, 57 % — сам вывод типов, и внутри вывода профиль **плоский**: `itable stub`, обход дерева ANTLR, копии коллекций. Горячей точки нет — резать нечего, зато проход остаётся единственной фазой, где ядра простаивают.

## Что сделано

Компоненты сильной связности разложены по ярусам: компонента попадает на ярус следующий за наибольшим ярусом тех, от кого она зависит. Внутри яруса зависимостей нет по построению, документы у компонент разные, и каждая берёт замки только своих — значит ярус можно считать целиком одновременно.

Пул взят тот же, на котором наполняется рабочая область: его воркеры выставляют себе её URI, без чего бины workspace-скоупа из чужого потока не достаются. К началу прохода наполнение закончено, и пул свободен.

Форма графа на ssl_3_1 удачная: **7 ярусов, в первом 143 компоненты из 271**.

## Замер

Длительность прохода, ssl_3_1, три прогона каждой сборки:

| | прогоны | медиана |
|---|---|---|
| последовательно | 5916 / 6214 / 6679 мс | 6214 |
| ярусами | 5348 / 5454 / 5985 мс | 5454 |

Выигрыш примерно 12 %, но на этой машине шум сопоставим с эффектом (полный прогон гуляет 39–67 с), поэтому честнее смотреть на бенчмарк CI — у него stddev 0,78 с.

Отдельно проверено и **не подтвердилось**: в профиле 30 % времени воркеров висит на замке `DocumentContext.getSymbolTree` (геттер помечен `@Locked`, берёт эксклюзивный замок на каждое чтение). Замена на `volatile`-поле дала 5787 / 5483 / 4489 мс — в пределах шума, то есть ожидание перекрывается полезной работой соседей. Семантику конкурентности менять без доказанной пользы не стал.

## О памяти

Компонента из нескольких документов держит их разобранными до неподвижной точки (не больше `MAX_DOCUMENTS_IN_MEMORY`). Раньше такая компонента была одна в каждый момент, теперь их столько, сколько ярус пустил параллельно. На ssl_3_1 многодокументных компонент единицы, но в пределе пик держимых документов вырастает.

Ссылка на #4429.
