### PR TITLE
fix(types): обращение в ещё не разобранный общий модуль больше не застывает пустым

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -709,12 +709,15 @@ public class ExpressionTypeInferencer {
       // совпадает с element-ref'ом коллекции.
       var elementSet = leftTypes.getElementTypes(leftType);
       var members = typeRegistry.getMembers(leftType, ctx.documentContext.getFileType());
-      // Тип конфигурационного модуля без единого члена — модуль, чей файл ещё не разобран:
-      // сами по себе типы объявлены заранее, а члены приходят с разбором. Пока области
-      // наполняются, до части модулей очередь не дошла, и обращение в такой модуль
-      // отвечает пустотой, ничем не отличимой от честной. Расчёт придётся повторить.
+      // Тип конфигурации, у которого нет ни одного члена из самой конфигурации, — модуль,
+      // чей файл ещё не разобран: типы объявлены заранее, а члены приносит разбор.
+      // Платформенные члены (у общего модуля это ЭтотОбъект) не в счёт: они приходят из
+      // синтакс-помощника и о разборе ничего не говорят — потому и различаются по
+      // standardLibrary. Пока область наполняется, обращение в такой модуль отвечает
+      // пустотой, ничем не отличимой от честной; расчёт придётся повторить.
       unparsedModule = unparsedModule
-        || (leftType.kind() == TypeKind.CONFIGURATION && members.isEmpty());
+        || (leftType.kind() == TypeKind.CONFIGURATION
+        && members.stream().allMatch(MemberDescriptor::standardLibrary));
       for (var member : members) {
         result = result.union(typesOfMember(member, memberName, expectedKind, elementSet, ctx));
       }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -628,6 +628,47 @@ public class ExpressionTypeInferencer {
     return result;
   }
 
+  /**
+   * Типы, которые даёт один член получателя, если он тот самый.
+   *
+   * @param member       член типа-получателя.
+   * @param memberName   имя, которое ищется.
+   * @param expectedKind вид: метод или свойство.
+   * @param elementSet   элементы получателя — их поля прокидываются на строку, возвращённую
+   *                     методами вида {@code Добавить}/{@code Получить}.
+   * @param ctx          контекст расчёта.
+   * @return типы члена; {@link TypeSet#EMPTY}, если член не тот.
+   */
+  private TypeSet typesOfMember(MemberDescriptor member, String memberName, MemberKind expectedKind,
+                                TypeSet elementSet, InferenceContext ctx) {
+    if (member.kind() != expectedKind || !member.matches(memberName)) {
+      return TypeSet.EMPTY;
+    }
+    // Для метода проектного модуля (в т.ч. вызванного межмодульно как
+    // ОбщийМодуль.Метод()) берём полный тип возврата из индекса символов —
+    // с localFields структуры/ТЗ, объявленными в JsDoc. MemberDescriptor
+    // несёт лишь головной ref, поэтому без этого поля структуры терялись.
+    if (expectedKind == MemberKind.METHOD) {
+      var symbolReturn = member.getSourceSymbol()
+        .filter(MethodSymbol.class::isInstance)
+        .map(MethodSymbol.class::cast)
+        .map(sourceMethod -> methodReturnType(sourceMethod, ctx))
+        .filter(returned -> !returned.isEmpty());
+      if (symbolReturn.isPresent()) {
+        return symbolReturn.get();
+      }
+    }
+    // Возможные типы члена (union); UNKNOWN-ref'ы отбрасываем.
+    var result = TypeSet.EMPTY;
+    for (var ref : member.returnTypes().refs()) {
+      if (ref != null && ref.kind() != TypeKind.UNKNOWN) {
+        var returned = enrichReturnRefWithElementFields(ref, elementSet);
+        result = result.union(carryDeclaredDecorations(member.returnTypes(), ref, returned));
+      }
+    }
+    return result;
+  }
+
   private TypeSet inferDereference(BinaryOperationNode node, InferenceContext ctx) {
     var leftTypes = inferInternal(node.getLeft(), ctx);
     if (leftTypes.isEmpty()) {
@@ -675,34 +716,7 @@ public class ExpressionTypeInferencer {
       unparsedModule = unparsedModule
         || (leftType.kind() == TypeKind.CONFIGURATION && members.isEmpty());
       for (var member : members) {
-        if (member.kind() != expectedKind) {
-          continue;
-        }
-        if (!member.matches(memberName)) {
-          continue;
-        }
-        // Для метода проектного модуля (в т.ч. вызванного межмодульно как
-        // ОбщийМодуль.Метод()) берём полный тип возврата из индекса символов —
-        // с localFields структуры/ТЗ, объявленными в JsDoc. MemberDescriptor
-        // несёт лишь головной ref, поэтому без этого поля структуры терялись.
-        if (expectedKind == MemberKind.METHOD) {
-          var symbolReturn = member.getSourceSymbol()
-            .filter(MethodSymbol.class::isInstance)
-            .map(MethodSymbol.class::cast)
-            .map(sourceMethod -> methodReturnType(sourceMethod, ctx))
-            .filter(returned -> !returned.isEmpty());
-          if (symbolReturn.isPresent()) {
-            result = result.union(symbolReturn.get());
-            continue;
-          }
-        }
-        // Возможные типы члена (union); UNKNOWN-ref'ы отбрасываем.
-        for (var ref : member.returnTypes().refs()) {
-          if (ref != null && ref.kind() != TypeKind.UNKNOWN) {
-            var returned = enrichReturnRefWithElementFields(ref, elementSet);
-            result = result.union(carryDeclaredDecorations(member.returnTypes(), ref, returned));
-          }
-        }
+        result = result.union(typesOfMember(member, memberName, expectedKind, elementSet, ctx));
       }
     }
     if (result.isEmpty() && unparsedModule) {

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -660,13 +660,21 @@ public class ExpressionTypeInferencer {
       }
     }
     TypeSet result = TypeSet.EMPTY;
+    var unparsedModule = false;
     for (var leftType : leftTypes.refs()) {
       // Колонки/поля, накопленные на elementTypes левого типа (например, ТЗ с
       // Колонки.Добавить("X")) должны прокидываться на строку, возвращённую
       // методами вида .Добавить()/.Получить()/.Вставить(), у которых return-тип
       // совпадает с element-ref'ом коллекции.
       var elementSet = leftTypes.getElementTypes(leftType);
-      for (var member : typeRegistry.getMembers(leftType, ctx.documentContext.getFileType())) {
+      var members = typeRegistry.getMembers(leftType, ctx.documentContext.getFileType());
+      // Тип конфигурационного модуля без единого члена — модуль, чей файл ещё не разобран:
+      // сами по себе типы объявлены заранее, а члены приходят с разбором. Пока области
+      // наполняются, до части модулей очередь не дошла, и обращение в такой модуль
+      // отвечает пустотой, ничем не отличимой от честной. Расчёт придётся повторить.
+      unparsedModule = unparsedModule
+        || (leftType.kind() == TypeKind.CONFIGURATION && members.isEmpty());
+      for (var member : members) {
         if (member.kind() != expectedKind) {
           continue;
         }
@@ -696,6 +704,9 @@ public class ExpressionTypeInferencer {
           }
         }
       }
+    }
+    if (result.isEmpty() && unparsedModule) {
+      ctx.sawMissing = true;
     }
     return attachDefaultElementTypes(result);
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
@@ -36,6 +36,7 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
 import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
 import com.github._1c_syntax.bsl.mdo.Form;
 import com.github._1c_syntax.bsl.mdo.MD;
+import com.github._1c_syntax.bsl.types.MDOType;
 import com.github._1c_syntax.bsl.types.ModuleType;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
@@ -108,6 +109,30 @@ public class ConfigurationModuleMembersProvider {
   public void handleEvent(DocumentContextContentChangedEvent event) {
     var documentContext = event.getSource();
     register(documentContext);
+  }
+
+  /**
+   * Объявляет тип общего модуля, не дожидаясь разбора его файла.
+   * <p>
+   * Имя общего модуля известно из метаданных, а разбор нужен только его членам. Без этого
+   * объявления имя модуля до разбора его файла не разрешается ни во что: обращение
+   * {@code ОбщийМодуль.Метод()} из чужого документа не находит даже получателя, тип
+   * результата выходит пустым — и сообщить о пропуске некому, потому что и метода-то не
+   * нашлось. Документы разбираются параллельно, поэтому кому не повезло, решает порядок,
+   * разный от запуска к запуску.
+   * <p>
+   * Члены остаются за разбором: здесь объявляется только сам тип и его видимость как
+   * глобального имени. Символ-источник для навигации доложит {@link #register}, когда
+   * дойдёт очередь до файла модуля.
+   *
+   * @param mdObject объект метаданных общего модуля.
+   */
+  public void declareCommonModuleType(MD mdObject) {
+    var name = mdObject.getName();
+    if (name == null || name.isBlank()) {
+      return;
+    }
+    typeRegistry.registerGlobalPropertyType(typeRegistry.registerConfigurationType(name), FileType.BSL);
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationModuleMembersProvider.java
@@ -129,7 +129,7 @@ public class ConfigurationModuleMembersProvider {
    */
   public void declareCommonModuleType(MD mdObject) {
     var name = mdObject.getName();
-    if (name == null || name.isBlank()) {
+    if (name.isBlank()) {
       return;
     }
     typeRegistry.registerGlobalPropertyType(typeRegistry.registerConfigurationType(name), FileType.BSL);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -268,12 +268,6 @@ public class ConfigurationTypesProvider {
     recorderIndex.index(children);
     int count = 0;
     for (var md : children) {
-      if (md.getMdoType() == MDOType.COMMON_MODULE) {
-        // Имя общего модуля известно уже здесь, а разбор его файла нужен только членам.
-        // Объявляем тип сразу: иначе обращение в модуль из документа, разобранного раньше
-        // него, не находит даже получателя.
-        moduleMembersProvider.declareCommonModuleType(md);
-      }
       if (processMdoChild(md, commonAttributes, collectionMembersByType)) {
         count++;
       }
@@ -336,6 +330,13 @@ public class ConfigurationTypesProvider {
       return false;
     }
     var mdoType = md.getMdoType();
+    if (mdoType == MDOType.COMMON_MODULE) {
+      // Имя общего модуля известно уже здесь, а разбор его файла нужен только членам.
+      // Тип объявляется сразу: иначе обращение в модуль из документа, разобранного раньше
+      // него, не находит даже получателя.
+      moduleMembersProvider.declareCommonModuleType(md);
+      return false;
+    }
     if (!MANAGER_TYPES.contains(mdoType)) {
       return false;
     }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProvider.java
@@ -185,6 +185,7 @@ public class ConfigurationTypesProvider {
   private final CatalogOwnerTypesRegistrar catalogOwnerTypes;
   private final ServiceModuleEventRegistrar serviceModuleEventRegistrar;
   private final FormTypesProvider formTypesProvider;
+  private final ConfigurationModuleMembersProvider moduleMembersProvider;
   private final XdtoTypesProvider xdtoTypesProvider;
   private final FormDataTypesRegistrar formDataTypesRegistrar;
   private final RegisterTypesRegistrar registerTypesRegistrar;
@@ -267,6 +268,12 @@ public class ConfigurationTypesProvider {
     recorderIndex.index(children);
     int count = 0;
     for (var md : children) {
+      if (md.getMdoType() == MDOType.COMMON_MODULE) {
+        // Имя общего модуля известно уже здесь, а разбор его файла нужен только членам.
+        // Объявляем тип сразу: иначе обращение в модуль из документа, разобранного раньше
+        // него, не находит даже получателя.
+        moduleMembersProvider.declareCommonModuleType(md);
+      }
       if (processMdoChild(md, commonAttributes, collectionMembersByType)) {
         count++;
       }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/UnparsedModuleCallTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/UnparsedModuleCallTest.java
@@ -1,0 +1,77 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.types.inferencer.ExpressionTypeInferencer;
+import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterClass;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import com.github._1c_syntax.utils.Absolute;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Path;
+
+import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Обращение в общий модуль, файл которого ещё не разобран.
+ * <p>
+ * Документы разбираются параллельно, поэтому вызов может встретиться раньше, чем разобран
+ * вызываемый модуль. Тип модуля к этому моменту объявлен по метаданным, но членов у него
+ * ещё нет, и результат вызова выходит пустым. Пустота эта временная, и расчёт обязан
+ * сообщить о ней — иначе он застынет с ней навсегда, а повезло ему или нет, будет решать
+ * порядок наполнения.
+ */
+@CleanupContextBeforeClassAndAfterClass
+class UnparsedModuleCallTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private ExpressionTypeInferencer inferencer;
+
+  @Test
+  void callIntoUnparsedModuleReportsIncompleteness() {
+    // given: рабочая область добавлена, но её документы не разобраны.
+    initServerContext(Path.of(PATH_TO_METADATA), false);
+    var documentContext = TestUtils.getDocumentContext(
+      Absolute.uri(Path.of(PATH_TO_METADATA, "Ext", "Вызывающий.bsl").toUri()),
+      """
+        Функция Значение() Экспорт
+        	Возврат ОбщегоНазначения.НекийМетод();
+        КонецФункции
+        """,
+      context);
+    var method = documentContext.getSymbolTree().getMethods().get(0);
+
+    // when
+    var computed = inferencer.computeReturnTypes(method);
+
+    // then: значение пустое, и расчёт это признаёт неполнотой.
+    assertThat(computed.types().isEmpty())
+      .as("членов у неразобранного модуля ещё нет, поэтому значение вызова пусто")
+      .isTrue();
+    assertThat(computed.incomplete())
+      .as("расчёт сообщает о неполноте, чтобы проход пересчитал его после наполнения")
+      .isTrue();
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/CommonModuleTypesDeclaredBeforeParseTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/CommonModuleTypesDeclaredBeforeParseTest.java
@@ -1,0 +1,62 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.registry;
+
+import com.github._1c_syntax.bsl.languageserver.context.AbstractServerContextAwareTest;
+import com.github._1c_syntax.bsl.languageserver.context.FileType;
+import org.junit.jupiter.api.Test;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.nio.file.Path;
+
+import static com.github._1c_syntax.bsl.languageserver.util.TestUtils.PATH_TO_METADATA;
+import static org.assertj.core.api.Assertions.assertThat;
+
+/**
+ * Имя общего модуля известно из метаданных, а разбор его файла нужен только членам. Типы
+ * общих модулей объявляются сразу по добавлению рабочей области — иначе обращение
+ * {@code ОбщийМодуль.Метод()} из документа, разобранного раньше модуля, не находит даже
+ * получателя, и результат выходит пустым, ничем не отличимым от честной пустоты.
+ * <p>
+ * {@code populate=false} здесь намеренно: доказывается, что объявление не зависит от того,
+ * разобран ли хоть один документ.
+ */
+class CommonModuleTypesDeclaredBeforeParseTest extends AbstractServerContextAwareTest {
+
+  @Autowired
+  private TypeRegistry typeRegistry;
+
+  @Test
+  void commonModuleTypeIsDeclaredWithoutParsingItsFile() {
+    // given: рабочая область добавлена, но ни один документ не разобран.
+    initServerContext(Path.of(PATH_TO_METADATA), false);
+    assertThat(context.getDocuments()).isEmpty();
+
+    // then: тип общего модуля уже объявлен и виден как глобальное имя.
+    assertThat(typeRegistry.resolve("ОбщегоНазначения"))
+      .as("тип общего модуля объявлен по метаданным, без разбора его файла")
+      .isPresent();
+    assertThat(typeRegistry.getMembers(TypeRegistry.GLOBAL_CONTEXT, FileType.BSL))
+      .as("имя общего модуля видно без префикса — оно член глобальной области")
+      .anyMatch(member -> member.matches("ОбщегоНазначения"));
+  }
+}

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderHelpersTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/ConfigurationTypesProviderHelpersTest.java
@@ -336,7 +336,8 @@ class ConfigurationTypesProviderHelpersTest {
     return new ConfigurationTypesProvider(registry, serverProvider, globalScope, lsConfig, mcs,
       new ConfigurationGenericExpander(registry, serverProvider), new CatalogOwnerTypesRegistrar(registry),
       new ServiceModuleEventRegistrar(registry),
-      formTypesProvider, new XdtoTypesProvider(registry), formDataTypesRegistrar,
+      formTypesProvider, mock(ConfigurationModuleMembersProvider.class),
+      new XdtoTypesProvider(registry), formDataTypesRegistrar,
       new RegisterTypesRegistrar(registry, recorderIndex), recorderIndex,
       new SimpleAsyncTaskExecutor());
   }


### PR DESCRIPTION
Ссылка на #4429. Продолжение #4449 и #4454.

## Причина

Документы конфигурации разбираются параллельно. Тип общего модуля объявлялся при разборе **его собственного файла** (`ConfigurationModuleMembersProvider.handleEvent` по событию изменения содержимого), поэтому обращение `ОбщийМодуль.Метод()` из документа, до которого очередь дошла раньше, не находило **даже получателя**: имя не разрешалось ни во что, член не искался, результат выходил пустым — и сообщить о пропуске было некому, потому что и метода-то не нашлось. Расчёт считал себя завершённым, значение застывало навсегда, а повезло методу или нет, решал порядок обхода файлов.

Прослежено на живом случае. `ПользователиСлужебный.НастройкиВхода` собирает структуру из межмодульных вызовов:

```bsl
Настройки.Вставить("Пользователи", Пользователи.НовоеОписаниеНастроекВхода());
```

По снимкам содержимого индекса после наполнения (три прогона ssl_3_1):

- **вызванный** `Пользователи.НовоеОписаниеНастроекВхода` — посчитан один раз при разборе, значение полное, **одинаковое во всех трёх прогонах**;
- **вызывающий** — то 1825 знаков, то 196: в двух прогонах из трёх поля остались голыми именами без типов;
- история записи вызывающего в бедном прогоне — просто «разбор», **без пометок «неполно» и «на отложенном»**: расчёт не заметил ничего пропущенного.

## Правка

**Тип объявляется по метаданным.** Имя общего модуля известно до разбора любого `.bsl`, а разбор нужен только членам. Объявление добавлено в общий обход конфигурации (`ConfigurationTypesProvider.processMdoChild`), туда же, где регистрируются прочие конфигурационные типы. Регистрируются только сам тип и видимость имени; члены и символ-источник по-прежнему приносит разбор файла модуля — существующий путь регистрации не тронут.

**Пустота стала отличима от честной.** Обращение к типу конфигурации, у которого нет ни одного члена **из конфигурации**, помечает расчёт неполным. Платформенные члены не в счёт: они приходят из синтакс-помощника и о разборе файла ничего не говорят — у общего модуля это `ЭтотОбъект`. Различает их `standardLibrary`, который дескриптор члена несёт сам, так что новых сущностей и состояний не понадобилось. Дальше работает уже существующий механизм: неполнота кладёт метод в очередь отложенных, и общий проход пересчитывает его после наполнения.

Признак самоограничен: внутри прохода все файлы разобраны, у каждого модуля есть члены из конфигурации, поэтому он не взводится и лишних волн не создаёт.

Третий коммит — вынос тела цикла по членам в `typesOfMember`. Поведение не меняет, появился под замечание Sonar `java:S135`: правка тронула строки цикла с тремя `continue` подряд.

## Чего правка не делает

Она **не убирает временной разрыв**: члены модуля появляются только с разбором его файла, поэтому межмодульный вызов при наполнении по-прежнему может вернуть пусто. Убрано другое — немота: такая пустота теперь заметна и чинится проходом.

## Замеры

ssl_3_1, конфиг только с диагностиками системы типов, прогоны сборок чередовались, чтобы условия были одни. Две пары мерились в разное время, поэтому сведены отдельно — метрика гуляет от запуска к запуску, и складывать их в одно число нельзя.

| сравнение | мерцающих строк | расхождения между парами прогонов |
|---|---|---|
| develop → объявление типов + признак «членов нет» | 141 → 84 | 52–101 → 17–66 |
| признак «членов нет» → признак «нет членов из конфигурации» | 103 → **55** | 46–62 → **6–48** |

Бенчмарк CI против базы `ba3ff614f` (98,20 с):

| коммит | бенчмарк |
|---|---|
| `3873677` — объявление типов | 103,89 с (stddev 2,60) |
| `7983595` — + вынос метода | 106,24 с (stddev 1,26) |
| `00a0c12` — + признак по происхождению | 106,66 с (stddev 1,16) |

Уточнение признака стоит **+0,42 с** — на фоне разброса ±1,2 с внутри прогона это неотличимо от шума. Условие начинается с проверки вида типа, поэтому платформенные получатели до перебора членов не доходят.

Цена PR целиком — около **+8,5 с** к базе, и она не в признаке, а в доразрешении: отложенных методов ~1900 против ~960, разборов документов 373 против 271.

## Что отвергнуто замером

- **Признак по символу глобального свойства** (символ ставится при разборе): мерцающих 104 против 71. Коллекции-пространства имён (`Справочники`, `Документы`) регистрируются глобальными свойствами без символа навсегда — в коде прямо сказано «declaration у коллекции нет», — и признак считал их вечно незарегистрированными.
- **Явная пометка «объявлен по метаданным»** — работала бы, но требует нового состояния в модели.
- Компенсации без устранения немоты, все хуже базы по расхождению содержимого индекса: пометка неполноты на любом неразрешившемся получателе, она же однократно, она же с монотонным накоплением, доведение документа до неподвижной точки внутри прохода.

Побочная находка, оставленная как есть: в `registerCommonModule` символ регистрируется **до** источников членов, так что есть окно, в котором чужой поток видит модуль готовым, не находит члена и молчит о неполноте. Нынешнему признаку это безразлично, но если однажды судить по символу — начинать надо с этого порядка.
