### PR TITLE
fix(types): объявленное поле не пропадает из-за неразрешённого типа

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndex.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndex.java
@@ -878,16 +878,23 @@ public class SymbolTypeIndex {
     var result = elementRef == null ? base : TypeSet.of(elementRef);
     for (var field : fields) {
       var eager = TypeSet.EMPTY;
+      var lazy = false;
       for (var fieldType : field.types()) {
         var localFunction = localFunctionSeeRef(fieldType, context);
         if (localFunction != null) {
           result = result.withLazyField(fieldsRef, field.name(),
             lazyReturnTypes(localFunction), fieldDescription(field));
+          lazy = true;
         } else {
           eager = eager.union(resolveTypes(List.of(fieldType), context));
         }
       }
-      if (!eager.isEmpty()) {
+      // Поле объявлено — значит, оно есть, даже если написанный у него тип сейчас никуда
+      // не ведёт: ссылка в модуль, до которого очередь ещё не дошла, не разрешается ни во
+      // что. Выбросить поле вместе с именем значило бы превратить «тип неизвестен» в
+      // «члена не существует», а разрешится ссылка или нет, решает порядок разбора,
+      // разный от запуска к запуску.
+      if (!eager.isEmpty() || !lazy) {
         result = result.withField(fieldsRef, field.name(), eager, fieldDescription(field));
       }
     }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/DeclaredFieldWithUnresolvedTypeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/DeclaredFieldWithUnresolvedTypeTest.java
@@ -1,0 +1,96 @@
+/*
+ * This file is a part of BSL Language Server.
+ *
+ * Copyright (c) 2018-2026
+ * Alexey Sosnoviy <labotamy@gmail.com>, Nikita Fedkin <nixel2007@gmail.com> and contributors
+ *
+ * SPDX-License-Identifier: LGPL-3.0-or-later
+ *
+ * BSL Language Server is free software; you can redistribute it and/or
+ * modify it under the terms of the GNU Lesser General Public
+ * License as published by the Free Software Foundation; either
+ * version 3.0 of the License, or (at your option) any later version.
+ *
+ * BSL Language Server is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with BSL Language Server.
+ */
+package com.github._1c_syntax.bsl.languageserver.types.index;
+
+import com.github._1c_syntax.bsl.languageserver.context.DocumentContext;
+import com.github._1c_syntax.bsl.languageserver.context.events.DocumentContextContentChangedEvent;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeKind;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeRef;
+import com.github._1c_syntax.bsl.languageserver.types.model.TypeSet;
+import com.github._1c_syntax.bsl.languageserver.types.registry.FormByNameResolver;
+import com.github._1c_syntax.bsl.languageserver.types.registry.TypeRegistry;
+import com.github._1c_syntax.bsl.languageserver.util.TestUtils;
+import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Test;
+import org.springframework.boot.test.context.SpringBootTest;
+
+import java.util.Optional;
+
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.anyString;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+/**
+ * Поле структуры, объявленное в описании метода ссылкой в другой модуль.
+ * <p>
+ * Пока рабочая область наполняется, такая ссылка никуда не ведёт: модуля, на который она
+ * показывает, ещё нет. Тип поля из неё не выводится — но само поле объявлено, и потерять
+ * его имя нельзя: обращение к нему выглядело бы обращением к несуществующему члену, а
+ * повезло ссылке разрешиться или нет, решает порядок разбора, разный от запуска к запуску.
+ */
+@SpringBootTest
+class DeclaredFieldWithUnresolvedTypeTest {
+
+  private static final String MODULE = """
+    // Возвращаемое значение:
+    //  Структура:
+    //   * Ключ - см. ЧужойМодуль.Значение
+    //
+    Функция Состояние() Экспорт
+     Возврат Новый Структура("Ключ");
+    КонецФункции
+    """;
+
+  private static final TypeRef STRUCTURE = new TypeRef(TypeKind.PLATFORM, "Структура");
+
+  private SymbolTypeIndex index;
+  private DocumentContext documentContext;
+
+  @BeforeEach
+  void prepare() {
+    var typeRegistry = mock(TypeRegistry.class);
+    when(typeRegistry.resolve("Структура")).thenReturn(Optional.of(STRUCTURE));
+    // Ссылка в чужой модуль никуда не ведёт — так же, как во время наполнения области.
+    when(typeRegistry.resolve(anyString())).thenReturn(Optional.empty());
+    when(typeRegistry.resolve("Структура")).thenReturn(Optional.of(STRUCTURE));
+    when(typeRegistry.resolveSet(anyString())).thenReturn(TypeSet.EMPTY);
+    when(typeRegistry.getDefaultElementTypes(any())).thenReturn(TypeSet.EMPTY);
+    when(typeRegistry.intern(any(), anyString()))
+      .thenAnswer(invocation -> new TypeRef(invocation.getArgument(0), invocation.getArgument(1)));
+    index = new SymbolTypeIndex(typeRegistry, mock(FormByNameResolver.class));
+    documentContext = TestUtils.getDocumentContext(MODULE);
+  }
+
+  @Test
+  void fieldWithUnresolvedTypeKeepsItsName() {
+    // given / when: документ разобран, когда ссылка ещё никуда не ведёт.
+    index.handleEvent(new DocumentContextContentChangedEvent(documentContext));
+
+    // then: поле объявлено, поэтому оно есть — пусть и без типа.
+    var declared = index.getDeclaredReturnTypes(documentContext.getSymbolTree().getMethods().get(0));
+    assertThat(declared.getAllFieldNames())
+      .as("объявленное поле не должно пропадать из-за неразрешённой ссылки на его тип")
+      .contains("Ключ");
+  }
+}


### PR DESCRIPTION
## Описание

Поле структуры, объявленное в описании метода, добавлялось только если его тип разрешился:

```java
if (!eager.isEmpty()) {
  result = result.withField(fieldsRef, field.name(), eager, fieldDescription(field));
}
```

Поэтому поле, у которого тип написан ссылкой в другой модуль (`* КлючСеанса - см. СерверныеОповещения.КлючСеанса`), пропадало **целиком — вместе с именем**, когда ссылка никуда не вела: до модуля, на который она показывает, очередь разбора ещё не дошла. Обращение к такому полю выглядело обращением к несуществующему члену, а разрешится ссылка или нет, решал порядок разбора — разный от запуска к запуску.

**Как исправлено.** Объявленное поле остаётся с неизвестным типом: оно объявлено, значит, оно есть. «Тип неизвестен» — не то же самое, что «члена не существует».

## Связанные задачи

Часть решения #4429 (вторая из четырёх правок).

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

Задачи `precommit` в проекте сейчас нет — вместо неё прогнаны `spotlessCheck` и тесты затронутой области.

## Дополнительно

**Как нашлось.** Зонд в точке рождения замечания показал: у структуры, которую возвращает `СерверныеОповещенияКлиент.СостояниеПолучения`, в одних прогонах 25 полей, в других 24. Не хватало ровно тех двух из двадцати пяти, что объявлены через `см.`; все остальные, объявленные обычными типами, были на месте.

По пути отброшены две версии этого же очага, обе проверкой, а не рассуждением: совпадение имени поля с именем функции модуля (переименовал функцию — ничего не изменилось) и гонка на очистке значений при перечитывании документа (при том же тексте отпечаток содержимого совпадает, сброс не выполняется, окна нет).

**Замеры на ssl_3_1, по 4 прогона**, поверх правки из #4476:

| | без правки | с правкой |
|---|---|---|
| мерцающих замечаний | 2 | 1 |
| всего замечаний | 28461–28469 | 28346–28347 |

Ложных `UnknownMember` стало меньше примерно на 120.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Preserved declared structure fields when their referenced types cannot be resolved.
  * Prevented unresolved or deferred type references from incorrectly making fields appear nonexistent.

* **Tests**
  * Added coverage confirming fields remain available when their types are unresolved.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->