### PR TITLE
fix(types): разрыв рекурсии не подмешивает значение из индекса

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/types/inferencer/ExpressionTypeInferencer.java
@@ -851,7 +851,11 @@ public class ExpressionTypeInferencer {
    */
   private TypeSet recursiveKnot(MethodSymbol method, InferenceContext ctx) {
     var approximation = ctx.inProgress.get(method);
-    var known = approximation == null ? symbolTypeIndex.getReturnTypes(method) : approximation;
+    // Приближения на руках нет — значит, метод считается прямо сейчас этим же расчётом, и
+    // о нём пока не известно ничего. Прочитать про него из индекса значит взять то, что
+    // успел положить туда чужой поток: результат стал бы зависеть от того, как далеко
+    // продвинулось наполнение области. Уточняющий проход поднимет значение снизу сам.
+    var known = approximation != null ? approximation : TypeSet.EMPTY;
     if (known.isEmpty()) {
       return TypeSet.EMPTY;
     }
@@ -971,7 +975,7 @@ public class ExpressionTypeInferencer {
       ctx.consulted.addAll(refining.consulted);
       ctx.dependencies.addAll(refining.dependencies);
       ctx.sawMissing = ctx.sawMissing || refining.sawMissing;
-      if (refined.isEmpty() || refined.getAllFieldNames().equals(current.getAllFieldNames())) {
+      if (refined.isEmpty() || refined.equals(current)) {
         return refined.isEmpty() ? current : refined;
       }
       current = refined;


### PR DESCRIPTION
## Описание

При разрыве цикла приближение бралось **из индекса**, если своего у расчёта не было:

```java
var known = approximation == null ? symbolTypeIndex.getReturnTypes(method) : approximation;
```

Индекс — общее изменяемое состояние: что в нём лежит на этот момент, зависит от того, как далеко продвинулось наполнение области. Поэтому значение функции, которая через переменную модуля зависит от самой себя, выходило разным от запуска к запуску.

Пример с ssl_3_1 — `ПанельОтчетов.НачатьЗамер`: переменная `Замер` объявлена переменной модуля (`Перем Замер;`), её тип собирается объединением по всему модулю и включает `Замер = НачатьЗамер(...)`, а сама `НачатьЗамер` возвращает `Возврат Замер`. В дампах индекса тип возврата этой функции в одних прогонах `Неопределено`, в других `Неопределено + Структура`.

**Как исправлено.** Приближения на руках нет — значит, метод считается прямо сейчас этим же расчётом, и о нём пока не известно ничего: берётся пустой набор. Поднимает значение снизу уточняющий проход, который теперь останавливается по равенству самих наборов, а не только имён полей, — иначе итерация обрывалась раньше неподвижной точки.

## Связанные задачи

Closes #4429 (четвёртая, завершающая правка серии).

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [ ] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

**Теста нет, и это осознанно.** Расхождение возникает только при параллельном наполнении области: на одиночном модуле уточняющий проход перекрывает подложенное в индекс значение своим приближением, и проверка перестаёт различать правку. Я написал две такие проверки (самозависимость через переменную модуля и взаимная рекурсия двух функций) — обе оказались зелёными и без правки, поэтому я их удалил: неразличающий тест даёт ложную уверенность. Правка подтверждена замером на живой конфигурации, см. ниже.

Задачи `precommit` в проекте сейчас нет — вместо неё прогнаны `spotlessCheck` и тесты вывода типов.

## Дополнительно

**Замеры на ssl_3_1**, поверх правок из #4476, #4477 и #4478:

| | без правки | с правкой |
|---|---|---|
| мерцающих замечаний | 10 на серии из 10 прогонов | **0 на серии из 6 прогонов** |
| совпадающих прогонов | 9 из 10 | 6 из 6, подписи побайтово одинаковы |

Важно: на серии из 4 прогонов без этой правки получался ноль — и это было везение, серия из 10 его опровергла. Поэтому вывод сделан по полной серии, и её стоит повторить на другом железе.

Замечание в `ПанельОтчетов` после правки присутствует стабильно во всех прогонах, то есть результат стал детерминированным, а не «через раз».

Прогнаны наборы `*Recursi*`, `*Inference*`, `MethodReturnTypeIndexerTest`, `GuardNarrowingTest` — все зелёные.

**Отброшенные по замерам подходы к этой же причине:**

- считать разрыв цикла признаком неполноты и откладывать такой метод — мерцание выросло с 2 до 12;
- затравка узла пустым значением только на верхнем входе расчёта — изолированный случай стал нестабильным (8 замечаний против 2 между прогонами).
