### PR TITLE
docs: убрана версия Gradle из CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -40,7 +40,7 @@ stdio/SSE/Streamable HTTP, либо флагом `--mcp` рядом с `lsp`/`we
 - **Java**, компиляция таргетится на **Java 21** (`targetCompatibility = VERSION_21`), поэтому и
   минимальный рантайм — 21: байт-код версии 65 более старая JVM не загрузит. CI собирает и гоняет
   тесты на 21 и 25, на трёх ОС.
-- **Gradle 9.6** (wrapper, Kotlin DSL — `build.gradle.kts`); **Spring Boot 4** (DI, кэш, websocket, MCP).
+- **Gradle** (wrapper, Kotlin DSL — `build.gradle.kts`); **Spring Boot 4** (DI, кэш, websocket, MCP).
 - Парсер [`bsl-parser`](https://github.com/1c-syntax/bsl-parser) (ANTLR4, грамматики BSL и SDBL-запросов);
   метаданные 1С — [`mdclasses`](https://github.com/1c-syntax/mdclasses); LSP — Eclipse LSP4J.
 - Кэш Caffeine + EhCache · NLP JLanguageTool (ru/en) · AspectJ (AOP) · Lombok · JSpecify · picocli (CLI).


### PR DESCRIPTION
Версия wrapper'а меняется бампами и в документе быстро устаревает
(указано 9.6, в gradle-wrapper.properties — 9.7.0). Версия и не нужна:
сборка идёт только через ./gradlew.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01RhVN6E1DVLZjLyC97a7Kzb

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated technology stack documentation to omit the specific Gradle version while retaining references to the Gradle wrapper and Kotlin DSL.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->