### PR TITLE
test(types): моки реестра знают про собственный тип элемента

### DIFF
--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/DeclaredFieldWithUnresolvedTypeTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/DeclaredFieldWithUnresolvedTypeTest.java
@@ -76,6 +76,7 @@ class DeclaredFieldWithUnresolvedTypeTest {
     when(typeRegistry.resolve("Структура")).thenReturn(Optional.of(STRUCTURE));
     when(typeRegistry.resolveSet(anyString())).thenReturn(TypeSet.EMPTY);
     when(typeRegistry.getDefaultElementTypes(any())).thenReturn(TypeSet.EMPTY);
+    when(typeRegistry.getOwnElementTypes(any())).thenReturn(TypeSet.EMPTY);
     when(typeRegistry.intern(any(), anyString()))
       .thenAnswer(invocation -> new TypeRef(invocation.getArgument(0), invocation.getArgument(1)));
     index = new SymbolTypeIndex(typeRegistry, mock(FormByNameResolver.class));

--- a/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndexDeclaredTypesTest.java
+++ b/src/test/java/com/github/_1c_syntax/bsl/languageserver/types/index/SymbolTypeIndexDeclaredTypesTest.java
@@ -75,6 +75,7 @@ class SymbolTypeIndexDeclaredTypesTest {
     when(typeRegistry.intern(TypeKind.USER, "Массив"))
       .thenReturn(new TypeRef(TypeKind.USER, "Массив"));
     when(typeRegistry.getDefaultElementTypes(any())).thenReturn(TypeSet.EMPTY);
+    when(typeRegistry.getOwnElementTypes(any())).thenReturn(TypeSet.EMPTY);
     index = new SymbolTypeIndex(typeRegistry, mock(FormByNameResolver.class));
     documentContext = TestUtils.getDocumentContext(MODULE);
   }


### PR DESCRIPTION
SymbolTypeIndex спрашивает у реестра getOwnElementTypes (#4430), а моки в
двух тестах закрывали только getDefaultElementTypes — незаглушенный метод
мока отдавал null, и разбор объявления падал с NPE.

Тесты и вызов пришли в develop разными пулл-реквестами: ветка #4430
отпочковалась 10 августа и с тех пор с develop не сливалась, а тесты
появились 11 и 20 августа. Текстового конфликта нет, компиляция проходит,
поэтому оба пулл-реквеста были зелёными по отдельности, а develop с их
слиянием стал красным.

Co-Authored-By: Claude <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01JGS9uSja6ibfpAtM2xRNiE

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Updated type-resolution test coverage to account for additional registry interactions.
  * Improved test stability when processing unresolved and declared types.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->