### PR TITLE
fix(types): проход доразрешения пересчитывает устаревшие значения

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
@@ -418,6 +418,11 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
     var valueChanged = !symbolTypeIndex.getReturnTypes(method).equals(previous);
     computedAt.put(method, startedAt);
     if (valueChanged) {
+      // Обе отметки берутся из одной точки — до расчёта. Строго полнее было бы отмечать
+      // изменение уже после того, как значение выложено: тогда ловился бы и расчёт,
+      // начавшийся раньше выкладки, но успевший прочитать прежнее значение. Пока так
+      // делать нельзя — лишние пересчёты вскрывают немонотонность самого пересчёта, и
+      // воспроизводимость падает вместо того, чтобы вырасти (замеры в #4480).
       changedAt.merge(method.getOwner().getUri(), startedAt, Math::max);
     }
     return valueChanged;

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexer.java
@@ -62,6 +62,7 @@ import java.util.concurrent.CopyOnWriteArrayList;
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicLong;
 import java.util.function.Supplier;
 
 /**
@@ -134,6 +135,19 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
   /** Методы, тела которых уже разбирались: пустой ответ у них значит «ничего не возвращает». */
   private final Set<MethodSymbol> indexed = ConcurrentHashMap.newKeySet();
 
+  /**
+   * Часы, по которым видно, что чей расчёт застал, а что появилось уже после него. Своё
+   * время, а не системное: сравниваются только порядковые отметки, и брать их надо в том
+   * же порядке, в каком идут сами события.
+   */
+  private final AtomicLong clock = new AtomicLong();
+
+  /** Отметка часов на момент, когда начинался последний расчёт метода. */
+  private final Map<MethodSymbol, Long> computedAt = new ConcurrentHashMap<>();
+
+  /** Отметка часов на момент, когда в документе в последний раз менялось чьё-то значение. */
+  private final Map<URI, Long> changedAt = new ConcurrentHashMap<>();
+
   /** Сколько раз пришлось перечитать документ за общий проход — для отладочного счёта. */
   private final AtomicInteger rebuilt = new AtomicInteger();
 
@@ -157,7 +171,8 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
     if (indexed.contains(method) || !method.isFunction() || !isReadable(method)) {
       return;
     }
-    store(method, computation.get());
+    var startedAt = clock.incrementAndGet();
+    store(method, computation.get(), startedAt);
     rememberMethodOfUri(method);
   }
 
@@ -276,9 +291,13 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
   @Override
   public void clear(URI uri) {
     unlinkDependencies(uri);
+    changedAt.remove(uri);
     var methods = methodsByUri.remove(uri);
     if (methods != null) {
-      methods.forEach(indexed::remove);
+      methods.forEach(method -> {
+        indexed.remove(method);
+        computedAt.remove(method);
+      });
     }
   }
 
@@ -347,17 +366,21 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
    * @return {@code true}, если набор типов изменился.
    */
   private boolean recompute(MethodSymbol method) {
-    return store(method, inferencer.computeReturnTypes(method));
+    // Отметка снимается до расчёта: значение, изменившееся уже во время него, расчёт
+    // застать не мог, и вызывающему понадобится ещё один заход.
+    var startedAt = clock.incrementAndGet();
+    return store(method, inferencer.computeReturnTypes(method), startedAt);
   }
 
   /**
    * Запоминает результат расчёта и обновляет связи метода.
    *
-   * @param method   метод.
-   * @param computed результат расчёта.
+   * @param method    метод.
+   * @param computed  результат расчёта.
+   * @param startedAt отметка часов на момент начала расчёта.
    * @return {@code true}, если набор типов изменился.
    */
-  private boolean store(MethodSymbol method, ComputedReturnTypes computed) {
+  private boolean store(MethodSymbol method, ComputedReturnTypes computed, long startedAt) {
     link(method, computed.consulted());
     if (!maintenance && computed.consulted().stream().anyMatch(pending::contains)) {
       // Расчёт опирался на значение, которое само ждёт пересчёта: вызванный метод посчитан,
@@ -392,7 +415,41 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
     var previous = symbolTypeIndex.getReturnTypes(method);
     symbolTypeIndex.putReturnTypes(method, computed.types());
     indexed.add(method);
-    return !symbolTypeIndex.getReturnTypes(method).equals(previous);
+    var valueChanged = !symbolTypeIndex.getReturnTypes(method).equals(previous);
+    computedAt.put(method, startedAt);
+    if (valueChanged) {
+      changedAt.merge(method.getOwner().getUri(), startedAt, Math::max);
+    }
+    return valueChanged;
+  }
+
+  /**
+   * Методы, чей расчёт устарел: документ, на значениях которого он построен, изменился уже
+   * после того, как расчёт прошёл.
+   * <p>
+   * Отложить такой метод в момент расчёта было некому: значение, на котором он построился,
+   * выглядело посчитанным, а обогатилось позже. Учёт по документам, а не по методам: по
+   * документам держатся и сами связи, а лишний пересчёт стоит дешевле, чем хранение связей
+   * по методам — их на реальной конфигурации на порядок больше.
+   *
+   * @return методы, которые надо посчитать заново.
+   */
+  private Set<MethodSymbol> outdated() {
+    var outdated = new LinkedHashSet<MethodSymbol>();
+    for (var method : indexed) {
+      var dependencies = dependenciesByUri.get(method.getOwner().getUri());
+      if (dependencies == null) {
+        continue;
+      }
+      var computed = computedAt.getOrDefault(method, 0L);
+      for (var dependency : dependencies) {
+        if (changedAt.getOrDefault(dependency, 0L) > computed) {
+          outdated.add(method);
+          break;
+        }
+      }
+    }
+    return outdated;
   }
 
   /**
@@ -471,8 +528,12 @@ public class MethodReturnTypeIndexer extends AbstractDocumentLifecycleClearableI
       planned += documentsOf(roots);
       progressReporter.setSize(planned);
       resolveAll(serverContext, roots, progressReporter);
-      LOGGER.debug("Волна {}: пересчитано методов {}, снова отложено {}",
-        pass + 1, roots.size(), pending.size());
+      // План волны строится по связям, известным на её начало, а вскрываются они её же
+      // расчётом: метод, чья зависимость обогатилась после него, отложить было некому.
+      var outdated = outdated();
+      pending.addAll(outdated);
+      LOGGER.debug("Волна {}: пересчитано методов {}, снова отложено {}, из них устаревших {}",
+        pass + 1, roots.size(), pending.size(), outdated.size());
     }
   }
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexerTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/MethodReturnTypeIndexerTest.java
@@ -223,6 +223,28 @@ class MethodReturnTypeIndexerTest {
   }
 
   @Test
+  void consumerIsRecomputedWhenDependencyChangesLaterInPass() {
+    // given: отложены оба метода. Связь, известная проходу на старте, ведёт от источника к
+    // потребителю, поэтому потребитель считается первым. Обратной связи — что сам он
+    // построен на источнике — в плане прохода нет: она вскроется только его расчётом.
+    indexer.computeIfAbsent(sourceMethod,
+      () -> new ComputedReturnTypes(TypeSet.EMPTY, Set.of(consumerMethod), true));
+    indexer.computeIfAbsent(consumerMethod,
+      () -> new ComputedReturnTypes(TypeSet.EMPTY, Set.of(), true));
+    when(inferencer.computeReturnTypes(consumerMethod)).thenAnswer(invocation ->
+      new ComputedReturnTypes(symbolTypeIndex.getReturnTypes(sourceMethod), Set.of(sourceMethod), false));
+    returns(sourceMethod, NUMBER, consumerMethod);
+
+    // when: рабочая область наполнена.
+    indexer.handleServerContextPopulated(new ServerContextPopulatedEvent(serverContextOf(source, consumer)));
+
+    // then: источник изменился уже после того, как потребитель на нём построился, и
+    // потребитель пересчитан по новому значению. Иначе он навсегда остался бы с тем, что
+    // успело попасться, а что успело — решает порядок разбора, разный от запуска к запуску.
+    assertThat(symbolTypeIndex.getReturnTypes(consumerMethod)).isEqualTo(NUMBER);
+  }
+
+  @Test
   void releasedDocumentIsLoadedForRecomputeAndReleasedBack() {
     // given: отложенный метод лежит в документе, вторичные данные которого уже освобождены.
     returns(consumerMethod, TypeSet.EMPTY, sourceMethod);


### PR DESCRIPTION
## Описание

Проход доразрешения типов возврата не доводил индекс до неподвижной точки.

Метод пересчитывался проходом, только если сам попал в очередь отложенных, а попадал он туда по признакам, снятым **в момент своего расчёта**: зависимость уже в очереди, значение пустое, расчёт видел непосчитанное. Если зависимость на тот момент выглядела посчитанной, а обогатилась **позже**, вызывающий об этом не узнавал: разнос по потребителям во время прохода отключён намеренно, а порядок обработки строится по графу связей, который сам достраивается по ходу прохода.

Замер зондом на ssl_3_1: **761–862 метода из ~6700** в каждом прогоне были посчитаны раньше последнего изменения своей зависимости, и **13 из 16** ключей индекса, реально разошедшихся между двумя прогонами, приходились именно на них.

**Как исправлено.** Индексатор ведёт свои часы: у метода запоминается отметка на начало расчёта, у документа — отметка последнего изменения значений в нём. В конце каждой волны прохода в очередь добираются те, чья зависимость изменилась после них. Отметка снимается **до** расчёта, а не после: значение, обогатившееся во время расчёта, вызывающий застать не мог, и такой случай обязан считаться устаревшим.

Волны сходятся быстро и с запасом до предохранителя: на ssl_3_1 это 843 → 190 → 72 → 10 → 0.

## Связанные задачи

Часть решения #4429 (первая из четырёх правок).

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

Задачи `precommit` в проекте сейчас нет (в `build.gradle.kts` она не объявлена) — вместо неё прогнаны `spotlessCheck` и тесты затронутой области.

## Дополнительно

**Замеры на ssl_3_1, по 4 прогона на вариант, диагностики `UnknownMember` и `EventHandlerInvalidSignature`:**

| | develop | с правкой |
|---|---|---|
| мерцающих замечаний | 22 | 2 |
| попарные расхождения прогонов | 2–22 | 0–2 |
| всего замечаний | 28732–28742 | 28461–28469 |
| время анализа | 71–74 с | 86–91 с |

Ложных `UnknownMember` стало меньше примерно на 270: это та же причина с другой стороны — значения, застревавшие бедными, давали замечания на существующих членах.

**Про время: на железе CI роста нет.** Bench-история `test_analyze_ssl31`: develop — 105,56 / 105,14 / 104,58 с, с этой правкой — 104,16 и 104,77 с, то есть внутри разброса develop. Цифры «86–91 с против 71–74 с» выше получены локально в **урезанной** конфигурации: включены только две диагностики вместо полного набора и отдано 5 ядер из 12, поэтому доля прохода доразрешения там несоразмерно велика. Для сравнения вариантов между собой она годится, для оценки цены в бою — нет.

Пробовал три более дешёвых варианта прохода, все отброшены по замерам:

- учёт зависимостей только по чужим документам — 65 с, но мерцание почти не лечится (28748 замечаний против 28755 у develop);
- сходимость документа на месте по устаревшим соседям — 59 с, но мерцание выросло до 29, то есть хуже develop;
- ранний расчёт всех функций, а не только экспортных — мерцание выросло в 4,5 раза.

Замеры делались на машине с ограничением в 5 из 12 ядер, поэтому абсолютные времена ниже к сравнению между собой, а не с CI.
