### PR TITLE
fix(types): примитивы видимы в OneScript-файлах

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -1452,7 +1452,23 @@ public class TypeRegistry {
     if (!decl.name().isEmpty()) {
       displayNames.putIfAbsent(ref, decl.name());
     }
-    registerFileType(ref, fileType);
+    registerPackFileType(ref, fileType);
+  }
+
+  /**
+   * Языковая видимость типа из пака. Примитивы видимы в обоих языках независимо от того,
+   * чей пак их принёс: {@code Строка}/{@code Число}/{@code Дата}/{@code Булево}/
+   * {@code Неопределено}/{@code Null} есть и в BSL, и в OneScript, но объявляет их только
+   * BSL-сторона — ни встроенный OneScript-пак, ни OneScript-провайдеры примитивов не содержат.
+   * Без этого {@link #isVisibleIn} признаёт примитив «зарегистрированным в чужом языке»,
+   * и {@code resolve(имя, OS)} возвращает пусто для всех примитивов сразу.
+   */
+  private void registerPackFileType(TypeRef ref, FileType fileType) {
+    if (ref.kind() == TypeKind.PRIMITIVE) {
+      visibleTypes.keySet().forEach(language -> registerFileType(ref, language));
+    } else {
+      registerFileType(ref, fileType);
+    }
   }
 
   /**

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistry.java
@@ -1452,23 +1452,7 @@ public class TypeRegistry {
     if (!decl.name().isEmpty()) {
       displayNames.putIfAbsent(ref, decl.name());
     }
-    registerPackFileType(ref, fileType);
-  }
-
-  /**
-   * Языковая видимость типа из пака. Примитивы видимы в обоих языках независимо от того,
-   * чей пак их принёс: {@code Строка}/{@code Число}/{@code Дата}/{@code Булево}/
-   * {@code Неопределено}/{@code Null} есть и в BSL, и в OneScript, но объявляет их только
-   * BSL-сторона — ни встроенный OneScript-пак, ни OneScript-провайдеры примитивов не содержат.
-   * Без этого {@link #isVisibleIn} признаёт примитив «зарегистрированным в чужом языке»,
-   * и {@code resolve(имя, OS)} возвращает пусто для всех примитивов сразу.
-   */
-  private void registerPackFileType(TypeRef ref, FileType fileType) {
-    if (ref.kind() == TypeKind.PRIMITIVE) {
-      visibleTypes.keySet().forEach(language -> registerFileType(ref, language));
-    } else {
-      registerFileType(ref, fileType);
-    }
+    registerFileType(ref, fileType);
   }
 
   /**

--- a/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-oscript-platform-types.json
+++ b/src/main/resources/com/github/_1c_syntax/bsl/languageserver/types/registry/builtin-oscript-platform-types.json
@@ -19492,5 +19492,47 @@
         "kind": "PROPERTY"
       }
     ]
+  },
+  {
+    "kind": "PRIMITIVE_TYPE",
+    "name": "Строка",
+    "aliases": [
+      "String"
+    ]
+  },
+  {
+    "kind": "PRIMITIVE_TYPE",
+    "name": "Число",
+    "aliases": [
+      "Number"
+    ]
+  },
+  {
+    "kind": "PRIMITIVE_TYPE",
+    "name": "Дата",
+    "aliases": [
+      "Date"
+    ]
+  },
+  {
+    "kind": "PRIMITIVE_TYPE",
+    "name": "Булево",
+    "aliases": [
+      "Boolean"
+    ]
+  },
+  {
+    "kind": "PRIMITIVE_TYPE",
+    "name": "Неопределено",
+    "aliases": [
+      "Undefined"
+    ]
+  },
+  {
+    "kind": "PRIMITIVE_TYPE",
+    "name": "Null",
+    "aliases": [
+      "null"
+    ]
   }
 ]

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/semantictokens/BslDocSemanticTokensSupplierTest.java
@@ -294,6 +294,27 @@ class BslDocSemanticTokensSupplierTest {
   }
 
   @Test
+  void testOsVariableDescriptionPrimitiveTypeHighlighting() {
+    // given - описание переменной OneScript-модуля с примитивом в начале. Примитивы объявлены
+    // только BSL-паком, поэтому при регистрации их видимости строго по языку пака
+    // TypeService.resolve в OS-файле не находил тип, и вся строка описания уезжала
+    // одним комментарием.
+    String os = """
+      // Строка - Ключ владельца, удерживающего блокировку записи.
+      Перем ВладелецЗаписи;
+      """;
+
+    // when
+    var decoded = helper.getDecodedTokensForOs(os, supplier);
+
+    // then - «Строка» подсвечена как тип, ровно как в BSL-модуле
+    helper.assertContainsTokens(decoded, List.of(
+      new ExpectedToken(0, 3, 6, SemanticTokenTypes.Type,
+        Set.of(SemanticTokenModifiers.Documentation), "Строка")
+    ));
+  }
+
+  @Test
   void testTrailingVariableDescriptionUnresolvedTypeNotHighlighted() {
     // given - висячий комментарий, у которого первый токен (по нотации «тип в начале») — свободный
     // текст, не резолвящийся в реальный тип.

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryRegistrationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryRegistrationTest.java
@@ -111,11 +111,12 @@ class TypeRegistryRegistrationTest {
     // when
     var bsl = typeRegistry.resolve(name, FileType.BSL);
 
-    // then — в OneScript примитивы те же самые, и это тот же самый тип
+    // then — в OneScript примитив резолвится в тот же самый (интернированный) TypeRef,
+    // а не в равный ему: реестр обязан отдавать канонический ref обоим языкам.
     assertThat(bsl).isNotEmpty();
-    assertThat(typeRegistry.resolve(name, FileType.OS))
+    assertThat(typeRegistry.resolve(name, FileType.OS).orElseThrow())
       .as("примитив «%s» должен резолвиться в OneScript-файле", name)
-      .isEqualTo(bsl);
+      .isSameAs(bsl.orElseThrow());
   }
 
   @Test

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryRegistrationTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/registry/TypeRegistryRegistrationTest.java
@@ -31,6 +31,8 @@ import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
 import com.github._1c_syntax.bsl.languageserver.util.CleanupContextBeforeClassAndAfterEachTestMethod;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import org.junit.jupiter.params.ParameterizedTest;
+import org.junit.jupiter.params.provider.ValueSource;
 import org.mockito.Mock;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.beans.factory.annotation.Autowired;
@@ -97,6 +99,23 @@ class TypeRegistryRegistrationTest {
     // then
     assertThat(typeRegistry.resolve("МойOSКласс", FileType.OS)).contains(ref);
     assertThat(typeRegistry.resolve("МойOSКласс", FileType.BSL)).isEmpty();
+  }
+
+  @ParameterizedTest
+  @ValueSource(strings = {"Строка", "Число", "Дата", "Булево", "Неопределено", "Null"})
+  void primitiveTypesAreVisibleInBothLanguages(String name) {
+    // given — примитивы объявлены только BSL-паком: ни встроенный OneScript-пак,
+    // ни OneScript-провайдеры их не содержат. При регистрации видимости строго по языку
+    // пака isVisibleIn признавал бы примитив «зарегистрированным в чужом языке».
+
+    // when
+    var bsl = typeRegistry.resolve(name, FileType.BSL);
+
+    // then — в OneScript примитивы те же самые, и это тот же самый тип
+    assertThat(bsl).isNotEmpty();
+    assertThat(typeRegistry.resolve(name, FileType.OS))
+      .as("примитив «%s» должен резолвиться в OneScript-файле", name)
+      .isEqualTo(bsl);
   }
 
   @Test


### PR DESCRIPTION
## Описание

`TypeService.resolve(«Строка», FileType.OS)` возвращал пусто — и так для всех примитивов сразу:

```
                BSL     OS  (до)      OS (после)
Строка          true    false         true
Число           true    false         true
Дата            true    false         true
Булево          true    false         true
Соответствие    true    true          true
```

Причина — дефект данных. Примитивы (`Строка`, `Число`, `Дата`, `Булево`, `Неопределено`, `Null`) объявляла только BSL-сторона: `builtin-platform-types.json` даёт их с `"kind": "PRIMITIVE_TYPE"`, а в `builtin-oscript-platform-types.json` не было ни одного `PRIMITIVE_TYPE` (единственное вхождение `"Число"` там — `PROPERTY` внутри перечисления «Тип значения JSON»). `TypeRegistry` регистрирует видимость по языку своего пака, а `isVisibleIn` трактует «зарегистрирован в другом языке ⇒ здесь невидим» — примитив уходил во вторую ветку и в OS пропадал.

Правка — в самих данных: шесть объявлений `PRIMITIVE_TYPE` дописаны в OneScript-пак, зеркалом BSL-пака, включая англоязычные алиасы. Тип интернируется по паре (`TypeKind.PRIMITIVE`, имя), поэтому оба пака сходятся на одном `TypeRef`, а видимость становится аддитивной. Java-код не тронут вовсе.

Отсутствие примитивов в OneScript-паке было именно дефектом, а не намеренным сужением: в OneScript они существуют (`ТипЗнч(1) = Тип("Число")`), и `resolve(«Число», OS)` обязан был их находить с самого начала.

Затронут был любой потребитель `resolve(..., FileType.OS)` — вывод типов, hover, диагностики на типах. Заметнее всего — semantic tokens: в OneScript-модуле тип из описания переменной не проходил `isResolvable` (у описаний переменных `validateTypeResolution = true`), и вся строка уезжала одним `comment.documentation`:

```bsl
// Строка - Ключ владельца, удерживающего блокировку записи.
Перем ВладелецЗаписи;
```

```
до:     [0,0,60]  comment.documentation          ← одним куском
после:  [0,0,3]   comment.documentation  "// "
        [0,3,6]   type.documentation     "Строка"
        [0,9,51]  comment.documentation
```

## Связанные задачи

Closes #4471

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков — не применимо, диагностики не затронуты

## Дополнительно

**Тесты**

- `TypeRegistryRegistrationTest.primitiveTypesAreVisibleInBothLanguages` — параметризованный по `Строка`/`Число`/`Дата`/`Булево`/`Неопределено`/`Null`: резолв в OS даёт тот же самый (интернированный) `TypeRef`, что и в BSL.
- `BslDocSemanticTokensSupplierTest.testOsVariableDescriptionPrimitiveTypeHighlighting` — сквозной: в `.os` тип из описания переменной подсвечивается как `type` + `documentation`.

Без правки пака эти 7 тестов падают, с ней проходят. Пакеты `types.*` и `semantictokens.*` прогнаны целиком — 232 класса, падений нет. **Полный `gradlew test` не догонялся** (и `precommit` не запускался) — прошу обратить на это внимание при ревью, CI закроет.

**История ветки**

Первая версия правки (`579afd6`) делала то же самое особым правилом в `TypeRegistry.registerPack`. Заменено на правку данных (`a747637`) — Java-часть откачена, в диффе её нет.

**Осознанно вне диапазона правки**

У примитивов в OneScript-паке объявлены только имя и алиасы — без описаний и членов. Hover на `Строка` в `.os` теперь резолвит тип, но текст описания возьмётся не всегда. Это строго лучше прежнего поведения (тип не резолвился вовсе), однако вопрос закрыт не до конца — если нужно, вынесу отдельной задачей.

**Не входит в этот PR**

По ходу разбора нашёлся независимый дефект в `BslDocSemanticTokensSupplier.addBslDocTokensWithMultilineSupport` — заведён отдельно: #4469.