### PR TITLE
fix(types): опиравшийся на отложенное значение пересчитывается тоже

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
@@ -359,6 +359,14 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
    */
   private boolean store(MethodSymbol method, ComputedReturnTypes computed) {
     link(method, computed.consulted());
+    if (!maintenance && computed.consulted().stream().anyMatch(pending::contains)) {
+      // Расчёт опирался на значение, которое само ждёт пересчёта: вызванный метод посчитан,
+      // но предварительно. Когда проход доведёт его до полного, вызывающему понадобится
+      // пересчёт — иначе он навсегда останется с предварительным, а каким оно вышло, решает
+      // порядок наполнения. Шаг один, без обхода потребителей по цепочке: цепочку проход
+      // разматывает сам, волна за волной.
+      pending.add(method);
+    }
     if (!maintenance && computed.types().isEmpty()) {
       // Пустое значение функции, посчитанное при наполнении области, значит «неизвестно»
       // чаще, чем «ничего не возвращает»: вызов в модуль, до которого очередь ещё не

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexerTest.java
@@ -270,10 +270,10 @@ class MethodReturnTypeIndexerTest {
   }
 
   /**
-   * Рабочая область, в которой живёт документ: блокировки настоящие, состояние документа
+   * Рабочая область, в которой живут документы: блокировки настоящие, состояние документа
    * спрашивается у неё же.
    *
-   * @param documentContext документ.
+   * @param documentContexts документы рабочей области.
    * @return рабочая область.
    */
   private static ServerContext serverContextOf(DocumentContext... documentContexts) {

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexerTest.java
@@ -41,6 +41,7 @@ import org.junit.jupiter.api.AfterEach;
 import org.junit.jupiter.api.BeforeEach;
 import org.junit.jupiter.api.Test;
 
+import java.net.URI;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.concurrent.ExecutorService;
@@ -202,6 +203,26 @@ class MethodReturnTypeIndexerTest {
   }
 
   @Test
+  void consumerOfDeferredMethodIsRecomputedToo() {
+    // given: значение источника вышло неполным и отложено, а значение потребителя посчитано
+    // на нём — то есть на значении, которое само ещё ждёт пересчёта. Сам потребитель
+    // неполным не считается: вызванный метод посчитан, просто посчитан предварительно.
+    indexer.computeIfAbsent(sourceMethod, () -> new ComputedReturnTypes(TypeSet.EMPTY, Set.of(), true));
+    indexer.computeIfAbsent(consumerMethod,
+      () -> new ComputedReturnTypes(STRING, Set.of(sourceMethod), false));
+    returns(sourceMethod, NUMBER);
+    when(inferencer.computeReturnTypes(consumerMethod)).thenAnswer(invocation ->
+      new ComputedReturnTypes(symbolTypeIndex.getReturnTypes(sourceMethod), Set.of(sourceMethod), false));
+
+    // when: рабочая область наполнена.
+    indexer.handleServerContextPopulated(new ServerContextPopulatedEvent(serverContextOf(source, consumer)));
+
+    // then: потребитель пересчитан по доразрешённому значению источника. Иначе он навсегда
+    // остался бы с предварительным, а каким оно вышло, решает порядок наполнения.
+    assertThat(symbolTypeIndex.getReturnTypes(consumerMethod)).isEqualTo(NUMBER);
+  }
+
+  @Test
   void releasedDocumentIsLoadedForRecomputeAndReleasedBack() {
     // given: отложенный метод лежит в документе, вторичные данные которого уже освобождены.
     returns(consumerMethod, TypeSet.EMPTY, sourceMethod);
@@ -255,11 +276,16 @@ class MethodReturnTypeIndexerTest {
    * @param documentContext документ.
    * @return рабочая область.
    */
-  private static ServerContext serverContextOf(DocumentContext documentContext) {
-    var serverContext = documentContext.getServerContext();
-    var documents = Map.of(documentContext.getUri(), documentContext);
+  private static ServerContext serverContextOf(DocumentContext... documentContexts) {
+    var serverContext = documentContexts[0].getServerContext();
+    var documents = new HashMap<URI, DocumentContext>();
+    for (var documentContext : documentContexts) {
+      documents.put(documentContext.getUri(), documentContext);
+      when(documentContext.getServerContext()).thenReturn(serverContext);
+      when(serverContext.getDocumentState(documentContext)).thenReturn(DocumentState.WITH_CONTENT);
+    }
     when(serverContext.getDocumentLock(any())).thenReturn(new ReentrantReadWriteLock());
-    when(serverContext.getDocuments()).thenReturn(documents);
+    when(serverContext.getDocuments()).thenReturn(Map.copyOf(documents));
     return serverContext;
   }
 


### PR DESCRIPTION
Ссылка на #4429. Продолжение #4449.

## Причина

#4449 научил проход доводить до полного значение метода, чей расчёт видел непосчитанное. Но тот, кто на этом значении построен, отложенным не считался: вызванный метод к тому моменту **посчитан** — просто посчитан предварительно, по неполной ещё области. Такой вызывающий навсегда оставался с предварительным значением.

Каким оно вышло, решает порядок параллельного наполнения — то есть от запуска к запуску по-разному.

Замерено дампом содержимого индекса после наполнения (6146 методов, три прогона на develop): расходится 211–231 строка, и **самый крупный класс расхождений — «один прогон знает строго больше»**: 52 метода из 79 обоюдно непустых. Ровно этот класс правка и закрывает.

## Правка

Метод откладывается и тогда, когда его расчёт опирался на уже отложенное значение. Шаг один, без обхода потребителей по цепочке: цепочку проход разматывает сам, волна за волной.

## Замер

ssl_3_1, конфиг только с диагностиками системы типов:

| | develop | PR |
|---|---|---|
| мерцающих строк (4 прогона) | 143 | **92** |
| расхождения между парами прогонов | 19–118 | **40–61** |
| расхождение содержимого индекса (3 прогона) | 211–231 | **125–196** |
| проход доразрешения | 5,5–6,8 с | 3,3–5,2 с |
| разборов документов в проходе | 271 | 280–293 |
| замечаний | 28905–28927 | 28887–28935 |

Цены нет: отложенных методов стало ~1200 против ~960, но документов почти столько же, а время прохода в пределах разброса.

## Что отвергнуто замером по дороге

- **Полный рабочий список** (изменилось значение → в очередь все методы документов-потребителей, каскадом): расхождение индекса 117–217, но проход **21–24 с** вместо шести, разборов документов 1071–1327 вместо 260, и замечаний на 400 меньше. Тот же выигрыш достигается одним шагом и бесплатно.
- **Монотонное накопление в проходе** (значение копится, а не замещается): расхождение 178–271 против 211–231 — в пределах разброса, пользы нет.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved method analysis recalculation so dependent results are updated after required information is finalized.
  * Preserved existing handling for empty or incomplete calculations.
  * Improved consistency of analysis results when dependencies are recalculated in sequence.

* **Tests**
  * Added coverage for recalculating dependent method return types after workspace population.
  * Expanded test scenarios to support multiple documents and shared analysis contexts.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->