### PR TITLE
fix(context): читать модули по UNC через Path.of

### DIFF
--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -43,6 +43,7 @@ import com.github._1c_syntax.bsl.parser.BSLTokenizer;
 import com.github._1c_syntax.bsl.parser.SDBLTokenizer;
 import com.github._1c_syntax.bsl.support.SupportVariant;
 import com.github._1c_syntax.bsl.types.ModuleType;
+import com.github._1c_syntax.utils.Absolute;
 import com.github._1c_syntax.utils.Lazy;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -50,7 +51,6 @@ import lombok.Locked;
 import lombok.Setter;
 import lombok.extern.slf4j.Slf4j;
 import org.antlr.v4.runtime.Token;
-import org.apache.commons.io.FileUtils;
 import org.apache.commons.io.FilenameUtils;
 import org.eclipse.lsp4j.Diagnostic;
 import org.eclipse.lsp4j.Position;
@@ -61,10 +61,10 @@ import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.context.annotation.Scope;
 import org.springframework.stereotype.Component;
 
-import java.io.File;
 import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
+import java.nio.file.Files;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -420,7 +420,7 @@ public class DocumentContext implements Comparable<DocumentContext> {
 
   protected void rebuildFromFileSystem() {
     try {
-      var newContent = FileUtils.readFileToString(new File(uri), StandardCharsets.UTF_8);
+      var newContent = Files.readString(Absolute.path(uri), StandardCharsets.UTF_8);
       rebuild(newContent, 0);
     } catch (IOException e) {
       LOGGER.error("Can't rebuild content from uri", e);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -422,7 +422,7 @@ public class DocumentContext implements Comparable<DocumentContext> {
     try {
       var newContent = Files.readString(Path.of(uri), StandardCharsets.UTF_8);
       rebuild(newContent, 0);
-    } catch (IOException e) {
+    } catch (IOException | IllegalArgumentException e) {
       LOGGER.error("Can't rebuild content from uri", e);
     }
   }

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContext.java
@@ -43,7 +43,6 @@ import com.github._1c_syntax.bsl.parser.BSLTokenizer;
 import com.github._1c_syntax.bsl.parser.SDBLTokenizer;
 import com.github._1c_syntax.bsl.support.SupportVariant;
 import com.github._1c_syntax.bsl.types.ModuleType;
-import com.github._1c_syntax.utils.Absolute;
 import com.github._1c_syntax.utils.Lazy;
 import lombok.EqualsAndHashCode;
 import lombok.Getter;
@@ -65,6 +64,7 @@ import java.io.IOException;
 import java.net.URI;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
+import java.nio.file.Path;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.Arrays;
@@ -420,7 +420,7 @@ public class DocumentContext implements Comparable<DocumentContext> {
 
   protected void rebuildFromFileSystem() {
     try {
-      var newContent = Files.readString(Absolute.path(uri), StandardCharsets.UTF_8);
+      var newContent = Files.readString(Path.of(uri), StandardCharsets.UTF_8);
       rebuild(newContent, 0);
     } catch (IOException e) {
       LOGGER.error("Can't rebuild content from uri", e);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/GitBlameComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/GitBlameComputer.java
@@ -21,6 +21,7 @@
  */
 package com.github._1c_syntax.bsl.languageserver.context.computer;
 
+import com.github._1c_syntax.utils.Absolute;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.api.Git;
@@ -60,12 +61,11 @@ public class GitBlameComputer implements Computer<GitBlameComputer.Data> {
       return Data.empty();
     }
 
-    var file = new File(uri);
-    if (!file.exists()) {
-      return Data.empty();
-    }
-
     try {
+      var file = Absolute.path(uri).toFile();
+      if (!file.exists()) {
+        return Data.empty();
+      }
       return computeWithGit(file);
     } catch (Exception e) {
       LOGGER.debug("Failed to compute git blame for {}", uri, e);

--- a/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/GitBlameComputer.java
+++ b/src/main/java/com/github/_1c_syntax/bsl/languageserver/context/computer/GitBlameComputer.java
@@ -21,7 +21,6 @@
  */
 package com.github._1c_syntax.bsl.languageserver.context.computer;
 
-import com.github._1c_syntax.utils.Absolute;
 import lombok.AllArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.eclipse.jgit.api.Git;
@@ -31,6 +30,7 @@ import org.eclipse.lsp4j.Diagnostic;
 
 import java.io.File;
 import java.net.URI;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.HashSet;
 import java.util.Locale;
@@ -62,7 +62,7 @@ public class GitBlameComputer implements Computer<GitBlameComputer.Data> {
     }
 
     try {
-      var file = Absolute.path(uri).toFile();
+      var file = Path.of(uri).toFile();
       if (!file.exists()) {
         return Data.empty();
       }

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContextTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContextTest.java
@@ -294,6 +294,21 @@ class DocumentContextTest {
     assertThat(documentContext.getFileType()).isEqualTo(FileType.BSL);
   }
 
+  @Test
+  void rebuildFromFileSystemDoesNotThrowOnUriWithAuthority() {
+    // given: LSP-клиент на UNC отдаёт file://host/share/... — у URI есть authority.
+    // new File(uri) бросает IllegalArgumentException и рвёт populateContext.
+    var uri = URI.create("file://192.168.113.131/share/does-not-exist.bsl");
+    var documentContext = TestUtils.getDocumentContext(
+      uri,
+      "Процедура Тест() КонецПроцедуры",
+      TestUtils.getRegisteredServerContext()
+    );
+
+    // when-then: файл может отсутствовать (IOException логируется), но не IAE.
+    assertThatCode(documentContext::rebuildFromFileSystem).doesNotThrowAnyException();
+  }
+
   @SneakyThrows
   public DocumentContext getDocumentContext() {
 

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContextTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/context/DocumentContextTest.java
@@ -305,7 +305,8 @@ class DocumentContextTest {
       TestUtils.getRegisteredServerContext()
     );
 
-    // when-then: файл может отсутствовать (IOException логируется), но не IAE.
+    // when-then: нет файла → IOException; на Unix Path.of(file://host/...) → IAE.
+    // Оба логируются, populate не рвётся.
     assertThatCode(documentContext::rebuildFromFileSystem).doesNotThrowAnyException();
   }
 


### PR DESCRIPTION
﻿## Описание
`DocumentContext.rebuildFromFileSystem` читал диск через `new File(uri)`.
Для `file://host/share/...` (UNC из Cursor/VS Code) `File(URI)` бросает
`IllegalArgumentException: URI has an authority component` — падает `populateContext`,
дальше NPE в `getAst`.

Чтение заменено на `Files.readString(Absolute.path(uri), UTF_8)` по соглашению проекта
(как MCP roots в #4119). Тот же `new File(uri)` убран в `GitBlameComputer`.
`catch` по-прежнему только `IOException`.

## Связанные задачи
Closes #4481

## Чеклист

### Общие

- [x] Ветка PR обновлена из develop
- [x] Отладочные, закомментированные и прочие, не имеющие смысла участки кода удалены
- [x] Изменения покрыты тестами
- [ ] Обязательные действия перед коммитом выполнены (запускал команду `gradlew precommit`)

### Для диагностик

- [ ] Описание диагностики заполнено для обоих языков (присутствуют файлы для обоих языков, для русского заполнено все подробно, перевод на английский можно опустить)

## Дополнительно
Локально: `DocumentContextTest` (включая `rebuildFromFileSystemDoesNotThrowOnUriWithAuthority`) и `spotlessApply`.

Связано с #934 / leftover после `Absolute.path`. Возможно пересекается с #3157.
Плагин: 1c-syntax/vsc-language-1c-bsl#381 (не тот репозиторий).


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of file-based document operations for URIs containing an authority component, including UNC-style paths.
  * Prevented errors when rebuilding documents from file-system locations that do not exist.
  * Improved reliability when determining file locations for source history information.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->